### PR TITLE
RavenDB-23695 HNSW indexing: handle updates in PostingList

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -10,6 +10,7 @@ using Sparrow.Compression;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
+using Sparrow.Server.Utils.VxSort;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Lookups;
@@ -937,11 +938,23 @@ public unsafe partial class Hnsw
             
             long MergePostingList(long postingList, NativeList<long> modifications)
             {
+                // We may have duplicates in the list.
+                // Scenarios:
+                // 1) additions: when the source document contains a list of the same vectors
+                // 2) removals: when the deleted document contained a list of the same vectors
+                // However, the HNSW does not use frequency. So we want to have information in buffer about:
+                // - There was an addition
+                // - There was a removal
+                // In such case, we can just sort and remove duplicates to have unique list.
+                modifications.Shrink(Sorting.SortAndRemoveDuplicates(modifications.ToSpan()));
+                
                 listBuffer.Clear();
                 listBuffer.AddRange(modifications.ToSpan());
+                
                 int currentSize = 0;
                 bool hasSmallPostingList = false;
                 long rawPostingListId = postingList & Constants.Graphs.VectorId.ContainerType;
+                
                 switch (postingList & Constants.Graphs.VectorId.EnsureIsSingleMask)
                 {
                     case Constants.Graphs.VectorId.Tombstone: // nothing there
@@ -956,8 +969,16 @@ public unsafe partial class Hnsw
                     case Constants.Graphs.VectorId.PostingList:
                         return UpdatePostingList(rawPostingListId, in modifications, pforEncoder, ref pforDecoder, ref listBuffer);
                 }
+
+                // Due to deduplication performed before reading the posting list from disk, we can now have the following scenarios:
+                // 1) 2x Additions + 1x Removal
+                // There was an update of the document. So, we have 1x addition and 1x removal from indexing, plus the loaded entry id from disk -> the ID will remain in the buffer
+                // 2) 1x Addition + 1x Removal:
+                // There was a delete operation during indexing, plus the loaded entry id from disk: id will be removed from buffer
+                // 3) 1x Addition: New document 
+                // INFO: All other scenarios are invalid.
+                PostingList.SortModificationsAndRemoveDuplicates(ref listBuffer);
                 
-                PostingList.SortEntriesAndRemoveDuplicatesAndRemovals(ref listBuffer);
                 if (listBuffer.Count is 0 or 1)
                 {
                     if (hasSmallPostingList)

--- a/src/Voron/Data/PostingLists/PostingList.cs
+++ b/src/Voron/Data/PostingLists/PostingList.cs
@@ -729,5 +729,38 @@ namespace Voron.Data.PostingLists
 
             list.Count = (int)(outputBufferPtr - list.RawItems + 1);
         }
+        
+        //The method is used to prepare final list that should be stored in the posting list.
+        //It should:
+        // - Filter updates (sequence: [ X, X, X | 1] ) => [X] )
+        // - Filter removals (sequence: [X, X | 1] => [] )
+        // - Addition (sequence: [X] => [X] )
+        public static void SortModificationsAndRemoveDuplicates(ref ContextBoundNativeList<long> list)
+        {
+            if (list.Count <= 1)
+                return;
+            
+            list.Sort();
+
+            int outputIdx = 1;
+            for (int i = 1; i < list.Count; i++)
+            {
+                if ((list[i] & 1) == 1) //removal
+                {
+                    var isRemovalPrevious = (list[i - 1] | 1) == list[i];
+                    Debug.Assert((list[i - 1] & 1) == 0, "orphaned removal, not supposed to happen");
+                    if (isRemovalPrevious)
+                    {
+                        outputIdx--; // remove from output
+                        continue;
+                    }
+                }
+                
+                list[outputIdx] = list[i];
+                outputIdx++;
+            }
+
+            list.Shrink(outputIdx);
+        }
     }
 }

--- a/src/Voron/Util/PFor/FastPForEncoder.cs
+++ b/src/Voron/Util/PFor/FastPForEncoder.cs
@@ -321,7 +321,13 @@ public sealed unsafe class FastPForEncoder  : IDisposable
         return (_offset - oldOffset, sizeUsed);
     }
 
-    public long NextValueToEncode => _entries[Math.Min(_offset, _count-1)];
+    public long NextValueToEncode =>
+#if DEBUG
+        // Prevents AVE in debug mode, since debugger can tries to evaluate the property even it is not initialized
+        (_entries is null || Math.Min(_offset, _count - 1) >= _count) ? -1L : _entries[Math.Min(_offset, _count - 1)];
+#else
+        _entries[Math.Min(_offset, _count-1)];
+#endif
 
     private int WriteLastBatchAsVarIntDelta(int count, byte* output, int outputSize)
     {

--- a/test/FastTests/Corax/RavenDB_23695.cs
+++ b/test/FastTests/Corax/RavenDB_23695.cs
@@ -1,0 +1,133 @@
+﻿using System.Linq;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Voron.Data.PostingLists;
+using Voron.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class RavenDB_23695 : RavenTestBase
+{
+    public RavenDB_23695(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public void CanPerformNoopUpdateOfVector()
+    {
+        using var store = GetDocumentStore();
+        string id = "Products/1-A";
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product() { Name = "abc", Category = "first"}, id);
+            session.SaveChanges();
+            _ = session.Advanced.DocumentQuery<Product>().WhereEquals(s => s.Category, "first").OrElse().VectorSearch(f => f.WithText(s => s.Name), v => v.ByText("abc"))
+                .ToList();
+            Indexes.WaitForIndexing(store);
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var p = session.Load<Product>(id);
+            p.Category = "updated"; 
+            session.SaveChanges();
+            Indexes.WaitForIndexing(store);
+
+
+            var result = session.Advanced.DocumentQuery<Product>().WhereEquals(s => s.Category, "first").OrElse().VectorSearch(f => f.WithText(s => s.Name), v => v.ByText("abc"))
+                .ToList();
+            Assert.Equal(1, result.Count);
+            
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineData(4, 5)]
+    [InlineData(5, 4)]
+    public void CanPerformListDegradationAndUpgrade(int from, int to)
+    {
+        using var store = GetDocumentStore();
+        string id = "Products/1-A";
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product() { Name = "abc", Category = "first", Names = Enumerable.Range(0, from).Select(_ => "abc").ToArray()}, id);
+            session.SaveChanges();
+            _ = session.Advanced.DocumentQuery<Product>().WhereEquals(s => s.Category, "first").OrElse().VectorSearch(f => f.WithText(s => s.Names), v => v.ByText("abc"))
+                .ToList();
+            Indexes.WaitForIndexing(store);
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var p = session.Load<Product>(id);
+            p.Names =  Enumerable.Range(0, to).Select(_ => "abc").ToArray();
+            session.SaveChanges();
+            Indexes.WaitForIndexing(store);
+
+
+            var result = session.Advanced.DocumentQuery<Product>().WhereEquals(s => s.Category, "first").OrElse().VectorSearch(f => f.WithText(s => s.Names), v => v.ByText("abc"))
+                .ToList();
+            Assert.Equal(1, result.Count);
+            
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public void CanProperlyPrepareListForPostingList_Update()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        var clb = new ContextBoundNativeList<long>(ctx);
+        clb.Add(4);
+        clb.Add(4);
+        clb.Add(5);
+        
+        //The method is used to prepare final list that should be stored in the posting list.
+        //It should:
+        // - Filter updates (sequence: [ X, X, X | 1] ) => [X] )
+        // - Filter removals (sequence: [X, X | 1] => [] )
+        // - Addition (sequence: [X] => [X] )
+        PostingList.SortModificationsAndRemoveDuplicates(ref clb);
+        Assert.Equal(1, clb.Count);
+        Assert.Equal(4, clb[0]);
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void CanProperlyPrepareListForPostingList_Removal()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        var clb = new ContextBoundNativeList<long>(ctx);
+        clb.Add(4);
+        clb.Add(5);
+        clb.Add(16);
+        
+        PostingList.SortModificationsAndRemoveDuplicates(ref clb);
+        Assert.Equal(1, clb.Count);
+        Assert.Equal(16, clb[0]);
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void CanProperlyPrepareListForPostingList_Insert()
+    {
+        using var ctx = new ByteStringContext(SharedMultipleUseFlag.None);
+        var clb = new ContextBoundNativeList<long>(ctx);
+        clb.Add(4);
+        clb.Add(8);
+        clb.Add(16);
+        
+        PostingList.SortModificationsAndRemoveDuplicates(ref clb);
+        Assert.Equal(3, clb.Count);
+        Assert.Equal(4, clb[0]);
+        Assert.Equal(8, clb[1]);
+        Assert.Equal(16, clb[2]);
+    }
+
+    private class Product
+    {
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public string[] Names { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23695

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
