### PR TITLE
RavenDB-23766 - NRE in server store initialization

### DIFF
--- a/src/Raven.Server/NotificationCenter/ServerStoreNotificationStorage.cs
+++ b/src/Raven.Server/NotificationCenter/ServerStoreNotificationStorage.cs
@@ -1,5 +1,9 @@
-﻿using Raven.Server.ServerWide;
+﻿using Raven.Server.Json;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 
 namespace Raven.Server.NotificationCenter;
 
@@ -12,6 +16,45 @@ public sealed class ServerStoreNotificationStorage(ServerStore serverStore) : No
         {
             Documents.Schemas.Notifications.Current.Create(tx, TableName, 16);
             tx.Commit();
+        }
+    }
+
+    protected override void Cleanup()
+    {
+        RemoveNewVersionAvailableAlertIfNecessary();
+    }
+
+    private void RemoveNewVersionAvailableAlertIfNecessary()
+    {
+        var buildNumber = ServerVersion.Build;
+
+        var id = AlertRaised.GetKey(AlertType.Server_NewVersionAvailable, null);
+        using (Read(id, out var ntv))
+        {
+            using (ntv)
+            {
+                if (ntv == null)
+                    return;
+
+                var delete = true;
+
+                if (buildNumber != ServerVersion.DevBuildNumber)
+                {
+                    if (ntv.Json.TryGetMember(nameof(AlertRaised.Details), out var o)
+                        && o is BlittableJsonReaderObject detailsJson)
+                    {
+                        if (detailsJson.TryGetMember(nameof(NewVersionAvailableDetails.VersionInfo), out o)
+                            && o is BlittableJsonReaderObject newVersionDetailsJson)
+                        {
+                            var value = JsonDeserializationServer.LatestVersionCheckVersionInfo(newVersionDetailsJson);
+                            delete = value.BuildNumber <= buildNumber;
+                        }
+                    }
+                }
+
+                if (delete)
+                    Delete(id);
+            }
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -848,7 +848,6 @@ namespace Raven.Server.ServerWide
             _server.Statistics.Load(ContextPool, Logger);
 
             _timer = new Timer(IdleOperations, null, _frequencyToCheckForIdleDatabases, TimeSpan.FromDays(7));
-            _notificationsStorage.Initialize(_env, ContextPool);
             _operationsStorage.Initialize(_env, ContextPool);
             DatabaseInfoCache.Initialize(_env, ContextPool);
         }
@@ -862,6 +861,7 @@ namespace Raven.Server.ServerWide
             var myUrl = GetNodeHttpServerUrl();
             _engine.Initialize(_env, Configuration, clusterChanges, myUrl, Server.Time, out _lastClusterTopologyIndex, ServerShutdown);
 
+            _notificationsStorage.Initialize(_env, ContextPool);
             NotificationCenter.Initialize();
             foreach (var alertRaised in _storeAlertForLateRaise)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23766/NRE-in-server-store-initialization

### Additional description

- Move the notification storage initialization from PreInitialize to Initialize.
- Remove the new version available alert only for the server store notification storage.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
