### PR TITLE
RavenDB-23640 omnisearch: revisions should not come up on top

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ src/Sparrow.Server/Utils/VxSort/codegen/__pycache__/
 
 /bench/Vector.Benchmark/vectors
 /.cache
+
+.cursorignore

--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/bits/StudioSearchDatabaseResults.tsx
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/bits/StudioSearchDatabaseResults.tsx
@@ -36,11 +36,7 @@ export default function StudioSearchDatabaseResults(props: {
         );
     }
 
-    const matchedKeys = Object.keys(databaseResults).filter(
-        (groupType: StudioSearchResultDatabaseGroup) => databaseResults[groupType].length > 0
-    );
-
-    return matchedKeys.map((groupType: StudioSearchResultDatabaseGroup) => (
+    return getSortedKeys(databaseResults).map((groupType: StudioSearchResultDatabaseGroup) => (
         <div key={groupType} className="studio-search__database-col__group">
             <DropdownItem header className="studio-search__database-col__group__header">
                 <StudioSearchDatabaseGroupHeader groupType={groupType} />
@@ -50,4 +46,18 @@ export default function StudioSearchDatabaseResults(props: {
             ))}
         </div>
     ));
+}
+
+function getSortedKeys(databaseResults: StudioSearchResult["database"]): string[] {
+    let keys = Object.keys(databaseResults).filter(
+        (groupType: StudioSearchResultDatabaseGroup) => databaseResults[groupType].length > 0
+    );
+
+    // move revisions after documents
+    if (keys.includes("revisions") && keys.includes("documents")) {
+        keys = keys.filter((x) => x !== "revisions");
+        keys.splice(keys.indexOf("documents") + 1, 0, "revisions");
+    }
+
+    return keys;
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23640/omnisearch-revisions-should-not-come-up-on-top

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
