### PR TITLE
RavenDB-22419 - Fix Leader Election Failure and State Transition Issue

### DIFF
--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -164,11 +164,8 @@ namespace Raven.Server.Rachis
 
 
                             if (rv.IsForcedElection == false &&
-                                (
-                                    _engine.CurrentState == RachisState.Leader ||
-                                    _engine.CurrentState == RachisState.LeaderElect
-                                )
-                            )
+                                (_engine.CurrentState == RachisState.Leader || _engine.CurrentState == RachisState.LeaderElect) && 
+                                _engine.CurrentLeader?.Running == true)
                             {
                                 _connection.Send(context, new RequestVoteResponse
                                 {

--- a/test/SlowTests/Issues/RavenDB-22419.cs
+++ b/test/SlowTests/Issues/RavenDB-22419.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Session;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22419 : ClusterTestBase
+    {
+        public RavenDB_22419(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Dispose_Leader_Without_Changing_State_Shuoldnt_Cause_The_Leader_To_Stuck(Options options)
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+            var (_, leader) = await CreateRaftCluster(2);
+            options.Server = leader;
+            options.ReplicationFactor = 2;
+
+            using (var leaderStore = GetDocumentStore(options))
+            {
+                using (var session = leaderStore.OpenAsyncSession(new SessionOptions
+                       {
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/1", new User());
+                    await session.SaveChangesAsync();
+                }
+
+                await ActionWithLeader((l) =>
+                {
+                    l.ServerStore.Engine.CurrentLeader?.Dispose();
+                    return Task.CompletedTask;
+                });
+
+                using (var session = leaderStore.OpenAsyncSession(new SessionOptions
+                       {
+                           TransactionMode = TransactionMode.ClusterWide
+                       }))
+                {
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/2", new User());
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        public class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22419/StressTests.Cluster.ClusterTransactionTestsStress.CanCreateClusterTransactionRequest2options-DatabaseMode-Sharded

### Additional description

The test is failing because there is no leader for 15 seconds.
The problem was that the old leader failed to change state, so the other node tried to be the new leader, so the old leader voted for him on the trial election but the real election failed because the old leader 'thought' he was still the leader (because its CurrentState didn't change from 'Leader'/'LeaderElect') although the 'Leader' instance is already disposed (by 'CastVoteInTerm').

Also fixed race between updating term and disposing the leader - Put async happens after updating term and before disposing the Leader instance by SetNewStateInTx:
The outdated leader, that didn't got to be disposed yet, gets a command by 'SendtoLeaderAsync->PutAsync'
Its '_engine' has a higher term because it was updated by "CastVoteInTem" (12->13), but the (readonly) '_term' of the outdated leader is outdated too (12) so the InserToLeaderLog throws on 'ValidateTerm' ('TermValidationException').
For example:
1. CastVoteInTerm: node=B - CurrentTerm changed from 11 to 12 (numOfRuns=1) | 2025-02-05T13:21:58.8385415Z | msg: "Casting vote as elector"
2. PutAsync
3. SetNewStateAsync: node=B | oldState=Leader newState=Follower - 'Leader instance' is disposed | msg: "Accepted a new connection from A in term 12"
(This issue: https://issues.hibernatingrhinos.com/issue/RavenDB-22345/StressTests.Cluster.ClusterTransactionTestsStress.CanCreateClusterTransactionRequest2options-DatabaseMode-Single)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
