### PR TITLE
RavenDB-23675 - changing the SizeGetter component logic

### DIFF
--- a/src/Raven.Studio/package-lock.json
+++ b/src/Raven.Studio/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@hookform/resolvers": "^3.9.0",
+                "@juggle/resize-observer": "^3.4.0",
                 "@reduxjs/toolkit": "^2.2.6",
                 "@tanstack/react-table": "^8.19.3",
                 "@tanstack/react-virtual": "^3.8.3",
@@ -1903,6 +1904,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@juggle/resize-observer": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+            "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+            "license": "Apache-2.0"
         },
         "node_modules/@mdx-js/react": {
             "version": "3.1.0",

--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -103,6 +103,7 @@
     },
     "dependencies": {
         "@hookform/resolvers": "^3.9.0",
+        "@juggle/resize-observer": "^3.4.0",
         "@reduxjs/toolkit": "^2.2.6",
         "@tanstack/react-table": "^8.19.3",
         "@tanstack/react-virtual": "^3.8.3",

--- a/src/Raven.Studio/scripts/setup_jest.js
+++ b/src/Raven.Studio/scripts/setup_jest.js
@@ -2,6 +2,7 @@ const lodash = require("lodash");
 const knockout = require("knockout");
 require("knockout-postbox");
 const jquery = require("jquery");
+const ROP = require("@juggle/resize-observer")
 
 global._ = lodash;
 global.ko = knockout;
@@ -70,3 +71,12 @@ Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
     configurable: true,
     value: 500,
 });
+
+Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    value: 500,
+});
+
+if (!window.ResizeObserver) {
+  window.ResizeObserver = ROP.ResizeObserver;
+}

--- a/src/Raven.Studio/typescript/components/common/SizeGetter.tsx
+++ b/src/Raven.Studio/typescript/components/common/SizeGetter.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { useState, useEffect } from "react";
+import { useResizeObserver } from "hooks/useResizeObserver";
 
 interface SizeGetterProps {
     render: (size: { width: number; height: number }) => JSX.Element;
@@ -9,24 +9,7 @@ interface SizeGetterProps {
 export default function SizeGetter({ render, isHeighRequired = false }: SizeGetterProps) {
     const ref = useRef<HTMLDivElement>();
 
-    const [width, setWidth] = useState(0);
-    const [height, setHeight] = useState(0);
-
-    useEffect(() => {
-        const currentRef = ref.current;
-        const handleResize = () => {
-            setWidth(currentRef.scrollWidth);
-            setHeight(currentRef.scrollHeight);
-        };
-
-        currentRef.addEventListener("resize", handleResize);
-        handleResize();
-
-        return () => {
-            currentRef.removeEventListener("resize", handleResize);
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ref.current]);
+    const { width, height } = useResizeObserver({ ref });
 
     const canRender = !!(isHeighRequired ? width && height : width);
 

--- a/src/Raven.Studio/typescript/components/hooks/useIsMounted.ts
+++ b/src/Raven.Studio/typescript/components/hooks/useIsMounted.ts
@@ -1,0 +1,15 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useIsMounted(): () => boolean {
+    const isMounted = useRef(false);
+
+    useEffect(() => {
+        isMounted.current = true;
+
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
+
+    return useCallback(() => isMounted.current, []);
+}

--- a/src/Raven.Studio/typescript/components/hooks/useResizeObserver.ts
+++ b/src/Raven.Studio/typescript/components/hooks/useResizeObserver.ts
@@ -1,0 +1,95 @@
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useIsMounted } from "hooks/useIsMounted";
+
+type Size = {
+    width: number | undefined;
+    height: number | undefined;
+};
+
+type UseResizeObserverOptions<T extends HTMLElement = HTMLElement> = {
+    ref: RefObject<T>;
+    onResize?: (size: Size) => void;
+    box?: "border-box" | "content-box" | "device-pixel-content-box";
+};
+
+const initialSize: Size = {
+    width: undefined,
+    height: undefined,
+};
+
+export function useResizeObserver<T extends HTMLElement = HTMLElement>(options: UseResizeObserverOptions<T>): Size {
+    const { ref, box = "content-box" } = options;
+    const [{ width, height }, setSize] = useState<Size>(initialSize);
+    const isMounted = useIsMounted();
+    const previousSize = useRef<Size>({ ...initialSize });
+    const onResize = useRef<((size: Size) => void) | undefined>(undefined);
+    onResize.current = options.onResize;
+
+    useEffect(() => {
+        if (!ref.current) {
+            return;
+        }
+
+        if (typeof window === "undefined" || !("ResizeObserver" in window)) {
+            return;
+        }
+
+        const observer = new ResizeObserver(([entry]) => {
+            const boxProp =
+                box === "border-box"
+                    ? "borderBoxSize"
+                    : box === "device-pixel-content-box"
+                      ? "devicePixelContentBoxSize"
+                      : "contentBoxSize";
+
+            const newWidth = extractSize(entry, boxProp, "inlineSize");
+            const newHeight = extractSize(entry, boxProp, "blockSize");
+
+            const hasChanged = previousSize.current.width !== newWidth || previousSize.current.height !== newHeight;
+
+            if (hasChanged) {
+                const newSize: Size = { width: newWidth, height: newHeight };
+                previousSize.current.width = newWidth;
+                previousSize.current.height = newHeight;
+
+                if (onResize.current) {
+                    onResize.current(newSize);
+                } else {
+                    if (isMounted()) {
+                        setSize(newSize);
+                    }
+                }
+            }
+        });
+
+        observer.observe(ref.current, { box });
+
+        return () => {
+            observer.disconnect();
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [box, ref?.current, isMounted]);
+
+    return { width, height };
+}
+
+type BoxSizesKey = keyof Pick<ResizeObserverEntry, "borderBoxSize" | "contentBoxSize" | "devicePixelContentBoxSize">;
+
+function extractSize(
+    entry: ResizeObserverEntry,
+    box: BoxSizesKey,
+    sizeType: keyof ResizeObserverSize
+): number | undefined {
+    if (!entry[box]) {
+        if (box === "contentBoxSize") {
+            return entry.contentRect[sizeType === "inlineSize" ? "width" : "height"];
+        }
+        return undefined;
+    }
+
+    return Array.isArray(entry[box])
+        ? entry[box][0][sizeType]
+        : // @ts-expect-error Support Firefox's non-standard behavior
+          (entry[box][sizeType] as number);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23675

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
