### PR TITLE
RavenDB-23360 - Replace "reactstrap" with "react-bootstrap" (Button)

### DIFF
--- a/src/Raven.Studio/.eslintrc.js
+++ b/src/Raven.Studio/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     "react/react-in-jsx-scope": "off",
     "local-rules/no-reactstrap-alert": "warn",
     "local-rules/mixed-imports": "error",
+    "local-rules/no-reactstrap-button-color-prop": "error",
     "curly": "warn",
     "react/jsx-curly-brace-presence": [
       'warn',

--- a/src/Raven.Studio/.eslintrc.js
+++ b/src/Raven.Studio/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "local-rules/no-reactstrap-alert": "warn",
     "local-rules/mixed-imports": "error",
     "local-rules/no-reactstrap-button-color-prop": "error",
+    "local-rules/no-reactstrap-button": "error",
     "curly": "warn",
     "react/jsx-curly-brace-presence": [
       'warn',

--- a/src/Raven.Studio/eslint-local-rules.js
+++ b/src/Raven.Studio/eslint-local-rules.js
@@ -52,5 +52,32 @@ module.exports = {
                 },
             }
         }
-    }
+    },
+    "no-reactstrap-button-color-prop": {
+        meta: {
+            type: "problem",
+            fixable: "code",
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement: function(node) {
+                    const nodeName = node.name?.name;
+                    if (nodeName === "Button" || nodeName === "ButtonWithSpinner") {
+                        const colorProp = node?.attributes.find(x => x?.name?.name === "color");
+
+                        if (colorProp) {
+                            context.report({
+                                node: node,
+                                message: "'color' is deprecated since we are migrating to react-bootstrap. Use 'variant' prop.",
+                                fix(fixer) {
+                                    return fixer.replaceText(colorProp.name, "variant");
+                                },
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
 };

--- a/src/Raven.Studio/eslint-local-rules.js
+++ b/src/Raven.Studio/eslint-local-rules.js
@@ -65,17 +65,99 @@ module.exports = {
                     const nodeName = node.name?.name;
                     if (nodeName === "Button" || nodeName === "ButtonWithSpinner") {
                         const colorProp = node?.attributes.find(x => x?.name?.name === "color");
+                        const outlineProp = node?.attributes.find(x => x?.name?.name === "outline");
 
-                        if (colorProp) {
+                        if (colorProp?.value?.type === "Literal") {
+                            const colorValue = colorProp.value?.value;
+                            const replacement = outlineProp && colorValue
+                              ? `variant="outline-${colorValue}"`
+                              : "variant";
+
                             context.report({
                                 node: node,
                                 message: "'color' is deprecated since we are migrating to react-bootstrap. Use 'variant' prop.",
                                 fix(fixer) {
-                                    return fixer.replaceText(colorProp.name, "variant");
+                                    const fixes = [fixer.replaceText(colorProp, replacement)];
+                                    if (outlineProp) {
+                                        fixes.push(fixer.remove(outlineProp));
+                                    }
+                                    return fixes;
                                 },
+                            });
+                        } else if (colorProp) {
+                            context.report({
+                                node,
+                                message: `'color' is deprecated since we are migrating to react-bootstrap. Use 'variant' prop. Fix cannot be used because color value is not Literal.`,
                             });
                         }
                     }
+                },
+            };
+        },
+    },
+    "no-reactstrap-button": {
+        meta: {
+            type: "problem",
+            fixable: "code",
+            schema: [],
+        },
+        create: function (context) {
+            return {
+                ImportDeclaration(node) {
+                    if (node.source.value !== "reactstrap") {
+                        return;
+                    }
+
+                    const buttonSpecifiers = node.specifiers.filter(
+                        (specifier) =>
+                            specifier.type === "ImportSpecifier" &&
+                            specifier.imported.name === "Button"
+                    );
+
+                    if (buttonSpecifiers.length === 0) {
+                        return;
+                    }
+
+                    context.report({
+                        node: node,
+                        message: "Button import from reactstrap is deprecated. Use 'import Button from \"react-bootstrap/Button\"' instead.",
+                        fix(fixer) {
+                            const fixes = [];
+                            const sourceCode = context.getSourceCode();
+
+                            if (node.specifiers.length === buttonSpecifiers.length) {
+                                fixes.push(
+                                    fixer.replaceText(
+                                        node,
+                                        'import Button from "react-bootstrap/Button";'
+                                    )
+                                );
+                            } else {
+                                buttonSpecifiers.forEach((specifier) => {
+                                    let [start, end] = specifier.range;
+
+                                    const tokenBefore = sourceCode.getTokenBefore(specifier);
+                                    if (tokenBefore && tokenBefore.value === ",") {
+                                        start = tokenBefore.range[0];
+                                    } else {
+                                        const tokenAfter = sourceCode.getTokenAfter(specifier);
+                                        if (tokenAfter && tokenAfter.value === ",") {
+                                            end = tokenAfter.range[1];
+                                        }
+                                    }
+                                    fixes.push(fixer.removeRange([start, end]));
+                                });
+
+                                fixes.push(
+                                    fixer.insertTextBefore(
+                                        node,
+                                        'import Button from "react-bootstrap/Button";\n'
+                                    )
+                                );
+                            }
+                            return fixes;
+                        },
+                    });
                 },
             };
         },

--- a/src/Raven.Studio/package-lock.json
+++ b/src/Raven.Studio/package-lock.json
@@ -55,6 +55,7 @@
                 "react": "^18.3.1",
                 "react-ace": "^12.0.0",
                 "react-async-hook": "^4.0.0",
+                "react-bootstrap": "^2.10.9",
                 "react-datepicker": "^4.25.0",
                 "react-dnd": "^16.0.1",
                 "react-dnd-html5-backend": "^16.0.1",
@@ -2349,6 +2350,21 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
+        "node_modules/@react-aria/ssr": {
+            "version": "3.9.7",
+            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
+            "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "engines": {
+                "node": ">= 12"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+            }
+        },
         "node_modules/@react-dnd/asap": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
@@ -2385,6 +2401,60 @@
                 "react-redux": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@restart/hooks": {
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+            "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@restart/ui": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+            "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@popperjs/core": "^2.11.8",
+                "@react-aria/ssr": "^3.5.0",
+                "@restart/hooks": "^0.5.0",
+                "@types/warning": "^3.0.3",
+                "dequal": "^2.0.3",
+                "dom-helpers": "^5.2.0",
+                "uncontrollable": "^8.0.4",
+                "warning": "^4.0.3"
+            },
+            "peerDependencies": {
+                "react": ">=16.14.0",
+                "react-dom": ">=16.14.0"
+            }
+        },
+        "node_modules/@restart/ui/node_modules/@restart/hooks": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+            "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@restart/ui/node_modules/uncontrollable": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+            "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.14.0"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -3607,6 +3677,15 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
         "node_modules/@swc/types": {
             "version": "0.1.17",
             "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
@@ -4305,6 +4384,12 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
             "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
             "dev": true
+        },
+        "node_modules/@types/warning": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+            "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+            "license": "MIT"
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
@@ -10072,6 +10157,15 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "node_modules/ip-address": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -14162,6 +14256,19 @@
                 "react-is": "^16.13.1"
             }
         },
+        "node_modules/prop-types-extra": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+            "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+            "license": "MIT",
+            "dependencies": {
+                "react-is": "^16.3.2",
+                "warning": "^4.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=0.14.0"
+            }
+        },
         "node_modules/property-expr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
@@ -14433,6 +14540,37 @@
                 "react": ">=16.8"
             }
         },
+        "node_modules/react-bootstrap": {
+            "version": "2.10.9",
+            "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.9.tgz",
+            "integrity": "sha512-TJUCuHcxdgYpOqeWmRApM/Dy0+hVsxNRFvq2aRFQuxhNi/+ivOxC5OdWIeHS3agxvzJ4Ev4nDw2ZdBl9ymd/JQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.24.7",
+                "@restart/hooks": "^0.4.9",
+                "@restart/ui": "^1.9.4",
+                "@types/prop-types": "^15.7.12",
+                "@types/react-transition-group": "^4.4.6",
+                "classnames": "^2.3.2",
+                "dom-helpers": "^5.2.1",
+                "invariant": "^2.2.4",
+                "prop-types": "^15.8.1",
+                "prop-types-extra": "^1.1.0",
+                "react-transition-group": "^4.4.5",
+                "uncontrollable": "^7.2.1",
+                "warning": "^4.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.14.8",
+                "react": ">=16.14.0",
+                "react-dom": ">=16.14.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-datepicker": {
             "version": "4.25.0",
             "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.25.0.tgz",
@@ -14568,6 +14706,12 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-lifecycles-compat": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+            "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+            "license": "MIT"
         },
         "node_modules/react-onclickoutside": {
             "version": "6.13.1",
@@ -16719,8 +16863,7 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "node_modules/ttf2eot": {
             "version": "3.1.0",
@@ -16911,6 +17054,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/uncontrollable": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+            "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.6.3",
+                "@types/react": ">=16.9.11",
+                "invariant": "^2.2.4",
+                "react-lifecycles-compat": "^3.0.4"
+            },
+            "peerDependencies": {
+                "react": ">=15.0.0"
             }
         },
         "node_modules/underscore": {

--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -149,6 +149,7 @@
         "react": "^18.3.1",
         "react-ace": "^12.0.0",
         "react-async-hook": "^4.0.0",
+        "react-bootstrap": "^2.10.9",
         "react-datepicker": "^4.25.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",

--- a/src/Raven.Studio/typescript/components/common/AboutView.tsx
+++ b/src/Raven.Studio/typescript/components/common/AboutView.tsx
@@ -5,11 +5,11 @@ import {
     AccordionHeader,
     AccordionItem,
     Badge,
-    Button,
     PopoverBody,
     UncontrolledAccordion,
     UncontrolledPopover,
 } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import classNames from "classnames";
 import { Icon } from "./Icon";
 import IconName from "typings/server/icons";
@@ -54,7 +54,7 @@ const AboutViewFloating = (props: AboutViewProps) => {
 
     return (
         <div className={classNames(className)}>
-            <Button id={aboutViewId} color="secondary" className="hub-btn" type="button">
+            <Button id={aboutViewId} variant="secondary" className="hub-btn" type="button">
                 Info Hub
             </Button>
 

--- a/src/Raven.Studio/typescript/components/common/ButtonGroupWithLabel.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/ButtonGroupWithLabel.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta } from "@storybook/react";
 import React from "react";
 import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
-import { Button } from "reactstrap";
 import { ButtonGroupWithLabel } from "./ButtonGroupWithLabel";
 import { Icon } from "./Icon";
+import Button from "react-bootstrap/Button";
 
 export default {
     title: "Bits/Buttons",
@@ -15,11 +15,11 @@ export function GroupWithLabel() {
     return (
         <>
             <ButtonGroupWithLabel label="Button group with label">
-                <Button color="danger">
+                <Button variant="danger">
                     <Icon icon="trash" />
                     <span>Delete</span>
                 </Button>
-                <Button>
+                <Button variant="secondary">
                     <Icon icon="lock" />
                     <span>Set delete lock mode</span>
                 </Button>

--- a/src/Raven.Studio/typescript/components/common/ButtonVariants.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/ButtonVariants.stories.tsx
@@ -1,8 +1,8 @@
 ﻿import { Meta } from "@storybook/react";
 import React from "react";
 import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
-import { Button } from "reactstrap";
 import ButtonWithSpinner from "./ButtonWithSpinner";
+import Button from "react-bootstrap/Button";
 
 export default {
     title: "Bits/Buttons",
@@ -99,7 +99,7 @@ function AllButtonColors(props: AllButtonColorsProps) {
     return (
         <div className="hstack gap-1">
             {colors.map((color) => (
-                <Button color={color} size={size} outline={outline} active={active} disabled={disabled}>
+                <Button variant={outline ? `outline-${color}` : color} size={size} active={active} disabled={disabled}>
                     {color}
                 </Button>
             ))}
@@ -111,7 +111,7 @@ function AllButtonWithSpinnerColors({ size }: AllButtonColorsProps) {
     return (
         <div className="hstack gap-1">
             {colors.map((color) => (
-                <ButtonWithSpinner color={color} size={size} isSpinning>
+                <ButtonWithSpinner variant={color} size={size} isSpinning>
                     {color}
                 </ButtonWithSpinner>
             ))}

--- a/src/Raven.Studio/typescript/components/common/ButtonWithSpinner.tsx
+++ b/src/Raven.Studio/typescript/components/common/ButtonWithSpinner.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { Button, ButtonProps, Spinner } from "reactstrap";
+import { Spinner } from "reactstrap";
 import { Icon, IconProps } from "components/common/Icon";
 import IconName from "typings/server/icons";
 import classNames from "classnames";
+import Button from "react-bootstrap/Button";
 
-interface ButtonWithSpinnerProps extends ButtonProps {
+interface ButtonWithSpinnerProps extends Button.BtnProps {
     isSpinning: boolean;
     icon?: IconName | IconProps;
     iconMargin?: string;

--- a/src/Raven.Studio/typescript/components/common/Buttons.scss
+++ b/src/Raven.Studio/typescript/components/common/Buttons.scss
@@ -6,6 +6,14 @@
     @include button-outline-variant($secondary-outline); //fix outline button contrast
 }
 
+.btn-outline-node {
+    @include button-outline-variant($node-color);
+}
+
+.btn-outline-shard {
+    @include button-outline-variant($shard-color);
+}
+
 .rounded-group {
     & > .btn {
         border-radius: $border-radius-lg;

--- a/src/Raven.Studio/typescript/components/common/Code.tsx
+++ b/src/Raven.Studio/typescript/components/common/Code.tsx
@@ -4,7 +4,7 @@ import "./Code.scss";
 import { Icon } from "components/common/Icon";
 import classNames from "classnames";
 import copyToClipboard from "common/copyToClipboard";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 require("prismjs/components/prism-javascript");
 require("prismjs/components/prism-csharp");
@@ -25,8 +25,6 @@ type Language =
     | "clike"
     | "javascript"
     | "csharp"
-    | "json"
-    | "csharp"
     | "json";
 
 interface CodeProps {
@@ -43,6 +41,7 @@ export default function Code({ code, language, className, elementToCopy }: CodeP
         <div className={classNames("code d-flex flex-grow-1 position-relative", className)}>
             {elementToCopy && (
                 <Button
+                    variant="secondary"
                     className="rounded-pill position-absolute end-gutter-xs top-gutter-xs"
                     size="xs"
                     title="Copy to clipboard"

--- a/src/Raven.Studio/typescript/components/common/ConfirmDialog.tsx
+++ b/src/Raven.Studio/typescript/components/common/ConfirmDialog.tsx
@@ -1,8 +1,9 @@
 import { TextColor } from "components/models/common";
-import React, { ReactNode, createContext, useContext, useState, PropsWithChildren, useRef } from "react";
-import { Modal, ModalBody, Button, ModalFooter } from "reactstrap";
+import React, { createContext, PropsWithChildren, ReactNode, useContext, useRef, useState } from "react";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
 import IconName from "typings/server/icons";
 import { Icon } from "./Icon";
+import Button from "react-bootstrap/Button";
 
 interface ConfirmOptions {
     title: ReactNode;
@@ -58,16 +59,16 @@ export function ConfirmDialogProvider({ children }: PropsWithChildren) {
                             </div>
                         )}
                         <div className="position-absolute m-2 end-0 top-0">
-                            <Button close onClick={onCancel} />
+                            <CloseButton onClick={onCancel} />
                         </div>
                         <div className="text-center lead">{title}</div>
                         {message}
                     </ModalBody>
                     <ModalFooter>
-                        <Button color="link" onClick={onCancel} className="link-muted">
+                        <Button variant="link" onClick={onCancel} className="link-muted">
                             Cancel
                         </Button>
-                        <Button color={actionColor} onClick={onConfirm} className="rounded-pill">
+                        <Button variant={actionColor} onClick={onConfirm} className="rounded-pill">
                             {confirmIcon && <Icon icon={confirmIcon} />}
                             {confirmText}
                         </Button>

--- a/src/Raven.Studio/typescript/components/common/DropdownPanel.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/DropdownPanel.stories.tsx
@@ -2,7 +2,7 @@
 import { Meta } from "@storybook/react";
 import { DropdownPanel, UncontrolledButtonWithDropdownPanel } from "./DropdownPanel";
 import React, { useCallback, useState } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 export default {
     title: "Bits/Dropdown Panel",
@@ -23,11 +23,15 @@ export function UncontrolledDropdown() {
 
             <UncontrolledButtonWithDropdownPanel buttonText="I'm dropdown">
                 <div>
-                    <Button onClick={enabledClick}>Enabled button</Button>
-                    <Button onClick={enabledClick} disabled>
+                    <Button variant="secondary" onClick={enabledClick}>
+                        Enabled button
+                    </Button>
+                    <Button variant="secondary" onClick={enabledClick} disabled>
                         Disabled button
                     </Button>
-                    <Button className={DropdownPanel.closerClass}>I can close this dropdown</Button>
+                    <Button variant="secondary" className={DropdownPanel.closerClass}>
+                        I can close this dropdown
+                    </Button>
                 </div>
             </UncontrolledButtonWithDropdownPanel>
 

--- a/src/Raven.Studio/typescript/components/common/DropdownPanel.tsx
+++ b/src/Raven.Studio/typescript/components/common/DropdownPanel.tsx
@@ -2,7 +2,7 @@
 import classNames from "classnames";
 import React from "react";
 import { usePopper } from "react-popper";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import useBoolean from "hooks/useBoolean";
 
 interface DropdownPanelProps {
@@ -84,7 +84,12 @@ export function UncontrolledButtonWithDropdownPanel(props: UncontrolledButtonWit
 
     return (
         <React.Fragment>
-            <Button innerRef={setReferenceElement} onClick={togglePopper} className={classNames("dropdown-toggle")}>
+            <Button
+                ref={setReferenceElement}
+                variant="secondary"
+                onClick={togglePopper}
+                className={classNames("dropdown-toggle")}
+            >
                 {buttonText}
             </Button>
 

--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
@@ -3,7 +3,8 @@ import { useRavenLink } from "components/hooks/useRavenLink";
 import { useAppSelector } from "components/store";
 import { uniqueId } from "lodash";
 import { ReactNode } from "react";
-import { Button, Table, UncontrolledPopover, UncontrolledTooltip } from "reactstrap";
+import { Table, UncontrolledPopover, UncontrolledTooltip } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import IconName from "typings/server/icons";
 import { licenseSelectors } from "./shell/licenseSlice";
 import { Icon } from "./Icon";
@@ -112,7 +113,7 @@ export function FeatureAvailabilitySummary(props: FeatureAvailabilitySummaryProp
                                                         </div>
 
                                                         <Button
-                                                            color="link"
+                                                            variant="link"
                                                             size="sm"
                                                             href="https://ravendb.net/l/FLDLO4#developer"
                                                             target="_blank"

--- a/src/Raven.Studio/typescript/components/common/FileDropzone.tsx
+++ b/src/Raven.Studio/typescript/components/common/FileDropzone.tsx
@@ -2,9 +2,9 @@ import "./FileDropzone.scss";
 import classNames from "classnames";
 import { Icon } from "components/common/Icon";
 import React, { useState, useRef, DragEvent, ChangeEvent } from "react";
-import { Button } from "reactstrap";
 import useBoolean from "components/hooks/useBoolean";
 import genUtils from "common/generalUtils";
+import Button from "react-bootstrap/Button";
 
 interface FileDropzoneProps {
     onChange: (files: File[]) => void;
@@ -100,7 +100,7 @@ function DropzoneBody({ files, error }: DropzoneBodyProps) {
                 <Icon icon="warning" color="danger" className="fs-2" margin="m-0" />
                 <div>
                     <p className="m-0 text-danger">{error}</p>
-                    <Button color="link">Try again</Button>
+                    <Button variant="link">Try again</Button>
                 </div>
             </div>
         );
@@ -136,7 +136,7 @@ function DropzoneBody({ files, error }: DropzoneBodyProps) {
                     )}
                 </div>
 
-                <Button color="link">Change file</Button>
+                <Button variant="link">Change file</Button>
             </div>
         </div>
     );

--- a/src/Raven.Studio/typescript/components/common/Form.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.stories.tsx
@@ -18,7 +18,9 @@ import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
 import { useForm } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { Button, Input, InputGroup, InputGroupText, Label } from "reactstrap";
+import { Input, InputGroup, InputGroupText, Label } from "reactstrap";
+import Button from "react-bootstrap/Button";
+import { Icon } from "components/common/Icon";
 
 export default {
     title: "Bits/Form",
@@ -155,7 +157,8 @@ export function Form({ isDefaultValid }: { isDefaultValid: boolean }) {
 
             <div className="input-group">
                 <FormInput type="text" control={control} name="inputText" />
-                <Button color="secondary" icon="rocket" title="Test connection">
+                <Button variant="secondary" title="Test connection">
+                    <Icon icon="rocket" />
                     Test connection
                 </Button>
             </div>

--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -2,7 +2,8 @@ import React, { ComponentProps, ReactNode, useRef, useState } from "react";
 import genUtils from "common/generalUtils";
 import { Checkbox, CheckboxProps, Radio, Switch } from "components/common/Checkbox";
 import { Control, ControllerProps, FieldPath, FieldValues, useController } from "react-hook-form";
-import { Button, Input, InputGroup, InputGroupText, InputProps } from "reactstrap";
+import { Input, InputGroup, InputGroupText, InputProps } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { InputType } from "reactstrap/types/lib/Input";
 import { RadioToggleWithIcon } from "./toggles/RadioToggle";
 import AceEditor, { AceEditorProps } from "./AceEditor";
@@ -470,7 +471,7 @@ function FormInputGeneral<
                         {addon && <InputGroupText>{addon}</InputGroupText>}
                         {passwordPreview && (
                             <Button
-                                color="link-muted"
+                                variant="link-muted"
                                 onClick={() => setShowPassword(!showPassword)}
                                 className={classNames("input-btn", invalid && "me-3")}
                             >

--- a/src/Raven.Studio/typescript/components/common/FormCollectionsSelect.tsx
+++ b/src/Raven.Studio/typescript/components/common/FormCollectionsSelect.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps } from "react";
-import { Collapse, Row, Col, Button } from "reactstrap";
+import { Collapse, Row, Col } from "reactstrap";
 import { EmptySet } from "./EmptySet";
+import Button from "react-bootstrap/Button";
 import { FlexGrow } from "./FlexGrow";
 import { FormRadioToggleWithIcon, FormSelect, FormSelectCreatable } from "./Form";
 import { RadioToggleWithIconInputItem } from "./toggles/RadioToggle";
@@ -97,7 +98,7 @@ export default function FormCollectionsSelect<TFieldValues extends FieldValues, 
                             )}
                         </Col>
                         <Col sm="auto" className="d-flex">
-                            <Button color="info" onClick={addAllCollections} disabled={isAddAllCollectionsDisabled}>
+                            <Button variant="info" onClick={addAllCollections} disabled={isAddAllCollectionsDisabled}>
                                 <Icon icon="documents" addon="plus" /> Add all
                             </Button>
                         </Col>
@@ -107,7 +108,7 @@ export default function FormCollectionsSelect<TFieldValues extends FieldValues, 
                     <h4 className="m-0">Selected collections</h4>
                     <FlexGrow />
                     {collections.length > 0 && !isReadOnly && (
-                        <Button color="link" size="xs" onClick={removeAllCollections} className="p-0">
+                        <Button variant="link" size="xs" onClick={removeAllCollections} className="p-0">
                             Remove all
                         </Button>
                     )}
@@ -119,7 +120,7 @@ export default function FormCollectionsSelect<TFieldValues extends FieldValues, 
                                 <div className="flex-grow-1">{name}</div>
                                 {!isReadOnly && (
                                     <Button
-                                        color="link"
+                                        variant="link"
                                         size="xs"
                                         onClick={() => removeCollection(name)}
                                         className="p-0"

--- a/src/Raven.Studio/typescript/components/common/FormEncryption.tsx
+++ b/src/Raven.Studio/typescript/components/common/FormEncryption.tsx
@@ -2,7 +2,8 @@ import { FormCheckbox, FormInput } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import React, { useEffect, useRef, useState, ElementRef, PropsWithChildren } from "react";
 import { FieldPath, FieldValues, Control } from "react-hook-form";
-import { Row, Col, InputGroup, Button, UncontrolledPopover, PopoverBody } from "reactstrap";
+import { Row, Col, InputGroup, UncontrolledPopover, PopoverBody } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { useServices } from "components/hooks/useServices";
 import { useAsync, useAsyncCallback } from "react-async-hook";
 import { QRCode } from "qrcodejs";
@@ -111,6 +112,7 @@ export default function FormEncryption<TFieldValues extends FieldValues, TName e
                             {!isReadOnly && (
                                 <Button
                                     type="button"
+                                    variant="secondary"
                                     title="Regenerate key"
                                     onClick={() => asyncGenerateSecret.execute(true)}
                                 >
@@ -120,6 +122,7 @@ export default function FormEncryption<TFieldValues extends FieldValues, TName e
                         </InputGroup>
                         <ActionButton isEncryptionKeyValid={isEncryptionKeyValid}>
                             <Button
+                                variant="secondary"
                                 type="button"
                                 title="Copy to clipboard"
                                 onClick={() =>
@@ -138,8 +141,7 @@ export default function FormEncryption<TFieldValues extends FieldValues, TName e
                             <ActionButton isEncryptionKeyValid={isEncryptionKeyValid}>
                                 <Button
                                     type="button"
-                                    block
-                                    color="primary"
+                                    variant="primary"
                                     size="sm"
                                     onClick={() => fileDownloader.downloadAsTxt(keyText, fileName)}
                                     disabled={!isEncryptionKeyValid}
@@ -153,7 +155,7 @@ export default function FormEncryption<TFieldValues extends FieldValues, TName e
                             <ActionButton isEncryptionKeyValid={isEncryptionKeyValid}>
                                 <Button
                                     type="button"
-                                    block
+                                    variant="secondary"
                                     size="sm"
                                     onClick={() =>
                                         printEncryptionKey(keyText, fileName, qrContainerRef.current.innerHTML)

--- a/src/Raven.Studio/typescript/components/common/LazyLoad.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/LazyLoad.stories.tsx
@@ -13,7 +13,8 @@ import {
 import React from "react";
 
 import useBoolean from "hooks/useBoolean";
-import { Button, Collapse } from "reactstrap";
+import { Collapse } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import {
     DistributionItem,
     DistributionLegend,
@@ -40,8 +41,8 @@ const TemplatePanel = (args: { loadingActive: boolean }) => {
                     <RichPanelName>This is header</RichPanelName>
                 </RichPanelInfo>
                 <RichPanelActions>
-                    <Button>Actions are placed here</Button>
-                    <Button color="shard" onClick={toggleOpen} outline={!open}>
+                    <Button variant="secondary">Actions are placed here</Button>
+                    <Button variant={!open ? "outline-shard" : "shard"} onClick={toggleOpen}>
                         <Icon icon="sharding" margin="m-0" />
                     </Button>
                 </RichPanelActions>

--- a/src/Raven.Studio/typescript/components/common/LoadError.tsx
+++ b/src/Raven.Studio/typescript/components/common/LoadError.tsx
@@ -1,5 +1,5 @@
-﻿import { Button } from "reactstrap";
-import React from "react";
+﻿import React from "react";
+import Button from "react-bootstrap/Button";
 import { FlexGrow } from "components/common/FlexGrow";
 import { Icon } from "./Icon";
 import RichAlert from "components/common/RichAlert";
@@ -22,7 +22,7 @@ export function LoadError(props: LoadErrorProps) {
 
                 <FlexGrow />
                 {refresh && (
-                    <Button onClick={refresh}>
+                    <Button variant="secondary" onClick={refresh}>
                         <Icon icon="refresh" /> Refresh
                     </Button>
                 )}

--- a/src/Raven.Studio/typescript/components/common/RichAlert.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/RichAlert.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import RichAlert from "components/common/RichAlert";
-import { Button } from "reactstrap";
 import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import Button from "react-bootstrap/Button";
 
 export default {
     title: "Bits/Rich Alert",

--- a/src/Raven.Studio/typescript/components/common/RichPanel.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/RichPanel.stories.tsx
@@ -14,7 +14,8 @@ import {
 import React from "react";
 import { Checkbox } from "./Checkbox";
 import useBoolean from "hooks/useBoolean";
-import { Button, Collapse } from "reactstrap";
+import { Collapse } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import {
     DistributionItem,
     DistributionLegend,
@@ -46,8 +47,8 @@ const Template = (args: { withCheckbox: boolean }) => {
                     <RichPanelName>This is header</RichPanelName>
                 </RichPanelInfo>
                 <RichPanelActions>
-                    <Button>Actions are placed here</Button>
-                    <Button color="shard" onClick={toggleOpen} outline={!open}>
+                    <Button variant="secondary">Actions are placed here</Button>
+                    <Button variant={!open ? "outline-shard" : "shard"} onClick={toggleOpen}>
                         <Icon icon="sharding" margin="m-0" />
                     </Button>
                 </RichPanelActions>

--- a/src/Raven.Studio/typescript/components/common/RunScriptButton.tsx
+++ b/src/Raven.Studio/typescript/components/common/RunScriptButton.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Button, ButtonProps, Spinner } from "reactstrap";
+import { Spinner } from "reactstrap";
 import { Icon } from "./Icon";
+import Button from "react-bootstrap/Button";
 
-interface RunScriptButtonProps extends ButtonProps {
+interface RunScriptButtonProps extends Button.BtnProps {
     isSpinning?: boolean;
 }
 
@@ -11,7 +12,13 @@ export default function RunScriptButton(props: RunScriptButtonProps) {
 
     return (
         <div className="run-script-button">
-            <Button color="primary" size="lg" className="px-4 py-2" onClick={onClick} disabled={disabled || isSpinning}>
+            <Button
+                variant="primary"
+                size="lg"
+                className="px-4 py-2"
+                onClick={onClick}
+                disabled={disabled || isSpinning}
+            >
                 {isSpinning ? <Spinner /> : <Icon icon="play" className="fs-1 d-inline-block" margin="mb-2" />}
                 <div className="kbd">
                     <kbd>ctrl</kbd> <strong>+</strong> <kbd>enter</kbd>

--- a/src/Raven.Studio/typescript/components/common/customAnalyzers/DeleteCustomAnalyzerConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/common/customAnalyzers/DeleteCustomAnalyzerConfirm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Modal, ModalBody, Button, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "../Icon";
 import IconName from "typings/server/icons";
 
@@ -27,7 +28,7 @@ export default function DeleteCustomAnalyzerConfirm(props: DeleteCustomAnalyzerC
                     <Icon icon={iconName} color="danger" className="fs-1" margin="m-0" />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 <div className="text-center lead">
                     You&apos;re about to <span className="text-danger">delete</span> following{" "}
@@ -39,10 +40,10 @@ export default function DeleteCustomAnalyzerConfirm(props: DeleteCustomAnalyzerC
                 </span>
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button variant="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color="danger" onClick={onSubmit} className="rounded-pill">
+                <Button variant="danger" onClick={onSubmit} className="rounded-pill">
                     <Icon icon="trash" />
                     Delete
                 </Button>

--- a/src/Raven.Studio/typescript/components/common/customSorters/DeleteCustomSorterConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/common/customSorters/DeleteCustomSorterConfirm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Modal, ModalBody, Button, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "../Icon";
 import IconName from "typings/server/icons";
 
@@ -27,7 +28,7 @@ export default function DeleteCustomSorterConfirm(props: DeleteCustomSorterConfi
                     <Icon icon={iconName} color="danger" className="fs-1" margin="m-0" />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 <div className="text-center lead">
                     You&apos;re about to <span className="text-danger">delete</span> following{" "}
@@ -39,10 +40,10 @@ export default function DeleteCustomSorterConfirm(props: DeleteCustomSorterConfi
                 </span>
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button variant="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color="danger" onClick={onSubmit} className="rounded-pill">
+                <Button variant="danger" onClick={onSubmit} className="rounded-pill">
                     <Icon icon="trash" />
                     Delete
                 </Button>

--- a/src/Raven.Studio/typescript/components/common/formDestinations/AmazonGlacier.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/AmazonGlacier.tsx
@@ -131,7 +131,7 @@ export default function AmazonGlacier() {
                                 <FlexGrow />
                                 <ButtonWithSpinner
                                     type="button"
-                                    color="secondary"
+                                    variant="secondary"
                                     onClick={asyncTest.execute}
                                     isSpinning={asyncTest.loading}
                                     icon="rocket"

--- a/src/Raven.Studio/typescript/components/common/formDestinations/AmazonS3.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/AmazonS3.tsx
@@ -204,7 +204,7 @@ export default function AmazonS3() {
                                     <FlexGrow />
                                     <ButtonWithSpinner
                                         type="button"
-                                        color="secondary"
+                                        variant="secondary"
                                         onClick={asyncTest.execute}
                                         isSpinning={asyncTest.loading}
                                         icon="rocket"

--- a/src/Raven.Studio/typescript/components/common/formDestinations/Azure.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/Azure.tsx
@@ -121,7 +121,7 @@ export default function Azure() {
                                 <FlexGrow />
                                 <ButtonWithSpinner
                                     type="button"
-                                    color="secondary"
+                                    variant="secondary"
                                     onClick={asyncTest.execute}
                                     isSpinning={asyncTest.loading}
                                     icon="rocket"

--- a/src/Raven.Studio/typescript/components/common/formDestinations/Ftp.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/Ftp.tsx
@@ -157,7 +157,7 @@ export default function Ftp() {
                                 <FlexGrow />
                                 <ButtonWithSpinner
                                     type="button"
-                                    color="secondary"
+                                    variant="secondary"
                                     onClick={asyncTest.execute}
                                     isSpinning={asyncTest.loading}
                                     icon="rocket"

--- a/src/Raven.Studio/typescript/components/common/formDestinations/GoogleCloud.tsx
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/GoogleCloud.tsx
@@ -1,5 +1,6 @@
 ﻿import React from "react";
-import { Badge, Button, Card, CardBody, Collapse, Label, PopoverBody, UncontrolledPopover } from "reactstrap";
+import { Badge, Card, CardBody, Collapse, Label, PopoverBody, UncontrolledPopover } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { FormInput, FormSwitch } from "components/common/Form";
 import { useFormContext, useWatch } from "react-hook-form";
 import OverrideConfiguration from "./OverrideConfiguration";
@@ -123,7 +124,7 @@ export default function GoogleCloud({ isForNewConnection }: GoogleCloudProps) {
                             </div>
                             <Button
                                 type="button"
-                                color="secondary"
+                                variant="secondary"
                                 className="w-fit-content mb-2"
                                 onClick={toggleCredentialsJsonVisible}
                             >
@@ -144,7 +145,7 @@ export default function GoogleCloud({ isForNewConnection }: GoogleCloudProps) {
                                 <FlexGrow />
                                 <ButtonWithSpinner
                                     type="button"
-                                    color="secondary"
+                                    variant="secondary"
                                     onClick={asyncTest.execute}
                                     isSpinning={asyncTest.loading}
                                     icon="rocket"

--- a/src/Raven.Studio/typescript/components/common/pathSelector/PathSelector.tsx
+++ b/src/Raven.Studio/typescript/components/common/pathSelector/PathSelector.tsx
@@ -7,7 +7,8 @@ import useBoolean from "components/hooks/useBoolean";
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
 import React, { useEffect, useImperativeHandle, useState } from "react";
 import { AsyncStateStatus } from "react-async-hook";
-import { Button, Modal, ModalBody, FormGroup, Label, Input, ModalFooter, CloseButton } from "reactstrap";
+import { Modal, ModalBody, FormGroup, Label, Input, ModalFooter, CloseButton } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 export interface PathSelectorStateRef {
     toggle: () => void;
@@ -70,7 +71,7 @@ export default function PathSelector<ParamsType extends unknown[] = unknown[]>(p
     return (
         <>
             <Button
-                color="link"
+                variant="link"
                 onClick={toggleIsModalOpen}
                 disabled={disabled}
                 title={selectorTitle || "Select path"}
@@ -90,7 +91,11 @@ export default function PathSelector<ParamsType extends unknown[] = unknown[]>(p
 
                         <div className="hstack">
                             <strong className="flex-grow">
-                                <Button className="btn-link text-info p-0 border-0" onClick={() => setPathInput("")}>
+                                <Button
+                                    variant="secondary"
+                                    className="btn-link text-info p-0 border-0"
+                                    onClick={() => setPathInput("")}
+                                >
                                     Computer
                                 </Button>
                                 <span className="mx-1">&gt;</span>
@@ -98,6 +103,7 @@ export default function PathSelector<ParamsType extends unknown[] = unknown[]>(p
                                     .filter((x) => x)
                                     .map((part) => (
                                         <Button
+                                            variant="secondary"
                                             key={part}
                                             className="btn-link text-info p-0 border-0"
                                             onClick={() => setPathToDir(part)}
@@ -109,8 +115,8 @@ export default function PathSelector<ParamsType extends unknown[] = unknown[]>(p
                             </strong>
                             {canGoBack && (
                                 <Button
+                                    variant="link"
                                     className="btn-link"
-                                    color="link"
                                     onClick={() => setPathInput(parentDir)}
                                     title="Go back"
                                 >
@@ -144,10 +150,10 @@ export default function PathSelector<ParamsType extends unknown[] = unknown[]>(p
                         </FormGroup>
                     </ModalBody>
                     <ModalFooter className="hstack gap-2 justify-content-end">
-                        <Button color="secondary" onClick={toggleIsModalOpen}>
+                        <Button variant="secondary" onClick={toggleIsModalOpen}>
                             Cancel
                         </Button>
-                        <Button color="primary" onClick={handleSelectWithClose} disabled={disabled}>
+                        <Button variant="primary" onClick={handleSelectWithClose} disabled={disabled}>
                             Select
                         </Button>
                     </ModalFooter>
@@ -189,7 +195,7 @@ function PathList({ fetchStatus, paths, pathInput, setPathInput }: PathSelectorL
     };
 
     return paths.map((path) => (
-        <Button key={path} className="btn-link hstack gap-2" onClick={() => handleItemClick(path)}>
+        <Button key={path} variant="secondary" className="btn-link hstack gap-2" onClick={() => handleItemClick(path)}>
             <Icon icon="folder" color="info" />
             <span className="text-info text-start text-break">{formatPathInList(path, pathInput)}</span>
         </Button>

--- a/src/Raven.Studio/typescript/components/common/steps/Steps.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/steps/Steps.stories.tsx
@@ -2,9 +2,10 @@
 import Steps from "./Steps";
 import React, { useState } from "react";
 import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
-import { Button, Card } from "reactstrap";
+import { Card } from "reactstrap";
 import { FlexGrow } from "../FlexGrow";
 import { Icon } from "../Icon";
+import Button from "react-bootstrap/Button";
 
 export default {
     title: "Bits/Steps",
@@ -85,17 +86,17 @@ export function StepsExample() {
             </div>
             <div className="d-flex my-4">
                 {!isFirstStep && (
-                    <Button onClick={prevStep}>
+                    <Button variant="secondary" onClick={prevStep}>
                         <Icon icon="arrow-left" /> Back
                     </Button>
                 )}
                 <FlexGrow />
                 {isLastStep ? (
-                    <Button color="success">
+                    <Button variant="success">
                         <Icon icon="rocket" /> Finish
                     </Button>
                 ) : (
-                    <Button color="primary" onClick={nextStep} disabled={isLastStep}>
+                    <Button variant="primary" onClick={nextStep} disabled={isLastStep}>
                         Next <Icon icon="arrow-right" margin="ms-1" />
                     </Button>
                 )}

--- a/src/Raven.Studio/typescript/components/common/toggles/MultiCheckboxToggle.tsx
+++ b/src/Raven.Studio/typescript/components/common/toggles/MultiCheckboxToggle.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import useBoolean from "components/hooks/useBoolean";
 import { InputItem } from "components/models/common";
 import { Icon } from "../Icon";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import ToggleItemLabel from "components/common/toggles/partials/ToggleItemLabel";
 
 interface MultiCheckboxToggleProps<T extends string | number = string> {
@@ -67,6 +67,7 @@ export function MultiCheckboxToggle<T extends string | number = string>({
                 {selectAll && (
                     <>
                         <Button
+                            variant="secondary"
                             className={classNames("multi-toggle-button", { "clear-selected": !isSelectedAll })}
                             size="sm"
                             onClick={onChangeSelectAll}

--- a/src/Raven.Studio/typescript/components/common/virtualTable/cells/CellDocumentPreview.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/cells/CellDocumentPreview.tsx
@@ -2,8 +2,9 @@ import { Getter } from "@tanstack/react-table";
 import Code from "components/common/Code";
 import { Icon } from "components/common/Icon";
 import useBoolean from "components/hooks/useBoolean";
-import { Button, CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
 import document from "models/database/documents/document";
+import Button from "react-bootstrap/Button";
 
 interface CellDocumentPreviewProps {
     document: document;
@@ -19,7 +20,7 @@ export default function CellDocumentPreview({ document }: CellDocumentPreviewPro
 
     return (
         <>
-            <Button type="button" title="Show preview" color="link" onClick={toggleIsOpen}>
+            <Button type="button" title="Show preview" variant="link" onClick={toggleIsOpen}>
                 <Icon icon="preview" margin="m-0" />
             </Button>
             <Modal toggle={toggleIsOpen} isOpen={isOpen} wrapClassName="bs5" size="lg" centered>
@@ -45,7 +46,7 @@ export default function CellDocumentPreview({ document }: CellDocumentPreviewPro
                     </pre>
                 </ModalBody>
                 <ModalFooter>
-                    <Button type="button" onClick={toggleIsOpen}>
+                    <Button type="button" variant="secondary" onClick={toggleIsOpen}>
                         <Icon icon="close" />
                         Close
                     </Button>

--- a/src/Raven.Studio/typescript/components/common/virtualTable/cells/CellWithCopy.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/cells/CellWithCopy.tsx
@@ -5,7 +5,7 @@ import { Icon } from "components/common/Icon";
 import { PopoverWithHover } from "components/common/PopoverWithHover";
 import CellValue from "components/common/virtualTable/cells/CellValue";
 import { PropsWithChildren, useState } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface CellWithCopyProps extends PropsWithChildren {
     value: unknown;
@@ -37,7 +37,7 @@ export function CellWithCopy({ value, children }: CellWithCopyProps) {
                     </pre>
                     <span className="small-label">Actions</span>
                     <div>
-                        <Button onClick={handleCopyToClipboard} color="primary" title="Copy to clipboard">
+                        <Button onClick={handleCopyToClipboard} size="sm" variant="primary" title="Copy to clipboard">
                             <Icon icon="copy-to-clipboard" margin="m-0" />
                         </Button>
                     </div>

--- a/src/Raven.Studio/typescript/components/common/virtualTable/commonComponents/columnsSelect/TableDisplaySettings.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/commonComponents/columnsSelect/TableDisplaySettings.tsx
@@ -1,11 +1,12 @@
 import "./TableDisplaySettings.scss";
 import { Table as TanstackTable } from "@tanstack/react-table";
 import { Checkbox } from "components/common/Checkbox";
-import { Button, Dropdown, DropdownMenu, DropdownToggle } from "reactstrap";
+import { Dropdown, DropdownMenu, DropdownToggle } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { useTableDisplaySettings } from "components/common/virtualTable/commonComponents/columnsSelect/useTableDisplaySettings";
 import { ClassNameProps } from "components/models/common";
 import classNames from "classnames";
+import Button from "react-bootstrap/Button";
 
 // TODO Add custom column and reorder with dnd https://issues.hibernatingrhinos.com/issue/RavenDB-22509
 
@@ -53,14 +54,19 @@ export default function TableDisplaySettings<T>({ table, className }: TableColum
                     </div>
                     <hr className="m-0" />
                     <div className="d-flex gap-1 px-3 pt-3 pb-2">
-                        <Button type="button" title="Reset to default" onClick={handlers.handleReset}>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            title="Reset to default"
+                            onClick={handlers.handleReset}
+                        >
                             <Icon icon="reset" />
                             Reset to default
                         </Button>
                         <Button type="button" className="ms-3" title="Close" onClick={handlers.handleCloseDropdown}>
                             Close
                         </Button>
-                        <Button type="button" color="success" title="Apply changes" onClick={handlers.handleSave}>
+                        <Button type="button" variant="success" title="Apply changes" onClick={handlers.handleSave}>
                             <Icon icon="save" />
                             Apply
                         </Button>

--- a/src/Raven.Studio/typescript/components/common/virtualTable/partials/VirtualTableColumnSettings.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/partials/VirtualTableColumnSettings.tsx
@@ -3,7 +3,8 @@ import classNames from "classnames";
 import { HStack } from "components/common/HStack";
 import { Icon } from "components/common/Icon";
 import { useState, useMemo } from "react";
-import { Button, UncontrolledDropdown, DropdownToggle, DropdownMenu, Label, Input } from "reactstrap";
+import { UncontrolledDropdown, DropdownToggle, DropdownMenu, Label, Input } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 export default function VirtualTableColumnSettings<T>({ column }: { column: Column<T, unknown> }) {
     const [localFilter, setLocalFilter] = useState("");
@@ -46,7 +47,7 @@ export default function VirtualTableColumnSettings<T>({ column }: { column: Colu
             {column.getCanSort() && (
                 <div className="sorting-controls">
                     <Button
-                        color="link"
+                        variant="link"
                         onClick={() => handleSort("asc")}
                         title="Sort A to Z"
                         className={classNames(column.getIsSorted() === "asc" && "active-sorting")}
@@ -54,7 +55,7 @@ export default function VirtualTableColumnSettings<T>({ column }: { column: Colu
                         <Icon icon="arrow-thin-top" margin="m-0" />
                     </Button>
                     <Button
-                        color="link"
+                        variant="link"
                         onClick={() => handleSort("desc")}
                         title="Sort Z to A"
                         className={classNames(column.getIsSorted() === "desc" && "active-sorting")}
@@ -89,7 +90,7 @@ export default function VirtualTableColumnSettings<T>({ column }: { column: Colu
                                 />
                                 {localFilter && (
                                     <div className="clear-button">
-                                        <Button color="secondary" size="sm" onClick={() => handleFilterChange("")}>
+                                        <Button variant="secondary" size="sm" onClick={() => handleFilterChange("")}>
                                             <Icon icon="clear" margin="m-0" />
                                         </Button>
                                     </div>

--- a/src/Raven.Studio/typescript/components/pages/BootstrapPlaygroundPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/BootstrapPlaygroundPage.tsx
@@ -2,7 +2,6 @@
 import React, { useState } from "react";
 import {
     Alert,
-    Button,
     Card,
     CardBody,
     CardLink,
@@ -42,6 +41,7 @@ import {
     OffcanvasBody,
     OffcanvasHeader,
 } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 const items = [
     {
@@ -71,7 +71,7 @@ function ModalUsage(args: any) {
 
     return (
         <div>
-            <Button color="danger" onClick={toggle}>
+            <Button variant="danger" onClick={toggle}>
                 Click Me
             </Button>
             <Modal wrapClassName="bs5" fade isOpen={modal} toggle={toggle} {...args}>
@@ -84,10 +84,10 @@ function ModalUsage(args: any) {
                     culpa qui officia deserunt mollit anim id est laborum.
                 </ModalBody>
                 <ModalFooter>
-                    <Button color="primary" onClick={toggle}>
+                    <Button variant="primary" onClick={toggle}>
                         Do Something
                     </Button>{" "}
-                    <Button color="secondary" onClick={toggle}>
+                    <Button variant="secondary" onClick={toggle}>
                         Cancel
                     </Button>
                 </ModalFooter>
@@ -200,7 +200,7 @@ function Example({ direction, ...args }: any) {
             </div>
             <div className="margin-bottom">
                 <h1>Popover</h1>
-                <Button id="Popover1" type="button">
+                <Button variant="secondary" id="Popover1" type="button">
                     Launch Popover
                 </Button>
                 <Popover flip target="Popover1" className="bs5">
@@ -213,7 +213,7 @@ function Example({ direction, ...args }: any) {
             </div>
             <div className="margin-bottom">
                 <div>
-                    <Button color="primary">Open Offcanvas</Button>
+                    <Button variant="primary">Open Offcanvas</Button>
                     <Offcanvas>
                         <OffcanvasHeader>Offcanvas</OffcanvasHeader>
                         <OffcanvasBody>
@@ -386,7 +386,7 @@ function FormExample() {
                         size: 10,
                     }}
                 >
-                    <Button>Submit</Button>
+                    <Button variant="secondary">Submit</Button>
                 </Col>
             </FormGroup>
         </Form>
@@ -984,7 +984,7 @@ To edit settings, press <kbd><kbd>ctrl</kbd> + <kbd>,</kbd></kbd>
                 <CardExample />
                 <AlertExample />
 
-                <Button type="button" color="primary">
+                <Button type="button" variant="primary">
                     TEST
                 </Button>
                 <FormExample />

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/MergeIndexesCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/MergeIndexesCard.tsx
@@ -10,7 +10,8 @@ import {
 } from "components/pages/database/indexes/cleanup/useIndexCleanup";
 import { useAppSelector } from "components/store";
 import React from "react";
-import { Card, Table, Button } from "reactstrap";
+import { Card, Table } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface MergeIndexesCardProps {
     mergable: UseIndexCleanupResult["mergable"];
@@ -69,7 +70,7 @@ function MainPanel({ mergable }: MergeIndexesCardProps) {
                     <RichPanelHeader className="px-3 py-2 flex-wrap flex-row gap-3">
                         <div className="mt-1">
                             <Button
-                                color="primary"
+                                variant="primary"
                                 size="sm"
                                 className="rounded-pill"
                                 onClick={() => mergable.navigateToMergeSuggestion(mergableGroup)}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/MergeSuggestionsErrorsCarouselCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/MergeSuggestionsErrorsCarouselCard.tsx
@@ -7,7 +7,8 @@ import useBoolean from "components/hooks/useBoolean";
 import { MergeSuggestionsError } from "components/pages/database/indexes/cleanup/useIndexCleanup";
 import { useAppSelector } from "components/store";
 import React from "react";
-import { Button, Card, Table } from "reactstrap";
+import { Card, Table } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface MergeSuggestionsErrorsCarouselCardProps {
     errors: MergeSuggestionsError[];
@@ -86,7 +87,7 @@ function ErrorTableRow({ error }: ErrorTableRowProps) {
                     </code>
                 </div>
                 <div className="d-flex justify-content-end">
-                    <Button color="link" size="sm" onClick={toggleIsStackTraceVisible}>
+                    <Button variant="link" size="sm" onClick={toggleIsStackTraceVisible}>
                         {isStackTraceVisible ? (
                             <>
                                 <Icon icon="collapse-vertical" />
@@ -103,7 +104,7 @@ function ErrorTableRow({ error }: ErrorTableRowProps) {
             </td>
             <td>
                 <Button
-                    color="primary"
+                    variant="primary"
                     size="sm"
                     className="rounded-pill"
                     onClick={() =>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/RemoveSubindexesCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/RemoveSubindexesCard.tsx
@@ -43,7 +43,7 @@ function MainPanel({ surpassing }: RemoveSubindexesCardProps) {
     return (
         <div className="p-2">
             <ButtonWithSpinner
-                color="primary"
+                variant="primary"
                 className="mb-2 rounded-pill"
                 onClick={surpassing.deleteSelected}
                 isSpinning={surpassing.isDeleting}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/RemoveUnusedIndexesCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/RemoveUnusedIndexesCard.tsx
@@ -38,7 +38,7 @@ function MainPanel({ unused }: RemoveUnusedIndexesCardProps) {
     return (
         <div className="p-2">
             <ButtonWithSpinner
-                color="primary"
+                variant="primary"
                 className="mb-2 rounded-pill"
                 onClick={unused.deleteSelected}
                 isSpinning={unused.isDeleting}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/BulkIndexOperationConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/BulkIndexOperationConfirm.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { ReactNode, useState } from "react";
-import { Button, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { IndexSharedInfo } from "components/models/indexes";
 import {
     DatabaseActionContexts,
@@ -77,7 +78,7 @@ export function BulkIndexOperationConfirm(props: BulkIndexOperationConfirmProps)
                     />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 {indexGroups.map((indexGroup, idx) => (
                     <div key={"indexGroup" + idx}>
@@ -129,10 +130,10 @@ export function BulkIndexOperationConfirm(props: BulkIndexOperationConfirmProps)
                 )}
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button variant="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color={getColorForType(type)} onClick={onSubmit} className="rounded-pill">
+                <Button variant={getColorForType(type)} onClick={onSubmit} className="rounded-pill">
                     <Icon icon={icon} /> {infinitive}
                 </Button>
             </ModalFooter>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndexes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndexes.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { useState } from "react";
-import { Button, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import {
     DatabaseActionContexts,
@@ -77,7 +78,7 @@ export function ConfirmResetIndexes(props: ConfirmResetIndexesProps) {
                     <Icon icon="index" color="warning" addon="reset-index" className="fs-1" margin="m-0" />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={closeConfirm} />
+                    <CloseButton onClick={closeConfirm} />
                 </div>
                 <div className="text-center lead">
                     You&apos;re about to <span className="text-warning">reset</span> following{" "}
@@ -118,11 +119,11 @@ export function ConfirmResetIndexes(props: ConfirmResetIndexesProps) {
                 )}
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={closeConfirm} className="link-muted">
+                <Button variant="link" onClick={closeConfirm} className="link-muted">
                     Cancel
                 </Button>
                 <Button
-                    color="warning"
+                    variant="warning"
                     onClick={onSubmit}
                     className="rounded-pill"
                     disabled={selectedActionContexts.length === 0}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmSwapSideBySideIndex.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmSwapSideBySideIndex.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { useState } from "react";
-import { Button, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import {
     DatabaseActionContexts,
@@ -32,7 +33,7 @@ export function ConfirmSwapSideBySideIndex(props: ConfirmSwapSideBySideIndexProp
                     <Icon icon="index" color="warning" addon="swap" className="fs-1" margin="m-0" />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 <div className="text-center lead">
                     You&apos;re about to <span className="text-warning">swap</span> following index
@@ -57,10 +58,10 @@ export function ConfirmSwapSideBySideIndex(props: ConfirmSwapSideBySideIndexProp
                 )}
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button variant="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color="warning" onClick={onSubmit} className="rounded-pill">
+                <Button variant="warning" onClick={onSubmit} className="rounded-pill">
                     <Icon icon="swap" />
                     Swap Now
                 </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -12,7 +12,7 @@ import {
 } from "components/common/LocationDistribution";
 import assertUnreachable from "../../../../utils/assertUnreachable";
 import { ProgressCircle } from "components/common/ProgressCircle";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import IconName from "typings/server/icons";
 import IndexDistributionStatusChecker from "./IndexDistributionStatusChecker";
@@ -75,7 +75,7 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                 {nodeInfo.details?.faulty && (
                     <div className="text-center">
                         <Button
-                            color="danger"
+                            variant="danger"
                             className="px-1 py-0 my-1"
                             size="xs"
                             onClick={() => openFaulty(nodeInfo.location)}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
@@ -1,11 +1,12 @@
 ﻿import { IndexStatus, IndexFilterCriteria, IndexType, IndexGroupBy, IndexSortBy } from "components/models/indexes";
-import { Button, Input, PopoverBody, UncontrolledPopover } from "reactstrap";
+import { Input, PopoverBody, UncontrolledPopover } from "reactstrap";
 import { produce } from "immer";
 import { Icon } from "components/common/Icon";
 import { MultiCheckboxToggle } from "components/common/toggles/MultiCheckboxToggle";
 import { InputItem, SortDirection } from "components/models/common";
 import { Switch } from "components/common/Checkbox";
 import { SortDropdown, SortDropdownRadioList, sortItem } from "components/common/SortDropdown";
+import Button from "react-bootstrap/Button";
 
 interface IndexFilterProps {
     filter: IndexFilterCriteria;
@@ -85,7 +86,7 @@ export default function IndexFilter(props: IndexFilterProps) {
                     />
                     {filter.searchText && (
                         <div className="clear-button">
-                            <Button color="secondary" size="sm" onClick={() => onFilterValueChange("searchText", "")}>
+                            <Button variant="secondary" size="sm" onClick={() => onFilterValueChange("searchText", "")}>
                                 <Icon icon="clear" margin="m-0" />
                             </Button>
                         </div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexGlobalIndexing.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexGlobalIndexing.tsx
@@ -1,11 +1,12 @@
 ﻿import { Icon } from "components/common/Icon";
 import React from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 export default function IndexGlobalIndexing() {
     return (
         <div className="pull-right" id="toggleIndexing" data-bind="requiredAccess: 'DatabaseReadWrite'">
             <Button
+                variant="secondary"
                 className="disable-indexing"
                 title="Pause indexing process for ALL indexes until restart - Local node"
                 data-bind="click: stopIndexing, visible: $root.globalIndexingStatus() !== 'Paused', 
@@ -16,7 +17,7 @@ export default function IndexGlobalIndexing() {
                 Pause indexing until restart - Local node
             </Button>
             <Button
-                color="success"
+                variant="success"
                 className="enable-indexing"
                 title="Resume indexing process"
                 data-bind="click: startIndexing, visible: $root.globalIndexingStatus() === 'Paused', enable: !spinners.globalStartStop(), css: { 'btn-spinner': spinners.globalStartStop() }"

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -23,7 +23,6 @@ import {
 } from "components/common/RichPanel";
 import {
     Badge,
-    Button,
     ButtonGroup,
     Collapse,
     DropdownItem,
@@ -34,6 +33,7 @@ import {
     UncontrolledDropdown,
     UncontrolledTooltip,
 } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import assertUnreachable from "components/utils/assertUnreachable";
 import useUniqueId from "components/hooks/useUniqueId";
 import useBoolean from "hooks/useBoolean";
@@ -356,23 +356,25 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
 
                         <ButtonGroup>
                             {!IndexUtils.isAutoIndex(index) && hasDatabaseWriteAccess && (
-                                <Button href={editUrl} title="Edit index">
+                                <Button variant="secondary" href={editUrl} title="Edit index">
                                     <Icon icon="edit" margin="m-0" />
                                 </Button>
                             )}
                             {(IndexUtils.isAutoIndex(index) || !hasDatabaseWriteAccess) && (
-                                <Button href={editUrl} title="View index">
+                                <Button href={editUrl} variant="secondary" title="View index">
                                     <Icon icon="preview" margin="m-0" />
                                 </Button>
                             )}
                         </ButtonGroup>
 
                         {localFaultyNodeInfo && (
-                            <Button onClick={() => openFaulty(localFaultyNodeInfo.location)}>Open faulty index</Button>
+                            <Button variant="secondary" onClick={() => openFaulty(localFaultyNodeInfo.location)}>
+                                Open faulty index
+                            </Button>
                         )}
                         {!IndexUtils.isAutoIndex(index) && (
                             <>
-                                <Button title="Export index" onClick={toggleIsExportIndexModalOpen}>
+                                <Button variant="secondary" title="Export index" onClick={toggleIsExportIndexModalOpen}>
                                     <Icon icon="export" margin="m-0" />
                                 </Button>
                                 {isExportIndexModalOpen && (
@@ -390,7 +392,7 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                                     resetIndex={resetIndex}
                                     sideBySideDisabledReason={getSideBySideResetDisabledReason(index)}
                                 />
-                                <Button color="danger" onClick={deleteIndex} title="Delete the index">
+                                <Button variant="danger" onClick={deleteIndex} title="Delete the index">
                                     <Icon icon="trash" margin="m-0" />
                                 </Button>
                             </>
@@ -400,6 +402,7 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                 <RichPanelDetails className="pb-1">
                     <RichPanelDetailItem>
                         <Button
+                            variant="secondary"
                             onClick={togglePanelCollapsed}
                             title={panelCollapsed ? "Expand distribution details" : "Collapse distribution details"}
                             className="btn-toggle-panel rounded-pill"

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -18,7 +18,7 @@ import {
 import { NamedProgress, NamedProgressItem } from "components/common/NamedProgress";
 import { Icon } from "components/common/Icon";
 import copyToClipboard from "common/copyToClipboard";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface IndexProgressTooltipProps {
     target: HTMLElement;
@@ -42,7 +42,7 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
                             </span>
                             <Button
                                 className="rounded-pill"
-                                color="primary"
+                                variant="primary"
                                 size="xs"
                                 onClick={() =>
                                     copyToClipboard.copy(

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
@@ -1,6 +1,7 @@
 ﻿import React, { useState } from "react";
 import IndexLockMode = Raven.Client.Documents.Indexes.IndexLockMode;
-import { Button, DropdownItem, DropdownMenu, DropdownToggle, Spinner, UncontrolledDropdown } from "reactstrap";
+import { DropdownItem, DropdownMenu, DropdownToggle, Spinner, UncontrolledDropdown } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import { Checkbox } from "components/common/Checkbox";
 import { SelectionActions } from "components/common/SelectionActions";
@@ -67,7 +68,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                     </div>
                     <div className="hstack gap-2 flex-wrap justify-content-center">
                         <Button
-                            color="primary"
+                            variant="primary"
                             disabled={selectedIndexes.length === 0}
                             onClick={toggleIsExportIndexModalOpen}
                             className="rounded-pill flex-grow-0"
@@ -145,7 +146,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                         </UncontrolledDropdown>
                         <ResetIndexesButton isRounded resetIndex={resetSelectedIndexes} />
                         <Button
-                            color="danger"
+                            variant="danger"
                             disabled={selectedIndexes.length === 0}
                             onClick={deleteSelectedIndexes}
                             className="rounded-pill flex-grow-0"
@@ -154,7 +155,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                             <span>Delete</span>
                         </Button>
                     </div>
-                    <Button onClick={onCancel} color="link">
+                    <Button onClick={onCancel} variant="link">
                         Cancel
                     </Button>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -5,7 +5,6 @@ import IndexUtils from "../../../../utils/IndexUtils";
 import { useAppUrls } from "hooks/useAppUrls";
 import "./IndexesPage.scss";
 import {
-    Button,
     Col,
     DropdownItem,
     DropdownMenu,
@@ -14,6 +13,7 @@ import {
     UncontrolledDropdown,
     UncontrolledPopover,
 } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { LoadingView } from "components/common/LoadingView";
 import { StickyHeader } from "components/common/StickyHeader";
 import { BulkIndexOperationConfirm } from "components/pages/database/indexes/list/BulkIndexOperationConfirm";
@@ -183,7 +183,7 @@ export function IndexesPage(props: IndexesPageProps) {
                                 <div id="NewIndexButton">
                                     <UncontrolledDropdown group className="button-dropdown-pill">
                                         <Button
-                                            color="primary"
+                                            variant="primary"
                                             href={newIndexUrl}
                                             disabled={isNewIndexDisabled}
                                             className="button-dropdown-btn"

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -78,7 +78,7 @@ export default function IndexesPageList({
                                         <Icon icon="swap" /> Side by side
                                     </div>
                                     <ButtonWithSpinner
-                                        color="warning"
+                                        variant="warning"
                                         size="sm"
                                         onClick={() => swapSideBySideData.setIndexName(index.name)}
                                         title="Click to replace the current index definition with the replacement index"

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/migration/export/ExportIndexes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/migration/export/ExportIndexes.tsx
@@ -18,9 +18,10 @@ import IndexUtils from "components/utils/IndexUtils";
 import moment from "moment";
 import React, { useEffect, useMemo, useState } from "react";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
-import { Button, Form, InputGroup, InputGroupText, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Form, InputGroup, InputGroupText, Modal, ModalBody, ModalFooter } from "reactstrap";
 import * as yup from "yup";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 type ExportMode = "database" | "file";
 
@@ -134,7 +135,7 @@ export function ExportIndexes(props: ExportIndexesProps) {
             <Form control={control} onSubmit={handleSubmit(handleExport)}>
                 <ModalBody className="vstack gap-4 position-relative">
                     <div className="position-absolute m-2 end-0 top-0">
-                        <Button close onClick={toggle} />
+                        <CloseButton onClick={toggle} />
                     </div>
 
                     <Icon icon="index-import" color="primary" className="text-center fs-1" margin="m-0" />
@@ -184,12 +185,12 @@ export function ExportIndexes(props: ExportIndexesProps) {
                     </div>
                 </ModalBody>
                 <ModalFooter>
-                    <Button type="button" color="link" title="Cancel" className="link-muted" onClick={toggle}>
+                    <Button type="button" variant="link" title="Cancel" className="link-muted" onClick={toggle}>
                         Cancel
                     </Button>
                     <ButtonWithSpinner
                         type="submit"
-                        color="success"
+                        variant="success"
                         title="Export indexes"
                         className="rounded-pill"
                         isSpinning={formState.isSubmitting}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/migration/import/ImportIndexes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/migration/import/ImportIndexes.tsx
@@ -18,7 +18,8 @@ import IndexUtils from "components/utils/IndexUtils";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useAsync } from "react-async-hook";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
-import { Button, Form, InputGroup, InputGroupText, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Form, InputGroup, InputGroupText, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import * as yup from "yup";
 import RichAlert from "components/common/RichAlert";
 
@@ -250,16 +251,16 @@ export function ImportIndexes(props: ImportIndexesProps) {
                     </div>
 
                     <div className="position-absolute m-2 end-0 top-0">
-                        <Button close onClick={toggle} />
+                        <CloseButton onClick={toggle} />
                     </div>
                 </ModalBody>
                 <ModalFooter>
-                    <Button type="button" color="link" className="link-muted" onClick={toggle}>
+                    <Button type="button" variant="link" className="link-muted" onClick={toggle}>
                         Cancel
                     </Button>
                     <ButtonWithSpinner
                         type="submit"
-                        color="success"
+                        variant="success"
                         title="Import indexes"
                         className="rounded-pill"
                         icon="import"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from "react";
-import { Form, Col, Button, Row, Spinner, Input, InputGroup, UncontrolledPopover, Card } from "reactstrap";
+import { Form, Col, Row, Spinner, Input, InputGroup, UncontrolledPopover, Card } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { FormCheckbox, FormInput, FormRadioToggleWithIcon, FormSelect, FormSwitch } from "components/common/Form";
 import { useServices } from "components/hooks/useServices";
@@ -120,7 +121,7 @@ export default function ClientDatabaseConfiguration() {
                             <div id="saveClientConfiguration" className="w-fit-content">
                                 <Button
                                     type="submit"
-                                    color="primary"
+                                    variant="primary"
                                     disabled={formState.isSubmitting || !formState.isDirty}
                                 >
                                     {formState.isSubmitting ? (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolution.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { useEffect } from "react";
-import { Button, Card, CardBody, Col, Row, UncontrolledTooltip } from "reactstrap";
+import { Card, CardBody, Col, Row, UncontrolledTooltip } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { useAppDispatch, useAppSelector } from "components/store";
@@ -75,7 +76,7 @@ export default function ConflictResolution() {
                             <>
                                 <div id="saveConflictResolutionScript" className="d-flex w-fit-content gap-3 mb-3">
                                     <ButtonWithSpinner
-                                        color="primary"
+                                        variant="primary"
                                         icon="save"
                                         isSpinning={asyncSave.loading}
                                         onClick={asyncSave.execute}
@@ -97,7 +98,7 @@ export default function ConflictResolution() {
                                     hasDatabaseAdminAccess && (
                                         <div id="addNewScriptButton">
                                             <Button
-                                                color="info"
+                                                variant="info"
                                                 size="sm"
                                                 className="rounded-pill"
                                                 title="Add a new Conflicts Resolution script"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolutionConfigPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolutionConfigPanel.tsx
@@ -8,7 +8,8 @@ import {
     RichPanelDetails,
     RichPanelDetailItem,
 } from "components/common/RichPanel";
-import { Button, Collapse, Form, InputGroup, Label, UncontrolledTooltip } from "reactstrap";
+import { Collapse, Form, InputGroup, Label, UncontrolledTooltip } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import { EditConflictResolutionSyntaxModal } from "components/pages/database/settings/conflictResolution/EditConflictResolutionSyntaxModal";
 import { useAppDispatch, useAppSelector } from "components/store";
@@ -136,7 +137,7 @@ export default function ConflictResolutionConfigPanel({ initialConfig }: Conflic
                             <Label className="d-flex flex-wrap justify-content-between">
                                 Script
                                 <Button
-                                    color="link"
+                                    variant="link"
                                     size="xs"
                                     onClick={toggleIsSyntaxModalOpen}
                                     className="p-0 align-self-end"
@@ -186,10 +187,10 @@ function PanelActions({
         if (isInEditMode) {
             return (
                 <React.Fragment key="actions-in-edit">
-                    <Button type="submit" color="success" title={isNewUnsaved ? "Add Script" : "Update Script"}>
+                    <Button type="submit" variant="success" title={isNewUnsaved ? "Add Script" : "Update Script"}>
                         <Icon icon="tick" margin="m-0" /> {isNewUnsaved ? "Add" : "Update"}
                     </Button>
-                    <Button type="button" color="secondary" title="Discard changes" onClick={discard}>
+                    <Button type="button" variant="secondary" title="Discard changes" onClick={discard}>
                         <Icon icon="cancel" margin="m-0" /> Discard
                     </Button>
                 </React.Fragment>
@@ -199,7 +200,7 @@ function PanelActions({
                 <React.Fragment key="actions-not-in-edit">
                     <Button
                         type="button"
-                        color="secondary"
+                        variant="secondary"
                         title="Edit this script"
                         onClick={() => dispatch(conflictResolutionActions.edited(configId))}
                     >
@@ -207,7 +208,7 @@ function PanelActions({
                     </Button>
                     <Button
                         type="button"
-                        color="danger"
+                        variant="danger"
                         title="Delete this script"
                         onClick={() => dispatch(conflictResolutionActions.deleted(configId))}
                     >
@@ -222,7 +223,7 @@ function PanelActions({
         return (
             <Button
                 type="button"
-                color="secondary"
+                variant="secondary"
                 title="Hide this script"
                 onClick={() => dispatch(conflictResolutionActions.editDiscarded(configId))}
             >
@@ -233,7 +234,7 @@ function PanelActions({
         return (
             <Button
                 type="button"
-                color="secondary"
+                variant="secondary"
                 title="Show this script"
                 onClick={() => dispatch(conflictResolutionActions.edited(configId))}
             >

--- a/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/EditConflictResolutionSyntaxModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/EditConflictResolutionSyntaxModal.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Modal, ModalBody } from "reactstrap";
+﻿import { CloseButton, Modal, ModalBody } from "reactstrap";
 import React from "react";
 import Code from "components/common/Code";
 
@@ -11,7 +11,7 @@ export function EditConflictResolutionSyntaxModal({ toggle }: EditConflictResolu
         <Modal isOpen size="lg" wrapClassName="bs5" toggle={toggle} contentClassName="modal-border bulge-primary">
             <ModalBody>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 <h5 className="mb-1">Conflicted documents</h5>
                 <div className="d-flex gap-3 flex-wrap mb-3">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { useEffect } from "react";
-import { Button, Col, Row, UncontrolledTooltip } from "reactstrap";
+import { Col, Row, UncontrolledTooltip } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { useAppDispatch, useAppSelector } from "components/store";
@@ -69,7 +70,7 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
                         <>
                             <div id={addNewButtonId} style={{ width: "fit-content" }}>
                                 <Button
-                                    color="primary"
+                                    variant="primary"
                                     onClick={() => dispatch(connectionStringsActions.newConnectionModalOpened())}
                                     title="Add new connection string"
                                     disabled={hasNoneInLicense}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanel.tsx
@@ -6,7 +6,8 @@ import {
     RichPanelName,
     RichPanelActions,
 } from "components/common/RichPanel";
-import { Button, UncontrolledTooltip } from "reactstrap";
+import { UncontrolledTooltip } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import { Connection } from "./connectionStringsTypes";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
@@ -69,7 +70,7 @@ export default function ConnectionStringsPanel(props: ConnectionStringsPanelProp
                     {hasDatabaseAdminAccess && (
                         <RichPanelActions>
                             <Button
-                                color="secondary"
+                                variant="secondary"
                                 title="Edit connection string"
                                 onClick={() => dispatch(connectionStringsActions.editConnectionModalOpened(connection))}
                             >
@@ -77,7 +78,7 @@ export default function ConnectionStringsPanel(props: ConnectionStringsPanelProp
                             </Button>
                             <div id={deleteButtonId}>
                                 <ButtonWithSpinner
-                                    color="danger"
+                                    variant="danger"
                                     title="Delete connection string"
                                     disabled={isDeleteDisabled}
                                     onClick={onDelete}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanels.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanels.tsx
@@ -3,7 +3,7 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import { useAppSelector } from "components/store";
 import React from "react";
 import { useDispatch } from "react-redux";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import ConnectionStringsPanel from "./ConnectionStringsPanel";
 import { Connection } from "./connectionStringsTypes";
 import { connectionStringsActions } from "./store/connectionStringsSlice";
@@ -29,7 +29,7 @@ export default function ConnectionStringsPanels({ connections, connectionsType }
                 right={
                     hasDatabaseAdminAccess && (
                         <Button
-                            color="info"
+                            variant="info"
                             size="sm"
                             className="rounded-pill"
                             title="Add new credentials"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/EditConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/EditConnectionStrings.tsx
@@ -1,6 +1,7 @@
 ﻿import { Icon } from "components/common/Icon";
 import React, { useState } from "react";
-import { Button, InputGroup, Label, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { InputGroup, Label, Modal, ModalBody, ModalFooter } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import Select, { SelectOptionWithIcon, SingleValueWithIcon } from "components/common/select/Select";
 import { Connection, EditConnectionStringFormProps } from "./connectionStringsTypes";
 import RavenConnectionString from "./editForms/RavenConnectionString";
@@ -103,7 +104,7 @@ export default function EditConnectionStrings(props: EditConnectionStringsProps)
             <ModalFooter className="mt-2">
                 <Button
                     type="button"
-                    color="link"
+                    variant="link"
                     className="link-muted"
                     onClick={() => dispatch(connectionStringsActions.editConnectionModalClosed())}
                     title="Cancel"
@@ -114,7 +115,7 @@ export default function EditConnectionStrings(props: EditConnectionStringsProps)
                     <ButtonWithSpinner
                         form="connection-string-form"
                         type="submit"
-                        color="success"
+                        variant="success"
                         title="Save credentials"
                         icon="save"
                         className="rounded-pill"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/ElasticSearchCertificate.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/ElasticSearchCertificate.tsx
@@ -2,8 +2,9 @@ import certificateUtils from "common/certificateUtils";
 import { Icon } from "components/common/Icon";
 import moment from "moment";
 import React from "react";
-import { Button, Card, CardBody, CardHeader } from "reactstrap";
+import { Card, CardBody, CardHeader } from "reactstrap";
 import IconName from "typings/server/icons";
+import Button from "react-bootstrap/Button";
 
 interface ElasticSearchCertificateProps {
     certBase64: string;
@@ -30,7 +31,7 @@ export default function ElasticSearchCertificate({ certBase64, onDelete }: Elast
                     <Icon icon="certificate" />
                     {certInfo.thumbprint}
                 </div>
-                <Button onClick={onDelete} color="danger">
+                <Button onClick={onDelete} variant="danger">
                     <Icon icon="trash" margin="m-0" />
                 </Button>
             </CardHeader>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/ElasticSearchConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/ElasticSearchConnectionString.tsx
@@ -1,4 +1,4 @@
-﻿import { Badge, Button, Form, Label } from "reactstrap";
+﻿import { Badge, Form, Label } from "reactstrap";
 import { FormInput, FormSelect } from "components/common/Form";
 import React from "react";
 import { SubmitHandler, UseFormTrigger, useFieldArray, useForm, useWatch } from "react-hook-form";
@@ -28,6 +28,7 @@ import { useAppUrls } from "components/hooks/useAppUrls";
 import ElasticSearchCertificate from "./ElasticSearchCertificate";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
+import Button from "react-bootstrap/Button";
 
 type FormData = ConnectionFormData<ElasticSearchConnection>;
 
@@ -129,7 +130,7 @@ export default function ElasticSearchConnectionString({
                         />
                     ))}
                 </div>
-                <Button color="info" className="mt-4" onClick={() => urlFieldArray.append({ url: null })}>
+                <Button variant="info" className="mt-4" onClick={() => urlFieldArray.append({ url: null })}>
                     <Icon icon="plus" />
                     Add URL
                 </Button>
@@ -297,12 +298,12 @@ function NodeUrl({ idx, control, formValues, isDeleteButtonVisible, onDelete, tr
                     autoComplete="off"
                 />
                 {isDeleteButtonVisible && (
-                    <Button color="danger" onClick={onDelete} disabled={asyncTest.loading}>
+                    <Button variant="danger" onClick={onDelete} disabled={asyncTest.loading}>
                         <Icon icon="trash" margin="m-0" title="Delete URL" />
                     </Button>
                 )}
                 <ButtonWithSpinner
-                    color="secondary"
+                    variant="secondary"
                     onClick={asyncTest.execute}
                     isSpinning={asyncTest.loading}
                     icon={{

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/KafkaConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/KafkaConnectionString.tsx
@@ -1,4 +1,4 @@
-﻿import { Badge, Button, Form, Label, PopoverBody, UncontrolledPopover } from "reactstrap";
+﻿import { Badge, Form, Label, PopoverBody, UncontrolledPopover } from "reactstrap";
 import { FormInput, FormSwitch } from "components/common/Form";
 import React, { useEffect } from "react";
 import { SubmitHandler, useFieldArray, useForm, useWatch } from "react-hook-form";
@@ -16,6 +16,7 @@ import ConnectionTestError from "components/common/connectionTests/ConnectionTes
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import Button from "react-bootstrap/Button";
 
 type FormData = ConnectionFormData<KafkaConnection>;
 
@@ -116,7 +117,7 @@ export default function KafkaConnectionString({
                         autoComplete="off"
                     />
                     <ButtonWithSpinner
-                        color="secondary"
+                        variant="secondary"
                         icon="rocket"
                         title="Test connection"
                         onClick={asyncTest.execute}
@@ -169,7 +170,10 @@ export default function KafkaConnectionString({
                                         autoComplete="off"
                                     />
                                     {isDeleteUrlVisible(option.key) && (
-                                        <Button color="danger" onClick={() => connectionOptionsFieldArray.remove(idx)}>
+                                        <Button
+                                            variant="danger"
+                                            onClick={() => connectionOptionsFieldArray.remove(idx)}
+                                        >
                                             <Icon icon="trash" margin="m-0" title="Delete" />
                                         </Button>
                                     )}
@@ -179,7 +183,7 @@ export default function KafkaConnectionString({
                     ))}
                 </div>
                 <Button
-                    color="info"
+                    variant="info"
                     className={connectionOptionsFieldArray.fields.length > 0 ? "mt-3" : "mt-1"}
                     onClick={() => connectionOptionsFieldArray.append({ key: null, value: null })}
                 >

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/RabbitMqConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/RabbitMqConnectionString.tsx
@@ -94,7 +94,7 @@ export default function RabbitMqConnectionString({
                 <div className="d-flex mt-4">
                     <FlexGrow />
                     <ButtonWithSpinner
-                        color="secondary"
+                        variant="secondary"
                         icon="rocket"
                         onClick={asyncTest.execute}
                         isSpinning={asyncTest.loading}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/RavenConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/RavenConnectionString.tsx
@@ -1,4 +1,4 @@
-﻿import { Badge, Button, Form, Label } from "reactstrap";
+﻿import { Badge, Form, Label } from "reactstrap";
 import { FormInput } from "components/common/Form";
 import React from "react";
 import { Control, SubmitHandler, UseFormTrigger, UseFormWatch, useFieldArray, useForm } from "react-hook-form";
@@ -14,6 +14,7 @@ import ConnectionStringUsedByTasks from "./shared/ConnectionStringUsedByTasks";
 import ConnectionTestError from "../../../../../common/connectionTests/ConnectionTestError";
 import { yupObjectSchema } from "components/utils/yupUtils";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 type FormData = ConnectionFormData<RavenConnection>;
 
@@ -87,7 +88,7 @@ export default function RavenConnectionString({
                         />
                     ))}
                 </div>
-                <Button color="info" className="mt-3" onClick={() => urlFieldArray.append({ url: null })}>
+                <Button variant="info" className="mt-3" onClick={() => urlFieldArray.append({ url: null })}>
                     <Icon icon="plus" />
                     Add next discovery URL
                 </Button>
@@ -148,12 +149,12 @@ function DiscoveryUrl({ idx, control, isDeleteButtonVisible, trigger, watch, onD
                     autoComplete="off"
                 />
                 {isDeleteButtonVisible && (
-                    <Button color="danger" title="Delete URL" onClick={onDelete} disabled={asyncTest.loading}>
+                    <Button variant="danger" title="Delete URL" onClick={onDelete} disabled={asyncTest.loading}>
                         <Icon icon="trash" margin="m-0" />
                     </Button>
                 )}
                 <ButtonWithSpinner
-                    color="secondary"
+                    variant="secondary"
                     onClick={asyncTest.execute}
                     isSpinning={asyncTest.loading}
                     title="Test connection"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/SqlConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/SqlConnectionString.tsx
@@ -133,7 +133,7 @@ export default function SqlConnectionString({
                 <div className="d-flex mt-4">
                     <FlexGrow />
                     <ButtonWithSpinner
-                        color="secondary"
+                        variant="secondary"
                         icon="rocket"
                         onClick={asyncTest.execute}
                         isSpinning={asyncTest.loading}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
@@ -1,5 +1,6 @@
 ﻿import React from "react";
-import { Button, Col, Row, UncontrolledPopover } from "reactstrap";
+import { Col, Row, UncontrolledPopover } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { HrHeader } from "components/common/HrHeader";
@@ -79,7 +80,7 @@ export default function DatabaseCustomAnalyzers() {
                         <>
                             <div id="newCustomAnalyzer" className="w-fit-content">
                                 <Button
-                                    color="primary"
+                                    variant="primary"
                                     className="mb-3"
                                     onClick={addNewAnalyzer}
                                     disabled={isLimitReached}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersListItem.tsx
@@ -22,12 +22,13 @@ import {
     RichPanelInfo,
     RichPanelName,
 } from "components/common/RichPanel";
-import { Button, Collapse, Form, InputGroup, Label, UncontrolledTooltip } from "reactstrap";
+import { Collapse, Form, InputGroup, Label, UncontrolledTooltip } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import DeleteCustomAnalyzerConfirm from "components/common/customAnalyzers/DeleteCustomAnalyzerConfirm";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormAceEditor, FormInput } from "components/common/Form";
 import fileImporter from "common/fileImporter";
+import Button from "react-bootstrap/Button";
 
 interface DatabaseCustomAnalyzersListItemProps {
     initialAnalyzer: CustomAnalyzerFormData;
@@ -190,11 +191,11 @@ function CustomAnalyzersActions({
 
     if (!hasDatabaseAdminAccess) {
         return isEditMode ? (
-            <Button key="preview" onClick={toggleIsEditMode}>
+            <Button variant="secondary" key="preview" onClick={toggleIsEditMode}>
                 <Icon icon="preview-off" margin="m-0" />
             </Button>
         ) : (
-            <Button key="edit" onClick={toggleIsEditMode}>
+            <Button variant="secondary" key="edit" onClick={toggleIsEditMode}>
                 <Icon icon="preview" margin="m-0" />
             </Button>
         );
@@ -204,16 +205,16 @@ function CustomAnalyzersActions({
         <>
             {isEditMode ? (
                 <>
-                    <Button key="save" type="submit" color="success" disabled={isSubmitting}>
+                    <Button key="save" type="submit" variant="success" disabled={isSubmitting}>
                         <Icon icon="save" /> Save changes
                     </Button>
-                    <Button key="cancel" type="button" color="secondary" onClick={onDiscard}>
+                    <Button key="cancel" type="button" variant="secondary" onClick={onDiscard}>
                         <Icon icon="cancel" /> Discard
                     </Button>
                 </>
             ) : (
                 <>
-                    <Button key="edit" onClick={toggleIsEditMode}>
+                    <Button variant="secondary" key="edit" onClick={toggleIsEditMode}>
                         <Icon icon={hasDatabaseAdminAccess ? "edit" : "preview"} margin="m-0" />
                     </Button>
                     {hasDatabaseAdminAccess && (
@@ -227,7 +228,7 @@ function CustomAnalyzersActions({
                             )}
                             <ButtonWithSpinner
                                 key="delete"
-                                color="danger"
+                                variant="danger"
                                 onClick={() => setNameToConfirmDelete(name)}
                                 icon="trash"
                                 isSpinning={asyncDeleteAnalyzer.status === "loading"}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorterTest.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorterTest.tsx
@@ -48,7 +48,7 @@ export default function DatabaseCustomSorterTest({ name }: DatabaseCustomSorterT
     return (
         <Card className="gap-2 p-4">
             <ButtonWithSpinner
-                color="primary"
+                variant="primary"
                 onClick={asyncTest.execute}
                 className="w-fit-content"
                 icon="play"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorterTestResult.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorterTestResult.tsx
@@ -12,8 +12,9 @@ import TableDisplaySettings from "components/common/virtualTable/commonComponent
 import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
 import VirtualTable from "components/common/virtualTable/VirtualTable";
 import { useState } from "react";
-import { Button, Badge } from "reactstrap";
+import { Badge } from "reactstrap";
 import document from "models/database/documents/document";
+import Button from "react-bootstrap/Button";
 
 type TestResultTab = "results" | "diagnostics";
 
@@ -91,6 +92,7 @@ function DatabaseCustomSorterTestResultWithSize({
 
             <div className="d-flex mt-2 gap-2">
                 <Button
+                    variant="secondary"
                     size="sm"
                     className="rounded-pill"
                     onClick={() => setCurrentTab("results")}
@@ -104,6 +106,7 @@ function DatabaseCustomSorterTestResultWithSize({
                 <Button
                     size="sm"
                     className="rounded-pill"
+                    variant="secondary"
                     onClick={() => setCurrentTab("diagnostics")}
                     active={currentTab === "diagnostics"}
                 >

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Col, Row, UncontrolledPopover } from "reactstrap";
+﻿import { Col, Row, UncontrolledPopover } from "reactstrap";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { HrHeader } from "components/common/HrHeader";
@@ -19,6 +19,7 @@ import DatabaseCustomSortersServerWideList from "components/pages/database/setti
 import { useCustomSorters } from "components/common/customSorters/useCustomSorters";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 export default function DatabaseCustomSorters() {
     const db = useAppSelector(databaseSelectors.activeDatabase);
@@ -88,7 +89,7 @@ export default function DatabaseCustomSorters() {
                 {hasDatabaseAdminAccess && (
                     <>
                         <div id="newCustomSorter" className="w-fit-content">
-                            <Button color="primary" className="mb-3" onClick={addNewSorter} disabled={isLimitReached}>
+                            <Button variant="primary" className="mb-3" onClick={addNewSorter} disabled={isLimitReached}>
                                 <Icon icon="plus" />
                                 Add a custom sorter
                             </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersListItem.tsx
@@ -27,10 +27,11 @@ import React from "react";
 import { useState } from "react";
 import { UseAsyncReturn, useAsyncCallback } from "react-async-hook";
 import { useForm, useWatch, SubmitHandler } from "react-hook-form";
-import { Form, UncontrolledTooltip, Button, Collapse, InputGroup, Label } from "reactstrap";
+import { Form, UncontrolledTooltip, Collapse, InputGroup, Label } from "reactstrap";
 import DatabaseCustomSorterTest from "components/pages/database/settings/customSorters/DatabaseCustomSorterTest";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import Button from "react-bootstrap/Button";
 
 interface DatabaseCustomSortersListItemProps {
     initialSorter: CustomSorterFormData;
@@ -206,11 +207,11 @@ function CustomSortersActions({
 
     if (!hasDatabaseAdminAccess) {
         return isEditMode ? (
-            <Button key="preview" onClick={toggleIsEditMode}>
+            <Button variant="secondary" key="preview" onClick={toggleIsEditMode}>
                 <Icon icon="preview-off" margin="m-0" />
             </Button>
         ) : (
-            <Button key="edit" onClick={toggleIsEditMode} disabled={isTestMode}>
+            <Button variant="secondary" key="edit" onClick={toggleIsEditMode} disabled={isTestMode}>
                 <Icon icon="preview" margin="m-0" />
             </Button>
         );
@@ -224,17 +225,17 @@ function CustomSortersActions({
                     message: "To test, first exit edit mode",
                 }}
             >
-                <Button key="test" onClick={toggleIsTestMode} disabled={isEditMode}>
+                <Button variant="secondary" key="test" onClick={toggleIsTestMode} disabled={isEditMode}>
                     <Icon icon="rocket" addon={isTestMode ? "cancel" : null} margin="m-0" />
                 </Button>
             </ConditionalPopover>
 
             {isEditMode ? (
                 <>
-                    <Button key="save" type="submit" color="success" disabled={isSubmitting}>
+                    <Button key="save" type="submit" variant="success" disabled={isSubmitting}>
                         <Icon icon="save" /> Save changes
                     </Button>
-                    <Button key="cancel" type="button" color="secondary" onClick={onDiscard}>
+                    <Button key="cancel" type="button" variant="secondary" onClick={onDiscard}>
                         <Icon icon="cancel" />
                         Discard
                     </Button>
@@ -247,7 +248,7 @@ function CustomSortersActions({
                             message: "To edit, first exit test mode",
                         }}
                     >
-                        <Button key="edit" onClick={toggleIsEditMode} disabled={isTestMode}>
+                        <Button variant="secondary" key="edit" onClick={toggleIsEditMode} disabled={isTestMode}>
                             <Icon icon={hasDatabaseAdminAccess ? "edit" : "preview"} margin="m-0" />
                         </Button>
                     </ConditionalPopover>
@@ -262,7 +263,7 @@ function CustomSortersActions({
                             )}
                             <ButtonWithSpinner
                                 key="delete"
-                                color="danger"
+                                variant="danger"
                                 onClick={() => setNameToConfirmDelete(name)}
                                 icon="trash"
                                 isSpinning={asyncDeleteSorter.status === "loading"}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem.tsx
@@ -11,7 +11,8 @@ import useBoolean from "components/hooks/useBoolean";
 import DatabaseCustomSorterTest from "components/pages/database/settings/customSorters/DatabaseCustomSorterTest";
 import { useAppSelector } from "components/store";
 import React from "react";
-import { Button, Collapse } from "reactstrap";
+import { Collapse } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface DatabaseCustomSortersServerWideListItemProps {
     sorter: Raven.Client.Documents.Queries.Sorting.SorterDefinition;
@@ -32,7 +33,7 @@ export default function DatabaseCustomSortersServerWideListItem({
 
                     {hasDatabaseAdminAccess && (
                         <RichPanelActions>
-                            <Button onClick={toggleIsTestMode}>
+                            <Button variant="secondary" onClick={toggleIsTestMode}>
                                 <Icon icon="rocket" addon={isTestMode ? "cancel" : null} margin="m-0" />
                             </Button>
                         </RichPanelActions>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
@@ -107,7 +107,7 @@ export default function DataArchival() {
                             <div id="saveDataArchival" className="w-fit-content">
                                 <ButtonWithSpinner
                                     type="submit"
-                                    color="primary"
+                                    variant="primary"
                                     className="mb-3"
                                     icon="save"
                                     disabled={!formState.isDirty || !hasDatabaseAdminAccess}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/databaseRecord/DatabaseRecord.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/databaseRecord/DatabaseRecord.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Button, Card, CardBody, Col, InputGroup, Row } from "reactstrap";
+import { Card, CardBody, Col, InputGroup, Row } from "reactstrap";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import useConfirm from "components/common/ConfirmDialog";
@@ -21,6 +21,7 @@ import ReactAce from "react-ace/lib/ace";
 import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 interface VisibleDocument {
     text: string;
@@ -175,21 +176,21 @@ export default function DatabaseRecord() {
                             {isEditMode ? (
                                 <>
                                     <ButtonWithSpinner
-                                        color="primary"
+                                        variant="primary"
                                         icon="save"
                                         onClick={saveDatabaseRecord}
                                         isSpinning={asyncSaveDatabaseRecord.loading}
                                     >
                                         Save
                                     </ButtonWithSpinner>
-                                    <Button color="secondary" onClick={discardDatabaseRecord}>
+                                    <Button variant="secondary" onClick={discardDatabaseRecord}>
                                         Cancel
                                     </Button>
                                 </>
                             ) : (
                                 <>
                                     <ButtonWithSpinner
-                                        color="primary"
+                                        variant="primary"
                                         onClick={refresh}
                                         isSpinning={asyncGetDatabaseRecord.loading}
                                         icon="refresh"
@@ -197,7 +198,7 @@ export default function DatabaseRecord() {
                                         Refresh
                                     </ButtonWithSpinner>
                                     <Button
-                                        color="secondary"
+                                        variant="secondary"
                                         onClick={toggleEditMode}
                                         disabled={asyncGetDatabaseRecord.loading}
                                     >
@@ -228,7 +229,7 @@ export default function DatabaseRecord() {
                                             </Switch>
                                         )}
                                         <Button
-                                            color="link"
+                                            variant="link"
                                             size="xs"
                                             className="p-0"
                                             onClick={isCollapsed ? expand : collapse}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentCompression/DocumentCompression.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentCompression/DocumentCompression.tsx
@@ -120,7 +120,7 @@ export default function DocumentCompression() {
                                         <div id="saveConfigButton" className="w-fit-content">
                                             <ButtonWithSpinner
                                                 type="submit"
-                                                color="primary"
+                                                variant="primary"
                                                 className="mb-3"
                                                 icon="save"
                                                 disabled={!formState.isDirty}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
@@ -139,7 +139,7 @@ export default function DocumentExpiration() {
                             <AboutViewHeading title="Document Expiration" icon="document-expiration" />
                             <ButtonWithSpinner
                                 type="submit"
-                                color="primary"
+                                variant="primary"
                                 className="mb-3"
                                 icon="save"
                                 disabled={!formState.isDirty || isLimitWarningVisible}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.tsx
@@ -132,7 +132,7 @@ export default function DocumentRefresh() {
                             <AboutViewHeading title="Document Refresh" icon="expos-refresh" />
                             <ButtonWithSpinner
                                 type="submit"
-                                color="primary"
+                                variant="primary"
                                 className="mb-3"
                                 icon="save"
                                 disabled={!formState.isDirty || isLimitWarningVisible}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useEffect, useState } from "react";
-import { Button, Col, Row, UncontrolledTooltip } from "reactstrap";
+import { Col, Row, UncontrolledTooltip } from "reactstrap";
 import { AboutViewAnchored, AboutViewHeading, AccordionItemWrapper } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { HrHeader } from "components/common/HrHeader";
@@ -36,6 +36,7 @@ import FeatureAvailabilitySummaryWrapper, {
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import activeDatabaseTracker from "common/shell/activeDatabaseTracker";
+import Button from "react-bootstrap/Button";
 
 interface EditRevisionData {
     onConfirm: (config: DocumentRevisionsConfig) => void;
@@ -181,7 +182,7 @@ export default function DocumentRevisions() {
                                 <Row>
                                     <div className="d-flex flex-wrap gap-2">
                                         <ButtonWithSpinner
-                                            color="primary"
+                                            variant="primary"
                                             icon="save"
                                             disabled={isSaveDisabled}
                                             onClick={asyncSaveConfigs.execute}
@@ -207,7 +208,7 @@ export default function DocumentRevisions() {
                                         </UncontrolledTooltip>
                                         <div id="enforceConfiguration">
                                             <ButtonWithSpinner
-                                                color="secondary"
+                                                variant="secondary"
                                                 onClick={toggleEnforceConfigurationModal}
                                                 disabled={isAnyModified}
                                                 isSpinning={asyncEnforceRevisionsConfiguration.status === "loading"}
@@ -231,7 +232,7 @@ export default function DocumentRevisions() {
                                         <>
                                             <div id="add-default-config-button">
                                                 <Button
-                                                    color="info"
+                                                    variant="info"
                                                     size="sm"
                                                     className="rounded-pill"
                                                     title="Create a default revision configuration for all (non-conflicting) documents"
@@ -305,7 +306,7 @@ export default function DocumentRevisions() {
                                 right={
                                     hasDatabaseAdminAccess ? (
                                         <Button
-                                            color="info"
+                                            variant="info"
                                             size="sm"
                                             className="rounded-pill"
                                             title="Create a revision configuration for a specific collection"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsConfigPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsConfigPanel.tsx
@@ -10,7 +10,8 @@ import {
     RichPanelDetails,
     RichPanelDetailItem,
 } from "components/common/RichPanel";
-import { Button, UncontrolledPopover } from "reactstrap";
+import { UncontrolledPopover } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import {
     DocumentRevisionsConfig,
@@ -85,7 +86,7 @@ export default function DocumentRevisionsConfigPanel(props: DocumentRevisionsCon
                         {hasDatabaseAdminAccess && (
                             <>
                                 <Button
-                                    color={config.Disabled ? "success" : "secondary"}
+                                    variant={config.Disabled ? "success" : "secondary"}
                                     onClick={onToggle}
                                     title={`Click to ${
                                         config.Disabled ? "enable" : "disable"
@@ -95,12 +96,12 @@ export default function DocumentRevisionsConfigPanel(props: DocumentRevisionsCon
                                     {config.Disabled ? "Enable" : "Disable"}
                                 </Button>
 
-                                <Button color="secondary" onClick={onEdit} title="Edit this revision configuration">
+                                <Button variant="secondary" onClick={onEdit} title="Edit this revision configuration">
                                     <Icon icon="edit" margin="m-0" />
                                 </Button>
                                 {onDelete && (
                                     <Button
-                                        color="danger"
+                                        variant="danger"
                                         onClick={() => {
                                             reportEvent("revisions", "remove");
                                             onDelete();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsSelectActions.tsx
@@ -3,7 +3,8 @@ import genUtils from "common/generalUtils";
 import { Icon } from "components/common/Icon";
 import { Checkbox } from "components/common/Checkbox";
 import { SelectionActions } from "components/common/SelectionActions";
-import { ButtonGroup, UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem, Button } from "reactstrap";
+import { ButtonGroup, UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { useAppSelector } from "components/store";
 import { documentRevisionsActions } from "./store/documentRevisionsSlice";
 import { documentRevisionsSelectors } from "./store/documentRevisionsSliceSelectors";
@@ -74,7 +75,7 @@ export default function DocumentRevisionsSelectActions() {
                         </UncontrolledDropdown>
 
                         <Button
-                            color="danger"
+                            variant="danger"
                             onClick={() => dispatch(documentRevisionsActions.selectedConfigsDeleted())}
                             className="rounded-pill flex-grow-0"
                         >
@@ -83,7 +84,7 @@ export default function DocumentRevisionsSelectActions() {
                     </ButtonGroup>
                     <Button
                         onClick={() => dispatch(documentRevisionsActions.allSelectedConfigNamesToggled())}
-                        color="link"
+                        variant="link"
                     >
                         Cancel
                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -1,6 +1,6 @@
 ﻿import { Icon } from "components/common/Icon";
 import React from "react";
-import { Button, Form, InputGroup, Label, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { Form, InputGroup, Label, Modal, ModalBody, ModalFooter } from "reactstrap";
 import { FormDurationPicker, FormInput, FormSelectCreatable, FormSwitch } from "components/common/Form";
 import { SubmitHandler, useForm } from "react-hook-form";
 import {
@@ -26,6 +26,7 @@ import generalUtils from "common/generalUtils";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import moment from "moment";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 const revisionsDelta = 100;
 const revisionsByAgeDelta = 604800; // 7 days
@@ -255,10 +256,10 @@ export default function EditRevision(props: EditRevisionProps) {
                     </RichAlert>
                 </ModalBody>
                 <ModalFooter>
-                    <Button type="button" color="link" className="link-muted" onClick={toggle}>
+                    <Button type="button" variant="link" className="link-muted" onClick={toggle}>
                         Cancel
                     </Button>
-                    <Button type="submit" color="success" disabled={isLimitExceeded} title="Add this configuration">
+                    <Button type="submit" variant="success" disabled={isLimitExceeded} title="Add this configuration">
                         <Icon icon={getSubmitIcon(taskType)} />
                         {_.startCase(taskType)} config
                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
@@ -1,5 +1,5 @@
 ﻿import React from "react";
-import { Button, Form, Modal, ModalBody, ModalFooter } from "reactstrap";
+import { Form, Modal, ModalBody, ModalFooter } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { useAppSelector } from "components/store";
 import * as yup from "yup";
@@ -9,6 +9,7 @@ import { collectionsTrackerSelectors } from "components/common/shell/collections
 import FormCollectionsSelect from "components/common/FormCollectionsSelect";
 import { FormSwitch } from "components/common/Form";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 interface EnforceConfigurationProps {
     toggle: () => void;
@@ -93,10 +94,10 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
                     </RichAlert>
                 </ModalBody>
                 <ModalFooter>
-                    <Button color="link" className="link-muted" onClick={toggle}>
+                    <Button variant="link" className="link-muted" onClick={toggle}>
                         Cancel
                     </Button>
-                    <Button type="submit" color="warning">
+                    <Button type="submit" variant="warning">
                         <Icon icon="rocket" />
                         Enforce Configuration
                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/revertRevisions/RevertRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/revertRevisions/RevertRevisions.tsx
@@ -82,7 +82,7 @@ export default function RevertRevisions() {
                     <div className="d-flex justify-content-between align-items-end">
                         <ButtonWithSpinner
                             type="submit"
-                            color="primary"
+                            variant="primary"
                             icon="revert-revisions"
                             disabled={!formState.isDirty}
                             isSpinning={asyncRevertRevisions.status === "loading"}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsAddNewButton.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsAddNewButton.tsx
@@ -3,7 +3,7 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import { useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
 import React from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { LicenseRestrictedMessage } from "components/common/LicenseRestrictedMessage";
 
 interface IntegrationsAddNewButtonProps {
@@ -31,7 +31,7 @@ export default function IntegrationsAddNewButton(props: IntegrationsAddNewButton
             ]}
         >
             <Button
-                color="info"
+                variant="info"
                 size="sm"
                 className="rounded-pill"
                 title="Add new credentials"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsUserListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsUserListItem.tsx
@@ -7,7 +7,7 @@ import {
     RichPanelActions,
     RichPanelDetails,
 } from "components/common/RichPanel";
-import { Button, Collapse, Form, InputGroup, Label } from "reactstrap";
+import { Collapse, Form, InputGroup, Label } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { FormInput } from "components/common/Form";
 import { HStack } from "components/common/HStack";
@@ -24,6 +24,7 @@ import { tryHandleSubmit } from "components/utils/common";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import copyToClipboard from "common/copyToClipboard";
+import Button from "react-bootstrap/Button";
 
 interface IntegrationsUserListProps {
     initialUsername: string;
@@ -105,7 +106,7 @@ export default function IntegrationsUserList(props: IntegrationsUserListProps) {
                                 <>
                                     <ButtonWithSpinner
                                         type="submit"
-                                        color="success"
+                                        variant="success"
                                         title="Save credentials"
                                         isSpinning={formState.isSubmitting}
                                         icon="save"
@@ -114,7 +115,7 @@ export default function IntegrationsUserList(props: IntegrationsUserListProps) {
                                     </ButtonWithSpinner>
                                     <Button
                                         type="button"
-                                        color="secondary"
+                                        variant="secondary"
                                         title="Discard changes"
                                         onClick={removeUser}
                                     >
@@ -125,7 +126,7 @@ export default function IntegrationsUserList(props: IntegrationsUserListProps) {
                             ) : (
                                 <ButtonWithSpinner
                                     type="button"
-                                    color="danger"
+                                    variant="danger"
                                     title="Delete credentials"
                                     onClick={onDeleteUser}
                                     isSpinning={asyncDeleteUser.loading}
@@ -160,6 +161,7 @@ export default function IntegrationsUserList(props: IntegrationsUserListProps) {
                                     />
                                 </div>
                                 <ButtonWithSpinner
+                                    variant="secondary"
                                     type="button"
                                     title="Generate a random password"
                                     onClick={asyncGeneratePassword.execute}
@@ -169,6 +171,7 @@ export default function IntegrationsUserList(props: IntegrationsUserListProps) {
                                     Generate password
                                 </ButtonWithSpinner>
                                 <Button
+                                    variant="secondary"
                                     type="button"
                                     title="Copy to clipboard"
                                     onClick={() =>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/studioConfiguration/StudioDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/studioConfiguration/StudioDatabaseConfiguration.tsx
@@ -98,7 +98,7 @@ export default function StudioDatabaseConfiguration() {
                             <div id="saveStudioConfiguration" className="w-fit-content">
                                 <ButtonWithSpinner
                                     type="submit"
-                                    color="primary"
+                                    variant="primary"
                                     className="mb-3"
                                     icon="save"
                                     disabled={!formState.isDirty}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
@@ -90,7 +90,7 @@ function TombstonesStateWithSize({ location, width }: TombstonesStateWithSizePro
             <div className="d-flex align-items-start gap-3 flex-wrap">
                 <ButtonWithSpinner
                     onClick={asyncGetTombstonesState.execute}
-                    color="primary"
+                    variant="primary"
                     isSpinning={asyncGetTombstonesState.loading}
                     icon="refresh"
                 >
@@ -98,7 +98,7 @@ function TombstonesStateWithSize({ location, width }: TombstonesStateWithSizePro
                 </ButtonWithSpinner>
                 <ButtonWithSpinner
                     onClick={forceCleanup}
-                    color="warning"
+                    variant="warning"
                     isSpinning={asyncForceTombstonesCleanup.loading}
                     disabled={asyncForceTombstonesCleanup.loading || asyncGetTombstonesState.loading}
                     icon="force"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/UnusedDatabaseIds.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/UnusedDatabaseIds.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button, Card, CardBody, Col, Row } from "reactstrap";
+import { Card, CardBody, Col, Row } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { AboutViewHeading } from "components/common/AboutView";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { CounterBadge } from "components/common/CounterBadge";
@@ -23,7 +24,7 @@ export default function UnusedDatabaseIds() {
                     <AboutViewHeading title="Unused Database IDs" icon="database-id" />
                     <ButtonWithSpinner
                         type="button"
-                        color="primary"
+                        variant="primary"
                         className="mb-3"
                         icon="save"
                         onClick={asyncSaveUnusedDatabaseIDs.execute}
@@ -59,7 +60,7 @@ export default function UnusedDatabaseIds() {
                                             <CounterBadge count={unusedIds.length} />
                                         </div>
                                         <Button
-                                            color="link"
+                                            variant="link"
                                             size="xs"
                                             onClick={unusedIdsActions.removeAll}
                                             className="p-0"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/PotentialUnusedId.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/PotentialUnusedId.tsx
@@ -1,6 +1,6 @@
 ﻿import React from "react";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface PotentialUnusedIdProps {
     id: string;
@@ -19,7 +19,13 @@ export default function PotentialUnusedId(props: PotentialUnusedIdProps) {
             }}
             popoverPlacement="top"
         >
-            <Button className="rounded-pill" onClick={addUnusedId} title="Copy ID" outline disabled={isAdded}>
+            <Button
+                className="rounded-pill"
+                onClick={addUnusedId}
+                title="Copy ID"
+                variant="outline-secondary"
+                disabled={isAdded}
+            >
                 <strong>{id}</strong>
             </Button>
         </ConditionalPopover>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/PotentialUnusedIdList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/PotentialUnusedIdList.tsx
@@ -2,7 +2,7 @@ import { CounterBadge } from "components/common/CounterBadge";
 import PotentialUnusedId from "components/pages/database/settings/unusedDatabaseIds/partials/PotentialUnusedId";
 import { UnusedIdsActions } from "components/pages/database/settings/unusedDatabaseIds/useUnusedDatabaseIds";
 import React from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface PotentialUnusedIdListProps {
     potentialUnusedId: string[];
@@ -25,7 +25,7 @@ export default function PotentialUnusedIdList(props: PotentialUnusedIdListProps)
                     <CounterBadge count={potentialUnusedId.length} />
                 </div>
                 <Button
-                    color="link"
+                    variant="link"
                     size="xs"
                     onClick={unusedIdsActions.addAllPotentialUnusedIds}
                     className="p-0"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/UnusedIdsForm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/UnusedIdsForm.tsx
@@ -5,8 +5,9 @@ import { FormInput } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import React from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { Form, Button } from "reactstrap";
+import { Form } from "reactstrap";
 import * as yup from "yup";
+import Button from "react-bootstrap/Button";
 
 interface UnusedIdsFormProps {
     ids: string[];
@@ -32,7 +33,7 @@ export default function UnusedIdsForm(props: UnusedIdsFormProps) {
         <Form onSubmit={handleSubmit(onAddId)}>
             <div className="d-flex gap-3 my-2">
                 <FormInput control={control} name="id" type="text" placeholder="Enter database ID to add" />
-                <Button type="submit" color="primary" title="Add ID to the list">
+                <Button type="submit" variant="primary" title="Add ID to the list">
                     <Icon icon="plus" /> Add ID
                 </Button>
             </div>
@@ -46,7 +47,7 @@ export default function UnusedIdsForm(props: UnusedIdsFormProps) {
                                 <div className="flex-grow-1">{id}</div>
                                 <div className="d-flex gap-1">
                                     <Button
-                                        color="link"
+                                        variant="link"
                                         size="xs"
                                         onClick={() => copyToClipboard.copy(id, `Copied ${id} vector to clipboard`)}
                                         className="p-0"
@@ -55,7 +56,7 @@ export default function UnusedIdsForm(props: UnusedIdsFormProps) {
                                         <Icon icon="copy-to-clipboard" margin="m-0" />
                                     </Button>
                                     <Button
-                                        color="link"
+                                        variant="link"
                                         size="xs"
                                         onClick={() => removeId(id)}
                                         className="p-0"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/UsedId.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/partials/UsedId.tsx
@@ -1,8 +1,8 @@
 ﻿import React from "react";
 import { Icon } from "components/common/Icon";
 import copyToClipboard from "common/copyToClipboard";
-import { Button } from "reactstrap";
 import { UsedIdData } from "components/pages/database/settings/unusedDatabaseIds/useUnusedDatabaseIds";
+import Button from "react-bootstrap/Button";
 
 interface UsedIdProps {
     usedIdData: UsedIdData;
@@ -16,7 +16,7 @@ export default function UsedId({ usedIdData }: UsedIdProps) {
             <Button
                 className="text-truncate rounded-pill"
                 title="Copy ID"
-                color="dark"
+                variant="dark"
                 onClick={() => copyToClipboard.copy(databaseId, `Copied ${databaseId} vector to clipboard`)}
             >
                 {databaseId}

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
@@ -2,12 +2,13 @@
 import React from "react";
 import genUtils from "common/generalUtils";
 import changeVectorUtils from "common/changeVectorUtils";
-import { Button, Card, PopoverBody, Table, UncontrolledPopover } from "reactstrap";
+import { Card, PopoverBody, Table, UncontrolledPopover } from "reactstrap";
 import { LazyLoad } from "components/common/LazyLoad";
 import { useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
 import { statisticsViewSelectors } from "components/pages/database/status/statistics/store/statisticsViewSlice";
 import copyToClipboard = require("common/copyToClipboard");
+import Button from "react-bootstrap/Button";
 
 interface DetailsBlockProps {
     children: (data: DetailedDatabaseStatistics, location: databaseLocationSpecifier) => JSX.Element;
@@ -97,7 +98,7 @@ export function DetailedDatabaseStats() {
                                         <>
                                             <div id={id} className="d-inline-flex flex-wrap gap-1">
                                                 <Button
-                                                    color="primary"
+                                                    variant="primary"
                                                     size="xs"
                                                     title="Copy to clipboard"
                                                     onClick={() => copyChangeVector(formattedChangeVector)}

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/EssentialDatabaseStatsComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/EssentialDatabaseStatsComponent.tsx
@@ -1,6 +1,6 @@
 ﻿import React from "react";
 import EssentialDatabaseStatistics = Raven.Client.Documents.Operations.EssentialDatabaseStatistics;
-import { Button, Card, Col, Row, UncontrolledPopover } from "reactstrap";
+import { Card, Col, Row, UncontrolledPopover } from "reactstrap";
 import { LazyLoad } from "components/common/LazyLoad";
 import {
     refresh,
@@ -9,6 +9,7 @@ import {
 import { useAppDispatch, useAppSelector } from "components/store";
 import { LoadError } from "components/common/LoadError";
 import { Icon } from "components/common/Icon";
+import Button from "react-bootstrap/Button";
 
 interface EssentialDatabaseStatsComponentProps {
     rawJsonUrl: string;
@@ -34,7 +35,7 @@ export function EssentialDatabaseStatsComponent(props: EssentialDatabaseStatsCom
                 <Col>
                     <h2 className="on-base-background">
                         General Database Stats
-                        <Button color="link" target="_blank" href={rawJsonUrl} title="Show raw output">
+                        <Button variant="link" target="_blank" href={rawJsonUrl} title="Show raw output">
                             <Icon icon="json" margin="m-0" />
                         </Button>
                     </h2>

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/StatsHeader.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/StatsHeader.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Col, Row } from "reactstrap";
+﻿import { Col, Row } from "reactstrap";
 import {
     refresh,
     statisticsViewSelectors,
@@ -9,6 +9,7 @@ import React from "react";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import Button from "react-bootstrap/Button";
 
 export function StatsHeader() {
     const dispatch = useAppDispatch();
@@ -21,7 +22,7 @@ export function StatsHeader() {
             <Row>
                 <Col sm="auto">
                     <Button
-                        color="secondary"
+                        variant="secondary"
                         onClick={() => dispatch(toggleDetails())}
                         title="Click to load detailed statistics"
                     >
@@ -32,7 +33,7 @@ export function StatsHeader() {
                 <Col />
                 <Col sm="auto">
                     <ButtonWithSpinner
-                        color="primary"
+                        variant="primary"
                         onClick={() => dispatch(refresh())}
                         title="Click to refresh stats"
                         isSpinning={isRefreshing}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
@@ -12,7 +12,8 @@ import PeriodicBackupStatus = Raven.Client.Documents.Operations.Backups.Periodic
 import { loadableData } from "components/models/common";
 import genUtils from "common/generalUtils";
 import moment from "moment";
-import { Button, Spinner } from "reactstrap";
+import { Spinner } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { HrHeader } from "components/common/HrHeader";
 import { RichPanel, RichPanelDetailItem, RichPanelDetails, RichPanelHeader } from "components/common/RichPanel";
 import { FlexGrow } from "components/common/FlexGrow";
@@ -279,6 +280,7 @@ export function BackupsPage() {
                 {hasDatabaseAdminAccess && (
                     <div className="flex-shrink-0 hstack gap-2 mb-4">
                         <Button
+                            variant="secondary"
                             onClick={navigateToRestoreDatabase}
                             title="Navigate to creating a new database from a backup"
                         >
@@ -331,7 +333,7 @@ export function BackupsPage() {
 
                     {hasDatabaseAdminAccess && (
                         <div className="mb-3 flex-shrink-0">
-                            <Button color="primary" title="Backup the database now" onClick={createManualBackup}>
+                            <Button variant="primary" title="Backup the database now" onClick={createManualBackup}>
                                 <Icon icon="backup" /> Create a Backup
                             </Button>
                         </div>
@@ -347,7 +349,7 @@ export function BackupsPage() {
                                 <Button
                                     size="xs"
                                     target="_blank"
-                                    color="link"
+                                    variant="link"
                                     title="Navigate to the Server-Wide Tasks View"
                                     href={serverWideTasksUrl}
                                 >
@@ -365,7 +367,7 @@ export function BackupsPage() {
                     {hasDatabaseWriteAccess && (
                         <div className="mb-3">
                             <Button
-                                color="primary"
+                                variant="primary"
                                 onClick={createNewPeriodicBackupTask}
                                 title="Create an ongoing periodic backup task"
                             >

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/createSampleData/CreateSampleData.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/createSampleData/CreateSampleData.tsx
@@ -1,6 +1,6 @@
 ﻿import React from "react";
 import { Icon } from "components/common/Icon";
-import { Button, Card, CardBody, Collapse, Spinner } from "reactstrap";
+import { Card, CardBody, Collapse, Spinner } from "reactstrap";
 import "./CreateSampleData.scss";
 import useBoolean from "components/hooks/useBoolean";
 import { useAsync, useAsyncCallback } from "react-async-hook";
@@ -16,6 +16,7 @@ import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import collectionsTracker from "common/helpers/database/collectionsTracker";
 import activeDatabaseTracker from "common/shell/activeDatabaseTracker";
+import Button from "react-bootstrap/Button";
 
 function CreateSampleData() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
@@ -72,7 +73,7 @@ function CreateSampleData() {
                             <ButtonWithSpinner
                                 size="lg"
                                 className="rounded-pill"
-                                color="primary"
+                                variant="primary"
                                 onClick={asyncCreateSampleData.execute}
                                 isSpinning={asyncCreateSampleData.status === "loading"}
                                 icon={asyncCreateSampleData.status === "success" ? "check" : "magic-wand"}
@@ -103,7 +104,12 @@ function CreateSampleData() {
                                 </div>
                             )}
                         </div>
-                        <Button size="sm" className="rounded-pill margin-bottom-md" onClick={toggleCodeSample}>
+                        <Button
+                            size="sm"
+                            variant="secondary"
+                            className="rounded-pill margin-bottom-md"
+                            onClick={toggleCodeSample}
+                        >
                             <Icon icon="hash" /> {isCodeSampleOpen ? "Hide" : "Show"} C# classes
                         </Button>
                     </div>
@@ -114,6 +120,7 @@ function CreateSampleData() {
                                     <h3>Sample data C# code</h3>
                                     {asyncGetSampleDataClasses.result && (
                                         <Button
+                                            variant="secondary"
                                             className="rounded-pill"
                                             onClick={() =>
                                                 copyToClipboard.copy(

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingEtlTaskProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingEtlTaskProgressTooltip.tsx
@@ -3,10 +3,11 @@ import { PopoverWithHover } from "components/common/PopoverWithHover";
 import { OngoingEtlTaskNodeInfo, OngoingTaskInfo } from "components/models/tasks";
 import { NamedProgress, NamedProgressItem } from "components/common/NamedProgress";
 import { Icon } from "components/common/Icon";
-import { Button, Modal, ModalBody } from "reactstrap";
+import { CloseButton, Modal, ModalBody } from "reactstrap";
 import useBoolean from "components/hooks/useBoolean";
 import Code from "components/common/Code";
 import copyToClipboard from "common/copyToClipboard";
+import Button from "react-bootstrap/Button";
 
 interface OngoingTaskEtlProgressTooltipProps {
     target: HTMLElement;
@@ -37,7 +38,7 @@ export function OngoingEtlTaskProgressTooltip(props: OngoingTaskEtlProgressToolt
                             >
                                 <code>{nodeInfo.details.error}</code>
                             </div>
-                            <Button size="sm" onClick={toggleErrorModal}>
+                            <Button variant="secondary" size="sm" onClick={toggleErrorModal}>
                                 Open error in modal <Icon icon="newtab" margin="ms-1" />
                             </Button>
                         </div>
@@ -52,7 +53,7 @@ export function OngoingEtlTaskProgressTooltip(props: OngoingTaskEtlProgressToolt
                 >
                     <ModalBody>
                         <div className="position-absolute m-2 end-0 top-0">
-                            <Button close onClick={toggleErrorModal} />
+                            <CloseButton onClick={toggleErrorModal} />
                         </div>
                         <div className="hstack gap-3 mb-4">
                             <div className="text-center">
@@ -65,7 +66,7 @@ export function OngoingEtlTaskProgressTooltip(props: OngoingTaskEtlProgressToolt
                         <div className="text-end">
                             <Button
                                 className="rounded-pill"
-                                color="primary"
+                                variant="primary"
                                 size="xs"
                                 onClick={() =>
                                     copyToClipboard.copy(nodeInfo.details.error, "Copied error message to clipboard")
@@ -93,7 +94,7 @@ export function OngoingEtlTaskProgressTooltip(props: OngoingTaskEtlProgressToolt
                             <div className="d-flex align-items-center justify-content-center gap-1">
                                 {transformationScriptProgress.transformationName}
                                 <Button
-                                    color="link"
+                                    variant="link"
                                     className="p-0"
                                     size="xs"
                                     title="Show script preview"
@@ -111,7 +112,7 @@ export function OngoingEtlTaskProgressTooltip(props: OngoingTaskEtlProgressToolt
                                         <div className="small-label d-flex align-items-center justify-content-center gap-1">
                                             Transactional Id
                                             <Button
-                                                color="link"
+                                                variant="link"
                                                 className="p-0"
                                                 size="xs"
                                                 onClick={() =>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTaskAddModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTaskAddModal.tsx
@@ -1,7 +1,7 @@
 import { CounterBadge } from "components/common/CounterBadge";
 import { HrHeader } from "components/common/HrHeader";
 import React, { ReactNode } from "react";
-import { Modal, ModalBody, Button, Row, Col, UncontrolledTooltip } from "reactstrap";
+import { Modal, ModalBody, Row, Col, UncontrolledTooltip, CloseButton } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import classNames from "classnames";
 import { useAppUrls } from "components/hooks/useAppUrls";
@@ -90,7 +90,7 @@ export default function OngoingTaskAddModal(props: OngoingTaskAddModalProps) {
         >
             <ModalBody>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 <div className="hstack gap-3 mb-4">
                     <div className="text-center">

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTaskSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTaskSelectActions.tsx
@@ -4,16 +4,9 @@ import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { Icon } from "components/common/Icon";
 import { Checkbox } from "components/common/Checkbox";
 import { SelectionActions } from "components/common/SelectionActions";
-import {
-    ButtonGroup,
-    UncontrolledDropdown,
-    DropdownToggle,
-    Spinner,
-    DropdownMenu,
-    DropdownItem,
-    Button,
-} from "reactstrap";
+import { ButtonGroup, UncontrolledDropdown, DropdownToggle, Spinner, DropdownMenu, DropdownItem } from "reactstrap";
 import { OngoingTaskOperationConfirmType } from "../shared/OngoingTaskOperationConfirm";
+import Button from "react-bootstrap/Button";
 
 interface OngoingTaskSelectActionsProps {
     allTasks: number[];
@@ -83,7 +76,7 @@ export default function OngoingTaskSelectActions(props: OngoingTaskSelectActions
                         </UncontrolledDropdown>
 
                         <ButtonWithSpinner
-                            color="danger"
+                            variant="danger"
                             onClick={() => onTaskOperation("delete")}
                             className="rounded-pill flex-grow-0"
                             isSpinning={isDeleting}
@@ -92,7 +85,7 @@ export default function OngoingTaskSelectActions(props: OngoingTaskSelectActions
                             Delete
                         </ButtonWithSpinner>
                     </ButtonGroup>
-                    <Button onClick={() => setSelectedTasks([])} color="link">
+                    <Button onClick={() => setSelectedTasks([])} variant="link">
                         Cancel
                     </Button>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksFilter.tsx
@@ -3,7 +3,8 @@ import { MultiCheckboxToggle } from "components/common/toggles/MultiCheckboxTogg
 import { InputItem } from "components/models/common";
 import { produce } from "immer";
 import React from "react";
-import { Input, Button } from "reactstrap";
+import { Input } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 export type OngoingTaskFilterType = "Replication" | "ETL" | "Sink" | "Backup" | "Subscription";
 
@@ -54,7 +55,7 @@ export default function OngoingTasksFilter(props: OngoingTasksFilterProps) {
                     />
                     {filter.searchText && (
                         <div className="clear-button">
-                            <Button color="secondary" size="sm" onClick={() => onSearchTextChange("")}>
+                            <Button variant="secondary" size="sm" onClick={() => onSearchTextChange("")}>
                                 <Icon icon="clear" margin="m-0" />
                             </Button>
                         </div>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -37,7 +37,7 @@ import TaskUtils from "../../../../utils/TaskUtils";
 import { KafkaEtlPanel } from "./panels/KafkaEtlPanel";
 import { RabbitMqEtlPanel } from "./panels/RabbitMqEtlPanel";
 import useInterval from "hooks/useInterval";
-import { Button, Row } from "reactstrap";
+import { Row } from "reactstrap";
 import { HrHeader } from "components/common/HrHeader";
 import { EmptySet } from "components/common/EmptySet";
 import { Icon } from "components/common/Icon";
@@ -63,6 +63,7 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { compareSets } from "common/typeUtils";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 export function OngoingTasksPage() {
     const db = useAppSelector(databaseSelectors.activeDatabase);
@@ -358,7 +359,7 @@ export function OngoingTasksPage() {
                                 />
                             )}
                             <div id="NewTaskButton">
-                                <Button onClick={toggleIsNewTaskModalOpen} color="primary" className="rounded-pill">
+                                <Button onClick={toggleIsNewTaskModalOpen} variant="primary" className="rounded-pill">
                                     <Icon icon="ongoing-tasks" addon="plus" />
                                     Add a Database Task
                                 </Button>
@@ -370,7 +371,7 @@ export function OngoingTasksPage() {
 
                     {isClusterAdminOrClusterNode && (
                         <Button
-                            color="link"
+                            variant="link"
                             size="sm"
                             target="_blank"
                             href={serverWideTasksUrl}

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SubscriptionPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SubscriptionPanel.tsx
@@ -21,7 +21,7 @@ import { useAppUrls } from "hooks/useAppUrls";
 import { SubscriptionTaskDistribution } from "./SubscriptionTaskDistribution";
 import genUtils from "common/generalUtils";
 import moment from "moment";
-import { Button, Collapse, Input } from "reactstrap";
+import { Collapse, Input } from "reactstrap";
 import { PopoverWithHover } from "components/common/PopoverWithHover";
 import { FlexGrow } from "components/common/FlexGrow";
 import { Icon } from "components/common/Icon";
@@ -29,6 +29,7 @@ import { SubscriptionConnectionsDetailsWithId } from "../OngoingTasksReducer";
 import { useAppSelector } from "components/store";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 type SubscriptionPanelProps = BaseOngoingTaskPanelProps<OngoingTaskSubscriptionInfo> & {
     refreshSubscriptionInfo: () => void;
@@ -138,7 +139,7 @@ function Details(props: SubscriptionPanelProps) {
             </RichPanelDetailItem>
             <FlexGrow />
             <div>
-                <Button onClick={refreshSubscriptionInfo}>
+                <Button variant="secondary" onClick={refreshSubscriptionInfo}>
                     <Icon icon="refresh" />
                     Refresh
                 </Button>
@@ -198,12 +199,11 @@ function ConnectedClients(props: ConnectedClientsProps) {
                         </div>
                         <div>
                             <Button
-                                color="danger"
+                                variant="outline-danger"
                                 title="Disconnect client from this subscription (unsubscribe client)"
                                 onClick={() => disconnectSubscription(connection.WorkerId)}
                                 size="xs"
                                 className="rounded-pill mt-2"
-                                outline
                             >
                                 <Icon icon="disconnected" />
                                 Disconnect

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/OngoingTaskOperationConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/OngoingTaskOperationConfirm.tsx
@@ -1,14 +1,15 @@
 import React, { ReactNode } from "react";
 import { OngoingTaskSharedInfo } from "components/models/tasks";
 import assertUnreachable from "components/utils/assertUnreachable";
-import OngoingTaskState = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState;
 import { capitalize } from "lodash";
 import { Icon } from "components/common/Icon";
-import classNames = require("classnames");
-import { Modal, ModalBody, Button, ModalFooter } from "reactstrap";
+import { CloseButton, Modal, ModalBody, ModalFooter } from "reactstrap";
 import IconName from "typings/server/icons";
 import { TextColor } from "components/models/common";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
+import classNames = require("classnames");
+import OngoingTaskState = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState;
 
 export type OngoingTaskOperationConfirmType = "enable" | "disable" | "delete";
 
@@ -63,7 +64,7 @@ export default function OngoingTaskOperationConfirm(props: OngoingTaskOperationC
                     />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 {taskGroups.map((taskGroup, idx) => (
                     <div key={"task-group-" + idx}>
@@ -107,10 +108,10 @@ export default function OngoingTaskOperationConfirm(props: OngoingTaskOperationC
                 {warningMessage && <RichAlert variant="warning">{warningMessage}</RichAlert>}
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button variant="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color={getTypeColor(type)} onClick={onSubmit} className="rounded-pill">
+                <Button variant={getTypeColor(type)} onClick={onSubmit} className="rounded-pill">
                     <Icon icon={getTypeIcon(type)} />
                     {getInfinitiveForType(type)}
                 </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/shared/shared.tsx
@@ -8,15 +8,7 @@ import useBoolean from "hooks/useBoolean";
 import React, { useCallback, useState } from "react";
 import router from "plugins/router";
 import { RichPanelDetailItem, RichPanelName } from "../../../../common/RichPanel";
-import {
-    Button,
-    ButtonGroup,
-    DropdownItem,
-    DropdownMenu,
-    DropdownToggle,
-    Spinner,
-    UncontrolledDropdown,
-} from "reactstrap";
+import { ButtonGroup, DropdownItem, DropdownMenu, DropdownToggle, Spinner, UncontrolledDropdown } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { OngoingTaskOperationConfirmType } from "./OngoingTaskOperationConfirm";
 import assertUnreachable from "components/utils/assertUnreachable";
@@ -26,6 +18,7 @@ import { useServices } from "components/hooks/useServices";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
+import Button from "react-bootstrap/Button";
 
 export interface BaseOngoingTaskPanelProps<T extends OngoingTaskInfo> {
     data: T;
@@ -168,17 +161,17 @@ export function OngoingTaskActions(props: OngoingTaskActionsProps) {
     return (
         <div className="actions">
             <ButtonGroup>
-                <Button onClick={toggleDetails} title="Click for details">
+                <Button variant="secondary" onClick={toggleDetails} title="Click for details">
                     <Icon icon="info" margin="m-0" />
                 </Button>
                 {!task.shared.serverWide && (
-                    <Button onClick={onEdit} title="Edit task">
+                    <Button variant="secondary" onClick={onEdit} title="Edit task">
                         <Icon icon="edit" margin="m-0" />
                     </Button>
                 )}
                 {!task.shared.serverWide && (
                     <ButtonWithSpinner
-                        color="danger"
+                        variant="danger"
                         disabled={!canEdit}
                         isSpinning={isDeleting}
                         onClick={() => onTaskOperation("delete", [task.shared])}

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/AboutFooter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/AboutFooter.tsx
@@ -1,4 +1,4 @@
-﻿import { Button } from "reactstrap";
+﻿import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 import React from "react";
 import feedback from "viewmodels/shell/feedback";
@@ -20,7 +20,7 @@ export function AboutFooter() {
         <div className="hstack align-items-center gap-4 flex-wrap justify-content-center mb-4">
             <div className="hstack">
                 <Button
-                    color="info"
+                    variant="info"
                     className="d-flex rounded-pill align-items-center py-1 ps-3 pe-4"
                     onClick={openSendFeedbackModal}
                 >

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/ChangeLogModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/ChangeLogModal.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Modal, ModalBody, ModalFooter, UncontrolledTooltip } from "reactstrap";
+﻿import { CloseButton, Modal, ModalBody, ModalFooter, UncontrolledTooltip } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { FlexGrow } from "components/common/FlexGrow";
 import React, { ReactNode, useState } from "react";
@@ -11,6 +11,7 @@ import genUtils from "common/generalUtils";
 import { useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import CustomPagination from "components/common/Pagination";
+import Button from "react-bootstrap/Button";
 
 interface ChangelogModalProps {
     mode: "whatsNew" | "changeLog" | "hidden";
@@ -201,20 +202,24 @@ function ModalWrapper(props: { children: ReactNode } & ChangelogModalProps) {
                 </div>
 
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={onClose} />
+                    <CloseButton onClick={onClose} />
                 </div>
                 <div className="text-center lead">{mode === "whatsNew" ? "What's New" : "Changelog"}</div>
                 {children}
             </ModalBody>
             <ModalFooter>
-                <Button color="secondary" outline onClick={onClose} className="rounded-pill px-3">
+                <Button variant="outline-secondary" onClick={onClose} className="rounded-pill px-3">
                     Close
                 </Button>
 
                 {mode === "whatsNew" && (
                     <React.Fragment key="footer-part">
                         <FlexGrow />
-                        <Button color="primary" className="rounded-pill px-3" href={aboutPageUrls.updateInstructions}>
+                        <Button
+                            variant="outline-primary"
+                            className="rounded-pill px-3"
+                            href={aboutPageUrls.updateInstructions}
+                        >
                             Update instructions <Icon icon="newtab" margin="m-0" />
                         </Button>
                     </React.Fragment>

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Col, Input, Row, Table } from "reactstrap";
+﻿import { Col, Input, Row, Table } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import React, { useState } from "react";
 import { RadioToggleWithIcon, RadioToggleWithIconInputItem } from "components/common/toggles/RadioToggle";
@@ -7,6 +7,7 @@ import { aboutPageUrls } from "components/pages/resources/about/partials/common"
 import { useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "hooks/useRavenLink";
+import Button from "react-bootstrap/Button";
 
 export function LicenseDetails() {
     const licenseId = useAppSelector(licenseSelectors.statusValue("Id"));
@@ -34,7 +35,7 @@ export function LicenseDetails() {
                             Applied
                         </h3>
                         <Button
-                            color="success"
+                            variant="success"
                             className="px-4 rounded-pill"
                             size="lg"
                             href={aboutPageUrls.getLicense}
@@ -128,7 +129,7 @@ function LicenseTable(props: LicenseTableProps) {
                     />
                     {searchText && (
                         <div className="clear-button">
-                            <Button color="secondary" size="sm" onClick={() => onSearchTextChange("")}>
+                            <Button variant="secondary" size="sm" onClick={() => onSearchTextChange("")}>
                                 <Icon icon="clear" margin="m-0" />
                             </Button>
                         </div>
@@ -157,7 +158,7 @@ function LicenseTable(props: LicenseTableProps) {
                                 <th className={classNames({ "bg-current": columns.length !== 4 })}></th>
                                 <th colSpan={columns.length < 4 ? columns.length - 1 : 2} className="px-3">
                                     <Button
-                                        color="primary"
+                                        variant="primary"
                                         className="w-100 rounded-pill"
                                         onClick={upgradeLicenseBtnHandler}
                                     >

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseSummary.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Card, CardBody, Col, PopoverBody, Row, UncontrolledPopover, UncontrolledTooltip } from "reactstrap";
+﻿import { Card, CardBody, Col, PopoverBody, Row, UncontrolledPopover, UncontrolledTooltip } from "reactstrap";
 import classNames from "classnames";
 import { Icon } from "components/common/Icon";
 import React, { useState } from "react";
@@ -19,6 +19,7 @@ import useUniqueId from "components/hooks/useUniqueId";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import moment from "moment";
 import genUtils = require("common/generalUtils");
+import Button from "react-bootstrap/Button";
 
 interface LicenseSummaryProps {
     asyncCheckLicenseServerConnectivity: AsyncState<ConnectivityStatus>;
@@ -114,7 +115,12 @@ function ConnectivityStatusComponent(props: {
                 </small>
                 <UncontrolledTooltip target={uniqueId}>Exception: {status.result.exception}</UncontrolledTooltip>
             </span>
-            <ButtonWithSpinner isSpinning={refreshing} outline className="mt-2 rounded-pill" onClick={refresh}>
+            <ButtonWithSpinner
+                isSpinning={refreshing}
+                variant="outline-secondary"
+                className="mt-2 rounded-pill"
+                onClick={refresh}
+            >
                 <Icon icon="refresh" title="Click to check connection" /> Test again
             </ButtonWithSpinner>
         </div>
@@ -184,7 +190,7 @@ function LicenseActions(props: LicenseActionsProps) {
                     <React.Fragment key="renew-container">
                         <span id="renew-license-btn">
                             <Button
-                                outline
+                                variant="outline-secondary"
                                 className="rounded-pill"
                                 onClick={renewLicense}
                                 disabled={!isRenewLicenseEnabled}
@@ -206,7 +212,7 @@ function LicenseActions(props: LicenseActionsProps) {
                     <React.Fragment key="replace-container">
                         <span id="replace-license-btn">
                             <Button
-                                outline
+                                variant="outline-secondary"
                                 className="rounded-pill"
                                 onClick={registerLicense}
                                 disabled={!isReplaceLicenseEnabled}
@@ -227,9 +233,9 @@ function LicenseActions(props: LicenseActionsProps) {
                 <span id="force-update-license-btn">
                     <ButtonWithSpinner
                         isSpinning={forcingUpdate}
-                        outline
                         disabled={!isForceUpdateEnabled}
                         className="rounded-pill"
+                        variant="outline-secondary"
                         onClick={forceUpdate}
                     >
                         <Icon icon="force" /> Force Update
@@ -251,7 +257,7 @@ function LicenseActions(props: LicenseActionsProps) {
     return (
         <Col className="d-flex flex-wrap gap-2 align-items-center justify-content-end">
             <Button
-                color="primary"
+                variant="primary"
                 className="rounded-pill"
                 onClick={registerLicense}
                 disabled={!isRegisterLicenseEnabled}

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/RequestSupportModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/RequestSupportModal.tsx
@@ -1,8 +1,21 @@
 ﻿import useBoolean from "hooks/useBoolean";
-import { Button, Col, Collapse, Form, FormGroup, Input, Label, Modal, ModalBody, ModalFooter, Row } from "reactstrap";
+import {
+    CloseButton,
+    Col,
+    Collapse,
+    Form,
+    FormGroup,
+    Input,
+    Label,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    Row,
+} from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { Checkbox, Switch } from "components/common/Checkbox";
 import React from "react";
+import Button from "react-bootstrap/Button";
 
 interface RequestSupportModalProps {
     visible: boolean;
@@ -32,7 +45,7 @@ export function RequestSupportModal(props: RequestSupportModalProps) {
                 </div>
 
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <CloseButton onClick={toggle} />
                 </div>
                 <div className="text-center lead">Request support</div>
 
@@ -105,10 +118,10 @@ export function RequestSupportModal(props: RequestSupportModalProps) {
                 </Form>
             </ModalBody>
             <ModalFooter>
-                <Button color="secondary" outline onClick={toggle} className="rounded-pill px-3">
+                <Button variant="outline-secondary" onClick={toggle} className="rounded-pill px-3">
                     Close
                 </Button>
-                <Button color="primary" className="rounded-pill px-3">
+                <Button variant="primary" className="rounded-pill px-3">
                     <Icon icon="support" />
                     Request support
                 </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/SupportDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/SupportDetails.tsx
@@ -1,6 +1,6 @@
 ﻿import React, { ReactNode } from "react";
 import { RichPanelHeader } from "components/common/RichPanel";
-import { Button, Col, Row } from "reactstrap";
+import { Col, Row } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import classNames from "classnames";
 import IconName from "../../../../../../typings/server/icons";
@@ -11,6 +11,7 @@ import licenseModel from "models/auth/licenseModel";
 import { AsyncState } from "react-async-hook";
 import { LazyLoad } from "components/common/LazyLoad";
 import { LoadError } from "components/common/LoadError";
+import Button from "react-bootstrap/Button";
 
 const supportImg = require("Content/img/pages/about/support.svg");
 const supportCharacterImg = require("Content/img/pages/about/supportCharacter.svg");
@@ -83,7 +84,7 @@ export function SupportDetails(props: SupportDetailsProps) {
                             Get help and connect with fellow users and RavenDB developers through our community forum.
                         </p>
                         <Button
-                            outline
+                            variant="outline-secondary"
                             href={aboutPageUrls.askCommunity}
                             className="rounded-pill align-self-center px-3"
                             target="_blank"
@@ -117,7 +118,7 @@ export function SupportDetails(props: SupportDetailsProps) {
                             </SupportAdvantage>
                         </Row>
                         <Button
-                            color="success"
+                            variant="success"
                             className="px-4 rounded-pill mt-4"
                             size="lg"
                             href={upgradeLink}
@@ -175,7 +176,7 @@ export function SupportDetails(props: SupportDetailsProps) {
                                         {isPaidSupport && (
                                             <Button
                                                 className="rounded-pill"
-                                                color={isCloud ? "cloud" : "primary"}
+                                                variant={isCloud ? "cloud" : "primary"}
                                                 href={
                                                     isCloud
                                                         ? aboutPageUrls.cloudPortal
@@ -208,7 +209,7 @@ export function SupportDetails(props: SupportDetailsProps) {
                             </Col>
                             <Col>
                                 <Button
-                                    outline
+                                    variant="outline-secondary"
                                     href={aboutPageUrls.askCommunity}
                                     className="rounded-pill align-self-center px-3"
                                     target="_blank"
@@ -226,7 +227,7 @@ export function SupportDetails(props: SupportDetailsProps) {
                                     <br />
                                     <small>We’re here for you 24/7</small>
                                 </div>
-                                <Button href={upgradeLink} color="success" className="px-4 rounded-pill" size="lg">
+                                <Button href={upgradeLink} variant="success" className="px-4 rounded-pill" size="lg">
                                     <Icon icon="upgrade-arrow" /> <strong>Upgrade to Production</strong>
                                 </Button>
                             </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/SupportSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/SupportSummary.tsx
@@ -1,4 +1,5 @@
-﻿import { Button, Card, CardBody, Col, Row } from "reactstrap";
+﻿import { Card, CardBody, Col, Row } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { aboutPageUrls, ConnectivityStatus, OverallInfoItem } from "components/pages/resources/about/partials/common";
 import classNames from "classnames";
 import { Icon } from "components/common/Icon";
@@ -59,12 +60,17 @@ export function SupportSummary(props: SupportSummaryProps) {
                                 href={isCloud ? aboutPageUrls.cloudPortal : aboutPageUrls.supportRequest(licenseId)}
                                 target="_blank"
                                 className="rounded-pill"
-                                color={isCloud ? "cloud" : "primary"}
+                                variant={isCloud ? "cloud" : "primary"}
                             >
                                 <Icon icon="notifications" /> Request support
                             </Button>
                         )}
-                        <Button outline className="rounded-pill" href={aboutPageUrls.askCommunity} target="_blank">
+                        <Button
+                            variant="outline-secondary"
+                            className="rounded-pill"
+                            href={aboutPageUrls.askCommunity}
+                            target="_blank"
+                        >
                             <Icon icon="group" /> Ask community <Icon icon="newtab" margin="ms-1" />
                         </Button>
                     </Col>

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/VersionsSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/VersionsSummary.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Card, CardBody, Col, Row } from "reactstrap";
+﻿import { Card, CardBody, Col, Row } from "reactstrap";
 import { OverallInfoItem } from "components/pages/resources/about/partials/common";
 import { Icon } from "components/common/Icon";
 import React, { useState } from "react";
@@ -10,6 +10,7 @@ import { LoadError } from "components/common/LoadError";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import genUtils from "common/generalUtils";
+import Button from "react-bootstrap/Button";
 
 interface VersionsSummaryProps {
     asyncLatestVersion: AsyncState<Raven.Server.ServerWide.BackgroundTasks.LatestVersionCheck.VersionInfo>;
@@ -48,7 +49,7 @@ export function VersionsSummary(props: VersionsSummaryProps) {
                         {serverFullVersion}
                     </OverallInfoItem>
                     <Col className="d-flex flex-wrap gap-2 align-items-center justify-content-end">
-                        <Button outline className="rounded-pill" onClick={showChangeLogModal}>
+                        <Button variant="outline-secondary" className="rounded-pill" onClick={showChangeLogModal}>
                             <Icon icon="logs" /> Changelog
                         </Button>
                     </Col>
@@ -65,7 +66,7 @@ export function VersionsSummary(props: VersionsSummaryProps) {
                         <Col className="d-flex flex-wrap gap-2 align-items-center justify-content-end">
                             <ButtonWithSpinner
                                 isSpinning={refreshing}
-                                outline
+                                variant="outline-secondary"
                                 className="rounded-pill"
                                 onClick={checkForUpdates}
                             >
@@ -111,7 +112,7 @@ function LatestVersion(props: {
                 </span>
                 <div className="small text-muted fw-light">
                     {latestVersion}
-                    <Button size="xs" color="link" onClick={showWhatsNewModal} className="fw-bold">
+                    <Button size="xs" variant="link" onClick={showWhatsNewModal} className="fw-bold">
                         What&apos;s new?
                     </Button>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
@@ -3,7 +3,6 @@ import { DatabasePanel } from "./partials/DatabasePanel";
 import { DatabasesSelectActions } from "./partials/DatabasesSelectActions";
 import { DatabasesFilter } from "./partials/DatabasesFilter";
 import { NoDatabases } from "./partials/NoDatabases";
-import { Button } from "reactstrap";
 import { useAppDispatch, useAppSelector } from "components/store";
 import router from "plugins/router";
 import appUrl from "common/appUrl";
@@ -21,6 +20,7 @@ import { StickyHeader } from "components/common/StickyHeader";
 import { Icon } from "components/common/Icon";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import CreateDatabase, { CreateDatabaseMode } from "./partials/create/CreateDatabase";
+import Button from "react-bootstrap/Button";
 
 interface DatabasesPageProps {
     activeDatabase?: string;
@@ -118,7 +118,7 @@ export function DatabasesPage(props: DatabasesPageProps) {
                     {isOperatorOrAbove && (
                         <>
                             <Button
-                                color="primary"
+                                variant="primary"
                                 onClick={() => setCreateDatabaseMode("regular")}
                                 className="rounded-pill"
                             >
@@ -134,7 +134,7 @@ export function DatabasesPage(props: DatabasesPageProps) {
                         </>
                     )}
                     {showToggleButton && (
-                        <Button color="secondary" className="rounded-pill" onClick={toggleFilterOptions}>
+                        <Button variant="secondary" className="rounded-pill" onClick={toggleFilterOptions}>
                             <Icon icon="filter" />
                             {showFilterOptions ? "Hide Filtering Options" : "Show Filtering Options"}
                         </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/BulkDatabaseResetConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/BulkDatabaseResetConfirm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { Modal, ModalBody, ModalFooter, Button, CloseButton } from "reactstrap";
+import { Modal, ModalBody, ModalFooter, CloseButton } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import {
     MultipleDatabaseLocationSelector,
     DatabaseActionContexts,
@@ -65,10 +66,10 @@ export default function BulkDatabaseResetConfirm({
                 </div>
             </ModalBody>
             <ModalFooter>
-                <Button color="link" className="link-muted" onClick={toggle}>
+                <Button variant="link" className="link-muted" onClick={toggle}>
                     Cancel
                 </Button>
-                <Button color="danger" onClick={onSubmit}>
+                <Button variant="danger" onClick={onSubmit}>
                     <Icon icon="reset" /> Restart
                 </Button>
             </ModalFooter>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -3,7 +3,6 @@ import { DatabaseLocalInfo, DatabaseSharedInfo } from "components/models/databas
 import classNames from "classnames";
 import { useAppUrls } from "hooks/useAppUrls";
 import {
-    Button,
     ButtonGroup,
     Collapse,
     DropdownItem,
@@ -13,6 +12,7 @@ import {
     Spinner,
     UncontrolledDropdown,
 } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import {
     RichPanel,
     RichPanelActions,
@@ -337,6 +337,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                         <RichPanelActions>
                             {isOperatorOrAbove && (
                                 <Button
+                                    variant="secondary"
                                     href={manageGroupUrl}
                                     title="Manage the Database Group"
                                     target={db.currentNode.isRelevant ? undefined : "_blank"}
@@ -352,7 +353,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                 <UncontrolledDropdown>
                                     <ButtonGroup>
                                         {isOperatorOrAbove && (
-                                            <Button onClick={onToggleDatabase}>
+                                            <Button variant="secondary" onClick={onToggleDatabase}>
                                                 {db.isDisabled ? (
                                                     <span>
                                                         <Icon icon="database" addon="play2" /> Enable
@@ -429,7 +430,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                                     ? "Remove database"
                                                     : "Database cannot be deleted because of the set lock mode"
                                             }
-                                            color={db.lockMode === "Unlock" ? "danger" : "secondary"}
+                                            variant={db.lockMode === "Unlock" ? "danger" : "secondary"}
                                             disabled={db.lockMode !== "Unlock"}
                                         >
                                             {lockChanges && <Spinner size="sm" />}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesFilter.tsx
@@ -1,12 +1,13 @@
 ﻿import React, { ChangeEvent } from "react";
 import { DatabaseFilterByStateOption, DatabaseFilterCriteria } from "components/models/databases";
-import { Button, Input } from "reactstrap";
+import { Input } from "reactstrap";
 import { useAppSelector } from "components/store";
 import { MultiCheckboxToggle } from "components/common/toggles/MultiCheckboxToggle";
 import { InputItem } from "components/models/common";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { databasesViewSelectors } from "components/pages/resources/databases/store/databasesViewSelectors";
 import { Icon } from "components/common/Icon";
+import Button from "react-bootstrap/Button";
 
 type FilterByStateOptions = InputItem<DatabaseFilterByStateOption>[];
 
@@ -52,7 +53,7 @@ export function DatabasesFilter(props: DatabasesFilterProps) {
                     {searchCriteria.name && (
                         <div className="clear-button">
                             <Button
-                                color="secondary"
+                                variant="secondary"
                                 size="sm"
                                 onClick={() =>
                                     setFilterCriteria({

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
@@ -1,13 +1,6 @@
 ﻿import React, { useCallback, useState } from "react";
-import {
-    Button,
-    ButtonGroup,
-    DropdownItem,
-    DropdownMenu,
-    DropdownToggle,
-    Spinner,
-    UncontrolledDropdown,
-} from "reactstrap";
+import { ButtonGroup, DropdownItem, DropdownMenu, DropdownToggle, Spinner, UncontrolledDropdown } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { DatabaseSharedInfo } from "components/models/databases";
 import DatabaseLockMode = Raven.Client.ServerWide.DatabaseLockMode;
@@ -195,7 +188,7 @@ export function DatabasesSelectActions({
                         )}
                         {isOperatorOrAbove && (
                             <ButtonWithSpinner
-                                color="danger"
+                                variant="danger"
                                 onClick={onDelete}
                                 disabled={!canDeleteSelection || deleteChanges}
                                 className="rounded-pill flex-grow-0"
@@ -206,7 +199,7 @@ export function DatabasesSelectActions({
                             </ButtonWithSpinner>
                         )}
                     </ButtonGroup>
-                    <Button onClick={() => setSelectedDatabaseNames([])} color="link">
+                    <Button onClick={() => setSelectedDatabaseNames([])} variant="link">
                         Cancel
                     </Button>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/NoDatabases.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/NoDatabases.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useState } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { EmptySet } from "components/common/EmptySet";
 import { FlexGrow } from "components/common/FlexGrow";
 import CreateDatabase, {
@@ -18,13 +18,13 @@ export function NoDatabases() {
                 <EmptySet>No databases have been created</EmptySet>
 
                 {isOperatorOrAbove && (
-                    <div className="d-flex gap-1">
+                    <div className="d-flex align-items-center gap-1">
                         <FlexGrow />
-                        <Button outline color="primary" onClick={() => setCreateDatabaseMode("regular")}>
+                        <Button variant="outline-primary" onClick={() => setCreateDatabaseMode("regular")}>
                             Create new database
                         </Button>
                         <div>or</div>
-                        <Button outline color="primary" onClick={() => setCreateDatabaseMode("fromBackup")}>
+                        <Button variant="outline-primary" onClick={() => setCreateDatabaseMode("fromBackup")}>
                             Restore one from backup
                         </Button>
                         <FlexGrow />

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
@@ -8,8 +8,9 @@ import { withPreventDefault } from "components/utils/common";
 import DatabaseUtils from "components/utils/DatabaseUtils";
 import BackupInfo = Raven.Client.ServerWide.Operations.BackupInfo;
 import { clusterSelectors } from "components/common/shell/clusterSlice";
-import { Badge, Button } from "reactstrap";
+import { Badge } from "reactstrap";
 import { Icon } from "components/common/Icon";
+import Button from "react-bootstrap/Button";
 import {
     selectDatabaseState,
     selectTopLevelState,
@@ -143,7 +144,7 @@ export function ValidDatabasePropertiesPanel(props: ValidDatabasePropertiesPanel
         <RichPanelDetails className="flex-wrap pb-1">
             <RichPanelDetailItem>
                 <Button
-                    color="secondary"
+                    variant="secondary"
                     title={panelCollapsed ? "Expand distribution details" : "Collapse distribution details"}
                     onClick={togglePanelCollapsed}
                     className="ms-1 btn-toggle-panel rounded-pill"

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanelAlertsPopover.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanelAlertsPopover.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ValidDatabasePropertiesPanelPopoverProps } from "./ValidDatabasePropertiesPanel";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 
 export default function ValidDatabasePropertiesPanelAlertsPopover({
@@ -28,7 +28,7 @@ export default function ValidDatabasePropertiesPanelAlertsPopover({
                             <Button
                                 type="button"
                                 size="xs"
-                                color="warning"
+                                variant="warning"
                                 className="rounded-pill"
                                 onClick={openNotificationCenter}
                             >
@@ -59,7 +59,7 @@ export default function ValidDatabasePropertiesPanelAlertsPopover({
                                     <strong>{x.alerts}</strong> {x.alerts === 1 ? "alert" : "alerts"}
                                 </span>
                                 <a href={getServerNodeUrl(x.nodeTag)} className="no-decor" target="_blank">
-                                    <Button type="button" size="xs" color="node" className="rounded-pill">
+                                    <Button type="button" size="xs" variant="node" className="rounded-pill">
                                         <Icon icon="newtab" />
                                         Open node
                                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanelPerfHintsPopover.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanelPerfHintsPopover.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ValidDatabasePropertiesPanelPopoverProps } from "./ValidDatabasePropertiesPanel";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { Icon } from "components/common/Icon";
 
 export default function ValidDatabasePropertiesPanelPerfHintsPopover({
@@ -28,7 +28,7 @@ export default function ValidDatabasePropertiesPanelPerfHintsPopover({
                             <Button
                                 type="button"
                                 size="xs"
-                                color="info"
+                                variant="info"
                                 className="rounded-pill"
                                 onClick={openNotificationCenter}
                             >
@@ -60,7 +60,7 @@ export default function ValidDatabasePropertiesPanelPerfHintsPopover({
                                     {x.performanceHints === 1 ? "hint" : "hints"}
                                 </span>
                                 <a href={getServerNodeUrl(x.nodeTag)} className="no-decor" target="_blank">
-                                    <Button type="button" size="xs" color="node" className="rounded-pill">
+                                    <Button type="button" size="xs" variant="node" className="rounded-pill">
                                         <Icon icon="newtab" />
                                         Open node
                                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/CreateDatabaseFromBackup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/CreateDatabaseFromBackup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Button, CloseButton, Form, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Form, ModalBody, ModalFooter } from "reactstrap";
 import { FlexGrow } from "components/common/FlexGrow";
 import { Icon } from "components/common/Icon";
 import Steps from "components/common/steps/Steps";
@@ -35,6 +35,7 @@ import { CreateDatabaseStep, createDatabaseUtils } from "../shared/createDatabas
 import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
 import { useCreateDatabaseShortcuts } from "../shared/useCreateDatabaseShortcuts";
+import Button from "react-bootstrap/Button";
 
 interface CreateDatabaseFromBackupProps {
     closeModal: () => void;
@@ -148,6 +149,7 @@ export default function CreateDatabaseFromBackup({
                     {isFirstStep ? (
                         <Button
                             type="button"
+                            variant="secondary"
                             onClick={changeCreateModeToRegular}
                             className="rounded-pill"
                             disabled={formState.isSubmitting}
@@ -155,7 +157,7 @@ export default function CreateDatabaseFromBackup({
                             <Icon icon="database" addon="star" /> Create new database
                         </Button>
                     ) : (
-                        <Button type="button" onClick={prevStep} className="rounded-pill">
+                        <Button type="button" onClick={prevStep} variant="secondary" className="rounded-pill">
                             <Icon icon="arrow-thin-left" /> Back
                         </Button>
                     )}
@@ -163,7 +165,7 @@ export default function CreateDatabaseFromBackup({
                     {isLastStep ? (
                         <ButtonWithSpinner
                             type="submit"
-                            color="success"
+                            variant="success"
                             className="rounded-pill"
                             isSpinning={formState.isSubmitting}
                             icon="rocket"
@@ -171,7 +173,7 @@ export default function CreateDatabaseFromBackup({
                             Finish
                         </ButtonWithSpinner>
                     ) : (
-                        <Button type="button" color="primary" className="rounded-pill" onClick={handleGoNext}>
+                        <Button type="button" variant="primary" className="rounded-pill" onClick={handleGoNext}>
                             Next <Icon icon="arrow-thin-right" margin="ms-1" />
                         </Button>
                     )}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/CreateDatabaseFromBackupStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/CreateDatabaseFromBackupStepBasicInfo.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "components/common/Icon";
 import React, { useEffect } from "react";
-import { Row, Col, Button } from "reactstrap";
+import { Row, Col } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { CreateDatabaseFromBackupFormData } from "../createDatabaseFromBackupValidation";
 import { useFormContext, useWatch } from "react-hook-form";
 import { FormInput } from "components/common/Form";
@@ -44,9 +45,8 @@ export default function CreateDatabaseFromBackupStepBasicInfo() {
                     <Button
                         active={!isSharded}
                         onClick={() => setValue("basicInfoStep.isSharded", false)}
-                        outline
                         className=" me-2 px-4 pt-3 w-100"
-                        color="node"
+                        variant="outline-node"
                     >
                         <Icon icon="database" margin="m-0" className="fs-2" />
                         <br />
@@ -57,8 +57,7 @@ export default function CreateDatabaseFromBackupStepBasicInfo() {
                     <Button
                         active={isSharded}
                         onClick={() => setValue("basicInfoStep.isSharded", true)}
-                        color="shard"
-                        outline
+                        variant="outline-shard"
                         className="px-4 pt-3 w-100"
                     >
                         <Icon icon="sharding" margin="m-0" className="fs-2" />

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/RestorePointField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/RestorePointField.tsx
@@ -9,7 +9,8 @@ import {
 import { components } from "react-select";
 import { Icon } from "components/common/Icon";
 import { GroupHeadingProps, OptionProps } from "react-select";
-import { Row, Button, Col } from "reactstrap";
+import { Row, Col } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { CreateDatabaseFromBackupFormData as FormData, RestorePoint } from "../../createDatabaseFromBackupValidation";
 import { FieldPath, useFormContext, useWatch } from "react-hook-form";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
@@ -101,7 +102,7 @@ export default function CreateDatabaseFromBackupRestorePoint({
                 {isSharded && (
                     <Col sm="2" xs="2" lg="1" className="align-self-center order-2 order-lg-4 text-end">
                         {index > 0 && (
-                            <Button outline color="danger" onClick={remove}>
+                            <Button variant="outline-danger" onClick={remove}>
                                 <Icon icon="trash" margin="m-0" />
                             </Button>
                         )}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/RestorePointsFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/RestorePointsFields.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useFormContext, useFieldArray, useWatch } from "react-hook-form";
-import { Row, Col, Label, Button } from "reactstrap";
+import { Row, Col, Label } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { CreateDatabaseFromBackupFormData as FormData } from "../../createDatabaseFromBackupValidation";
 import { Icon } from "components/common/Icon";
 
@@ -43,7 +44,7 @@ export default function RestorePointsFields(props: RestorePointsFieldsProps) {
                     {isSharded && (
                         <Button
                             size="sm"
-                            color="shard"
+                            variant="shard"
                             className="rounded-pill"
                             onClick={() => append({ restorePoint: null, nodeTag: "" })}
                         >

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/CreateDatabaseRegular.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/CreateDatabaseRegular.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useCallback } from "react";
-import { Button, CloseButton, Form, ModalBody, ModalFooter } from "reactstrap";
+import { CloseButton, Form, ModalBody, ModalFooter } from "reactstrap";
 import { FlexGrow } from "components/common/FlexGrow";
 import { Icon } from "components/common/Icon";
 import Steps from "components/common/steps/Steps";
@@ -37,6 +37,7 @@ import { createDatabaseRegularDataUtils } from "./createDatabaseRegularDataUtils
 import { CreateDatabaseStep, createDatabaseUtils } from "../shared/createDatabaseUtils";
 import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { useCreateDatabaseShortcuts } from "../shared/useCreateDatabaseShortcuts";
+import Button from "react-bootstrap/Button";
 
 interface CreateDatabaseRegularProps {
     closeModal: () => void;
@@ -168,6 +169,7 @@ export default function CreateDatabaseRegular({ closeModal, changeCreateModeToBa
                             type="button"
                             onClick={changeCreateModeToBackup}
                             className="rounded-pill"
+                            variant="secondary"
                             disabled={formState.isSubmitting}
                         >
                             <Icon icon="database" addon="arrow-up" /> Restore from backup
@@ -188,7 +190,7 @@ export default function CreateDatabaseRegular({ closeModal, changeCreateModeToBa
                     {isLastStep ? (
                         <ButtonWithSpinner
                             type="submit"
-                            color="success"
+                            variant="success"
                             className="rounded-pill"
                             icon="rocket"
                             isSpinning={formState.isSubmitting}
@@ -196,7 +198,7 @@ export default function CreateDatabaseRegular({ closeModal, changeCreateModeToBa
                             Finish
                         </ButtonWithSpinner>
                     ) : (
-                        <Button type="button" color="primary" className="rounded-pill" onClick={handleGoNext}>
+                        <Button type="button" variant="primary" className="rounded-pill" onClick={handleGoNext}>
                             Next <Icon icon="arrow-thin-right" margin="ms-1" />
                         </Button>
                     )}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/QuickCreateButton.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/QuickCreateButton.tsx
@@ -18,6 +18,7 @@ export default function QuickCreateButton({ formValues, isSubmitting, handleQuic
                 onClick={handleQuickCreate}
                 className="rounded-pill me-1"
                 id="quickCreateButton"
+                variant="secondary"
                 icon="star"
                 isSpinning={isSubmitting}
                 title="Quick Create (Ctrl + Enter)"

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useCallback } from "react";
-import { Button, Input, Label } from "reactstrap";
+import { Input, Label } from "reactstrap";
 import { UncontrolledButtonWithDropdownPanel } from "components/common/DropdownPanel";
 import useUniqueId from "components/hooks/useUniqueId";
 import useBoolean from "hooks/useBoolean";
@@ -17,6 +17,7 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import { SortableModeCounterProvider } from "./partials/useSortableModeCounter";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import Button from "react-bootstrap/Button";
 
 function getDynamicDatabaseDistributionWarning(
     hasDynamicNodesDistribution: boolean,
@@ -100,7 +101,7 @@ export function ManageDatabaseGroupPage() {
 
                     <FlexGrow />
                     {db.isSharded && (
-                        <Button color="shard" onClick={addNewShard}>
+                        <Button variant="shard" onClick={addNewShard}>
                             <Icon icon="shard" addon="plus" />
                             Add Shard
                         </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeGroup.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useCallback } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import {
@@ -137,8 +137,7 @@ export function NodeGroup(props: NodeGroupProps) {
                                 <DatabaseGroupActions>
                                     <Button
                                         size="xs"
-                                        color="success"
-                                        outline
+                                        variant="outline-success"
                                         className="rounded-pill stretched-link"
                                         disabled={!addNodeEnabled}
                                         onClick={addNode}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
@@ -1,12 +1,6 @@
 ﻿import React from "react";
-import {
-    Button,
-    DropdownItem,
-    DropdownMenu,
-    DropdownToggle,
-    UncontrolledDropdown,
-    UncontrolledTooltip,
-} from "reactstrap";
+import { DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown, UncontrolledTooltip } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import useUniqueId from "components/hooks/useUniqueId";
 import { useDraggableItem } from "hooks/useDraggableItem";
 import { DatabaseSharedInfo, NodeInfo } from "components/models/databases";
@@ -58,6 +52,7 @@ function PromoteButton({ databaseName, nodeTag }: PromoteButtonProps) {
 
     return (
         <ButtonWithSpinner
+            variant="secondary"
             className="rounded-pill justify-content-center"
             title="Promote to become a member"
             icon="promote"
@@ -80,8 +75,7 @@ export function OrchestratorInfoComponent(props: OrchestratorInfoComponentProps)
             <DatabaseGroupActions>
                 <Button
                     size="xs"
-                    color="danger"
-                    outline
+                    variant="outline-danger"
                     disabled={!canDelete}
                     className="rounded-pill"
                     onClick={() => deleteFromGroup(node.tag)}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/OrchestratorsGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/OrchestratorsGroup.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useCallback } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import {
@@ -134,8 +134,7 @@ export function OrchestratorsGroup() {
                                 <DatabaseGroupActions>
                                     <Button
                                         size="xs"
-                                        color="success"
-                                        outline
+                                        variant="outline-success"
                                         className="rounded-pill stretched-link"
                                         disabled={!addNodeEnabled}
                                         onClick={addNode}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useCallback, useState } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { NodeInfoReorderComponent } from "components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent";
 import { useDrop } from "react-dnd";
 import { NodeInfo } from "components/models/databases";
@@ -30,16 +30,16 @@ export function ReorderNodesControls(props: ReorderNodesControlsProps) {
     };
 
     return !sortableMode ? (
-        <Button disabled={canSort} onClick={enableReorder}>
+        <Button variant="secondary" disabled={canSort} onClick={enableReorder}>
             <Icon icon="reorder" />
             Reorder nodes
         </Button>
     ) : (
         <>
-            <ButtonWithSpinner color="success" onClick={onSaveClicked} isSpinning={saving} icon="save">
+            <ButtonWithSpinner variant="success" onClick={onSaveClicked} isSpinning={saving} icon="save">
                 Save reorder
             </ButtonWithSpinner>
-            <Button onClick={cancelReorder}>
+            <Button variant="secondary" onClick={cancelReorder}>
                 <Icon icon="cancel" />
                 <span>Cancel</span>
             </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ShardsGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ShardsGroup.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { useCallback } from "react";
-import { Button } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import {
@@ -141,8 +141,7 @@ export function ShardsGroup(props: ShardsGroupProps) {
                                 <DatabaseGroupActions>
                                     <Button
                                         size="xs"
-                                        color="success"
-                                        outline
+                                        variant="outline-success"
                                         className="rounded-pill stretched-link"
                                         disabled={!addNodeEnabled}
                                         onClick={addNode}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
-import { Form, Col, Button, Card, Row, Spinner, InputGroup, UncontrolledPopover } from "reactstrap";
+import { Form, Col, Card, Row, Spinner, InputGroup, UncontrolledPopover } from "reactstrap";
+import Button from "react-bootstrap/Button";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { FormCheckbox, FormInput, FormSelect, FormSwitch } from "components/common/Form";
 import {
@@ -91,7 +92,7 @@ export default function ClientGlobalConfiguration() {
                         <div id="saveClientConfiguration" className="w-fit-content mb-3">
                             <Button
                                 type="submit"
-                                color="primary"
+                                variant="primary"
                                 disabled={formState.isSubmitting || !formState.isDirty}
                             >
                                 {formState.isSubmitting ? <Spinner size="sm" className="me-1" /> : <Icon icon="save" />}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/gatherDebugInfo/GatherDebugInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/gatherDebugInfo/GatherDebugInfo.tsx
@@ -89,7 +89,7 @@ function GatherDebugInfo() {
                                         />
                                         <ButtonWithSpinner
                                             type="submit"
-                                            color="primary"
+                                            variant="primary"
                                             className="rounded-pill align-self-center"
                                             icon="default"
                                             isSpinning={isDownloading}
@@ -100,7 +100,7 @@ function GatherDebugInfo() {
                                             <ButtonWithSpinner
                                                 className="rounded-pill align-self-center"
                                                 icon="cancel"
-                                                color="warning"
+                                                variant="warning"
                                                 isSpinning={abortData.isAborting}
                                                 onClick={abortData.toggleIsConfirmVisible}
                                             >

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/gatherDebugInfo/GatherDebugInfoAbortConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/gatherDebugInfo/GatherDebugInfoAbortConfirm.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "components/common/Icon";
 import React from "react";
-import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface GatherDebugInfoAbortConfirmProps {
     isOpen: boolean;
@@ -27,10 +28,10 @@ export default function GatherDebugInfoAbortConfirm({ isOpen, toggle, onConfirm 
                 <div className="text-center lead">Do you want to abort package creation?</div>
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button variant="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color="warning" onClick={onSubmit} className="rounded-pill">
+                <Button variant="warning" onClick={onSubmit} className="rounded-pill">
                     <Icon icon="cancel" className="me-1" />
                     Abort
                 </Button>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzers.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzers.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Col, Row } from "reactstrap";
+import { Col, Row } from "reactstrap";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { HrHeader } from "components/common/HrHeader";
@@ -11,6 +11,7 @@ import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNo
 import { useCustomAnalyzers } from "components/common/customAnalyzers/useCustomAnalyzers";
 import ServerWideCustomAnalyzersList from "components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzersList";
 import ServerWideCustomAnalyzersInfoHub from "components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzersInfoHub";
+import Button from "react-bootstrap/Button";
 
 export default function ServerWideCustomAnalyzers() {
     const { analyzers, setAnalyzers, addNewAnalyzer, removeAnalyzer, mapFromDto } = useCustomAnalyzers();
@@ -46,7 +47,7 @@ export default function ServerWideCustomAnalyzers() {
                         />
                         <div id="newServerWideCustomAnalyzer" className="w-fit-content mt-4">
                             <Button
-                                color="primary"
+                                variant="primary"
                                 className="mb-3"
                                 onClick={addNewAnalyzer}
                                 disabled={!hasServerWideCustomAnalyzers}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideAnalyzers/ServerWideCustomAnalyzersListItem.tsx
@@ -18,12 +18,13 @@ import {
     RichPanelInfo,
     RichPanelName,
 } from "components/common/RichPanel";
-import { Button, Collapse, Form, InputGroup, Label } from "reactstrap";
+import { Collapse, Form, InputGroup, Label } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import DeleteCustomAnalyzerConfirm from "components/common/customAnalyzers/DeleteCustomAnalyzerConfirm";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormAceEditor, FormInput } from "components/common/Form";
 import fileImporter from "common/fileImporter";
+import Button from "react-bootstrap/Button";
 
 interface ServerWideCustomAnalyzersListItemProps {
     initialAnalyzer: CustomAnalyzerFormData;
@@ -91,17 +92,17 @@ export default function ServerWideCustomAnalyzersListItem(props: ServerWideCusto
                     <RichPanelActions>
                         {isEditMode ? (
                             <>
-                                <Button key="save" type="submit" color="success" disabled={formState.isSubmitting}>
+                                <Button key="save" type="submit" variant="success" disabled={formState.isSubmitting}>
                                     <Icon icon="save" /> Save changes
                                 </Button>
-                                <Button key="cancel" type="button" color="secondary" onClick={onDiscard}>
+                                <Button key="cancel" type="button" variant="secondary" onClick={onDiscard}>
                                     <Icon icon="cancel" />
                                     Discard
                                 </Button>
                             </>
                         ) : (
                             <>
-                                <Button key="edit" onClick={toggleIsEditMode}>
+                                <Button variant="secondary" key="edit" onClick={toggleIsEditMode}>
                                     <Icon icon="edit" margin="m-0" />
                                 </Button>
                                 {nameToConfirmDelete != null && (
@@ -113,7 +114,7 @@ export default function ServerWideCustomAnalyzersListItem(props: ServerWideCusto
                                 )}
                                 <ButtonWithSpinner
                                     key="delete"
-                                    color="danger"
+                                    variant="danger"
                                     onClick={() => setNameToConfirmDelete(formValues.name)}
                                     icon="trash"
                                     isSpinning={asyncDeleteAnalyzer.status === "loading"}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSorters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSorters.tsx
@@ -1,5 +1,5 @@
 ﻿import React from "react";
-import { Button, Col, Row } from "reactstrap";
+import { Col, Row } from "reactstrap";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { HrHeader } from "components/common/HrHeader";
@@ -12,6 +12,7 @@ import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNo
 import { useCustomSorters } from "components/common/customSorters/useCustomSorters";
 import ServerWideCustomSortersInfoHub from "components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSortersInfoHub";
 import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
 
 export default function ServerWideCustomSorters() {
     const { sorters, setSorters, addNewSorter, removeSorter, mapFromDto } = useCustomSorters();
@@ -52,7 +53,7 @@ export default function ServerWideCustomSorters() {
                         )}
                         <div id="newServerWideCustomSorter" className="w-fit-content mt-4">
                             <Button
-                                color="primary"
+                                variant="primary"
                                 className="mb-3"
                                 onClick={addNewSorter}
                                 disabled={!hasServerWideCustomSorters}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSortersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSortersListItem.tsx
@@ -23,7 +23,8 @@ import { Icon } from "components/common/Icon";
 import React, { useState } from "react";
 import { useAsyncCallback } from "react-async-hook";
 import { useForm, useWatch, SubmitHandler } from "react-hook-form";
-import { Button, Collapse, Form, InputGroup, Label } from "reactstrap";
+import { Collapse, Form, InputGroup, Label } from "reactstrap";
+import Button from "react-bootstrap/Button";
 
 interface ServerWideCustomSortersListItemProps {
     initialSorter: CustomSorterFormData;
@@ -91,17 +92,17 @@ export default function ServerWideCustomSortersListItem(props: ServerWideCustomS
                     <RichPanelActions>
                         {isEditMode ? (
                             <>
-                                <Button key="save" type="submit" color="success" disabled={formState.isSubmitting}>
+                                <Button key="save" type="submit" variant="success" disabled={formState.isSubmitting}>
                                     <Icon icon="save" /> Save changes
                                 </Button>
-                                <Button key="cancel" type="button" color="secondary" onClick={onDiscard}>
+                                <Button key="cancel" type="button" variant="secondary" onClick={onDiscard}>
                                     <Icon icon="cancel" />
                                     Discard
                                 </Button>
                             </>
                         ) : (
                             <>
-                                <Button key="edit" onClick={toggleIsEditMode}>
+                                <Button variant="secondary" key="edit" onClick={toggleIsEditMode}>
                                     <Icon icon="edit" margin="m-0" />
                                 </Button>
                                 {nameToConfirmDelete != null && (
@@ -113,7 +114,7 @@ export default function ServerWideCustomSortersListItem(props: ServerWideCustomS
                                 )}
                                 <ButtonWithSpinner
                                     key="delete"
-                                    color="danger"
+                                    variant="danger"
                                     onClick={() => setNameToConfirmDelete(formValues.name)}
                                     icon="trash"
                                     isSpinning={asyncDeleteSorter.status === "loading"}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
@@ -100,7 +100,7 @@ export default function StudioGlobalConfiguration() {
                         <div id="saveStudioConfiguration" className="w-fit-content">
                             <ButtonWithSpinner
                                 type="submit"
-                                color="primary"
+                                variant="primary"
                                 className="mb-3"
                                 icon="save"
                                 disabled={!formState.isDirty}

--- a/src/Raven.Studio/typings/_studio/react-bootstrap.d.ts
+++ b/src/Raven.Studio/typings/_studio/react-bootstrap.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="react-bootstrap" />
+import { BsPrefixRefForwardingComponent } from "react-bootstrap/helpers";
+import { ButtonProps } from "react-bootstrap";
+
+declare module "react-bootstrap/Button" {
+    export type RavenButtonVariants = ButtonProps["variant"] | "link-muted" | "outline-node" | "outline-shard" | "node" | "shard" | "cloud"
+    
+    export type RavenButtonSizes = ButtonProps["size"] | "xs"
+    
+    export interface BtnProps extends Omit<ButtonProps, "size"> {
+        size?: RavenButtonSizes;
+        variant?: RavenButtonVariants
+    }
+    
+    declare const Button: BsPrefixRefForwardingComponent<"button", BtnProps>;
+    export = Button;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23360

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
