### PR TITLE
RavenDB-23762 - Update the RevisionsBinConfiguration class

### DIFF
--- a/src/Raven.Client/Documents/Operations/Revisions/RevisionsBinConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevisionsBinConfiguration.cs
@@ -21,24 +21,25 @@ namespace Raven.Client.Documents.Operations.Revisions
         /// </summary>
         /// <value>
         /// The minimum <see cref="int"/> that revisions-bin entries (deleted docs with revisions) must be kept before being eligible for deletion.
-        /// A null value means no age restriction is applied.
+        /// When set to 0, all revisions bin entries will be deleted.
+        /// The default value is 30 days.
         /// </value>
-        public int? MinimumEntriesAgeToKeepInMin { get; set; }
+        public int MinimumEntriesAgeToKeepInMin { get; set; } = 30 * 24 * 60;
 
         /// <summary>
         /// Gets or sets the frequency (in seconds) at which the revisions bin cleaner executes cleaning.
         /// </summary>
         /// <value>
-        /// The <see cref="long"/> defining how often the cleaner will check for and process old entries (deleted docs with revisions).
+        /// This parameter defines how often the cleaner will check for and process and delete old entries (deleted docs with revisions).
         /// The default value is 5 minutes.
         /// </value>
-        public long RefreshFrequencyInSec { get; set; } = 5 * 60;
+        public long CleanerFrequencyInSec { get; set; } = 5 * 60;
 
         private bool Equals(RevisionsBinConfiguration other)
         {
             return Disabled == other.Disabled &&
                    MinimumEntriesAgeToKeepInMin == other.MinimumEntriesAgeToKeepInMin &&
-                   RefreshFrequencyInSec == other.RefreshFrequencyInSec;
+                   CleanerFrequencyInSec == other.CleanerFrequencyInSec;
         }
 
         public override bool Equals(object obj)
@@ -57,8 +58,8 @@ namespace Raven.Client.Documents.Operations.Revisions
             unchecked
             {
                 var hashCode = Disabled.GetHashCode();
-                hashCode = (hashCode * 397) ^ (MinimumEntriesAgeToKeepInMin?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ RefreshFrequencyInSec.GetHashCode();
+                hashCode = (hashCode * 397) ^ MinimumEntriesAgeToKeepInMin.GetHashCode();
+                hashCode = (hashCode * 397) ^ CleanerFrequencyInSec.GetHashCode();
                 return hashCode;
             }
         }
@@ -69,7 +70,7 @@ namespace Raven.Client.Documents.Operations.Revisions
             {
                 [nameof(Disabled)] = Disabled,
                 [nameof(MinimumEntriesAgeToKeepInMin)] = MinimumEntriesAgeToKeepInMin,
-                [nameof(RefreshFrequencyInSec)] = RefreshFrequencyInSec
+                [nameof(CleanerFrequencyInSec)] = CleanerFrequencyInSec
             };
         }
 

--- a/src/Raven.Server/Documents/RevisionsBinCleaner.cs
+++ b/src/Raven.Server/Documents/RevisionsBinCleaner.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents
 
         protected override async Task DoWork()
         {
-            await WaitOrThrowOperationCanceled(TimeSpan.FromSeconds(_configuration.RefreshFrequencyInSec));
+            await WaitOrThrowOperationCanceled(TimeSpan.FromSeconds(_configuration.CleanerFrequencyInSec));
 
             await ExecuteCleanup(_configuration);
         }
@@ -82,8 +82,7 @@ namespace Raven.Server.Documents
             config ??= _configuration;
 
             if (config == null ||
-                config.MinimumEntriesAgeToKeepInMin == null ||
-                config.MinimumEntriesAgeToKeepInMin.Value == int.MaxValue ||
+                config.MinimumEntriesAgeToKeepInMin == int.MaxValue ||
                 CancellationToken.IsCancellationRequested)
             {
                 if (Logger.IsInfoEnabled)
@@ -93,7 +92,7 @@ namespace Raven.Server.Documents
 
             try
             {
-                var before = _documentDatabase.Time.GetUtcNow() - TimeSpan.FromMinutes(config.MinimumEntriesAgeToKeepInMin.Value < 0 ? 0 : config.MinimumEntriesAgeToKeepInMin.Value);
+                var before = _documentDatabase.Time.GetUtcNow() - TimeSpan.FromMinutes(int.Max(0, config.MinimumEntriesAgeToKeepInMin));
 
                 while (CancellationToken.IsCancellationRequested == false)
                 {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
@@ -52,7 +52,7 @@ describe("RevisionsBinCleaner", () => {
         const user = userEvent.setup();
         const { screen } = await rtlRender_WithWaitForLoad(<DefaultRevisionsBinCleaner />);
 
-        const refreshFrequencyBefore = await screen.findByName("refreshFrequencyInSec");
+        const refreshFrequencyBefore = await screen.findByName("cleanerFrequencyInSec");
 
         await user.click(screen.getByRole("checkbox", { name: "Set custom cleaner frequency" }));
 
@@ -60,7 +60,7 @@ describe("RevisionsBinCleaner", () => {
 
         await user.click(screen.getByRole("checkbox", { name: "Enable Revisions Bin Cleaner" }));
 
-        const refreshFrequencyAfter = await screen.findByName("refreshFrequencyInSec");
+        const refreshFrequencyAfter = await screen.findByName("cleanerFrequencyInSec");
 
         expect(refreshFrequencyAfter).toBeDisabled();
         expect(refreshFrequencyAfter).toHaveValue(null);
@@ -107,7 +107,7 @@ describe("RevisionsBinCleaner", () => {
                 revisionsBinCleanerDto={{
                     Disabled: false,
                     MinimumEntriesAgeToKeepInMin: null,
-                    RefreshFrequencyInSec: 500,
+                    CleanerFrequencyInSec: 500,
                 }}
             />
         );
@@ -115,7 +115,7 @@ describe("RevisionsBinCleaner", () => {
         const refreshFrequencySwitchBefore = (await screen.findByRole("checkbox", {
             name: "Set custom cleaner frequency",
         })) as HTMLInputElement;
-        const refreshFrequencyBefore = await screen.findByName("refreshFrequencyInSec");
+        const refreshFrequencyBefore = await screen.findByName("cleanerFrequencyInSec");
 
         expect(refreshFrequencyBefore).toHaveValue(500);
         expect(refreshFrequencySwitchBefore.checked).toBe(true);
@@ -124,7 +124,7 @@ describe("RevisionsBinCleaner", () => {
         const refreshFrequencySwitchAfter = (await screen.findByRole("checkbox", {
             name: "Set custom cleaner frequency",
         })) as HTMLInputElement;
-        const refreshFrequencyAfter = await screen.findByName("refreshFrequencyInSec");
+        const refreshFrequencyAfter = await screen.findByName("cleanerFrequencyInSec");
 
         expect(refreshFrequencyAfter).toHaveValue(null);
         expect(refreshFrequencyAfter).toBeDisabled();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
@@ -167,7 +167,7 @@ export default function RevisionsBinCleaner() {
                                         </Collapse>
                                         <FormGroup>
                                             <FormSwitch
-                                                name="isRefreshFrequencyEnabled"
+                                                name="isCleanerFrequencyInSecEnabled"
                                                 control={control}
                                                 color="primary"
                                                 className="mb-3"
@@ -180,14 +180,14 @@ export default function RevisionsBinCleaner() {
                                                 Set custom cleaner frequency
                                             </FormSwitch>
                                             <FormInput
-                                                name="refreshFrequencyInSec"
+                                                name="cleanerFrequencyInSec"
                                                 control={control}
                                                 type="number"
                                                 disabled={
                                                     !hasDatabaseAdminAccess ||
                                                     formState.isSubmitting ||
                                                     !formValues.isRevisionsBinCleanerEnabled ||
-                                                    !formValues.isRefreshFrequencyEnabled
+                                                    !formValues.isCleanerFrequencyInSecEnabled
                                                 }
                                                 placeholder="Default (300)"
                                                 addon="seconds"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
@@ -8,7 +8,7 @@ function mapToDto(dto: RevisionsBinCleanerFormData): RevisionsBinConfiguration {
         MinimumEntriesAgeToKeepInMin: dto.isMinimumEntriesAgeToKeepEnabled
             ? moment.duration(dto.minimumEntriesAgeToKeep, "seconds").asMinutes()
             : 0,
-        RefreshFrequencyInSec: dto.isRefreshFrequencyEnabled ? dto.refreshFrequencyInSec : 300,
+        CleanerFrequencyInSec: dto.isCleanerFrequencyInSecEnabled ? dto.cleanerFrequencyInSec : 300,
     };
 }
 
@@ -18,8 +18,8 @@ function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormD
             isRevisionsBinCleanerEnabled: false,
             isMinimumEntriesAgeToKeepEnabled: false,
             minimumEntriesAgeToKeep: null,
-            isRefreshFrequencyEnabled: false,
-            refreshFrequencyInSec: null,
+            isCleanerFrequencyInSecEnabled: false,
+            cleanerFrequencyInSec: null,
         };
     }
 
@@ -29,8 +29,8 @@ function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormD
         minimumEntriesAgeToKeep: dto.MinimumEntriesAgeToKeepInMin
             ? moment.duration(dto.MinimumEntriesAgeToKeepInMin, "minutes").asSeconds() // minimumEntriesAgeToKeep are in minutes, so we need format minutes to seconds
             : null,
-        isRefreshFrequencyEnabled: dto.RefreshFrequencyInSec !== 300,
-        refreshFrequencyInSec: dto.RefreshFrequencyInSec !== 300 ? dto.RefreshFrequencyInSec : null,
+        isCleanerFrequencyInSecEnabled: dto.CleanerFrequencyInSec !== 300,
+        cleanerFrequencyInSec: dto.CleanerFrequencyInSec !== 300 ? dto.CleanerFrequencyInSec : null,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation.ts
@@ -13,13 +13,13 @@ const schema = yup.object({
             is: true,
             then: (schema) => schema.required(),
         }),
-    isRefreshFrequencyEnabled: yup.boolean(),
-    refreshFrequencyInSec: yup
+    isCleanerFrequencyInSecEnabled: yup.boolean(),
+    cleanerFrequencyInSec: yup
         .number()
         .nullable()
         .positive()
         .integer()
-        .when("isRefreshFrequencyEnabled", {
+        .when("isCleanerFrequencyInSecEnabled", {
             is: true,
             then: (schema) => schema.required(),
         }),

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects.tsx
@@ -13,7 +13,7 @@ export default function useRevisionsBinCleanerFormSideEffects(
                 case "isRevisionsBinCleanerEnabled": {
                     if (!values.isRevisionsBinCleanerEnabled) {
                         setValue("isMinimumEntriesAgeToKeepEnabled", false, { shouldValidate: true });
-                        setValue("isRefreshFrequencyEnabled", false, { shouldValidate: true });
+                        setValue("isCleanerFrequencyInSecEnabled", false, { shouldValidate: true });
                     }
                     break;
                 }
@@ -27,9 +27,9 @@ export default function useRevisionsBinCleanerFormSideEffects(
                     }
                     break;
                 }
-                case "isRefreshFrequencyEnabled": {
-                    if (!values.isRefreshFrequencyEnabled) {
-                        setValue("refreshFrequencyInSec", null, { shouldValidate: true });
+                case "isCleanerFrequencyInSecEnabled": {
+                    if (!values.isCleanerFrequencyInSecEnabled) {
+                        setValue("cleanerFrequencyInSec", null, { shouldValidate: true });
                     }
                 }
             }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -969,7 +969,7 @@ return docs[0];`,
         return {
             Disabled: false,
             MinimumEntriesAgeToKeepInMin: 1,
-            RefreshFrequencyInSec: 5 * TimeInSeconds.Minute,
+            CleanerFrequencyInSec: 5 * TimeInSeconds.Minute,
         };
     }
 }

--- a/test/SlowTests/Issues/RavenDB-21326.cs
+++ b/test/SlowTests/Issues/RavenDB-21326.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Issues
             var config = new RevisionsBinConfiguration
             {
                 MinimumEntriesAgeToKeepInMin = 0, 
-                RefreshFrequencyInSec = 1
+                CleanerFrequencyInSec = 1
             };
             await ConfigRevisionsBinCleaner(store, config);
 
@@ -160,7 +160,7 @@ namespace SlowTests.Issues
             var config = new RevisionsBinConfiguration
             {
                 MinimumEntriesAgeToKeepInMin = 15 * 60 * 24, // 15 days
-                RefreshFrequencyInSec = 1
+                CleanerFrequencyInSec = 1
             };
 
             var cleaner = new RevisionsBinCleaner(db, config);
@@ -225,7 +225,7 @@ namespace SlowTests.Issues
             var config = new RevisionsBinConfiguration
             {
                 MinimumEntriesAgeToKeepInMin = 15 * 24 * 60, // 15 days
-                RefreshFrequencyInSec = 1
+                CleanerFrequencyInSec = 1
             };
 
             var cleaner = new RevisionsBinCleaner(db, config);
@@ -447,7 +447,7 @@ namespace SlowTests.Issues
             var config = new RevisionsBinConfiguration
             {
                 MinimumEntriesAgeToKeepInMin = 0, 
-                RefreshFrequencyInSec = 1
+                CleanerFrequencyInSec = 1
             };
             await ConfigRevisionsBinCleaner(store, config);
 
@@ -523,7 +523,7 @@ namespace SlowTests.Issues
             var config = new RevisionsBinConfiguration
             {
                 MinimumEntriesAgeToKeepInMin = 0, 
-                RefreshFrequencyInSec = 1
+                CleanerFrequencyInSec = 1
             };
 
             var firsts = 0;
@@ -661,7 +661,7 @@ namespace SlowTests.Issues
             var config = new RevisionsBinConfiguration
             {
                 MinimumEntriesAgeToKeepInMin = 0, 
-                RefreshFrequencyInSec = 1
+                CleanerFrequencyInSec = 1
             };
 
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23762/Revisions-Bin-Cleaner-Fix-property-name

### Additional description
Update the RevisionsBinConfiguration class:
the property RefreshFrequencyInSec has been renamed to CleanerFrequencyInSec, MinimumEntriesAgeToKeepInMin is no longer nullable, and its default value is now set to 30 days, aligning with the studio configuration.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
