### PR TITLE
RavenDB-23740 - Make revisions size EP to get 1 cv and return 1 revision size

### DIFF
--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -220,13 +220,14 @@ namespace Raven.Server.Documents.Handlers
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
             {
-                if (Database.DocumentsStorage.RevisionsStorage.GetRevisionMetrics(context, changeVector, out var metrics) == false)
+                var metrics = Database.DocumentsStorage.RevisionsStorage.GetRevisionMetrics(context, changeVector);
+                if (metrics.HasValue == false)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
                     return;
                 }
 
-                size = new RevisionSizeDetails(changeVector, metrics);
+                size = new RevisionSizeDetails(changeVector, metrics.Value);
             }
             
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2484,15 +2484,20 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        public (int ActualSize, int AllocatedSize, bool IsCompressed)? GetRevisionMetrics(DocumentsOperationContext context, string changeVector)
+        public bool GetRevisionMetrics(DocumentsOperationContext context, string changeVector,out (int ActualSize, int AllocatedSize, bool IsCompressed) metrics)
         {
             var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
 
             using (Slice.From(context.Allocator, changeVector, out var cv))
             {
                 if (table.ReadByKey(cv, out TableValueReader tvr) == false)
-                    return null;
-                return GetMetrics(table, tvr);
+                {
+                    metrics = default;
+                    return false;
+                }
+
+                metrics = GetMetrics(table, tvr);
+                return true;
             }
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2484,20 +2484,16 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        public bool GetRevisionMetrics(DocumentsOperationContext context, string changeVector,out (int ActualSize, int AllocatedSize, bool IsCompressed) metrics)
+        public (int ActualSize, int AllocatedSize, bool IsCompressed)? GetRevisionMetrics(DocumentsOperationContext context, string changeVector)
         {
             var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
 
             using (Slice.From(context.Allocator, changeVector, out var cv))
             {
                 if (table.ReadByKey(cv, out TableValueReader tvr) == false)
-                {
-                    metrics = default;
-                    return false;
-                }
-
-                metrics = GetMetrics(table, tvr);
-                return true;
+                    return null;
+                
+                return GetMetrics(table, tvr);
             }
         }
 

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -244,8 +244,6 @@ namespace Raven.Server.Json
 
             public static readonly Func<BlittableJsonReaderObject, ReorderDatabaseMembersOperation.Parameters> MembersOrder = GenerateJsonDeserializationRoutine<ReorderDatabaseMembersOperation.Parameters>();
 
-            public static readonly Func<BlittableJsonReaderObject, RevisionsHandler.GetRevisionsSizeParameters> GetRevisionsSizeParameters = GenerateJsonDeserializationRoutine<RevisionsHandler.GetRevisionsSizeParameters>();
-
             public static readonly Func<BlittableJsonReaderObject, ToggleDatabasesStateOperation.Parameters> DisableDatabaseToggleParameters = GenerateJsonDeserializationRoutine<ToggleDatabasesStateOperation.Parameters>();
 
             public static readonly Func<BlittableJsonReaderObject, SetIndexesLockOperation.Parameters> SetIndexLockParameters = GenerateJsonDeserializationRoutine<SetIndexesLockOperation.Parameters>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23740/Edit-EP-to-display-appropriate-data-for-revision-sizes

### Additional description

The original EP was getting a change-vectors list and a return list of sizes objects.
Now the EP gets 1 cv and returns 1 revision size as requested.
Also, the EP's method is now  `GET` (not `POST`).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
