### PR TITLE
RavenDB-23618 In GitHub action use node version from .nvmrc instead o…

### DIFF
--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup nodejs
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version-file: 'src/Raven.Studio/.nvmrc'
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version-file: 'src/Raven.Studio/.nvmrc'
+          
       - name: Restore
         run: |
           npm install


### PR DESCRIPTION
…f hardcoding it

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23618 

### Additional description

One source of truth for nvm version. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
