### PR TITLE
RavenDB-23735 - Refactoring of the way we pass durandal props to react components

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -42,9 +42,7 @@ interface IndexesPageProps {
     isImportOpen?: boolean;
 }
 
-export function IndexesPage(props: IndexesPageProps) {
-    const { stale, indexName: indexToHighlight, isImportOpen = false } = props;
-
+export function IndexesPage(props: ReactProps<any, IndexesPageProps>) {
     const db = useAppSelector(databaseSelectors.activeDatabase);
     const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
     const { reportEvent } = useEventsCollector();
@@ -85,7 +83,7 @@ export function IndexesPage(props: IndexesPageProps) {
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,
-    } = useIndexesPage(stale, isImportOpen);
+    } = useIndexesPage(props?.queryParams?.stale, props?.queryParams?.isImportOpen);
 
     const deleteSelectedIndexes = () => {
         reportEvent("indexes", "delete-selected");
@@ -142,7 +140,7 @@ export function IndexesPage(props: IndexesPageProps) {
     const indexesPageListCommonProps: Omit<IndexesPageListProps, "indexes"> = {
         replacements,
         selectedIndexes,
-        indexToHighlight,
+        indexToHighlight: props?.queryParams?.indexName,
         globalIndexingStatus,
         resetIndexData,
         swapSideBySideData,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
@@ -20,9 +20,7 @@ export interface ConnectionStringsUrlParameters {
     type?: StudioEtlType;
 }
 
-export default function ConnectionStrings(props: ConnectionStringsUrlParameters) {
-    const { name: nameFromUrl, type: typeFromUrl } = props;
-
+export default function ConnectionStrings(props: ReactProps<any, ConnectionStringsUrlParameters>) {
     const { hasNone: hasNoneInLicense } = useConnectionStringsLicense();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
@@ -32,8 +30,8 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
     useEffect(() => {
         dispatch(
             connectionStringsActions.urlParametersLoaded({
-                name: nameFromUrl,
-                type: typeFromUrl,
+                name: props?.queryParams?.name,
+                type: props?.queryParams?.type,
             })
         );
         dispatch(connectionStringsActions.fetchData(databaseName));

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
@@ -135,7 +135,7 @@ export const CompactDatabaseAuto: StoryFn<typeof DatabasesPage> = () => {
 
     mockServices.databasesService.withGetDatabasesState((tag) => getDatabaseNamesForNode(tag, value));
 
-    return <DatabasesPage compact={value.name} />;
+    return <DatabasesPage queryParams={{ compact: value.name }} />;
 };
 
 function assignNodeType(tag: string): databaseGroupNodeType {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
@@ -23,17 +23,12 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import CreateDatabase, { CreateDatabaseMode } from "./partials/create/CreateDatabase";
 
 interface DatabasesPageProps {
-    activeDatabase?: string;
-    toggleSelectAll?: () => void;
-}
-
-interface DatabasesPageProps {
     compact?: string;
     shard?: number;
     restore?: boolean;
 }
 
-export function DatabasesPage(props: DatabasesPageProps) {
+export function DatabasesPage(props: ReactProps<any, DatabasesPageProps>) {
     const databases = useAppSelector(databaseSelectors.allDatabases);
     const nodeTags = useAppSelector(clusterSelectors.allNodeTags);
     const isOperatorOrAbove = useAppSelector(accessManagerSelectors.isOperatorOrAbove);
@@ -90,13 +85,13 @@ export function DatabasesPage(props: DatabasesPageProps) {
     }, []);
 
     useEffect(() => {
-        if (props.compact) {
-            const toCompact = databases.find((x) => x.name === props.compact);
+        if (props?.queryParams?.compact) {
+            const toCompact = databases.find((x) => x.name === props?.queryParams?.compact);
             if (toCompact) {
-                dispatch(compactDatabase(toCompact, props.shard));
+                dispatch(compactDatabase(toCompact, props?.queryParams?.shard));
             }
         }
-        if (props.restore) {
+        if (props?.queryParams?.restore) {
             setCreateDatabaseMode("fromBackup");
         }
 
@@ -105,7 +100,7 @@ export function DatabasesPage(props: DatabasesPageProps) {
             trigger: false,
             replace: true,
         });
-    }, [props.compact, props.restore, databases, dispatch, props.shard]);
+    }, [props?.queryParams?.compact, props?.queryParams?.restore, databases, dispatch, props?.queryParams?.shard]);
 
     const selectedDatabases = databases.filter((x) => selectedDatabaseNames.includes(x.name));
 

--- a/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
@@ -1,6 +1,7 @@
 ﻿import React = require("react");
 import viewModelBase = require("viewmodels/viewModelBase");
 import reactViewModelUtils = require("common/reactViewModelUtils");
+import router = require("plugins/router");
 
 abstract class reactViewModelBase extends viewModelBase {
 
@@ -24,12 +25,13 @@ abstract class reactViewModelBase extends viewModelBase {
 
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
+        const { params: pathParams, queryParams } = router.activeInstruction()
 
         const reactDirtyFlag = reactViewModelUtils.getReactDirtyFlag(this.dirtyFlag, this.customDiscardStayResult);
-        const reactProps = {
-            ...args,
-            db: this.activeDatabase()
-        }
+        const reactProps: ReactProps = {
+          pathParams,
+          queryParams: queryParams || {},
+        };
 
         this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }

--- a/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
@@ -2,6 +2,7 @@
 import React = require("react");
 import database = require("models/resources/database");
 import reactViewModelUtils = require("common/reactViewModelUtils");
+import router = require("plugins/router");
 
 abstract class shardedReactViewModelBase extends shardViewModelBase {
 
@@ -25,14 +26,14 @@ abstract class shardedReactViewModelBase extends shardViewModelBase {
 
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
+        const { params: pathParams, queryParams } = router.activeInstruction()
 
         const reactDirtyFlag = reactViewModelUtils.getReactDirtyFlag(this.dirtyFlag, this.customDiscardStayResult);
-        const reactProps = {
-            ...args,
-            db: this.db,
-            location: this.location,
+        const reactProps: ReactProps = {
+          pathParams,
+          queryParams: queryParams || {},
+          location: this.location,
         };
-
         this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1003,6 +1003,12 @@ interface ReactDirtyFlag {
     setIsDirty: (isDirty: boolean, customDialog?: () => JQueryPromise<confirmDialogResult>) => void;
 }
 
+interface ReactProps<PathParams = any, QueryParams = Record<string, unknown>> {
+    pathParams?: PathParams;
+    queryParams?: QueryParams;
+    location?: databaseLocationSpecifier
+}
+
 interface ReactInKnockoutOptions<T> {
     component: T;
     props?: Parameters<typeof T>[0];


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23735

### Additional description

Removed spreaded args and replaced it with pathParams and queryParams from durandal router.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
