### PR TITLE
RavenDB-23728 - Fix - 'Enforce Revisions Configuration' operation lasts forever (v6.0)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 
         public override async ValueTask ExecuteAsync()
         {
-            var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
+            var token = RequestHandler.CreateBackgroundOperationToken();
             var operationId = RequestHandler.GetLongQueryString("operationId", false) ?? GetNextOperationId();
 
             TOperationParameters parameters;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1771,7 +1771,11 @@ namespace Raven.Server.Documents.Revisions
             HashSet<string> collections,
             OperationCancelToken token) where TOperationResult : OperationResult
         {
-            if (collections != null)
+            if (collections == null)
+            {
+                collections = new HashSet<string>() { null };
+            }
+            else
             {
                 if (collections.Comparer?.Equals(StringComparer.OrdinalIgnoreCase) == false)
                     throw new InvalidOperationException("'collections' hashset must have an 'OrdinalIgnoreCase' comparer");
@@ -1791,111 +1795,123 @@ namespace Raven.Server.Documents.Revisions
                 OnProgress = onProgress
             };
 
-            parameters.LastScannedEtag = parameters.EtagBarrier;
-
             var ids = new List<string>();
             var sw = Stopwatch.StartNew();
 
             // send initial progress
             parameters.OnProgress?.Invoke(result);
 
+            foreach (var collection in collections)
+            {
+                await PerformRevisionsOperationOnSingleCollectionAsync(collection, ids, sw, createCommand, result, parameters, token);
+            }
+
+        }
+
+        private async Task PerformRevisionsOperationOnSingleCollectionAsync<TOperationResult>(
+            string collection, List<string> ids, Stopwatch sw,
+            Func<List<string>, TOperationResult, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            TOperationResult result,
+            Parameters parameters, OperationCancelToken token)
+            where TOperationResult : OperationResult
+        {
+            parameters.LastScannedEtag = parameters.EtagBarrier;
             var hasMore = true;
             while (hasMore)
             {
                 hasMore = false;
                 ids.Clear();
-                token.Delay();
                 sw.Restart();
 
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
                 {
                     using (ctx.OpenReadTransaction())
                     {
-                        var tables = GetRevisionsTables(ctx, collections, parameters.LastScannedEtag);
-
-                        foreach (var table in tables)
+                        if (GetRevisionsByCollection(ctx, collection, parameters.LastScannedEtag, out var revisions) == false)
                         {
-                            foreach (var tvr in table)
+                            /*  there is no collection named like that, or that collection doesn't have any revisions, 
+                                but we won't throw here because this will fail the whole operation, 
+                                so we'll just skip this collection.
+                             */
+                            return;
+                        }
+
+                        foreach (var tvr in revisions)
+                        {
+                            token.ThrowIfCancellationRequested();
+
+                            var state = ShouldProcessNextRevisionId(ctx, ref tvr.Reader, parameters, result, out var id);
+                            if (state == NextRevisionIdResult.Break)
+                                break;
+                            if (state == NextRevisionIdResult.Continue)
                             {
-                                token.ThrowIfCancellationRequested();
-
-                                var state = ShouldProcessNextRevisionId(ctx, ref tvr.Reader, parameters, result, out var id);
-                                if (state == NextRevisionIdResult.Break)
-                                    break;
-                                if (state == NextRevisionIdResult.Continue)
-                                {
-                                    if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)
-                                    {
-                                        hasMore = true;
-                                        break;
-                                    }
-                                    else
-                                        continue;
-                                }
-
-                                ids.Add(id);
-
                                 if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)
                                 {
                                     hasMore = true;
                                     break;
                                 }
+
+                                continue;
                             }
 
-                            var moreWork = true;
-                            while (moreWork)
+                            ids.Add(id);
+
+                            if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)
                             {
-                                token.Delay();
-                                var cmd = createCommand(ids, result, token);
-                                await _database.TxMerger.Enqueue(cmd);
-                                moreWork = cmd.MoreWork;
+                                hasMore = true;
+                                break;
                             }
                         }
                     }
 
-
-                }
-            }
-        }
-
-        private List<IEnumerable<TableValueHolder>> GetRevisionsTables(DocumentsOperationContext context, HashSet<string> collections, long lastScannedEtag)
-        {
-            var collectionsTables = new List<IEnumerable<TableValueHolder>>();
-
-            if (collections == null)
-            {
-                var revisions = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
-                var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastScannedEtag);
-                collectionsTables.Add(table);
-            }
-            else
-            {
-                foreach (var collection in collections)
-                {
-                    var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false) ?? new CollectionName(collection);
-                    var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
-                    var revisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
-                    if (revisions == null) // there is no revisions for that collection
+                    if (ids.Count > 0)
                     {
-                        continue;
+                        var moreWork = true;
+                        while (moreWork)
+                        {
+                            token.ThrowIfCancellationRequested();
+                            var cmd = createCommand(ids, result, token);
+                            await _database.TxMerger.Enqueue(cmd);
+                            moreWork = cmd.MoreWork;
+                        }
                     }
-
-                    var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
-
-                    collectionsTables.Add(table);
                 }
             }
-
-            return collectionsTables;
         }
 
+        private bool GetRevisionsByCollection(DocumentsOperationContext context, string collection, long lastScannedEtag, out IEnumerable<TableValueHolder> revisions)
+        {
+            revisions = null;
+            lastScannedEtag = long.Max(0, lastScannedEtag - 1);
+
+            if (collection == null)
+            {
+                var allRevisionsTable = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
+                revisions = allRevisionsTable.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastScannedEtag);
+                return true;
+            }
+
+            var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false) ?? new CollectionName(collection);
+            var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
+            var collectionRevisionsTable = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
+            if (collectionRevisionsTable != null) // there are existing revisions for that collection
+            {
+                revisions = collectionRevisionsTable.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
+                return true;
+            }
+
+            return false;
+        }
+        
         private static readonly RevisionsCollectionConfiguration ZeroConfiguration = new RevisionsCollectionConfiguration
         {
             MinimumRevisionsToKeep = 0
         };
 
-        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, bool skipForceCreated, ref bool moreWork)
+        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, bool skipForceCreated, out bool moreWork)
         {
+            moreWork = false;
+
             using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
             using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
             {
@@ -1925,8 +1941,7 @@ namespace Raven.Server.Documents.Revisions
                 var prevRevisionsCount = result.PreviousCount;
                 var currentRevisionsCount = result.Remaining;
 
-                if (needToDeleteMore && currentRevisionsCount > 0)
-                    moreWork = true;
+                moreWork = needToDeleteMore && currentRevisionsCount > 0;
 
                 if (currentRevisionsCount == 0)
                 {

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
@@ -23,13 +23,17 @@ internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOpe
     protected override long ExecuteCmd(DocumentsOperationContext context)
     {
         MoreWork = false;
-        foreach (var id in _ids)
+        for (int i = _ids.Count - 1; i >= 0; i--)
         {
             _token.ThrowIfCancellationRequested();
-            _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, ref MoreWork);
+            _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, _ids[i], _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, out var moreWork);
+            if (moreWork == false)
+                _ids.RemoveAt(i);
+            else
+                MoreWork = true;
         }
 
-        return _ids.Count;
+        return 1;
     }
 
     public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)

--- a/test/SlowTests/Issues/RavenDB-23728.cs
+++ b/test/SlowTests/Issues/RavenDB-23728.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23728 : RavenTestBase
+    {
+        public RavenDB_23728(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task EnforceRevisionsConfigurationLastsForever()
+        {
+            using var store = GetDocumentStore();
+
+            // 1 Document
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            for (int i = 0; i < 2; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i.ToString() }, "Users/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await AssertRevisionsCountAsync(store, "Users/1", 2);
+
+            configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+                {
+                    MinimumRevisionsToKeep = 1
+                }
+            };
+
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            database.DocumentsStorage.RevisionsStorage.SizeLimitInBytes = 0;
+
+            await EnforceConfigurationWithTimeout(store);
+
+            await AssertRevisionsCountAsync(store, "Users/1", 1);
+
+
+            // 2 Document
+
+            configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            for (int i = 2; i <= 4; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i.ToString() }, "Users/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            for (int i = 0; i < 2; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = i.ToString() }, "Users/2");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await AssertRevisionsCountAsync(store, "Users/1", 4);
+            await AssertRevisionsCountAsync(store, "Users/2", 2);
+
+
+            configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+                {
+                    MinimumRevisionsToKeep = 1
+                }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            await EnforceConfigurationWithTimeout(store);
+
+            await AssertRevisionsCountAsync(store, "Users/1", 1);
+            await AssertRevisionsCountAsync(store, "Users/2", 1);
+        }
+
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task EnforceRevisionsConfigurationSkipRevisions()
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration() };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var sizeInBytes = 1024 * 32;
+            database.DocumentsStorage.RevisionsStorage.SizeLimitInBytes = sizeInBytes;
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Company { Id = "Companies/1", Name = GenRandomString(1024) });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Id = "Users/1", Name = i.ToString() });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Id = "Users/2", Name = GenRandomString(sizeInBytes / 2) });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 5 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            // enforce
+            await EnforceConfigurationWithTimeout(store, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Users", "Companies" });
+
+            await AssertRevisionsCountAsync(store, "Companies/1", 5);
+            await AssertRevisionsCountAsync(store, "Users/2", 5);
+
+            await AssertRevisionsCountAsync(store, "Users/1", 5); // Fail
+
+        }
+
+        private static async Task AssertRevisionsCountAsync(DocumentStore store, string id, int expectedCount)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Advanced.Revisions.GetCountForAsync(id);
+                Assert.Equal(expectedCount, count);
+            }
+        }
+
+        private async Task EnforceConfigurationWithTimeout(DocumentStore store, HashSet<string> collections = null, long timeout = 15_000)
+        {
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeout)))
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, cts.Token, db.DatabaseShutdown))
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collections, token: token);
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Company
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-6886.cs
+++ b/test/SlowTests/Issues/RavenDB-6886.cs
@@ -292,7 +292,7 @@ namespace SlowTests.Issues
             //LoggingSource.Instance.SetupLogMode(LogMode.Information, "D:\\raven-test-log");
             const int clusterSize = 3;
             const string databaseName = "Cluster_identity_for_multiple_documents_on_different_nodes_should_work";
-            var (_, leaderServer) = await CreateRaftCluster(clusterSize, leaderIndex: 2);
+            var (_, leaderServer) = await CreateRaftCluster(clusterSize, watcherCluster: true);
             var followers = Servers.Where(s => s != leaderServer).ToList();
             using (var leaderStore = GetDocumentStore(new Options
             {

--- a/test/SlowTests/Issues/RavenDB_21934.cs
+++ b/test/SlowTests/Issues/RavenDB_21934.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.RavenDB_20425;
+
+namespace SlowTests.Issues;
+public class RavenDB_21934 : RavenTestBase
+{
+    public RavenDB_21934(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Revisions)]
+    public async Task EnforceRevisionsConfigurationShouldntSkipDocs()
+    {
+        using var store = GetDocumentStore();
+
+        var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Companies",
+            "Users"
+        };
+
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+            }
+        };
+        await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+        // 1026 users
+        for (int i = 0; i < 1026; i++)
+        {
+            var user = new User { Id = $"Users/{i}", Name = "user" };
+            await StoreRevisionsAsync(store, user);
+        }
+
+        // 1028 companies
+        for (int i = 0; i < 1028; i++)
+        {
+            var company = new Company { Id = $"Companies/{i}", Name = "company" };
+            await StoreRevisionsAsync(store, company);
+        }
+
+        configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 2
+            }
+        };
+        await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+        var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+        using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, true, collections, token: token);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var company1Count = await session.Advanced.Revisions.GetCountForAsync("Companies/1");
+            Assert.Equal(2, company1Count);
+            var company2Count = await session.Advanced.Revisions.GetCountForAsync("Companies/2");
+            Assert.Equal(2, company2Count);
+        }
+
+    }
+
+    private static async Task StoreRevisionsAsync(IDocumentStore store, IEntity o)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                o.Name += i;
+                await session.StoreAsync(o);
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+    private class User : IEntity
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Company : IEntity
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private interface IEntity
+    {
+        string Id { get; set; }
+        string Name { get; set; }
+    }
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23728/Enforce-Revision-Configuration-stuck

### Additional description
Issue 1:
Assuming the goal is to process the entire revisions table across multiple collections, the operation is hanging. 
When the condition `if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)` is met under the clause `if (state == NextRevisionIdResult.Continue)`, the process breaks out of the current loop iteration. 
Consequently, on the next iteration of the outer loop, the revisions table is re-accessed starting from the same `ETag` value (of the revision that caused the break on the previous iteration of the outer loop) due to the `SeekBackward` operation. 
This results in repeatedly hitting the same check `if (state == NextRevisionIdResult.Continue) => if (CanContinueBatch(ids, sw.Elapsed, ctx) == false)` with the same revision of the previous iteration. 
This recurring sequence causes an infinite loop, as the process continually returns to and re-evaluates the same data point without advancing the `ETag`, and not delete any revision.
This can occur, for example, when there is a document with several revisions, each of which is larger than 32 MB.

Issue 2:
The PR's "RavenDB_21934" and  "RavenDB-21812" have been merged on 5.4 but not on 6.0:
[https://github.com/ravendb/ravendb/commit/864db71be434c4d56f3c73a62cda7be9146c40e9#diff-a9f8aaf6b379ab6ce1ae242c69[…]c7545c55b67c2ece906873216879146](https://github.com/ravendb/ravendb/commit/864db71be434c4d56f3c73a62cda7be9146c40e9#diff-a9f8aaf6b379ab6ce1ae242c695bf1d9dc7545c55b67c2ece906873216879146)
This PR is also including those PRs changes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
