### PR TITLE
RavenDB-23597 move the ReadBalanceBehavior to be based on the conventions

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -319,14 +319,6 @@ namespace Raven.Client.Http
             TopologyHash = Http.TopologyHash.GetTopologyHash(initialUrls);
 
             UpdateConnectionLimit(initialUrls);
-
-            ClientConfigurationChanged += (_, args) =>
-            {
-                if (args.Configuration?.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
-                    _nodeSelector?.ScheduleSpeedTest();
-                else
-                    _nodeSelector?.DisableFastestNodeReadBalance();
-            };
         }
 
         ~RequestExecutor()
@@ -441,6 +433,12 @@ namespace Raven.Client.Http
                         return;
 
                     Conventions.UpdateFrom(result.Configuration);
+
+                    if (Conventions.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
+                        _nodeSelector?.ScheduleSpeedTest();
+                    else
+                        _nodeSelector?.DisableFastestNodeReadBalance();
+                    
                     ClientConfigurationEtag = result.Etag;
                     ClientConfigurationChanged?.Invoke(this, (result.Etag, result.Configuration));
                 }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -322,7 +322,7 @@ namespace Raven.Client.Http
 
             ClientConfigurationChanged += (_, args) =>
             {
-                if (args.Configuration.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
+                if (args.Configuration?.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
                     _nodeSelector?.ScheduleSpeedTest();
                 else
                     _nodeSelector?.DisableFastestNodeReadBalance();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23597

### Additional description

~~It seems that in very old versions (4.2 and before) we could get a `null` back during updating the configuration change.
Now it seems not to be the case and once we change the client configuration we always get an object back.
Because we can't delete a client config and the only way to do so is by updating the entire database record, but we has this to protect us:
`https://github.com/ravendb/ravendb/blob/1288740bcb91902aa4db3de9fbc02bbff277529d/src/Raven.Server/ServerWide/ClusterStateMachine.cs#L1940-L1945`~~

Update:
new approach is to base the `ReadBalanceBehavior` on the conventions that take into account things like `null` and `disabled` 


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
