### PR TITLE
RavenDB-23698 - WaitForIndexesAfterSaveChanges doesn't identify an index for all documents

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -563,11 +563,8 @@ namespace Raven.Server.Documents.Handlers
                     if (index.State is IndexState.Disabled)
                         continue;
 
-                    if (index.Collections.Contains(Constants.Documents.Collections.AllDocumentsCollection) ||
-                        index.WorksOnAnyCollection(modifiedCollections))
-                    {
+                    if (index.WorksOnAnyCollection(modifiedCollections))
                         indexesToCheck.Add(index);
-                    }
                 }
             }
             return indexesToCheck;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4291,6 +4291,9 @@ namespace Raven.Server.Documents.Indexes
             if (Collections.Count == 0)
                 return false;
 
+            if (HandleAllDocs)
+                return true;
+
             return Collections.Overlaps(collections);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23698/WaitForIndexesAfterSaveChanges-doesnt-identify-an-index-for-all-documents

### Additional description

Fix an issue where we didn't wait when using `WaitForIndexesAfterSaveChanges` when specifying an index(es) to wait for after save changes for an index that indexes all documents.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
