### PR TITLE
RavenDB-23782: Add TrafficWatch and EventListener configurations in TestBase

### DIFF
--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -25,6 +25,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes.Static.NuGet;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.Restore;
+using Raven.Server.EventListener;
 using Raven.Server.Logging;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
@@ -181,6 +182,16 @@ namespace FastTests
             configuration.Logs.MinLevel = LogLevel.Off;
 
             RavenLogManager.Instance.ConfigureLogging(configuration);
+
+            TrafficWatchToLog.Instance.UpdateConfiguration(RavenConfiguration.Default.TrafficWatch);
+            EventListenerToLog.Instance.UpdateConfiguration(new EventListenerToLog.EventListenerConfiguration
+            {
+                EventListenerMode = configuration.DebugConfiguration.EventListenerMode,
+                EventTypes = configuration.DebugConfiguration.EventTypes,
+                MinimumDurationInMs = configuration.DebugConfiguration.MinimumDuration.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingIntervalInMs = configuration.DebugConfiguration.AllocationsLoggingInterval.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingCount = configuration.DebugConfiguration.AllocationsLoggingCount
+            });
         }
 
         protected TestBase(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23782

### Additional description

The `EventListenerToLog` and `TrafficWatchToLog` functionality requires proper configuration when initializing an instance. 
However, in v7.0 branch, the necessary configuration code for `EventListenerToLog` and `TrafficWatchToLog` was omitted from the `TestBase` class during instance initialization for testing purposes. As a result, logging functionality is not working properly within tests.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
