### PR TITLE
RavenDB-23675 - fixes to sizeGetter, moving package to devDependencies, adding classname to sizegetter.

### DIFF
--- a/src/Raven.Studio/package-lock.json
+++ b/src/Raven.Studio/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.0.0",
             "dependencies": {
                 "@hookform/resolvers": "^3.9.0",
-                "@juggle/resize-observer": "^3.4.0",
                 "@reduxjs/toolkit": "^2.2.6",
                 "@tanstack/react-table": "^8.19.3",
                 "@tanstack/react-virtual": "^3.8.3",
@@ -73,6 +72,7 @@
             },
             "devDependencies": {
                 "@hookform/devtools": "^4.3.1",
+                "@juggle/resize-observer": "^3.4.0",
                 "@storybook/addon-a11y": "^8.4.7",
                 "@storybook/addon-actions": "^8.4.7",
                 "@storybook/addon-essentials": "^8.4.7",
@@ -1909,6 +1909,7 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
             "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@mdx-js/react": {

--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -22,6 +22,7 @@
     "private": true,
     "devDependencies": {
         "@hookform/devtools": "^4.3.1",
+        "@juggle/resize-observer": "^3.4.0",
         "@storybook/addon-a11y": "^8.4.7",
         "@storybook/addon-actions": "^8.4.7",
         "@storybook/addon-essentials": "^8.4.7",
@@ -103,7 +104,6 @@
     },
     "dependencies": {
         "@hookform/resolvers": "^3.9.0",
-        "@juggle/resize-observer": "^3.4.0",
         "@reduxjs/toolkit": "^2.2.6",
         "@tanstack/react-table": "^8.19.3",
         "@tanstack/react-virtual": "^3.8.3",

--- a/src/Raven.Studio/typescript/components/common/SizeGetter.tsx
+++ b/src/Raven.Studio/typescript/components/common/SizeGetter.tsx
@@ -4,9 +4,10 @@ import { useResizeObserver } from "hooks/useResizeObserver";
 interface SizeGetterProps {
     render: (size: { width: number; height: number }) => JSX.Element;
     isHeighRequired?: boolean;
+    className?: string;
 }
 
-export default function SizeGetter({ render, isHeighRequired = false }: SizeGetterProps) {
+export default function SizeGetter({ render, isHeighRequired = false, className }: SizeGetterProps) {
     const ref = useRef<HTMLDivElement>();
 
     const { width, height } = useResizeObserver({ ref });
@@ -14,7 +15,7 @@ export default function SizeGetter({ render, isHeighRequired = false }: SizeGett
     const canRender = !!(isHeighRequired ? width && height : width);
 
     return (
-        <div ref={ref} style={{ height: "100%", width: "100%" }}>
+        <div ref={ref} style={{ height: "100%", width: "100%" }} className={className}>
             {canRender && render({ width, height })}
         </div>
     );


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23675

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
