### PR TITLE
RavenDB-22903 and RavenDB-23060: Enhance diagnostic logging for compare exchange tombstone cleanup

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -613,17 +614,31 @@ namespace Raven.Server.ServerWide.Maintenance
             Debug.Assert(ShardHelper.IsShardName(databaseName) == false, $"Compare exchanges are put in cluster under sharded database name, so can't delete them from under shard name {databaseName}");
             const int amountToDelete = 8192;
 
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Starting {nameof(GetCompareExchangeTombstonesToCleanup)}:");
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Database: `{databaseName}`");
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"RawDatabaseRecord: `{mergedState.RawDatabase?.DatabaseName}`, IsSharded: `{mergedState.RawDatabase?.IsSharded}`");
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"PeriodicBackupTaskIds: {(mergedState.RawDatabase?.PeriodicBackupsTaskIds is { Count: > 0 } ? string.Join(", ", mergedState.RawDatabase.PeriodicBackupsTaskIds) : "none")}");
+
             if (_server.Cluster.HasCompareExchangeTombstones(context, databaseName) == false)
             {
+                ForTestingPurposes?.OnDiagnosticLog?.Invoke("No tombstones found in cluster.");
                 cleanupState = CompareExchangeTombstonesCleanupState.NoMoreTombstones;
                 return null;
             }
 
             cleanupState = GetMaxCompareExchangeTombstonesEtagToDelete(context, databaseName, mergedState, out long maxEtag);
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Computed maxEtag: `{maxEtag}`");
 
-            return cleanupState == CompareExchangeTombstonesCleanupState.HasMoreTombstones
-                ? new CleanCompareExchangeTombstonesCommand(databaseName, maxEtag, amountToDelete, RaftIdGenerator.NewId())
-                : null;
+            if (cleanupState != CompareExchangeTombstonesCleanupState.HasMoreTombstones)
+            {
+                ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Exiting early, cleanupState: `{cleanupState}`");
+                return null;
+            }
+
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke("Sending cleanup command with details:");
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"databaseName: `{databaseName}`, maxEtag: `{maxEtag}`, amountToDelete: `{amountToDelete}`");
+
+            return new CleanCompareExchangeTombstonesCommand(databaseName, maxEtag, amountToDelete, RaftIdGenerator.NewId());
         }
 
         public enum CompareExchangeTombstonesCleanupState
@@ -638,6 +653,7 @@ namespace Raven.Server.ServerWide.Maintenance
         {
             maxEtag = -1;
 
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Starting {nameof(GetMaxCompareExchangeTombstonesEtagToDelete)}...");
             var periodicBackupTaskIds = mergedState.RawDatabase.PeriodicBackupsTaskIds;
             var isSharded = mergedState.RawDatabase.IsSharded;
 
@@ -645,14 +661,19 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 //if sharded, we have to get backup status by shard name
                 var shardName = isSharded ? ShardHelper.ToShardName(databaseName, shardNumber) : databaseName;
+                ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Processing shard `{shardNumber}`, shardName: `{shardName}`");
 
                 if (periodicBackupTaskIds != null && periodicBackupTaskIds.Count > 0)
                 {
                     foreach (var taskId in periodicBackupTaskIds)
                     {
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Reading backup status for taskId: `{taskId}`");
                         var singleBackupStatus = _server.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(shardName, taskId));
                         if (singleBackupStatus == null)
+                        {
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke("Backup status is null, continuing...");
                             continue;
+                        }
 
                         if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastFullBackupInternal), out DateTime? lastFullBackupInternal) == false ||
                             lastFullBackupInternal == null)
@@ -660,7 +681,10 @@ namespace Raven.Server.ServerWide.Maintenance
                             // never backed up yet
                             if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastIncrementalBackupInternal), out DateTime? lastIncrementalBackupInternal) ==
                                 false || lastIncrementalBackupInternal == null)
+                            {
+                                ForTestingPurposes?.OnDiagnosticLog?.Invoke("No full or incremental backup found, continuing...");
                                 continue;
+                            }
                         }
 
                         if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastRaftIndex), out BlittableJsonReaderObject lastRaftIndexBlittable) == false ||
@@ -669,22 +693,31 @@ namespace Raven.Server.ServerWide.Maintenance
                             if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.Error), out BlittableJsonReaderObject error) == false || error != null)
                             {
                                 // backup errored on first run (lastRaftIndex == null) => cannot remove ANY tombstones
+                                ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Backup errored on first run (lastRaftIndex == null) => cannot remove ANY tombstones, error: `{error}`");
                                 return CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus;
                             }
-
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke("No LastRaftIndex found, continuing...");
                             continue;
                         }
 
                         if (lastRaftIndexBlittable.TryGet(nameof(PeriodicBackupStatus.LastEtag), out long? lastRaftIndex) == false || lastRaftIndex == null)
                         {
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Could not retrieve {nameof(PeriodicBackupStatus.LastEtag)}, continuing...");
                             continue;
                         }
 
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Task `{taskId}`: LastEtag = `{lastRaftIndex}`");
                         if (maxEtag == -1 || lastRaftIndex < maxEtag)
+                        {
                             maxEtag = lastRaftIndex.Value;
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Updated {nameof(maxEtag)}: {maxEtag}");
+                        }
 
                         if (maxEtag == 0)
+                        {
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"{nameof(maxEtag)} reached 0, returning `{nameof(CompareExchangeTombstonesCleanupState.NoMoreTombstones)}`.");
                             return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+                        }
                     }
                 }
 
@@ -692,7 +725,12 @@ namespace Raven.Server.ServerWide.Maintenance
                 foreach (var nodeTag in state.DatabaseTopology.AllNodes)
                 {
                     if (state.Current.ContainsKey(nodeTag) == false) // we have a state change, do not remove anything
+                    {
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"[ERROR] Invalid state: Missing report for node '{nodeTag}'");
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
+                    }
+
+                    ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Node '{nodeTag}' report found.");
                 }
 
                 foreach (var nodeTag in state.DatabaseTopology.AllNodes)
@@ -701,36 +739,60 @@ namespace Raven.Server.ServerWide.Maintenance
                     Debug.Assert(hasState, $"Could not find state for node '{nodeTag}' for database '{state.Name}'.");
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                     if (hasState == false)
+                    {
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Missing state for node '{nodeTag}'");
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
+                    }
 
                     var hasReport = nodeReport.Report.TryGetValue(state.Name, out var report);
                     Debug.Assert(hasReport || nodeReport.Error != null, $"Could not find report for node '{nodeTag}' for database '{state.Name}'.");
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                     if (hasReport == false)
+                    {
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Missing report for node '{nodeTag}' for database '{state.Name}'");
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
+                    }
 
+                    ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Node '{nodeTag}': LastClusterWideTransactionRaftIndex = {report.LastClusterWideTransactionRaftIndex}");
                     var clusterWideTransactionIndex = report.LastClusterWideTransactionRaftIndex;
                     if (maxEtag == -1 || clusterWideTransactionIndex < maxEtag)
+                    {
                         maxEtag = clusterWideTransactionIndex;
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Updated maxEtag to {maxEtag} based on node '{nodeTag}' LastClusterWideTransactionRaftIndex");
+                    }
 
                     foreach (var kvp in report.LastIndexStats)
                     {
                         var lastIndexedCompareExchangeReferenceTombstoneEtag = kvp.Value.LastIndexedCompareExchangeReferenceTombstoneEtag;
+                        ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Node '{nodeTag}', index '{kvp.Key}': LastIndexedCompareExchangeReferenceTombstoneEtag = {lastIndexedCompareExchangeReferenceTombstoneEtag}");
                         if (lastIndexedCompareExchangeReferenceTombstoneEtag == null)
+                        {
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"{nameof(lastIndexedCompareExchangeReferenceTombstoneEtag)} is null, continuing...");
                             continue;
+                        }
 
                         if (maxEtag == -1 || lastIndexedCompareExchangeReferenceTombstoneEtag < maxEtag)
+                        {
                             maxEtag = lastIndexedCompareExchangeReferenceTombstoneEtag.Value;
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Updated maxEtag to {maxEtag} based on node '{nodeTag}', index '{kvp.Key}'");
+                        }
 
                         if (maxEtag == 0)
+                        {
+                            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"maxEtag reached 0 for node '{nodeTag}', index '{kvp.Key}', returning {CompareExchangeTombstonesCleanupState.NoMoreTombstones}.");
                             return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+                        }
                     }
                 }
             }
 
             if (maxEtag == 0)
+            {
+                ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Final {nameof(maxEtag)} is 0, returning {CompareExchangeTombstonesCleanupState.NoMoreTombstones}.");
                 return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+            }
 
+            ForTestingPurposes?.OnDiagnosticLog?.Invoke($"Finished {nameof(GetMaxCompareExchangeTombstonesEtagToDelete)}. Returning {CompareExchangeTombstonesCleanupState.HasMoreTombstones}.");
             return CompareExchangeTombstonesCleanupState.HasMoreTombstones;
         }
 
@@ -968,6 +1030,21 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 return new MergedDatabaseObservationState(state.RawDatabase, state);
             }
+        }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal sealed class TestingStuff
+        {
+            internal Action<string> OnDiagnosticLog;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -1304,6 +1304,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 using (var store = GetDocumentStore(options))
                 {
                     Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
+                    server.ServerStore.Observer.ForTestingPurposesOnly().OnDiagnosticLog += logLine => sb.AppendLine(logLine);
 
                     var count = 1;
                     var indexesList = new List<long>();
@@ -1393,7 +1394,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         var numOfCompareExchanges = server.ServerStore.Cluster.GetNumberOfCompareExchange(context, store.Database);
                         sb.AppendLine($"Final Check - Tombstones: {numOfCompareExchangeTombstones}, CompareExchanges: {numOfCompareExchanges}");
 
-                        Assert.True(0 == numOfCompareExchangeTombstones, sb.ToString());
+                        Assert.True(numOfCompareExchangeTombstones.Equals(0), $"Expected 0, got {numOfCompareExchangeTombstones}{Environment.NewLine}{sb}");
                         Assert.Equal(allCount, numOfCompareExchanges);
                     }
                 }
@@ -1798,6 +1799,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 config.IncrementalBackupFrequency = "0 0 1 1 *";
                 var result2 = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
+                var diagnosticLogBuilder = new StringBuilder();
+                server.ServerStore.Observer.ForTestingPurposesOnly().OnDiagnosticLog += logLine => diagnosticLogBuilder.AppendLine(logLine);
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())
                 {
@@ -1805,7 +1808,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
                     // clean tombstones
-                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
+                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, ignoreClustrTrx:true, diagnosticLogBuilder);
                     Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1813,8 +1816,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     var numOfCompareExchangeTombstones = server.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
                     var numOfCompareExchanges = server.ServerStore.Cluster.GetNumberOfCompareExchange(context, store.Database);
-                    Assert.Equal(0, numOfCompareExchangeTombstones);
-                    Assert.Equal(2, numOfCompareExchanges);
+                    Assert.True(numOfCompareExchangeTombstones.Equals(0), $"Expected 0, but got {numOfCompareExchangeTombstones}{Environment.NewLine}{diagnosticLogBuilder}");
+                    Assert.True(numOfCompareExchanges.Equals(2), $"Expected 2, but got {numOfCompareExchanges}{Environment.NewLine}{diagnosticLogBuilder}");
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22903
https://issues.hibernatingrhinos.com/issue/RavenDB-23060

### Additional description

I noticed that sporadic test failures were due to the cleanup process exiting early—even when a tombstone was present—because the computed max etag sometimes ends up as 0. In such cases, the logic incorrectly concludes that there are no tombstones to clean.

To diagnose this, I enhanced the diagnostic logging in the cleanup flow. I modified both the `GetCompareExchangeTombstonesToCleanup` and `GetMaxCompareExchangeTombstonesEtagToDelete` methods to accept an optional diagnostic log (a `StringBuilder`). This log now captures key information such as the database name, sharding status, periodic backup task IDs, and details from each backup status and node report (including values like `LastEtag`, `LastClusterWideTransactionRaftIndex`, and `LastIndexedCompareExchangeReferenceTombstoneEtag`).

These changes do not alter the behavior of the cleanup logic; they merely provide richer diagnostic data. This additional information will help us correlate the conditions that lead to a `maxEtag` of 0 with the rare failure scenario, ultimately guiding any necessary adjustments to the cleanup mechanism.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
