### PR TITLE
RavenDB-23707 Copy to clipboard doesn't work on Document view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ src/Sparrow.Server/Utils/VxSort/codegen/.idea/
 src/Sparrow.Server/Utils/VxSort/codegen/__pycache__/
 
 /.cache
+
+.cursorignore

--- a/src/Raven.Studio/typescript/viewmodels/common/showDataDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/showDataDialog.ts
@@ -36,8 +36,8 @@ class showDataDialog extends dialogViewModelBase {
     }
 
     copyToClipboard() {
-        this.close();
-        copyToClipboard.copy(this.inputData(), this.title + " was copied to clipboard");
+      copyToClipboard.copy(this.inputData(), this.title + " was copied to clipboard", document.getElementById("showDataDialog"));
+      this.close();
     }
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/common/showDataDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/showDataDialog.html
@@ -1,4 +1,4 @@
-<div class="modal-dialog modal-lg" role="document">
+<div class="modal-dialog modal-lg" role="document" id="showDataDialog">
     <div class="modal-content">
         <div class="modal-header">
             <button type="button" class="close" data-bind="click: close" aria-hidden="true">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23707/Copy-to-clipboard-doesnt-work-on-Document-view

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
