### PR TITLE
[6.0] RavenDB-22468 - Server-wide backup wakes up all DBs at once causing timeouts

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1407,10 +1407,19 @@ namespace Raven.Server.Documents
                             var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
                             if (startDatabaseForBackup == null)
                             {
+                                // reached max concurrent loading of databases for backup, retry after 1 min
+
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases for backup, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
+
+                                RescheduleDatabaseWakeup();
+                            }
+                            else if (_serverStore.ConcurrentBackupsCounter.CanRunBackup == false)
+                            {
                                 // reached max concurrent backups, retry after 1 min
 
                                 if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in '{_dueTimeOnRetry}' ms");
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
 
                                 RescheduleDatabaseWakeup();
                             }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1407,35 +1407,32 @@ namespace Raven.Server.Documents
                         case IdleDatabaseActivityType.WakeUpDatabase:
                             if (_serverStore.ConcurrentBackupsCounter.CanRunBackup == false)
                             {
-                                // reached max concurrent backups, retry after 1 min
-
+                                // reached max concurrent backups
+                                var delayInMs = RescheduleDatabaseWakeup();
                                 if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
-
-                                RescheduleDatabaseWakeup();
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached " +
+                                                 $"max concurrent backups ({_serverStore.ConcurrentBackupsCounter.MaxNumberOfConcurrentBackups}), will retry the wakeup in {delayInMs:#,#;;0}ms");
                                 break;
                             }
 
-                            if (CanServerRunBackup() == false)
+                            if (BackupUtils.CanServerRunBackup(_serverStore) == false)
                             {
                                 // the server cannot run the backup anyway (low memory, low cpu credits or high dirty memory state)
-
+                                var delayInMs = RescheduleDatabaseWakeup();
                                 if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we are in a low memory state, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
-
-                                RescheduleDatabaseWakeup();
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we are in a low memory state, " +
+                                                 $"will retry the wakeup in {delayInMs:#,#;;0}ms");
                                 break;
                             }
 
                             var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
                             if (startDatabaseForBackup == null)
                             {
-                                // reached max concurrent loading of databases for backup, retry after 1 min
-
+                                // reached max concurrent loading of databases for backup
+                                var delayInMs = RescheduleDatabaseWakeup();
                                 if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases for backup, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
-
-                                RescheduleDatabaseWakeup();
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases " +
+                                                 $"for backup ({_serverStore.ConcurrentBackupsCounter.MaxNumberOfConcurrentBackups}), will retry the wakeup in {delayInMs:#,#;;0}ms");
                             }
                             else
                             {
@@ -1446,22 +1443,23 @@ namespace Raven.Server.Documents
                                     var ex = t.Exception.ExtractSingleInnerException();
                                     if (ex is DatabaseConcurrentLoadTimeoutException e)
                                     {
-                                        // database failed to load, retry after 1 min
-
+                                        // database failed to load
+                                        var delayInMs = RescheduleDatabaseWakeup();
                                         if (_logger.IsInfoEnabled)
-                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms", e);
-
-                                        RescheduleDatabaseWakeup();
+                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in {delayInMs:#,#;;0}ms", e);
                                     }
                                 });
                             }
                             break;
 
-                            void RescheduleDatabaseWakeup()
+                            int RescheduleDatabaseWakeup()
                             {
                                 ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
-                                nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(_dueTimeOnRetry);
+
+                                var delayInMs = _dueTimeOnRetry + Random.Shared.Next(0, _dueTimeOnRetry);
+                                nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(delayInMs);
                                 RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
+                                return delayInMs;
                             }
                     }
                 }
@@ -1478,19 +1476,6 @@ namespace Raven.Server.Documents
                     _logger.Operations($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
 
                 ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e, databaseName);
-            }
-        }
-
-        private bool CanServerRunBackup()
-        {
-            try
-            {
-                BackupUtils.CheckServerHealthBeforeBackup(_serverStore, name: null);
-                return true;
-            }
-            catch (BackupDelayException)
-            {
-                return false;
             }
         }
 

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1404,23 +1404,42 @@ namespace Raven.Server.Documents
                             break;
 
                         case IdleDatabaseActivityType.WakeUpDatabase:
-                            _ = TryGetOrCreateResourceStore(databaseName, nextIdleDatabaseActivity.DateTime).ContinueWith(t =>
+                            var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
+                            if (startDatabaseForBackup == null)
                             {
-                                var ex = t.Exception.ExtractSingleInnerException();
-                                if (ex is DatabaseConcurrentLoadTimeoutException e)
+                                // reached max concurrent backups, retry after 1 min
+
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in '{_dueTimeOnRetry}' ms");
+
+                                RescheduleDatabaseWakeup();
+                            }
+                            else
+                            {
+                                _ = TryGetOrCreateResourceStore(databaseName, nextIdleDatabaseActivity.DateTime).ContinueWith(t =>
                                 {
-                                    // database failed to load, retry after 1 min
+                                    startDatabaseForBackup.Dispose();
 
-                                    if (_logger.IsInfoEnabled)
-                                        _logger.Info($"Failed to start database '{databaseName}' on timer, will retry the wakeup in '{_dueTimeOnRetry}' ms", e);
+                                    var ex = t.Exception.ExtractSingleInnerException();
+                                    if (ex is DatabaseConcurrentLoadTimeoutException e)
+                                    {
+                                        // database failed to load, retry after 1 min
 
-                                    nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(_dueTimeOnRetry);
-                                    ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
+                                        if (_logger.IsInfoEnabled)
+                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in '{_dueTimeOnRetry}' ms", e);
 
-                                    RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
-                                }
-                            }, TaskContinuationOptions.OnlyOnFaulted);
+                                        RescheduleDatabaseWakeup();
+                                    }
+                                });
+                            }
                             break;
+
+                            void RescheduleDatabaseWakeup()
+                            {
+                                ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
+                                nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(_dueTimeOnRetry);
+                                RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
+                            }
                     }
                 }
                 finally

--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -42,6 +42,17 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
+        public bool CanRunBackup
+        {
+            get
+            {
+                lock (_locker)
+                {
+                    return _runningBackupsPerDatabase.Count - 1 > 0;
+                }
+            }
+        }
+
         public ConcurrentBackupsCounter(BackupConfiguration backupConfiguration, LicenseManager licenseManager)
         {
             _licenseManager = licenseManager;

--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -171,6 +171,9 @@ namespace Raven.Server.Documents.PeriodicBackup
             var utilizedCores = _licenseManager.GetCoresLimitForNode(out _);
             var newMaxConcurrentBackups = GetNumberOfCoresToUseForBackup(utilizedCores);
 
+            if (_maxConcurrentBackups == newMaxConcurrentBackups)
+                return;
+
             lock (_locker)
             {
                 _maxConcurrentBackups = newMaxConcurrentBackups;

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -416,6 +416,19 @@ internal static class BackupUtils
         }
     }
 
+    public static bool CanServerRunBackup(ServerStore serverStore)
+    {
+        try
+        {
+            CheckServerHealthBeforeBackup(serverStore, name: null);
+            return true;
+        }
+        catch (BackupDelayException)
+        {
+            return false;
+        }
+    }
+
     public static PathSetting GetBackupTempPath(RavenConfiguration configuration, string dir, out PathSetting basePath)
     {
         basePath = configuration.Backup.TempPath ?? configuration.Storage.TempPath ?? configuration.Core.DataDirectory;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22468/Server-wide-backup-wakes-up-all-DBs-at-once-causing-timeouts

### Additional description

Use the `ConcurrentBackupsCounter` when deciding if we need to wakeup the database for backup.
Also take into account if we are in a low memory state, have low CPU credits or in a high dirty memory state which will prevent us from doing the backup anyway.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
