### PR TITLE
RavenDB-23409 test should run on 64bit only

### DIFF
--- a/test/SlowTests/Issues/RavenDB-23409.cs
+++ b/test/SlowTests/Issues/RavenDB-23409.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Counters | RavenTestCategory.Voron)]
+        [RavenMultiplatformFact(RavenTestCategory.Counters | RavenTestCategory.Voron, RavenArchitecture.AllX64)]
         public async Task CanCleanCounterTombstones()
         {
             await using var replayStream = typeof(RavenDB_23409).Assembly.GetManifestResourceStream("SlowTests.Data.RavenDB-23409.rec");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23409

### Additional description

The tx recording contain async commits which can't be run on a 32bit archs, so this test should run only in 64bits

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
