### PR TITLE
RavenDB-23534 - Skip creating a a notification tree if it already exists

### DIFF
--- a/src/Raven.Server/NotificationCenter/DatabaseNotificationStorage.cs
+++ b/src/Raven.Server/NotificationCenter/DatabaseNotificationStorage.cs
@@ -1,0 +1,13 @@
+﻿using Raven.Server.Rachis.Commands;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.NotificationCenter;
+
+public sealed class DatabaseNotificationStorage(ServerStore serverStore, string resourceName) : NotificationsStorage(serverStore, resourceName)
+{
+    protected override void CreateSchema()
+    {
+        var command = new InitializeSchemaForNotificationsCommand(TableName);
+        serverStore.Engine.TxMerger.EnqueueSync(command);
+    }
+}

--- a/src/Raven.Server/NotificationCenter/DatabaseNotificationStorage.cs
+++ b/src/Raven.Server/NotificationCenter/DatabaseNotificationStorage.cs
@@ -8,6 +8,6 @@ public sealed class DatabaseNotificationStorage(ServerStore serverStore, string 
     protected override void CreateSchema()
     {
         var command = new InitializeSchemaForNotificationsCommand(TableName);
-        serverStore.Engine.TxMerger.EnqueueSync(command);
+        ServerStore.Engine.TxMerger.EnqueueSync(command);
     }
 }

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -439,13 +439,8 @@ namespace Raven.Server.NotificationCenter
                 throw new ArgumentNullException(nameof(database));
 
             var tableName = GetTableName(database);
-
-            using (var tx = Environment.WriteTransaction())
-            {
-                tx.DeleteTable(tableName);
-
-                tx.Commit();
-            }
+            var command = new DeleteTableForNotificationsCommand(tableName);
+            serverStore.Engine.TxMerger.EnqueueSync(command);
         }
 
         public void DeleteStorageFor<T>(TransactionOperationContext<T> ctx, string database) where T : RavenTransaction

--- a/src/Raven.Server/NotificationCenter/ServerStoreNotificationStorage.cs
+++ b/src/Raven.Server/NotificationCenter/ServerStoreNotificationStorage.cs
@@ -1,0 +1,17 @@
+﻿using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.NotificationCenter;
+
+public sealed class ServerStoreNotificationStorage(ServerStore serverStore) : NotificationsStorage(serverStore)
+{
+    protected override void CreateSchema()
+    {
+        using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        using (var tx = Environment.WriteTransaction(context.PersistentContext))
+        {
+            Documents.Schemas.Notifications.Current.Create(tx, TableName, 16);
+            tx.Commit();
+        }
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/DeleteTableForNotificationsCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/DeleteTableForNotificationsCommand.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class DeleteTableForNotificationsCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly string _tableName;
+
+    public DeleteTableForNotificationsCommand(string tableName)
+    {
+        _tableName = tableName;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        context.Transaction.InnerTransaction.DeleteTable(_tableName);
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/Rachis/Commands/InitializeSchemaForNotificationsCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/InitializeSchemaForNotificationsCommand.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Rachis.Commands;
+
+public class InitializeSchemaForNotificationsCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+{
+    private readonly string _tableName;
+
+    public InitializeSchemaForNotificationsCommand(string tableName)
+    {
+        _tableName = tableName;
+    }
+
+    protected override long ExecuteCmd(ClusterOperationContext context)
+    {
+        Documents.Schemas.Notifications.Current.Create(context.Transaction.InnerTransaction, _tableName, 16);
+        return 1;
+    }
+
+    public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -184,7 +184,7 @@ namespace Raven.Server.ServerWide
 
             DatabasesLandlord = new DatabasesLandlord(this);
 
-            _notificationsStorage = new NotificationsStorage(this);
+            _notificationsStorage = new ServerStoreNotificationStorage(this);
 
             NotificationCenter = new ServerNotificationCenter(this, _notificationsStorage);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23534/Failed-to-notify-of-blockage-in-tombstone-deletion

### Additional description

On notification storage initialization, check if the tree exists before trying to create it.
If we need to create it, use the transaction merger.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
