### PR TITLE
EmbeddedServer support cancellation

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -71,9 +71,16 @@ namespace Raven.Embedded
             await StartServerInternalAsync().ConfigureAwait(false);
         }
 
-        public void StartServer(ServerOptions? options = null)
+
+        private CancellationToken _shutdownToken;
+        private CancellationTokenRegistration _shutdownRegistration;
+
+        // Solution 1: Pass a shutdown token to start
+        public void StartServer(ServerOptions? options = null, CancellationToken shutdownToken)
         {
             _serverOptions = options ??= ServerOptions.Default;
+            _shutdownToken = shutdownToken;
+            _shutdownRegistration = shutdownToken.Register(()=>{this.Dispose()})
 
             if (options.Security != null)
             {
@@ -102,6 +109,12 @@ namespace Raven.Embedded
 
             var task = StartServerInternalAsync();
             GC.KeepAlive(task); // make sure that we aren't allowing to elide the call
+        }
+
+        // Solution 2: Add a STop method that allow graceful termination AND forceful termination via cancellation
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            // Run code from the Dispose and ensure ShutdownServerProcess is invoked with a cancellation token
         }
 
         private Task StartServerInternalAsync()
@@ -192,7 +205,7 @@ namespace Raven.Embedded
             return (await server.Value.WithCancellation(token).ConfigureAwait(false)).ServerUrl;
         }
 
-        private void ShutdownServerProcess(Process process)
+        private void ShutdownServerProcess(Process process, CancellationToken cancellationToken) // Solution B
         {
             if (process == null || process.HasExited)
                 return;
@@ -211,8 +224,10 @@ namespace Raven.Embedded
                     {
                         inputStream.WriteLine("shutdown no-confirmation");
                     }
+                    using var cts = CancellationTokenSource.CreateLinkedToken(_shutdownToken); // token from solution B
+                    cts.CancelAfter((int)_serverOptions!.GracefulShutdownTimeout.TotalMilliseconds);
 
-                    if (process.WaitForExit((int)_serverOptions!.GracefulShutdownTimeout.TotalMilliseconds))
+                    if (process.WaitForExitAsync(cts.Token).GetAwaiter().GetResult();
                         return;
                 }
                 catch (Exception e)


### PR DESCRIPTION
### Issue link

Support case 3664



### Additional description

Although we can set `GracefulShutdownTimeout` is isn't sufficient.

During a stop sequence when allowing graceful shutdown we don't know how long it will take before Dispose is invoked.


Lets say the OS host allows 30 seconds, Extensions.Hosting ShutdownTimeout is set to 25 seconds, GracefulShutdownTimeout is set to 20.

It could just be that Dispose is invoked 15 seconds after Extensions.Hosting signalled stop. 

This means GracefulShutdownTimeout should have been shorter.

It seems the only solution is that the EmbeddedServer supports cancellation.


> [!NOTE] I'm on Fedora, I can't build the RavenDB repo on my box due to a dependency on MSBUILD. Its a dependency issue I currently didn't want to resolve.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
