### PR TITLE
RavenDB-23671 - Subscription expiration is showing the next day

### DIFF
--- a/src/Raven.Server/Commercial/LicenseAttribute.cs
+++ b/src/Raven.Server/Commercial/LicenseAttribute.cs
@@ -38,6 +38,7 @@
         PostgreSqlIntegration,
         CanBeActivatedUntil,
         QueueEtl,
+        ServerWideBackups,
         ServerWideExternalReplications,
         ServerWideCustomSorters,
         ServerWideAnalyzers,

--- a/src/Raven.Studio/typescript/models/auth/licenseModel.ts
+++ b/src/Raven.Studio/typescript/models/auth/licenseModel.ts
@@ -41,7 +41,7 @@ class licenseModel {
         }
 
         const dateFormat = "YYYY MMMM Do";
-        const expiration = moment(licenseStatus.SubscriptionExpiration);
+        const expiration = moment.utc(licenseStatus.SubscriptionExpiration);
         const now = moment();
         const nextMonth = moment().add(1, 'month');
         if (now.isBefore(expiration)) {

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/customControlls/licenseAgpl.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/customControlls/licenseAgpl.ts
@@ -19,7 +19,7 @@ class licenseAgpl  {
         }
 
         const now = moment();
-        const firstStart = moment(licenseStatus.FirstServerStartDate);
+        const firstStart = moment.utc(licenseStatus.FirstServerStartDate);
         const weekAfterFirstStart = firstStart.clone().add("1", "week");
 
         return now.isBefore(weekAfterFirstStart) ? weekAfterFirstStart.format("YYYY-MM-DD") : null; 

--- a/src/Raven.Studio/typescript/viewmodels/shell/registration.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell/registration.ts
@@ -111,7 +111,7 @@ class registration extends dialogViewModelBase {
                 error += `: ${licenseStatus.ErrorMessage}`;
             }
         } else if (licenseStatus.Expired) {
-            const expiration = moment(licenseStatus.SubscriptionExpiration);
+            const expiration = moment.utc(licenseStatus.SubscriptionExpiration);
             error = "License has expired";
             if (expiration.isValid()) {
                 error += ` on ${expiration.format("YYYY MMMM Do")}`;
@@ -119,7 +119,7 @@ class registration extends dialogViewModelBase {
         }
         this.error(error);
 
-        const firstStart = moment(licenseStatus.FirstServerStartDate)
+        const firstStart = moment.utc(licenseStatus.FirstServerStartDate)
             .add("1", "week").add("1", "day");
 
         this.daysToRegister = ko.pureComputed(() => {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23671/Subscription-expiration-is-showing-the-next-day

### Additional description

Since all dates from the `/license/status` endpoint are in UTC, ensure they are always treated as such.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
