### PR TITLE
RavenDB-23705 - Negative unamanged memory in threads runaway

### DIFF
--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -32,6 +32,7 @@ namespace Voron.Impl.FileHeaders
 
         private FileHeader* _theHeader;
         private byte* _headerPtr;
+        private readonly NativeMemory.ThreadStats _stats;
 
         internal static string[] HeaderFileNames = { "headers.one", "headers.two" };
 
@@ -39,7 +40,7 @@ namespace Voron.Impl.FileHeaders
         {
             _env = env;
 
-            _headerPtr = NativeMemory.AllocateMemory(sizeof(FileHeader));
+            _headerPtr = NativeMemory.AllocateMemory(sizeof(FileHeader), out _stats);
             _theHeader = (FileHeader*)_headerPtr;
         }
 
@@ -305,7 +306,7 @@ namespace Voron.Impl.FileHeaders
             {
                 if (_headerPtr != null)
                 {
-                    NativeMemory.Free(_headerPtr, sizeof(FileHeader));
+                    NativeMemory.Free(_headerPtr, sizeof(FileHeader), _stats);
                     _headerPtr = null;
                     _theHeader = null;
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23705/Negative-unamanged-memory-in-threads-runaway

### Additional description

We’ve seen this issue before, but it became more frequent after the changes in [lucenenet/pull/70](https://github.com/ravendb/lucenenet/pull/70), where we switched from using managed memory to unmanaged memory for the query term cache.

We can’t update the thread stats because we don’t store it anywhere like we do in other cases.

Since this is a long-term allocation, we track the total allocated memory using `_totalLuceneUnmanagedAllocationsForTermCache` and `_totalLuceneUnmanagedAllocationsForSorting`, which means we don’t need to update it per thread.

### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
