### PR TITLE
RavenDB-23695: Optimization of the fix for modification lists.

### DIFF
--- a/src/Voron/Data/PostingLists/PostingList.cs
+++ b/src/Voron/Data/PostingLists/PostingList.cs
@@ -703,7 +703,7 @@ namespace Voron.Data.PostingLists
             // blog post explaining this
             // https://ayende.com/blog/200065-B/optimizing-a-three-way-merge?key=67d6f65d63ba4fb79d31dfc49ae5aa1d
 
-            // The idea here is that we can do all of the process with no branches at all and make this 
+            // The idea here is that we can do all the process with no branches at all and make this 
             // easily predictable to the CPU
 
             // Here we rely on the fact that the removals has been set with 1 at the bottom bit
@@ -729,35 +729,41 @@ namespace Voron.Data.PostingLists
 
             list.Count = (int)(outputBufferPtr - list.RawItems + 1);
         }
-        
+
+        private static ReadOnlySpan<int> _modificationsAndRemoveTable => [+1, 0, +1, -1];
+
         //The method is used to prepare final list that should be stored in the posting list.
         //It should:
-        // - Filter updates (sequence: [ X, X, X | 1] ) => [X] )
+        // - Filter updates (sequence: [X, X, X | 1] ) => [X] )
         // - Filter removals (sequence: [X, X | 1] => [] )
         // - Addition (sequence: [X] => [X] )
         public static void SortModificationsAndRemoveDuplicates(ref ContextBoundNativeList<long> list)
         {
             if (list.Count <= 1)
                 return;
-            
+
+            // Sort so that additions (LSB=0) come before any corresponding removals (LSB=1).
             list.Sort();
 
             int outputIdx = 1;
             for (int i = 1; i < list.Count; i++)
             {
-                if ((list[i] & 1) == 1) //removal
-                {
-                    var isRemovalPrevious = (list[i - 1] | 1) == list[i];
-                    Debug.Assert((list[i - 1] & 1) == 0, "orphaned removal, not supposed to happen");
-                    if (isRemovalPrevious)
-                    {
-                        outputIdx--; // remove from output
-                        continue;
-                    }
-                }
-                
+                // We preemptively copy, worst case scenario it is a useless copy. 
                 list[outputIdx] = list[i];
-                outputIdx++;
+
+                // Build a small 2-bit key
+                // 1x if this element is a removal, else 0x
+                // x1 if ignoring the LSB, the previous (output) item is the same, else x0
+                int key = ((int)(list[i] & 1) << 1) | ((list[outputIdx - 1] | 1) == list[i]).ToInt32();
+
+
+                // We embed the rules on how to update the index in a small table:
+                //   index : (isRem<<1 | isSame)
+                //     0 => +1 (place)   [add, different]
+                //     1 =>  0 (skip)    [add, duplicate]
+                //     2 => +1 (place)   [rem, different => "orphan removal"?]
+                //     3 => -1 (pop old) [rem, same => remove old, skip new]
+                outputIdx += _modificationsAndRemoveTable[key];
             }
 
             list.Shrink(outputIdx);

--- a/src/Voron/Data/PostingLists/PostingList.cs
+++ b/src/Voron/Data/PostingLists/PostingList.cs
@@ -745,17 +745,21 @@ namespace Voron.Data.PostingLists
             // Sort so that additions (LSB=0) come before any corresponding removals (LSB=1).
             list.Sort();
 
-            int outputIdx = 1;
-            for (int i = 1; i < list.Count; i++)
+            long* ptr = list.RawItems;
+            long* outPtr = ptr;
+            long* endPtr = ptr + list.Count;
+
+            // Process each element starting from the second one.
+            while (++ptr < endPtr)
             {
-                // We preemptively copy, worst case scenario it is a useless copy. 
-                list[outputIdx] = list[i];
+                // Preemptively copy the current element to outPtr + 1. 
+                // The redundant write is acceptable in this loop.
+                *(outPtr + 1) = *ptr;
 
                 // Build a small 2-bit key
                 // 1x if this element is a removal, else 0x
                 // x1 if ignoring the LSB, the previous (output) item is the same, else x0
-                int key = ((int)(list[i] & 1) << 1) | ((list[outputIdx - 1] | 1) == list[i]).ToInt32();
-
+                int key = ((int)(*ptr & 1) << 1) | ((*outPtr | 1) == *ptr).ToInt32();
 
                 // We embed the rules on how to update the index in a small table:
                 //   index : (isRem<<1 | isSame)
@@ -763,10 +767,10 @@ namespace Voron.Data.PostingLists
                 //     1 =>  0 (skip)    [add, duplicate]
                 //     2 => +1 (place)   [rem, different => "orphan removal"?]
                 //     3 => -1 (pop old) [rem, same => remove old, skip new]
-                outputIdx += _modificationsAndRemoveTable[key];
+                outPtr += _modificationsAndRemoveTable[key];
             }
 
-            list.Shrink(outputIdx);
+            list.Shrink((int)(outPtr - list.RawItems + 1));
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23695

### Additional description

Branchless rewrite of the method. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
