### PR TITLE
RavenDB-23716 do expression compilation once in BlittableJsonReader

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonReader.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonReader.cs
@@ -21,10 +21,10 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             public BlittableJsonReaderObject.PropertyDetails PropertyDetails;
         }
 
-        private readonly Action<JsonReader, State> _setState = ExpressionHelper.CreateFieldSetter<JsonReader, State>("_currentState");
-        private readonly Action<JsonReader, JsonToken> _setToken = ExpressionHelper.CreateFieldSetter<JsonReader, JsonToken>("_tokenType");
-        private readonly Action<JsonReader, bool> _setHasExceededMaxDepth = ExpressionHelper.CreateFieldSetter<JsonReader, bool>("_hasExceededMaxDepth");
-        private readonly Action<JsonReader> _clearStack = ExpressionHelper.SafelyClearList<JsonReader>("_stack");
+        private static readonly Action<JsonReader, State> _setState = ExpressionHelper.CreateFieldSetter<JsonReader, State>("_currentState");
+        private static readonly Action<JsonReader, JsonToken> _setToken = ExpressionHelper.CreateFieldSetter<JsonReader, JsonToken>("_tokenType");
+        private static readonly Action<JsonReader, bool> _setHasExceededMaxDepth = ExpressionHelper.CreateFieldSetter<JsonReader, bool>("_hasExceededMaxDepth");
+        private static readonly Action<JsonReader> _clearStack = ExpressionHelper.SafelyClearList<JsonReader>("_stack");
 
         public readonly JsonOperationContext Context;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23716

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
