### PR TITLE
RavenDB-23773 - Fix failing test SeekBackwardFrom_VoronOverloads_Random

### DIFF
--- a/test/SlowTests/Issues/RavenDB-23167-Voron.cs
+++ b/test/SlowTests/Issues/RavenDB-23167-Voron.cs
@@ -161,7 +161,9 @@ namespace SlowTests.Issues
                     int mid = entities.Count / 2;
                     entity = entities[mid];
                     AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag, empty: false, expectedEtag: entity.Etag);
-                    var expectedEtag = entities[mid + 1].Etag == entities[mid].Etag + 1 ? entities[mid].Etag + 1 : entities[mid].Etag;
+                    var expectedEtag = entities[mid].Etag;
+                    if(entities[mid + 1].Etag == entities[mid].Etag + 1)
+                        expectedEtag = entities[mid].Etag + 1;
                     AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag + 1, empty: false, expectedEtag: expectedEtag);
 
                     entity = entities.Last();
@@ -176,8 +178,10 @@ namespace SlowTests.Issues
                     mid = users.Count / 2;
                     user = users[mid];
                     AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag, empty: false, expectedEtag: user.Etag);
-                    var userExpectedEtag = users[mid + 1].Etag == users[mid].Etag + 1 ? users[mid].Etag + 1 : users[mid].Etag;
-                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag + 1, empty: false, expectedEtag: userExpectedEtag);
+                    var userExpectedEtag = users[mid].Etag;
+                    if (users[mid + 1].Etag == users[mid].Etag + 1 && users[mid + 1].Id == users[mid].Id)
+                        userExpectedEtag = users[mid].Etag + 1;
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag + 1, empty: false, expectedEtag: userExpectedEtag); //
 
                     user = users.Last();
                     AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag, empty: false, expectedEtag: user.Etag);
@@ -191,7 +195,9 @@ namespace SlowTests.Issues
                     mid = companies.Count / 2;
                     company = companies[mid];
                     AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag, empty: false, expectedEtag: company.Etag);
-                    var companyExpectedEtag = companies[mid + 1].Etag == companies[mid].Etag + 1 ? companies[mid].Etag + 1 : companies[mid].Etag;
+                    var companyExpectedEtag = companies[mid].Etag;
+                    if(companies[mid + 1].Etag == companies[mid].Etag + 1 && companies[mid + 1].Id == companies[mid].Id)
+                        companyExpectedEtag = companies[mid].Etag + 1;
                     AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag + 1, empty: false, expectedEtag: companyExpectedEtag);
 
                     company = companies.Last();
@@ -216,9 +222,15 @@ namespace SlowTests.Issues
             {
                 Assert.NotEmpty(keys);
                 var lastLocalKey = keys[0];
-            
+
                 if (expectedEtag.HasValue)
+                {
+                    if (expectedEtag.Value != lastLocalKey)
+                    {
+
+                    }
                     Assert.Equal(expectedEtag.Value, lastLocalKey);
+                }
                 else
                     Assert.True(endEtag >= lastLocalKey, $"endEtag {endEtag}, lastLocalEtag: {lastLocalKey}");
             }
@@ -247,9 +259,15 @@ namespace SlowTests.Issues
                     var tvr = seekResults[0].Result.Reader;
 
                     var lastLocalEtag = DocumentsStorage.TableValueToEtag((int)TestTable.Etag, ref tvr);
-                    
+
                     if (expectedEtag.HasValue)
+                    {
+                        if (expectedEtag.Value != lastLocalEtag)
+                        {
+
+                        }
                         Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                    }
                     else
                         Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
                     


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23773/SlowTests.Issues.RavenDB23167Voron.SeekBackwardFromVoronOverloadsRandomnumberOfEntities-10-seed-1261567364

### Additional description

Test was failing in line:
`AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag - 1, empty: true);`
because `user.Etag` value was `0`, so `user.Etag - 1` was `-1`, which is considered as `long.MaxValue` (represented the same as bytes - 'fff..fff').
That's why method `AssertSeekBackward` was seeking backward from `long.MaxValue` instead of `-1` and found all entries instead of finding no entries as expected (` empty: true`).
The fix:
`etag = random.NextInt64(numberOfEntities * 10);` => `etag = random.NextInt64(1, numberOfEntities * 10);`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
