### PR TITLE
RavenDB-23778 Improve pop-up msg when removing "Delete Revisions"

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/revisionsBin.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/revisionsBin.ts
@@ -149,26 +149,30 @@ class revisionsBin extends shardViewModelBase {
 
         eventsCollector.default.reportEvent("revisionsBin", "delete-selected");
         
-        this.confirmationMessage("Are you sure?", "Do you want to delete selected items and its revisions?", {
-            buttons: ["Cancel", "Yes, delete"]
-        })
+        this.confirmationMessage("Delete Revisions?",
+            `The selected "Delete Revision" items will be removed,<br/> 
+            and all their associated revisions will be permanently deleted.<br/><br/> 
+            This action cannot be undone.`,
+            {
+                buttons: ["Cancel", "Yes, delete"],
+                html: true
+            })
             .done(result => {
                 if (result.can) {
-
                     this.spinners.delete(true);
 
                     const parameters: Raven.Client.Documents.Operations.Revisions.DeleteRevisionsOperation.Parameters = {
                         DocumentIds: selectedIds,
                         RevisionsChangeVectors: [],
                         RemoveForceCreatedRevisions: true,
-                    }
+                    };
 
                     new deleteRevisionsForDocumentsCommand(this.db?.name, parameters)
                         .execute()
                         .always(() => {
                             this.spinners.delete(false);
                             this.gridController().reset(false);
-                        });
+                    });
                 }
             });
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23778/Improve-pop-up-msg-when-removing-Delete-Revisions

### Additional description
Improve pop-up msg when removing "Delete Revisions"

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
