### PR TITLE
RavenDB-23772 Fixing NRE when getting number of entries from a table that was supposed to be _forGlobalReadsOnly - all documents. We need to use an index to get the number of entries then.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
@@ -26,7 +26,7 @@ public class CoraxDocumentTrainSourceEnumerator
         if (table == null)
             yield break;
         
-        state.InitializeState(table);
+        state.InitializeState(table, table.NumberOfEntries);
         
         foreach (var (key, result) in table.IterateForDictionaryTraining(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.CollectionEtagsSlice], state.DocumentSkip, seek: state.CurrentKey))
         {
@@ -44,7 +44,10 @@ public class CoraxDocumentTrainSourceEnumerator
     public IEnumerable<Document> GetDocumentsForDictionaryTraining(DocumentsOperationContext context, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
     {
         var table = new Table(_documentsStorage.DocsSchema, context.Transaction.InnerTransaction);
-        state.InitializeState(table);
+
+        var numberOfEntries = table.GetNumberOfEntriesFor(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.AllDocsEtagsSlice]);
+
+        state.InitializeState(table, numberOfEntries);
         foreach (var (key, result) in table.IterateForDictionaryTraining(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.AllDocsEtagsSlice], state.DocumentSkip, state.CurrentKey))
         {
             state.CurrentKey = key;
@@ -75,12 +78,12 @@ public class CoraxDocumentTrainSourceState : PulsedEnumerationState<Document>
         Token = token;
     }
 
-    public void InitializeState(Table documentsTable)
+    public void InitializeState(Table documentsTable, long numberOfEntries)
     {
         if (_initialized)
             return;
         _initialized = true;
-        DocumentSkip = documentsTable.NumberOfEntries < _takeLimit ? 1 : documentsTable.NumberOfEntries / _takeLimit;
+        DocumentSkip = numberOfEntries < _takeLimit ? 1 : numberOfEntries / _takeLimit;
         Take = _takeLimit;
     }
     

--- a/test/SlowTests/Corax/RavenDB_23772.cs
+++ b/test/SlowTests/Corax/RavenDB_23772.cs
@@ -1,0 +1,53 @@
+﻿using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_23772 : RavenTestBase
+{
+    public RavenDB_23772(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void DictionaryTrainingMustNotFailNoAllDocs()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+        var index = new AllDocsMapIndex();
+
+        index.Execute(store);
+
+        Indexes.WaitForIndexing(store, allowErrors: false);
+    }
+
+    private class AllDocsMapIndex : AbstractIndexCreationTask<object>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+        }
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            var index = new IndexDefinition
+            {
+                Name = IndexName,
+
+                Maps =
+                {
+                    @"
+                        from doc in docs
+                        select new 
+                        {
+                            Name = doc.Name
+                        }"
+                }
+            };
+
+            return index;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23772/Corax-NRE-on-dictionary-training-in-alldocs-index

### Additional description

NRE was swallowed so effectively we didn't see any error.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
