### PR TITLE
RavenDB-23704 - Reset the allocation block size to its initial value when doing a reset

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -6,6 +6,7 @@ using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -94,7 +95,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.IsLazyTransaction)] = lowLevelTransaction.IsLazyTransaction,
                 [nameof(TxInfoResult.NumberOfModifiedPages)] = lowLevelTransaction.NumberOfModifiedPages,
                 [nameof(TxInfoResult.Committed)] = lowLevelTransaction.Committed,
-                [nameof(TxInfoResult.TotalEncryptionBufferSize)] = lowLevelTransaction.AdditionalMemoryUsageSize.ToString(),
+                [nameof(TxInfoResult.TotalAllocatedSize)] = new Size(lowLevelTransaction.TotalAllocatedInBytes, SizeUnit.Bytes).ToString(),
+                [nameof(TxInfoResult.DecompressedBufferSize)] = new Size(lowLevelTransaction.DecompressedBufferBytes, SizeUnit.Bytes).ToString(),
+                [nameof(TxInfoResult.TotalEncryptionBufferSize)] = lowLevelTransaction.TotalEncryptionBufferInBytes.ToString(),
             };
         }
     }
@@ -113,6 +116,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public bool IsLazyTransaction;
         public long NumberOfModifiedPages;
         public bool Committed;
+        public string TotalAllocatedSize;
+        public string DecompressedBufferSize;
         public string TotalEncryptionBufferSize;
     }
 }

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -749,7 +749,7 @@ namespace Sparrow.Server
         /// </summary>
         private readonly List<SegmentInformation> _wholeSegments;
         private readonly int _initialAllocationBlockSize;
-        private int _allocationBlockSize;
+        public int AllocationBlockSize { get; private set; }
 
         internal long _totalAllocated, _currentlyAllocated;
 
@@ -780,7 +780,7 @@ namespace Sparrow.Server
 
             _lowMemoryFlag = lowMemoryFlag;
             _initialAllocationBlockSize = allocationBlockSize;
-            _allocationBlockSize = allocationBlockSize;
+            AllocationBlockSize = allocationBlockSize;
 
             _wholeSegments = new List<SegmentInformation>();
             _internalReadyToUseMemorySegments = new List<SegmentInformation>();
@@ -825,7 +825,7 @@ namespace Sparrow.Server
                 stack?.Clear();
             }
             _internalReadyToUseMemorySegments.Clear();// memory here will be released from _wholeSegments
-            _allocationBlockSize = _initialAllocationBlockSize;
+            AllocationBlockSize = _initialAllocationBlockSize;
 
             _externalStringPool.Clear();
             _externalFastPoolCount = 0;
@@ -1040,9 +1040,9 @@ namespace Sparrow.Server
             {
                 if (_externalCurrentLeft == 0)
                 {
-                    var tmp = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, _allocationBlockSize * 2);
+                    var tmp = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, AllocationBlockSize * 2);
                     AllocateExternalSegment(tmp);
-                    _allocationBlockSize = tmp;
+                    AllocationBlockSize = tmp;
                 }
 
                 storagePtr = (ByteStringStorage*)_externalCurrent.Current;
@@ -1074,7 +1074,7 @@ namespace Sparrow.Server
             // This is even bigger than the configured allocation block size. There is no reason why we shouldn't
             // allocate it directly. When released (if released) this will be reused as a segment, ensuring that the context
             // could handle that.
-            if (allocationSize > _allocationBlockSize)
+            if (allocationSize > AllocationBlockSize)
             {
                 var segment = GetFromReadyToUseMemorySegments(allocationUnit);
                 if (segment != null)
@@ -1184,8 +1184,8 @@ namespace Sparrow.Server
             }
             else
             {
-                _allocationBlockSize = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, _allocationBlockSize * 2);
-                var toAllocate = Math.Max(_allocationBlockSize, allocationUnit);
+                AllocationBlockSize = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, AllocationBlockSize * 2);
+                var toAllocate = Math.Max(AllocationBlockSize, allocationUnit);
                 _internalCurrent = AllocateSegment(toAllocate);
                 Debug.Assert(_internalCurrent.SizeLeft >= allocationUnit, $"{_internalCurrent.SizeLeft} >= {allocationUnit}");
             }

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -748,6 +748,7 @@ namespace Sparrow.Server
         /// This list keeps all the segments already instantiated in order to release them after context finalization. 
         /// </summary>
         private readonly List<SegmentInformation> _wholeSegments;
+        private readonly int _initialAllocationBlockSize;
         private int _allocationBlockSize;
 
         internal long _totalAllocated, _currentlyAllocated;
@@ -778,6 +779,7 @@ namespace Sparrow.Server
                 throw new ArgumentException($"It is not a good idea to allocate chunks of less than the {nameof(ByteStringContext.MinBlockSizeInBytes)} value of {ByteStringContext.MinBlockSizeInBytes}");
 
             _lowMemoryFlag = lowMemoryFlag;
+            _initialAllocationBlockSize = allocationBlockSize;
             _allocationBlockSize = allocationBlockSize;
 
             _wholeSegments = new List<SegmentInformation>();
@@ -823,6 +825,7 @@ namespace Sparrow.Server
                 stack?.Clear();
             }
             _internalReadyToUseMemorySegments.Clear();// memory here will be released from _wholeSegments
+            _allocationBlockSize = _initialAllocationBlockSize;
 
             _externalStringPool.Clear();
             _externalFastPoolCount = 0;

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Sparrow.Server;
 using Sparrow.Threading;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -158,6 +159,39 @@ namespace FastTests.Sparrow
                     Assert.Equal(ptrLocation, (long)repeat._pointer);
                     context.Release(ref repeat);
                 }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Memory)]
+        public void CanResetAllocationBlockSize()
+        {
+            using (var context = new ByteStringContext<ByteStringDirectAllocator>(SharedMultipleUseFlag.None))
+            {
+                while (context.AllocationBlockSize == ByteStringContext.DefaultAllocationBlockSizeInBytes)
+                {
+                    context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2, out _);
+                }
+
+                Assert.NotEqual(ByteStringContext.DefaultAllocationBlockSizeInBytes, context.AllocationBlockSize);
+
+                context.Reset();
+
+                Assert.Equal(ByteStringContext.DefaultAllocationBlockSizeInBytes, context.AllocationBlockSize);
+            }
+
+            var blockSizeInBytes = ByteStringContext.MinBlockSizeInBytes * 8;
+            using (var context = new ByteStringContext<ByteStringDirectAllocator>(SharedMultipleUseFlag.None, allocationBlockSize: blockSizeInBytes))
+            {
+                while (context.AllocationBlockSize == blockSizeInBytes)
+                {
+                    context.Allocate(blockSizeInBytes / 2, out _);
+                }
+
+                Assert.NotEqual(ByteStringContext.MinBlockSizeInBytes, context.AllocationBlockSize);
+
+                context.Reset();
+
+                Assert.Equal(blockSizeInBytes, context.AllocationBlockSize);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23704/Unmanaged-memory-growing-up-to-OOM-during-backup

### Additional description

- When resetting the `ByteString`, reset the `AllocationBlockSize` to its initial value. Failure to do so will prevent us from reusing 
the returned memory to the pool because we rely on that value.
- Fix the calculation of `AdditionalMemory` to include the allocated memory in the `Allocator`. This will allow us to clone the read transaction which will defragment the allocator and allow us to reuse the memory.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
