### PR TITLE
RavenDB-23322 - don't read from tree on deletion [v5.4]

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1825,7 +1825,7 @@ namespace Raven.Server.Documents
                 var table = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
                     collectionName.GetTableName(CollectionTableType.Documents));
 
-                var ptr = table.DirectRead(doc.StorageId, out int size);
+                var ptr = table.DirectRead(doc.StorageId, out int size, out bool compressed);
                 var tvr = new TableValueReader(ptr, size);
                 var flags = TableValueToFlags((int)DocumentsTable.Flags, ref tvr).Strip(DocumentFlags.FromClusterTransaction) | documentFlags;
 
@@ -1898,7 +1898,7 @@ namespace Raven.Server.Documents
                         TimeSeriesStorage.DeleteAllTimeSeriesForDocument(context, id, collectionName);
                 }
 
-                table.Delete(doc.StorageId);
+                table.Delete(doc.StorageId, ptr, size, compressed);
 
                 context.Transaction.AddAfterCommitNotification(new DocumentChange
                 {

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -701,7 +701,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                         if (shouldSkip != null)
                         {
-                            var ptr = table.DirectRead(id, out int size);
+                            var ptr = table.DirectRead(id, out int size, out _);
                             if (tableValueHolder == null)
                                 tableValueHolder = new Table.TableValueHolder();
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -219,13 +219,13 @@ namespace Voron.Data.Tables
 
         public void DirectRead(long id, out TableValueReader tvr)
         {
-            var rawData = DirectRead(id, out int size);
+            var rawData = DirectRead(id, out int size/*, out _*/);
             tvr = new TableValueReader(id, rawData, size);
         }
 
-        public byte* DirectRead(long id, out int size)
+        public byte* DirectRead(long id, out int size/*, out bool compressed*/)
         {
-            var result = DirectReadRaw(id, out size, out var compressed);
+            var result = DirectReadRaw(id, out size, out var  compressed);
             if (compressed == false)
                 return result;
 
@@ -349,7 +349,6 @@ namespace Voron.Data.Tables
                 oldDataDecompressedScope = DecompressValue(_tx, oldData, oldDataSize, out var buffer);
                 oldData = buffer.Ptr;
                 oldDataSize = buffer.Length;
-                _tx.CachedDecompressedBuffersByStorageId?.Remove(id);
             }
 
             // first, try to fit in place, either in small or large sections
@@ -363,7 +362,11 @@ namespace Voron.Data.Tables
                         ref tvr,
                         builder,
                         forceUpdate);
-                    oldDataDecompressedScope.Dispose();
+                    if (oldCompressed)
+                    {
+                        oldDataDecompressedScope.Dispose();
+                        _tx.ForgetAbout(id);
+                    }
 
                     builder.CopyTo(pos);
 
@@ -387,7 +390,12 @@ namespace Voron.Data.Tables
 
                     var tvr = new TableValueReader(oldData, oldDataSize);
                     UpdateValuesFromIndex(id, ref tvr, builder, forceUpdate);
-                    oldDataDecompressedScope.Dispose();
+
+                    if (oldCompressed)
+                    {
+                        oldDataDecompressedScope.Dispose();
+                        _tx.ForgetAbout(id);
+                    }
 
                     // MemoryCopy into final position.
                     page.OverflowSize = builder.Size;
@@ -402,10 +410,11 @@ namespace Voron.Data.Tables
                     return id;
                 }
             }
-            oldDataDecompressedScope.Dispose();
 
             // can't fit in place, will just delete & insert instead
-            Delete(id);
+            Delete(id, oldData, oldDataSize);
+            oldDataDecompressedScope.Dispose();
+
             return Insert(builder);
         }
 
@@ -475,22 +484,43 @@ namespace Voron.Data.Tables
             var ptr = DirectReadRaw(id, out int size, out bool compressed);
 
             if (compressed)
+            {
                 _tx.ForgetAbout(id);
 
-            ByteStringContext<ByteStringMemoryCache>.InternalScope decompressValue = default;
+                using (var decompressValue = DecompressValue(_tx, ptr, size, out ByteString buffer))
+                {
+                    ptr = buffer.Ptr;
+                    size = buffer.Length;
 
-            if (compressed)
-            {
-                decompressValue = DecompressValue(_tx, ptr, size, out var buffer);
-                ptr = buffer.Ptr;
-                size = buffer.Length;
+                    var tvr = new TableValueReader(ptr, size);
+                    DeleteValueFromIndex(id, ref tvr);
+                }
             }
+            else
+            {
+                var tvr = new TableValueReader(ptr, size);
+                DeleteValueFromIndex(id, ref tvr);
+            }
+
+            DeleteInternal(id);
+        }
+
+        public void Delete(long id, byte* ptr, int size)
+        {
+            if (IsOwned(id) == false)
+                ThrowNotOwned(id);
+
+            AssertWritableTable();
 
             var tvr = new TableValueReader(ptr, size);
             DeleteValueFromIndex(id, ref tvr);
 
-            decompressValue.Dispose();
+            _tx.ForgetAbout(id);
+            DeleteInternal(id);
+        }
 
+        private void DeleteInternal(long id)
+        {
             var largeValue = (id % Constants.Storage.PageSize) == 0;
             if (largeValue)
             {
@@ -1570,7 +1600,7 @@ namespace Voron.Data.Tables
                             {
                                 value.Release(_tx.Allocator);
                                 value = it.CurrentKey.Clone(_tx.Allocator);
-                                Delete(id);
+                                Delete(id, ptr, size);
                                 break;
                             }
 
@@ -1919,9 +1949,14 @@ namespace Voron.Data.Tables
                             return deleted;
                         }
                         beforeDelete?.Invoke(tableValueHolder);
+
+                        Delete(id, ptr, size);
+                    }
+                    else
+                    {
+                        Delete(id);
                     }
 
-                    Delete(id);
                     deleted = true;
                 }
             }
@@ -1966,9 +2001,14 @@ namespace Voron.Data.Tables
                                 return deleted;
                             }
                             beforeDelete?.Invoke(tableValueHolder);
+                            Delete(fstIt.CurrentKey, ptr, size);
+                        }
+                        else
+                        {
+                            Delete(fstIt.CurrentKey);
                         }
 
-                        Delete(fstIt.CurrentKey);
+     
                         deleted++;
                     }
                 }
@@ -2011,7 +2051,7 @@ namespace Voron.Data.Tables
                         if (beforeDelete(tableValueHolder) == false)
                             return deleted;
 
-                        Delete(fstIt.CurrentKey);
+                        Delete(fstIt.CurrentKey, ptr, size);
                         deleted++;
                     }
                 }
@@ -2050,7 +2090,7 @@ namespace Voron.Data.Tables
                     if (currentIndex > upToIndex)
                         return false;
 
-                    Delete(id);
+                    Delete(id, ptr, size);
                     deleted++;
                 }
             }

--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -197,7 +197,7 @@ namespace Voron.Data.Tables
                     var cur = buffer.Ptr;
                     for (int i = 0; i < used; i++)
                     {
-                        var ptr = table.DirectRead(dataIds[i], out int size);
+                        var ptr = table.DirectRead(dataIds[i], out int size, out _);
                         Memory.Copy(cur, ptr, size);
                         cur += size;
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23322

### Additional description

When removing an entry (or updating) from tree we would read it from tree and then remove, but in some cases we already have the entry in memory, so we can straight process to removing it.

Perf Check:
https://issues.hibernatingrhinos.com/issue/RavenDB-23322/Check-Delete-voron-method-for-compressed-docs#focus=Comments-67-1060221.0-0

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
