### PR TITLE
RavenDB-23322 - don't read from tree on deletion [v6.0]

### DIFF
--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -701,7 +701,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                         if (shouldSkip != null)
                         {
-                            var ptr = table.DirectRead(id, out int size);
+                            var ptr = table.DirectRead(id, out int size, out _);
                             if (tableValueHolder == null)
                                 tableValueHolder = new Table.TableValueHolder();
 

--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -197,7 +197,7 @@ namespace Voron.Data.Tables
                     var cur = buffer.Ptr;
                     for (int i = 0; i < used; i++)
                     {
-                        var ptr = table.DirectRead(dataIds[i], out int size);
+                        var ptr = table.DirectRead(dataIds[i], out int size, out _);
                         Memory.Copy(cur, ptr, size);
                         cur += size;
                     }


### PR DESCRIPTION
### Issue link

CherryPick: https://github.com/ravendb/ravendb/pull/20112

https://issues.hibernatingrhinos.com/issue/RavenDB-23322

### Additional description

When removing an entry (or updating) from tree we would read it from tree and then remove, but in some cases we already have the entry in memory, so we can straight process to removing it.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed

