### PR TITLE
RavenDB-23728 - Fix, 'Enforce Revisions Configuration' operation lasts forever (v6.0)

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1939,13 +1939,13 @@ namespace Raven.Server.Documents.Revisions
                 OnProgress = onProgress
             };
 
-            parameters.LastScannedEtag = parameters.EtagBarrier;
-
             var ids = new List<string>();
             var sw = Stopwatch.StartNew();
 
             // send initial progress
             parameters.OnProgress?.Invoke(result);
+
+            var tablesLastScannedEtags = new Dictionary<string, long>();
 
             var hasMore = true;
             while (hasMore)
@@ -1959,15 +1959,16 @@ namespace Raven.Server.Documents.Revisions
                 {
                     using (ctx.OpenReadTransaction())
                     {
-                        var tables = GetRevisionsTables(ctx, collections, parameters.LastScannedEtag);
+                        var tables = GetRevisionsTables(ctx, collections, parameters.EtagBarrier, tablesLastScannedEtags);
 
-                        foreach (var table in tables)
+                        foreach (var (collection, table) in tables)
                         {
                             foreach (var tvr in table)
                             {
                                 token.ThrowIfCancellationRequested();
 
                                 var state = ShouldProcessNextRevisionId(ctx, ref tvr.Reader, parameters, result, out var id);
+                                tablesLastScannedEtags[collection] = parameters.LastScannedEtag;
                                 if (state == NextRevisionIdResult.Break)
                                     break;
                                 if (state == NextRevisionIdResult.Continue)
@@ -1990,13 +1991,17 @@ namespace Raven.Server.Documents.Revisions
                                 }
                             }
 
-                            var moreWork = true;
-                            while (moreWork)
+                            if (ids.Count != 0)
                             {
-                                token.Delay();
-                                var cmd = createCommand(ids, result, token);
-                                await _database.TxMerger.Enqueue(cmd);
-                                moreWork = cmd.MoreWork;
+                                var moreWork = true;
+                                while (moreWork)
+                                {
+                                    token.Delay();
+                                    var cmd = createCommand(ids, result, token);
+                                    await _database.TxMerger.Enqueue(cmd);
+                                    moreWork = cmd.MoreWork;
+                                }
+                                ids.Clear();
                             }
                         }
                     }
@@ -2006,17 +2011,18 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        private List<IEnumerable<TableValueHolder>> GetRevisionsTables(DocumentsOperationContext context, HashSet<string> collections, long lastScannedEtag)
+        private List<(string TableName, IEnumerable<TableValueHolder> Items)> GetRevisionsTables(DocumentsOperationContext context, HashSet<string> collections, long etagBarrier, Dictionary<string, long> tableEtags)
         {
-            lastScannedEtag = long.Max(lastScannedEtag - 1, 0);
-            
-            var collectionsTables = new List<IEnumerable<TableValueHolder>>();
+            var collectionsTables = new List<(string, IEnumerable<TableValueHolder>)>();
 
             if (collections == null)
             {
                 var revisions = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
-                var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastScannedEtag);
-                collectionsTables.Add(table);
+                if (tableEtags.TryGetValue(string.Empty, out var lastEtag) == false)
+                    tableEtags[string.Empty] = lastEtag = etagBarrier;
+                
+                var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastEtag - 1);
+                collectionsTables.Add((string.Empty, table));
             }
             else
             {
@@ -2030,9 +2036,12 @@ namespace Raven.Server.Documents.Revisions
                         continue;
                     }
 
-                    var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
+                    if (tableEtags.TryGetValue(collection, out var lastEtag) == false)
+                        tableEtags[collection] = lastEtag = etagBarrier;
 
-                    collectionsTables.Add(table);
+                    var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastEtag - 1);
+
+                    collectionsTables.Add((collection, table));
                 }
             }
 
@@ -2134,8 +2143,10 @@ namespace Raven.Server.Documents.Revisions
             return (moreWork, deleted);
         }
 
-        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, bool skipForceCreated, ref bool moreWork)
+        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, bool skipForceCreated, out bool moreWork)
         {
+            moreWork = false;
+
             using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
             using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
             {
@@ -2165,8 +2176,7 @@ namespace Raven.Server.Documents.Revisions
                 var prevRevisionsCount = result.PreviousCount;
                 var currentRevisionsCount = result.Remaining;
 
-                if (needToDeleteMore && currentRevisionsCount > 0)
-                    moreWork = true;
+                moreWork = needToDeleteMore && currentRevisionsCount > 0;
 
                 if (currentRevisionsCount == 0)
                 {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2008,6 +2008,8 @@ namespace Raven.Server.Documents.Revisions
 
         private List<IEnumerable<TableValueHolder>> GetRevisionsTables(DocumentsOperationContext context, HashSet<string> collections, long lastScannedEtag)
         {
+            lastScannedEtag = long.Max(lastScannedEtag - 1, 0);
+            
             var collectionsTables = new List<IEnumerable<TableValueHolder>>();
 
             if (collections == null)

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
@@ -23,13 +23,17 @@ internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOpe
     protected override long ExecuteCmd(DocumentsOperationContext context)
     {
         MoreWork = false;
-        foreach (var id in _ids)
+        for (int i = _ids.Count - 1; i >= 0; i--)
         {
             _token.ThrowIfCancellationRequested();
-            _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, ref MoreWork);
+            _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, _ids[i], _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, out var moreWork);
+            if (moreWork == false)
+                _ids.RemoveAt(i);
+            else
+                MoreWork = true;
         }
 
-        return _ids.Count;
+        return 1;
     }
 
     public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)

--- a/test/SlowTests/Issues/RavenDB-23728.cs
+++ b/test/SlowTests/Issues/RavenDB-23728.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23728 : RavenTestBase
+    {
+        public RavenDB_23728(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task EnforceRevisionsConfigurationLastsForever()
+        {
+            using var store = GetDocumentStore();
+
+            // 1 Document
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            for (int i = 0; i < 2; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i.ToString() }, "Users/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await AssertRevisionsCountAsync(store, "Users/1", 2);
+
+            configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+                {
+                    MinimumRevisionsToKeep = 1
+                }
+            };
+
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            database.DocumentsStorage.RevisionsStorage.SizeLimitInBytes = 0;
+
+            await WaitWithTimeoutAsync( () => EnforceConfiguration(store), timeout: TimeSpan.FromSeconds(15));
+
+            await AssertRevisionsCountAsync(store, "Users/1", 1);
+
+
+
+            // 2 Document
+
+            configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            for (int i = 2; i <= 4; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i.ToString() }, "Users/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+            
+            for (int i = 0; i < 2; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i.ToString() }, "Users/2");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await AssertRevisionsCountAsync(store, "Users/1", 4);
+            await AssertRevisionsCountAsync(store, "Users/2", 2);
+
+
+            configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+                {
+                    MinimumRevisionsToKeep = 1
+                }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            await WaitWithTimeoutAsync(() => EnforceConfiguration(store), timeout: TimeSpan.FromSeconds(15));
+
+            await AssertRevisionsCountAsync(store, "Users/1", 1);
+            await AssertRevisionsCountAsync(store, "Users/2", 1);
+        }
+
+        private static async Task WaitWithTimeoutAsync(Func<Task> act, TimeSpan timeout)
+        {
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var task = act();
+                var timeoutTask = Task.Delay(timeout, cancellationTokenSource.Token);
+                if (await Task.WhenAny(task, timeoutTask) == task)
+                {
+                    cancellationTokenSource.Cancel(); // Cancel delay task if operation completes within timeout
+                    await task; // Propagate any exceptions thrown by the task
+                }
+                else
+                {
+                    throw new TimeoutException("The operation has timed out.");
+                }
+            }
+        }
+
+        private static async Task AssertRevisionsCountAsync(DocumentStore store, string id, int expectedCount)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Advanced.Revisions.GetCountForAsync(id);
+                Assert.Equal(expectedCount, count);
+            }
+        }
+
+        private async Task EnforceConfiguration(DocumentStore store, long timeout = 15_000)
+        {
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (var token = new OperationCancelToken(TimeSpan.FromMilliseconds(timeout), db.DatabaseShutdown, CancellationToken.None))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, token: token);
+        }
+
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23728.cs
+++ b/test/SlowTests/Issues/RavenDB-23728.cs
@@ -62,7 +62,6 @@ namespace SlowTests.Issues
             await AssertRevisionsCountAsync(store, "Users/1", 1);
 
 
-
             // 2 Document
 
             configuration = new RevisionsConfiguration
@@ -116,7 +115,7 @@ namespace SlowTests.Issues
                 var timeoutTask = Task.Delay(timeout, cancellationTokenSource.Token);
                 if (await Task.WhenAny(task, timeoutTask) == task)
                 {
-                    cancellationTokenSource.Cancel(); // Cancel delay task if operation completes within timeout
+                    await cancellationTokenSource.CancelAsync(); // Cancel delay task if operation completes within timeout
                     await task; // Propagate any exceptions thrown by the task
                 }
                 else
@@ -124,6 +123,73 @@ namespace SlowTests.Issues
                     throw new TimeoutException("The operation has timed out.");
                 }
             }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task EnforceRevisionsConfigurationSkipRevisions()
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration()};
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+            
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            database.DocumentsStorage.RevisionsStorage.SizeLimitInBytes = 1024 * 32;
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Company { Id = "Companies/1", Name = GenerateLargeRandomString(1024) });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Id = "Users/1", Name = i.ToString() });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Id = "Users/2", Name = GenerateLargeRandomString(32 * 1024) });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 5 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            // enforce
+            await WaitWithTimeoutAsync(() => EnforceConfiguration(store, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Users", "Companies" }), timeout: TimeSpan.FromSeconds(15));
+
+            await AssertRevisionsCountAsync(store, "Companies/1", 5);
+            await AssertRevisionsCountAsync(store, "Users/2", 5);
+
+            await AssertRevisionsCountAsync(store, "Users/1", 5); // Fail
+
+        }
+
+        public static string GenerateLargeRandomString(int sizeInBytes)
+        {
+            int length = sizeInBytes / 2; // Each char is 2 bytes
+            Random random = new Random();
+            StringBuilder stringBuilder = new StringBuilder(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                // Generate a random lowercase letter from 'a' to 'z'
+                char randomChar = (char)random.Next('a', 'z' + 1);
+                stringBuilder.Append(randomChar);
+            }
+
+            return stringBuilder.ToString();
         }
 
         private static async Task AssertRevisionsCountAsync(DocumentStore store, string id, int expectedCount)
@@ -135,18 +201,24 @@ namespace SlowTests.Issues
             }
         }
 
-        private async Task EnforceConfiguration(DocumentStore store, long timeout = 15_000)
+        private async Task EnforceConfiguration(DocumentStore store, HashSet<string> collections = null)
         {
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
-            using (var token = new OperationCancelToken(TimeSpan.FromMilliseconds(timeout), db.DatabaseShutdown, CancellationToken.None))
-                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, token: token);
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collections, token: token);
         }
-
 
         private class User
         {
             public string Id { get; set; }
             public string Name { get; set; }
         }
+
+        private class Company
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23728/Enforce-Revision-Configuration-stuck

### Additional description
Issue 1:
Assuming the goal is to process the entire revisions table across multiple collections, the operation is hanging. 
When the condition `if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)` is met under the clause `if (state == NextRevisionIdResult.Continue)`, the process breaks out of the current loop iteration. 
Consequently, on the next iteration of the outer loop, the revisions table is re-accessed starting from the same `ETag` value (of the revision that caused the break on the previous iteration of the outer loop) due to the `SeekBackward` operation. 
This results in repeatedly hitting the same check `if (state == NextRevisionIdResult.Continue) => if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)` with the same revision of the previous itteration. 
This recurring sequence causes an infinite loop, as the process continually returns to and re-evaluates the same data point without advancing the `ETag`, and not delete any revision.
This can occur, for example, when there is a document with several revisions, each of which is larger than 32 MB.

Issue 2:
The 'enforce revisions configuration' has the possibility to skip revisions in case of enforcing multiple collections

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
