### PR TITLE
RavenDB-23668 `ByteStringMemoryManager` fixes

### DIFF
--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -933,16 +933,16 @@ namespace Sparrow.Server
                 _str = str;
             }
 
-            public override Memory<T> Memory => CreateMemory(_str.Length);
+            public override Memory<T> Memory => CreateMemory(_str.Length / sizeof(T));
 
-            public override Span<T> GetSpan() => new Span<T>(_str.Ptr, _str.Length);
+            public override Span<T> GetSpan() => new Span<T>(_str.Ptr, _str.Length / sizeof(T));
 
             public override MemoryHandle Pin(int elementIndex = 0)
             {
                 if (elementIndex < 0 || elementIndex >= _str.Length / sizeof(T))
                     throw new ArgumentOutOfRangeException(nameof(elementIndex));
 
-                return new MemoryHandle(_str._pointer + (elementIndex * sizeof(T)));
+                return new MemoryHandle(_str.Ptr + (elementIndex * sizeof(T)));
             }
 
             public override void Unpin()

--- a/test/SlowTests/Issues/RavenDB-23668.cs
+++ b/test/SlowTests/Issues/RavenDB-23668.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Reflection;
+using FastTests;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public unsafe class RavenDB_23668(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.Core | RavenTestCategory.Memory)]
+    public void ByteStringMemoryManagerAllocationTest()
+    {
+        const int arraySize = 65536;
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var scope = allocator.Allocate(arraySize, out Memory<long> memoryObject);
+        Assert.Equal(memoryObject.Length, arraySize);
+
+        var spanFromMemory = memoryObject.Span;
+        Assert.Equal(spanFromMemory.Length, arraySize);
+        
+        var field = scope.GetType()
+            .GetField("_str", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+
+        var byteStringObj = field.GetValue(scope);
+        Assert.NotNull(byteStringObj);
+        Assert.IsType<ByteString>(byteStringObj);
+
+        var bs = (ByteString)byteStringObj;
+        using (var pinned = memoryObject.Pin())
+        {
+            var pinnedPointer = pinned.Pointer;
+            var byteStringPointer = bs.Ptr;
+
+            Assert.Equal((ulong)byteStringPointer, (ulong)pinnedPointer);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23668

### Additional description

- `ByteStringMemoryManager` must calculate the length of `Span`/`Memory` taking sizeof `T` into account
- `ByteStringMemoryManager.Pin` must return the pointer of underlying memory instread of the pointer to `ByteStringStorage`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
