### PR TITLE
RavenDB-23735 - Refactoring of the way we pass durandal props to react components (type safety fix)

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -42,7 +42,7 @@ interface IndexesPageProps {
     isImportOpen?: boolean;
 }
 
-export function IndexesPage(props: ReactProps<any, IndexesPageProps>) {
+export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPageProps>) {
     const db = useAppSelector(databaseSelectors.activeDatabase);
     const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
     const { reportEvent } = useEventsCollector();
@@ -83,7 +83,7 @@ export function IndexesPage(props: ReactProps<any, IndexesPageProps>) {
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,
-    } = useIndexesPage(props?.queryParams?.stale, props?.queryParams?.isImportOpen);
+    } = useIndexesPage(queryParams?.stale, queryParams?.isImportOpen);
 
     const deleteSelectedIndexes = () => {
         reportEvent("indexes", "delete-selected");
@@ -140,7 +140,7 @@ export function IndexesPage(props: ReactProps<any, IndexesPageProps>) {
     const indexesPageListCommonProps: Omit<IndexesPageListProps, "indexes"> = {
         replacements,
         selectedIndexes,
-        indexToHighlight: props?.queryParams?.indexName,
+        indexToHighlight: queryParams?.indexName,
         globalIndexingStatus,
         resetIndexData,
         swapSideBySideData,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
@@ -20,7 +20,7 @@ export interface ConnectionStringsUrlParameters {
     type?: StudioEtlType;
 }
 
-export default function ConnectionStrings(props: ReactProps<any, ConnectionStringsUrlParameters>) {
+export default function ConnectionStrings({ queryParams }: ReactQueryParamsProps<ConnectionStringsUrlParameters>) {
     const { hasNone: hasNoneInLicense } = useConnectionStringsLicense();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
@@ -30,8 +30,8 @@ export default function ConnectionStrings(props: ReactProps<any, ConnectionStrin
     useEffect(() => {
         dispatch(
             connectionStringsActions.urlParametersLoaded({
-                name: props?.queryParams?.name,
-                type: props?.queryParams?.type,
+                name: queryParams?.name,
+                type: queryParams?.type,
             })
         );
         dispatch(connectionStringsActions.fetchData(databaseName));

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
@@ -28,7 +28,7 @@ interface DatabasesPageProps {
     restore?: boolean;
 }
 
-export function DatabasesPage(props: ReactProps<any, DatabasesPageProps>) {
+export function DatabasesPage({ queryParams }: ReactQueryParamsProps<DatabasesPageProps>) {
     const databases = useAppSelector(databaseSelectors.allDatabases);
     const nodeTags = useAppSelector(clusterSelectors.allNodeTags);
     const isOperatorOrAbove = useAppSelector(accessManagerSelectors.isOperatorOrAbove);
@@ -85,13 +85,13 @@ export function DatabasesPage(props: ReactProps<any, DatabasesPageProps>) {
     }, []);
 
     useEffect(() => {
-        if (props?.queryParams?.compact) {
-            const toCompact = databases.find((x) => x.name === props?.queryParams?.compact);
+        if (queryParams?.compact) {
+            const toCompact = databases.find((x) => x.name === queryParams?.compact);
             if (toCompact) {
-                dispatch(compactDatabase(toCompact, props?.queryParams?.shard));
+                dispatch(compactDatabase(toCompact, queryParams?.shard));
             }
         }
-        if (props?.queryParams?.restore) {
+        if (queryParams?.restore) {
             setCreateDatabaseMode("fromBackup");
         }
 
@@ -100,7 +100,7 @@ export function DatabasesPage(props: ReactProps<any, DatabasesPageProps>) {
             trigger: false,
             replace: true,
         });
-    }, [props?.queryParams?.compact, props?.queryParams?.restore, databases, dispatch, props?.queryParams?.shard]);
+    }, [queryParams?.compact, queryParams?.restore, databases, dispatch, queryParams?.shard]);
 
     const selectedDatabases = databases.filter((x) => selectedDatabaseNames.includes(x.name));
 

--- a/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/reactViewModelBase.ts
@@ -25,11 +25,11 @@ abstract class reactViewModelBase extends viewModelBase {
 
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
-        const { params: pathParams, queryParams } = router.activeInstruction()
+        const { params, queryParams } = router.activeInstruction()
 
         const reactDirtyFlag = reactViewModelUtils.getReactDirtyFlag(this.dirtyFlag, this.customDiscardStayResult);
-        const reactProps: ReactProps = {
-          pathParams,
+        const reactProps: ReactQueryParamsProps<typeof queryParams> & ReactPathParamsProps = {
+          pathParams: params.filter(x => typeof x === "string"),
           queryParams: queryParams || {},
         };
 

--- a/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shardedReactViewModelBase.ts
@@ -26,14 +26,15 @@ abstract class shardedReactViewModelBase extends shardViewModelBase {
 
     activate(args: any, parameters?: any) {
         super.activate(args, parameters);
-        const { params: pathParams, queryParams } = router.activeInstruction()
+        const { params, queryParams } = router.activeInstruction()
 
         const reactDirtyFlag = reactViewModelUtils.getReactDirtyFlag(this.dirtyFlag, this.customDiscardStayResult);
-        const reactProps: ReactProps = {
-          pathParams,
+        const reactProps: ReactQueryParamsProps<typeof queryParams> & ReactPathParamsProps & ReactLocationProps = {
+          pathParams: params.filter(x => typeof x === "string"),
           queryParams: queryParams || {},
           location: this.location,
         };
+
         this.reactOptions = this.createReactOptions(this.reactView, reactProps, reactDirtyFlag);
     }
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1002,10 +1002,16 @@ interface ReactDirtyFlag {
     setIsDirty: (isDirty: boolean, customDialog?: () => JQueryPromise<confirmDialogResult>) => void;
 }
 
-interface ReactProps<PathParams = any, QueryParams = Record<string, unknown>> {
-    pathParams?: PathParams;
-    queryParams?: QueryParams;
-    location?: databaseLocationSpecifier
+interface ReactQueryParamsProps<T extends Record<string, any>> {
+    queryParams?: T
+}
+
+interface ReactPathParamsProps {
+    pathParams?: string[]
+}
+
+interface ReactLocationProps {
+    location: databaseLocationSpecifier;
 }
 
 interface ReactInKnockoutOptions<T> {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23735

### Additional description

Changed types to more type safety

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
