### PR TITLE
RavenDB-22794 - Add comments for operations that implements IMaintenanceOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexPerformanceStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexPerformanceStatisticsOperation.cs
@@ -7,14 +7,23 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve performance statistics for some or all indexes.
+    /// </summary>
     public sealed class GetIndexPerformanceStatisticsOperation : IMaintenanceOperation<IndexPerformanceStats[]>
     {
         private readonly string[] _indexNames;
 
+        /// <summary>
+        /// Operation to retrieve performance statistics for all indexes.
+        /// </summary>
         public GetIndexPerformanceStatisticsOperation()
         {
         }
 
+        /// <inheritdoc cref="GetIndexPerformanceStatisticsOperation"/>
+        /// <param name="indexNames">An array of index names for which to retrieve performance statistics.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="indexNames"/> is null.</exception>
         public GetIndexPerformanceStatisticsOperation(string[] indexNames)
         {
             _indexNames = indexNames ?? throw new ArgumentNullException(nameof(indexNames));

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexStatisticsOperation.cs
@@ -8,10 +8,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve statistical information about a specific index.
+    /// </summary>
     public sealed class GetIndexStatisticsOperation : IMaintenanceOperation<IndexStats>
     {
         private readonly string _indexName;
 
+        /// <inheritdoc cref="GetIndexStatisticsOperation"/>
+        /// <param name="indexName">The name of the index for which to retrieve statistics.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="indexName"/> is null.</exception>
         public GetIndexStatisticsOperation(string indexName)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));

--- a/src/Raven.Client/Documents/Operations/Indexes/GetTermsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetTermsOperation.cs
@@ -7,6 +7,9 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve a list of unique terms from a specific index field.
+    /// </summary>
     public sealed class GetTermsOperation : IMaintenanceOperation<string[]>
     {
         private readonly string _indexName;
@@ -14,6 +17,12 @@ namespace Raven.Client.Documents.Operations.Indexes
         private readonly string _fromValue;
         private readonly int? _pageSize;
 
+        /// <inheritdoc cref="GetTermsOperation"/>
+        /// <param name="indexName">The name of the index from which to retrieve terms.</param>
+        /// <param name="field">The field within the index to retrieve terms from.</param>
+        /// <param name="fromValue">The starting term value from which to begin retrieval.</param>
+        /// <param name="pageSize">The maximum number of terms to return (optional).</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="indexName"/> or <paramref name="field"/> is null.</exception>
         public GetTermsOperation(string indexName, string field, string fromValue, int? pageSize = null)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));

--- a/src/Raven.Client/Documents/Operations/Indexes/IndexHasChangedOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/IndexHasChangedOperation.cs
@@ -8,10 +8,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to check if an index definition has changed compared to its existing version in the database.
+    /// </summary>
     public sealed class IndexHasChangedOperation : IMaintenanceOperation<bool>
     {
         private readonly IndexDefinition _definition;
 
+        /// <inheritdoc cref="IndexHasChangedOperation"/>
+        /// <param name="definition">The index definition to compare against the existing version.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="definition"/> is null.</exception>
         public IndexHasChangedOperation(IndexDefinition definition)
         {
             _definition = definition ?? throw new ArgumentNullException(nameof(definition));

--- a/src/Raven.Client/Documents/Operations/Indexes/PutIndexesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/PutIndexesOperation.cs
@@ -10,10 +10,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to create or update multiple indexes.
+    /// </summary>
     public sealed class PutIndexesOperation : IMaintenanceOperation<PutIndexResult[]>
     {
         private readonly IndexDefinition[] _indexToAdd;
 
+        /// <inheritdoc cref="PutIndexesOperation"/>
+        /// <param name="indexToAdd">An array of index definitions to be added or updated.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="indexToAdd"/> is null or empty.</exception>
         public PutIndexesOperation(params IndexDefinition[] indexToAdd)
         {
             if (indexToAdd == null || indexToAdd.Length == 0)

--- a/src/Raven.Client/Documents/Operations/Integrations/PostgreSQL/ConfigurePostgreSqlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Integrations/PostgreSQL/ConfigurePostgreSqlOperation.cs
@@ -10,10 +10,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Integrations.PostgreSQL
 {
+    /// <summary>
+    /// Operation to configure PostgreSQL integration.
+    /// This allows RavenDB to expose its data using a PostgreSQL-compatible interface.
+    /// </summary>
     public sealed class ConfigurePostgreSqlOperation : IMaintenanceOperation<ConfigurePostgreSqlOperationResult>
     {
         private readonly PostgreSqlConfiguration _configuration;
 
+        /// <inheritdoc cref="ConfigurePostgreSqlOperation"/>
+        /// <param name="configuration">The PostgreSQL integration configuration settings.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is null.</exception>
         public ConfigurePostgreSqlOperation(PostgreSqlConfiguration configuration)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/DeleteOngoingTaskOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/DeleteOngoingTaskOperation.cs
@@ -7,11 +7,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.OngoingTasks
 {
+    /// <summary>
+    /// Operation to delete an ongoing task.
+    /// </summary>
     public sealed class DeleteOngoingTaskOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly long _taskId;
         private readonly OngoingTaskType _taskType;
 
+        /// <inheritdoc cref="DeleteOngoingTaskOperation"/>
+        /// <param name="taskId">The unique identifier of the ongoing task to be deleted.</param>
+        /// <param name="taskType">The type of the ongoing task.</param>
         public DeleteOngoingTaskOperation(long taskId, OngoingTaskType taskType)
         {
             _taskId = taskId;

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/ToggleOngoingTaskStateOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/ToggleOngoingTaskStateOperation.cs
@@ -8,6 +8,9 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.OngoingTasks
 {
+    /// <summary>
+    /// Operation to enable or disable an ongoing task.
+    /// </summary>
     public sealed class ToggleOngoingTaskStateOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly long _taskId;
@@ -15,6 +18,10 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
         private readonly OngoingTaskType _type;
         private readonly bool _disable;
 
+        /// <inheritdoc cref="ToggleOngoingTaskStateOperation"/>
+        /// <param name="taskId">The unique identifier of the ongoing task.</param>
+        /// <param name="type">The type of the ongoing task.</param>
+        /// <param name="disable">A boolean flag indicating whether to disable (true) or enable (false) the task.</param>
         public ToggleOngoingTaskStateOperation(long taskId, OngoingTaskType type, bool disable)
         {
             _taskId = taskId;
@@ -22,6 +29,11 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             _disable = disable;
         }
 
+        /// <inheritdoc cref="ToggleOngoingTaskStateOperation"/>
+        /// <param name="taskName">The name of the ongoing task.</param>
+        /// <param name="type">The type of the ongoing task.</param>
+        /// <param name="disable">A boolean flag indicating whether to disable (true) or enable (false) the task.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="taskName"/> is null or whitespace.</exception>
         internal ToggleOngoingTaskStateOperation(string taskName, OngoingTaskType type, bool disable)
         {
             if (string.IsNullOrWhiteSpace(taskName)) 

--- a/src/Raven.Client/Documents/Operations/QueueSink/AddQueueSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/QueueSink/AddQueueSinkOperation.cs
@@ -10,10 +10,18 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.QueueSink
 {
+    /// <summary>
+    /// <para>Operation to add a queue sink configuration.</para>
+    /// A queue sink task is a data integration feature that allows RavenDB to receive data from external message queue systems 
+    /// such as Kafka or RabbitMQ and store it in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the connection string, which must inherit from <see cref="ConnectionString"/>.</typeparam>
     public class AddQueueSinkOperation<T> : IMaintenanceOperation<AddQueueSinkOperationResult> where T : ConnectionString
     {
         private readonly QueueSinkConfiguration _configuration;
 
+        /// <inheritdoc cref="AddQueueSinkOperation{T}"/>
+        /// <param name="configuration">The queue sink configuration to be added.</param>
         public AddQueueSinkOperation(QueueSinkConfiguration configuration)
         {
             _configuration = configuration;

--- a/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkConfiguration.cs
@@ -10,26 +10,56 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.QueueSink;
 
+/// <summary>
+/// The configuration for a queue sink task, which allows integrating with external queueing systems.
+/// </summary>
 public class QueueSinkConfiguration : IDynamicJsonValueConvertible, IDatabaseTask
 {
     private bool _initialized;
 
+    /// <summary>
+    /// Specifies the type of queue broker being used.
+    /// </summary>
     public QueueBrokerType BrokerType { get; set; }
 
+    /// <summary>
+    /// The unique identifier for the task.
+    /// </summary>
     public long TaskId { get; set; }
 
+    /// <summary>
+    /// Indicates whether the queue sink task is disabled.
+    /// </summary>
     public bool Disabled { get; set; }
 
+    /// <summary>
+    /// The name of the queue sink task.
+    /// </summary>
     public string Name { get; set; }
 
+    /// <summary>
+    /// The mentor node assigned to this task, if specified.
+    /// </summary>
     public string MentorNode { get; set; }
 
+    /// <summary>
+    /// Determines whether the task should be pinned to the mentor node.
+    /// </summary>
     public bool PinToMentorNode { get; set; }
 
+    /// <summary>
+    /// The name of the connection string used to connect to the queue broker.
+    /// </summary>
     public string ConnectionStringName { get; set; }
 
+    /// <summary>
+    /// Indicates whether the configuration is running in test mode.
+    /// </summary>
     internal bool TestMode { get; set; }
 
+    /// <summary>
+    /// A list of user-defined scripts that process incoming queue messages and define how they should be stored in RavenDB.
+    /// </summary>
     public List<QueueSinkScript> Scripts { get; set; } = new();
 
     [JsonDeserializationIgnore]

--- a/src/Raven.Client/Documents/Operations/QueueSink/UpdateQueueSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/QueueSink/UpdateQueueSinkOperation.cs
@@ -10,11 +10,20 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.QueueSink
 {
+    /// <summary>
+    /// <para>Operation to update an existing queue sink configuration.</para>
+    /// A queue sink task is a data integration feature that allows RavenDB to receive data from external message queue systems 
+    /// such as Kafka or RabbitMQ and store it in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the connection string, which must inherit from <see cref="ConnectionString"/>.</typeparam>
     public class UpdateQueueSinkOperation<T> : IMaintenanceOperation<UpdateQueueSinkOperationResult> where T : ConnectionString
     {
         private readonly long _taskId;
         private readonly QueueSinkConfiguration _configuration;
 
+        /// <inheritdoc cref="UpdateQueueSinkOperation{T}"/>
+        /// <param name="taskId">The unique identifier of the queue sink task to be updated.</param>
+        /// <param name="configuration">The updated queue sink configuration.</param>
         public UpdateQueueSinkOperation(long taskId, QueueSinkConfiguration configuration)
         {
             _taskId = taskId;

--- a/src/Raven.Client/Documents/Operations/TransactionsRecording/ReplayTransactionsRecordingOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TransactionsRecording/ReplayTransactionsRecordingOperation.cs
@@ -8,11 +8,21 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.TransactionsRecording
 {
+    /// <summary>
+    /// Operation to replay a recorded transaction.
+    /// This allows re-executing previously recorded transactions for debugging or recovery purposes.
+    /// </summary>
     public sealed class ReplayTransactionsRecordingOperation : IMaintenanceOperation<ReplayTxOperationResult>
     {
         private readonly Stream _replayStream;
         private readonly long _operationId;
 
+        /// <inheritdoc cref="ReplayTransactionsRecordingOperation"/>
+        /// <param name="replayStream">The stream containing the recorded transaction.</param>
+        /// <param name="operationId">A unique identifier for the replay operation.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="replayStream"/> does not have its position set to zero.
+        /// </exception>
         public ReplayTransactionsRecordingOperation(Stream replayStream, long operationId)
         {
             _replayStream = replayStream;

--- a/src/Raven.Client/ServerWide/Operations/Integrations/PostgreSQL/PostgreSqlConfiguration.cs
+++ b/src/Raven.Client/ServerWide/Operations/Integrations/PostgreSQL/PostgreSqlConfiguration.cs
@@ -2,9 +2,16 @@
 
 namespace Raven.Client.ServerWide.Operations.Integrations.PostgreSQL
 {
+    /// <summary>
+    /// The configuration for PostgreSQL integration within RavenDB
+    /// </summary>
     public sealed class PostgreSqlConfiguration : IDynamicJson
     {
+        /// <summary>
+        /// The authentication settings for connecting to the PostgreSQL database.
+        /// </summary>
         public PostgreSqlAuthenticationConfiguration Authentication;
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22794/Add-comments-for-operations-that-implements-IMaintenanceOperationT

### Additional description

Operations in this PR:

- `ToggleOngoingTaskStateOperation (in Raven.Client.Documents.Operations.OngoingTasks)`
- `AddQueueSinkOperation<T> (in Raven.Client.Documents.Operations.QueueSink)`
- `UpdateQueueSinkOperation<T> (in Raven.Client.Documents.Operations.QueueSink)`
- `ReplayTransactionsRecordingOperation (in Raven.Client.Documents.Operations.TransactionsRecording)`
- `DeleteOngoingTaskOperation (in Raven.Client.Documents.Operations.OngoingTasks)`
- `ConfigurePostgreSqlOperation (in Raven.Client.Documents.Operations.Integrations.PostgreSQL)`
- `PutIndexesOperation (in Raven.Client.Documents.Operations.Indexes)`
- `IndexHasChangedOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetTermsOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetIndexStatisticsOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetIndexPerformanceStatisticsOperation (in Raven.Client.Documents.Operations.Indexes)`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
