### PR TITLE
RavenDB-23603 MultiUnaryMatch - handle not existing

### DIFF
--- a/src/Corax/Querying/Matches/MultiUnaryMatch.cs
+++ b/src/Corax/Querying/Matches/MultiUnaryMatch.cs
@@ -75,6 +75,7 @@ public unsafe struct MultiUnaryItem
     private readonly delegate*<long, long, bool> _longComparerRight;
     private readonly delegate*<double, double, bool> _doubleComparerRight;
     private readonly delegate*<bool,bool> _compareNullLeft, _compareNullRight;
+    private readonly delegate*<bool,bool> _compareNonExistingLeft, _compareNonExistingRight;
     private readonly bool _leftIsNull, _rightIsNull;
 
     private MultiUnaryItem(in FieldMetadata binding, DataType dataType, bool isBetween, UnaryMatchOperation leftOperation, UnaryMatchOperation rightOperation)
@@ -96,14 +97,15 @@ public unsafe struct MultiUnaryItem
         _leftSideOperation = leftOperation;
         _rightSideOperation = rightOperation;
 
-        SelectComparers(leftOperation, out _byteComparerLeft, out _longComparerLeft, out _doubleComparerLeft, out _compareNullLeft);
-        SelectComparers(rightOperation, out _byteComparerRight, out _longComparerRight, out _doubleComparerRight, out _compareNullRight);
+        SelectComparers(leftOperation, out _byteComparerLeft, out _longComparerLeft, out _doubleComparerLeft, out _compareNullLeft, out _compareNonExistingLeft);
+        SelectComparers(rightOperation, out _byteComparerRight, out _longComparerRight, out _doubleComparerRight, out _compareNullRight, out _compareNonExistingRight);
 
         void SelectComparers(UnaryMatchOperation operation, 
             out delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, bool> byteComparer,
             out delegate*<long, long, bool> longComparer,
             out delegate*<double, double, bool> doubleComparer,
-            out delegate*<bool, bool> compareNull)
+            out delegate*<bool, bool> compareNull,
+            out delegate*<bool, bool> compareNotExisting)
         {
             static bool AlwaysFalse(bool _) => false;
             static bool AlwaysTrue(bool _) => true;
@@ -121,42 +123,49 @@ public unsafe struct MultiUnaryItem
                     longComparer = &LessThanMatchComparer.Compare;
                     doubleComparer = &LessThanMatchComparer.Compare;
                     compareNull = &TrueUnlessNull;
+                    compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.LessThanOrEqual:
                     byteComparer = &LessThanOrEqualMatchComparer.Compare;
                     longComparer = &LessThanOrEqualMatchComparer.Compare;
                     doubleComparer = &LessThanOrEqualMatchComparer.Compare;
                     compareNull = &AlwaysTrue;
+                    compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.GreaterThan:
                     byteComparer = &GreaterThanMatchComparer.Compare;
                     longComparer = &GreaterThanMatchComparer.Compare;
                     doubleComparer = &GreaterThanMatchComparer.Compare;
                     compareNull = &AlwaysFalse;
+                    compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.GreaterThanOrEqual:
                     byteComparer = &GreaterThanOrEqualMatchComparer.Compare;
                     longComparer = &GreaterThanOrEqualMatchComparer.Compare;
                     doubleComparer = &GreaterThanOrEqualMatchComparer.Compare;
                     compareNull = &FalseUnlessNull;
+                    compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.NotEquals:
                     byteComparer = &NotEqualsMatchComparer.Compare;
                     longComparer = &NotEqualsMatchComparer.Compare;
                     doubleComparer = &NotEqualsMatchComparer.Compare;
                     compareNull = &TrueUnlessNull;
+                    compareNotExisting = &AlwaysTrue;
                     break;
                 case UnaryMatchOperation.Equals:
                     byteComparer = &EqualsMatchComparer.Compare;
                     longComparer = &EqualsMatchComparer.Compare;
                     doubleComparer = &EqualsMatchComparer.Compare;
                     compareNull = &FalseUnlessNull;
+                    compareNotExisting = &AlwaysFalse;
                     break;
                 case UnaryMatchOperation.None:
                     byteComparer = &EmptyComparer.Compare;
                     longComparer = &EmptyComparer.Compare;
                     doubleComparer = &EmptyComparer.Compare;
                     compareNull = &ThrowWhenUsed;
+                    compareNotExisting = &ThrowWhenUsed;
                     break;
                 default:
                     throw new Exception("Unsupported type of operation: " + operation);
@@ -171,6 +180,11 @@ public unsafe struct MultiUnaryItem
         {
             return _compareNullLeft(_leftIsNull) && 
                    (_isBetween == false || _compareNullRight(_rightIsNull));
+        }
+        if (it.IsNonExisting)
+        {
+            return _compareNonExistingLeft(_leftIsNull) && 
+                   (_isBetween == false || _compareNonExistingRight(_rightIsNull));
         }
         bool leftResult;
         if (Type == DataType.Long)
@@ -194,6 +208,11 @@ public unsafe struct MultiUnaryItem
         {
             return _compareNullLeft(_leftIsNull) && 
                    (_isBetween == false || _compareNullRight(_rightIsNull));
+        }
+        if (it.IsNonExisting)
+        {
+            return _compareNonExistingLeft(_leftIsNull) && 
+                (_isBetween == false || _compareNonExistingRight(_rightIsNull));
         }
         
         ReadOnlySpan<byte> value = it.Current.Decoded();

--- a/test/SlowTests/Corax/CoraxNotExistingTests.cs
+++ b/test/SlowTests/Corax/CoraxNotExistingTests.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class CoraxNotExistingTests : RavenTestBase
+{
+    public CoraxNotExistingTests(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+        public string Prop1 { get; set; }
+    }
+    
+    private class WithExtraPropTestObj : TestObj
+    {
+        public string ExtraProp { get; set; }
+    }
+    
+    private class TestIndex : AbstractIndexCreationTask<WithExtraPropTestObj, TestIndex.Result>
+    {
+        public class Result
+        {
+            public string Prop { get; set; }
+            public string Prop1 { get; set; }
+            public string ExtraProp { get; set; }
+        }
+
+        public TestIndex()
+        {
+            Map = users => from o in users
+                select new Result
+                {
+                    Prop = o.Prop,
+                    Prop1 = o.Prop1,
+                    ExtraProp = o.ExtraProp
+                };
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void Corax_WhenQueryNotExisting_ShouldNotThrow(Options options)
+    {
+        const string somevalue = "somevalue";
+
+        options.ModifyDocumentStore = (s) =>
+        {
+            s.Conventions = new DocumentConventions { FindCollectionName = _ => "TestObjs" };
+        };
+        using var store = GetDocumentStore(options);
+
+        var testIndex = new TestIndex();
+        testIndex.Execute(store);
+        
+        using (var session = store.OpenSession())
+        {
+            session.Store(new TestObj
+            {
+                Prop = somevalue,
+                Prop1 = somevalue,
+                //ExtraProp not existing
+            });
+            session.Store(new WithExtraPropTestObj
+            {
+                Prop = somevalue,
+                Prop1 = somevalue,
+                ExtraProp = null
+            });
+            session.Store(new WithExtraPropTestObj
+            {
+                Prop = somevalue,
+                Prop1 = somevalue,
+                ExtraProp = somevalue
+            });
+            session.SaveChanges();
+        }
+        
+        Indexes.WaitForIndexing(store);
+        
+        using (var session = store.OpenSession())
+        {
+            string indexName =
+                $"""
+                 from index '{testIndex.IndexName}'
+                 where exists(ExtraProp) and ExtraProp != null and Prop == "somevalue"  and  Prop1 == "somevalue"
+                 order by ExtraProp
+                 """;
+            var results = session.Advanced.RawQuery<TestObj>(indexName).ToArray();
+            Assert.Equal(1, results.Length);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-22703_LowLevel.cs
+++ b/test/SlowTests/Issues/RavenDB-22703_LowLevel.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Text;
 using Corax;
 using Corax.Analyzers;
 using Corax.Indexing;
 using Corax.Mappings;
 using Corax.Querying;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
 using FastTests.Voron;
 using Sparrow.Server;
 using Sparrow.Threading;
@@ -66,6 +70,94 @@ public class RavenDB_22703_LowLevel : StorageTest
 
                 Assert.Equal(1, nullPostingList.State.LeafPages);
                 Assert.Equal(1, nonExistingPostingList.State.LeafPages);
+            }
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void NonExistingLiteral_WhenIterateAndCompare_ShouldNotUseTheInvalidReader()
+    {
+        const string compareWith = "compareWith";
+        NonExisting_WhenIterateAndCompare_ShouldNotUseTheInvalidReader(WriteValue, CreateMultiUnaryItem);
+        return;
+        void WriteValue(IndexWriter.IndexEntryBuilder builder) => builder.Write(BarBoolIndex, Encoding.UTF8.GetBytes(compareWith));
+        MultiUnaryItem CreateMultiUnaryItem(IndexSearcher searcher, FieldMetadata contentMetadata)
+        {
+            return new MultiUnaryItem(searcher, contentMetadata, "somevalue", UnaryMatchOperation.Equals);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void NonExistingDouble_WhenIterateAndCompare_ShouldNotUseTheInvalidReader()
+    {
+        NonExisting_WhenIterateAndCompare_ShouldNotUseTheInvalidReader(WriteValue, CreateMultiUnaryItem);
+        return;
+        void WriteValue(IndexWriter.IndexEntryBuilder builder)
+        {
+            const long value = 8L;
+            builder.Write(BarBoolIndex, null, value.ToString(), value, value);
+        }
+        
+        MultiUnaryItem CreateMultiUnaryItem(IndexSearcher searcher, FieldMetadata contentMetadata)
+        {
+            return new MultiUnaryItem(contentMetadata, 0.0, UnaryMatchOperation.Equals);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void NonExistingLong_WhenIterateAndCompare_ShouldNotUseTheInvalidReader()
+    {
+        NonExisting_WhenIterateAndCompare_ShouldNotUseTheInvalidReader(WriteValue, CreateMultiUnaryItem);
+        return;
+        void WriteValue(IndexWriter.IndexEntryBuilder builder)
+        {
+            builder.Write(BarBoolIndex, null, "8", 8, 8);
+        }
+        MultiUnaryItem CreateMultiUnaryItem(IndexSearcher searcher, FieldMetadata contentMetadata)
+        {
+            return new MultiUnaryItem(contentMetadata, 0L, UnaryMatchOperation.Equals);
+        }
+    }
+
+    private void NonExisting_WhenIterateAndCompare_ShouldNotUseTheInvalidReader(Action<IndexWriter.IndexEntryBuilder> writeValue, Func<IndexSearcher, FieldMetadata, MultiUnaryItem> create)
+    {
+        using (var bsc = new ByteStringContext(SharedMultipleUseFlag.None))
+        {
+            var knownFields = CreateKnownFields(bsc);
+
+            using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
+            {
+                using (var builder = indexWriter.Index("bars/1"))
+                {
+                    writeValue(builder);
+                    builder.EndWriting();
+                }
+                
+                using (var builder = indexWriter.Index("bars/2"))
+                {
+                    builder.Write(BarBoolIndex, Constants.NullValueSpan);
+                    builder.EndWriting();
+                }
+                
+                using (var builder = indexWriter.Index("bars/3"))
+                {
+                    builder.Write(BarBoolIndex, Constants.NonExistingValueSlice);
+                    builder.EndWriting();
+                }
+
+                indexWriter.Commit();
+            }
+
+            using (var indexSearcher = new IndexSearcher(Env, knownFields))
+            {
+                Span<long> ids = stackalloc long[10];
+                var contentMetadata = indexSearcher.FieldMetadataBuilder("BarBool", BarBoolIndex);
+                var match0 = indexSearcher.AllEntries();
+                var match1 = create(indexSearcher, contentMetadata);
+
+                var multiUnaryMatch = indexSearcher.CreateMultiUnaryMatch(match0, [match1]);
+
+                Assert.Equal(0, multiUnaryMatch.Fill(ids)); //Thrown here
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23603

### Additional description
A not existing value should not be decoded.
In this case, the current reader value is invalid. 
Instead, like for null, a specific logic was implemented for CompareLiteral.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
