### PR TITLE
RavenDB-23648: Add more details how to handle invalid or missing license in Embedded or TestDriver

### DIFF
--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -326,8 +326,13 @@ namespace Raven.Server.Commercial
                 _contextPool = contextPool;
             }
 
-            public LicenseVerificationErrorBuilder()
+            public LicenseVerificationErrorBuilder(bool isForTestingEmbeddedServer = true)
             {
+                if (isForTestingEmbeddedServer == false)
+                    return;
+
+                _configuration = RavenConfiguration.Default;
+                _configuration.Embedded.ParentProcessId = 1;
             }
 
             public void AppendInStorageLicenseExpiredMessage(DateTime expirationDate)
@@ -381,8 +386,48 @@ namespace Raven.Server.Commercial
             {
                 _errorBuilder.AppendLine();
                 _errorBuilder.AppendLine("To resolve this issue, you may consider the following options:");
-                _errorBuilder.AppendLine("- Ensure your license key is correctly embedded in 'settings.json', set as an environment variable, or included in your 'ServerOptions' if using an embedded server or Raven.TestDriver.");
-                _errorBuilder.AppendLine("- Alternatively, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.");
+                _errorBuilder.AppendLine("- Ensure your license key is correctly embedded in 'settings.json' or set as an environment variable.");
+                _errorBuilder.AppendLine("- Or, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.");
+
+                if (_configuration.Embedded.ParentProcessId.HasValue)
+                {
+                    _errorBuilder.AppendLine("""
+                        - Or, since you are using an embedded server (TestDriver or EmbeddedServer), you can provide a valid license using one of these approaches:
+                            * For RavenTestDriver:
+                              public class YourTestClass : RavenTestDriver
+                              {
+                                  static YourTestClass()
+                                  {
+                                      ConfigureServer(new TestServerOptions
+                                      {
+                                          Licensing = new ServerOptions.LicensingOptions 
+                                          { 
+                                              License = "your license here", // Replace with your actual license,
+                                              // or
+                                              LicensePath = "path to license.json file" // Replace with the actual path to your license.json file
+                                          }
+                                      });
+                                  }
+                              }
+                              IMPORTANT: This configuration must be done in a static constructor before any server initialization.
+
+                            * For EmbeddedServer:
+                              using (var embedded = new EmbeddedServer())
+                              {
+                                  var serverOptions = new ServerOptions
+                                  {
+                                      Licensing = new ServerOptions.LicensingOptions
+                                      {
+                                          License = "your license here", // Replace with your actual license,
+                                          // or
+                                          LicensePath = "path to license.json file" // Replace with the actual path to your license.json file
+                                      }
+                                  };
+
+                                  embedded.StartServer(serverOptions);
+                              }
+                        """);
+                }
             }
 
             public void AppendConfigurationLicenseExpiredMessage(Guid? inStorageLicenseId, Guid deserializedLicenseId, DateTime deserializedLicenseExpirationDate)
@@ -402,8 +447,23 @@ namespace Raven.Server.Commercial
 
             public void AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(bool throwOnInvalidOrMissingLicenseOptionEnabled, bool isInStorageLicenseExpired)
             {
-                if (throwOnInvalidOrMissingLicenseOptionEnabled && isInStorageLicenseExpired == false)
-                    _errorBuilder.AppendLine($"- Configure the '{RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense)}' option by setting it to 'False' to disable this strict licensing requirement for server startup.");
+                if (throwOnInvalidOrMissingLicenseOptionEnabled == false || isInStorageLicenseExpired)
+                    return;
+
+                _errorBuilder.AppendLine();
+                if (_configuration.Embedded.ParentProcessId.HasValue)
+                {
+                    _errorBuilder.AppendLine("""
+                                             - Alternatively, since you are using an embedded server, you can disable this strict licensing requirement by setting the 'ThrowOnInvalidOrMissingLicense' option to 'false' in your configuration, as demonstrated in the example above:
+                                                 * For RavenTestDriver: in your test class's static constructor
+                                                 * For EmbeddedServer: in ServerOptions.Licensing when calling StartServer
+                                             """);
+                }
+                else
+                {
+                    _errorBuilder.AppendLine(
+                        $"- Alternatively, you can disable this strict licensing requirement by setting the '{RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense)}' option to 'false' in your configuration.");
+                }
             }
 
             public override string ToString() => _errorBuilder.ToString();

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -312,7 +312,7 @@ namespace Raven.Server.Commercial
 
         public class LicenseVerificationErrorBuilder
         {
-            private readonly RavenConfiguration _configuration;
+            private protected RavenConfiguration Configuration;
             private readonly StorageEnvironment _storageEnvironment;
             private readonly TransactionContextPool _contextPool;
             private readonly StringBuilder _errorBuilder = new();
@@ -321,18 +321,9 @@ namespace Raven.Server.Commercial
 
             public LicenseVerificationErrorBuilder(RavenConfiguration configuration, StorageEnvironment storageEnvironment, TransactionContextPool contextPool)
             {
-                _configuration = configuration;
+                Configuration = configuration;
                 _storageEnvironment = storageEnvironment;
                 _contextPool = contextPool;
-            }
-
-            public LicenseVerificationErrorBuilder(bool isForTestingEmbeddedServer = true)
-            {
-                if (isForTestingEmbeddedServer == false)
-                    return;
-
-                _configuration = RavenConfiguration.Default;
-                _configuration.Embedded.ParentProcessId = 1;
             }
 
             public void AppendInStorageLicenseExpiredMessage(DateTime expirationDate)
@@ -379,7 +370,7 @@ namespace Raven.Server.Commercial
                         _errorBuilder.AppendLine($"- As a temporary measure, consider downgrading to the last working build ({buildInfo.FullVersion}).");
                 }
 
-                AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(_configuration.Licensing.ThrowOnInvalidOrMissingLicense, _isInStorageLicenseExpired);
+                AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(Configuration.Licensing.ThrowOnInvalidOrMissingLicense, _isInStorageLicenseExpired);
             }
 
             public void AppendGeneralSuggestions()
@@ -389,7 +380,7 @@ namespace Raven.Server.Commercial
                 _errorBuilder.AppendLine("- Ensure your license key is correctly embedded in 'settings.json' or set as an environment variable.");
                 _errorBuilder.AppendLine("- Or, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.");
 
-                if (_configuration.Embedded.ParentProcessId.HasValue)
+                if (Configuration.Embedded.ParentProcessId.HasValue)
                 {
                     _errorBuilder.AppendLine("""
                         - Or, since you are using an embedded server (TestDriver or EmbeddedServer), you can provide a valid license using one of these approaches:
@@ -451,7 +442,7 @@ namespace Raven.Server.Commercial
                     return;
 
                 _errorBuilder.AppendLine();
-                if (_configuration.Embedded.ParentProcessId.HasValue)
+                if (Configuration.Embedded.ParentProcessId.HasValue)
                 {
                     _errorBuilder.AppendLine("""
                                              - Alternatively, since you are using an embedded server, you can disable this strict licensing requirement by setting the 'ThrowOnInvalidOrMissingLicense' option to 'false' in your configuration, as demonstrated in the example above:

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -378,7 +378,7 @@ namespace Raven.Server.Commercial
                 _errorBuilder.AppendLine();
                 _errorBuilder.AppendLine("To resolve this issue, you may consider the following options:");
                 _errorBuilder.AppendLine("- Ensure your license key is correctly embedded in 'settings.json' or set as an environment variable.");
-                _errorBuilder.AppendLine("- Or, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.");
+                _errorBuilder.AppendLine($"- Or, check the '{RavenConfiguration.GetKey(x => x.Licensing.LicensePath)}' in your configuration to ensure it points to a valid 'license.json' file.");
 
                 if (Configuration.Embedded.ParentProcessId.HasValue)
                 {
@@ -403,20 +403,15 @@ namespace Raven.Server.Commercial
                               IMPORTANT: This configuration must be done in a static constructor before any server initialization.
 
                             * For EmbeddedServer:
-                              using (var embedded = new EmbeddedServer())
+                              EmbeddedServer.Instance.StartServer(new ServerOptions
                               {
-                                  var serverOptions = new ServerOptions
+                                  Licensing = new ServerOptions.LicensingOptions
                                   {
-                                      Licensing = new ServerOptions.LicensingOptions
-                                      {
-                                          License = "your license here", // Replace with your actual license,
-                                          // or
-                                          LicensePath = "path to license.json file" // Replace with the actual path to your license.json file
-                                      }
-                                  };
-
-                                  embedded.StartServer(serverOptions);
-                              }
+                                      License = "your license here", // Replace with your actual license,
+                                      // or
+                                      LicensePath = "path to license.json file" // Replace with the actual path to your license.json file
+                                  }
+                              });
                         """);
                 }
             }

--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -72,7 +72,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
                 StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -95,7 +95,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
             StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -117,7 +117,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
             StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -138,7 +138,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
             StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -160,7 +160,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
                 StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -183,7 +183,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
             StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -206,7 +206,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
             StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -229,7 +229,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var exception = Assert.Throws(typeof(AggregateException), () =>
             StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -421,7 +421,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -443,7 +443,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -465,7 +465,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -486,7 +486,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -507,7 +507,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -529,7 +529,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -552,7 +552,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -576,7 +576,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
             StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
-        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
         expectedMessageBuilder.AppendLicenseMissingMessage();
 
         expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
@@ -742,5 +742,14 @@ public static class LicenseOptionTestHelper
         Assert.IsType<T>(exception.InnerException);
         Assert.True(exception.InnerException.Message.Contains(expectedMessageBuilder.ToString()),
             userMessage: $"Exception message: {exception.InnerException.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
+    }
+}
+
+public class LicenseVerificationErrorBuilderForTestingPurposes : LicenseHelper.LicenseVerificationErrorBuilder
+{
+    public LicenseVerificationErrorBuilderForTestingPurposes() : base(null, null, null)
+    {
+        Configuration = RavenConfiguration.Default;
+        Configuration.Embedded.ParentProcessId = 1;
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23648/Add-more-details-how-to-handle-invalid-or-missing-license-in-Embedded-or-TestDriver

For reference - comments under the article: https://ravendb.net/docs/article-page/6.2/csharp/start/test-driver#comment-6635383467

### Additional description

For `EmbeddedServer` and `TestDriver` the exception looks like this:
```
The RavenDB server cannot start due to a missing license. Please review the details below to resolve the issue:

We attempted to obtain a valid license using the configuration key 'License', but this process was not successful for the following reason:
- The license is not provided in the configuration or environment variable.

We attempted to obtain a valid license using the configuration key 'License.Path', but this process was not successful for the following reason:
- An error occurred while trying to read the license from the file:
  Could not find file 'X:\ravendb-5.4\test\LicenseTests\bin\Debug\net8.0\Databases\CopyServer.1\RavenDBServer\license.json'.

To resolve this issue, you may consider the following options:
- Ensure your license key is correctly embedded in 'settings.json' or set as an environment variable.
- Or, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.
- Or, since you are using an embedded server (TestDriver or EmbeddedServer), you can provide a valid license using one of these approaches:
    * For RavenTestDriver:
      public class YourTestClass : RavenTestDriver
      {
          static YourTestClass()
          {
              ConfigureServer(new TestServerOptions
              {
                  Licensing = new ServerOptions.LicensingOptions 
                  { 
                      License = "your license here", // Replace with your actual license,
                      // or
                      LicensePath = "path to license.json file" // Replace with the actual path to your license.json file
                  }
              });
          }
      }
      IMPORTANT: This configuration must be done in a static constructor before any server initialization.

    * For EmbeddedServer:
      EmbeddedServer.Instance.StartServer(new ServerOptions
      {
          Licensing = new ServerOptions.LicensingOptions
          {
              License = "your license here", // Replace with your actual license,
              // or
              LicensePath = "path to license.json file" // Replace with the actual path to your license.json file
          }
      });

- Alternatively, since you are using an embedded server, you can disable this strict licensing requirement by setting the 'ThrowOnInvalidOrMissingLicense' option to 'false' in your configuration, as demonstrated in the example above:
    * For RavenTestDriver: in your test class's static constructor
    * For EmbeddedServer: in ServerOptions.Licensing when calling StartServer
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
