### PR TITLE
RavenDB-23604 - Vector field settings: Ensure Source and Destination selections are independent

### DIFF
--- a/src/Raven.Studio/typescript/models/database/index/vectorOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/vectorOptions.ts
@@ -70,17 +70,29 @@ class vectorOptions {
                 this.destinationEmbeddingType(value);
             }
         });
-
-        this.destinationEmbeddingType.subscribe((value) => {
-            if (value === "Int8" || value === "Binary") {
-                this.sourceEmbeddingType(value);
-            }
-        })
     }
 
     private initValidation() {
         this.destinationEmbeddingType.extend({
             required: true,
+            validation: [
+                {
+                    validator: (destValue: string) => {
+                        const srcValue = this.sourceEmbeddingType();
+                        const allowedMappings = {
+                            "Text": ["Single", "Int8", "Binary"],
+                            "Single": ["Single", "Int8", "Binary"],
+                            "Int8": ["Int8"],
+                            "Binary": ["Binary"],
+                        };
+                        if (!srcValue) {
+                            return true;
+                        }
+                        return allowedMappings[srcValue] && allowedMappings[srcValue].indexOf(destValue) !== -1;
+                    },
+                    message: "Destination embedding type is invalid for the selected source embedding type.",
+                },
+            ],
         });
 
         this.sourceEmbeddingType.extend({


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23604

### Additional description

Used this table for validation:

```
Source: Text - Destination: [Single, Int8, Binary]
Source: Single - Destination: [Single, Int8, Binary]
Source: Int8 - Destination: [Int8]
Source: Binary - Destination: [Binary]
```


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
