### PR TITLE
RavenDB-23763 Revisions Bin Cleaner: Fix About Text

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerInfoHub.tsx
@@ -17,7 +17,7 @@ export function RevisionsBinCleanerInfoHub() {
                 heading="About this view"
                 description="Get additional info on this feature"
             >
-                <p>
+                <div>
                     <strong>Automatic deletion</strong>:
                     <br />
                     This view allows you to configure automatic deletion of{" "}
@@ -31,19 +31,19 @@ export function RevisionsBinCleanerInfoHub() {
                     . You can set the following:
                     <ul className="mt-1">
                         <li className="mb-1">
-                            <strong>Minimum age</strong>:
+                            <strong>Minimum age</strong>
                             <br />
                             Revisions that have been in the Revisions Bin for longer than this duration will be removed
                             when the cleaner executes.
                         </li>
                         <li>
-                            <strong>Cleaner frequency</strong>:
+                            <strong>Cleaner frequency</strong>
                             <br />
                             Defines how often the cleaner executes to remove revisions.
                         </li>
                     </ul>
-                </p>
-                <p>
+                </div>
+                <div>
                     <strong>Manual deletion</strong>:
                     <br />
                     Manual deletion of individual &quot;Delete Revisions&quot; can be performed from the{" "}
@@ -51,7 +51,7 @@ export function RevisionsBinCleanerInfoHub() {
                         Revisions Bin View
                     </a>
                     .
-                </p>
+                </div>
             </AccordionItemWrapper>
         </AboutViewAnchored>
     );


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23763/Revisions-Bin-Cleaner-Fix-About-Text

### Additional description
Use `<div>` instead of `<p>` because `<ul>` cannot be inside of `<p>`

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
