### PR TITLE
RavenDB-22491 - Change the 'revisions/size' endpoint method to POST

### DIFF
--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -211,7 +211,7 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        [RavenAction("/databases/*/revisions/size", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        [RavenAction("/databases/*/revisions/size", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetRevisionsSize()
         {
             List<RevisionSizeDetails> sizes;

--- a/test/SlowTests/Issues/RavenDB-22491.cs
+++ b/test/SlowTests/Issues/RavenDB-22491.cs
@@ -121,7 +121,7 @@ public class RavenDB_22491 : RavenTestBase
 
                 return new HttpRequestMessage
                 {
-                    Method = HttpMethod.Get,
+                    Method = HttpMethod.Post,
                     Content = new BlittableJsonContent(async stream =>
                         await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false))
                 };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22491/Show-the-revision-size

### Additional description

Change the 'revisions/size' endpoint method to POST (from GET), because it requires a payload that can be big - it making sense to do that instead of using the URL query

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
