### PR TITLE
RavenDB-21764 - clean up tests

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.spec.tsx
@@ -1,6 +1,6 @@
 import { composeStories } from "@storybook/react";
 import * as stories from "./DocumentIdentities.stories";
-import { rtlRender, rtlRender_WithWaitForLoad } from "test/rtlTestUtils";
+import { rtlRender } from "test/rtlTestUtils";
 import React from "react";
 
 const { DocumentIdentitiesStory } = composeStories(stories);
@@ -29,7 +29,7 @@ describe("DocumentIdentities", () => {
     });
 
     it("should not display the edit column in table when database access is read-only", async () => {
-        const { screen } = await rtlRender(<DocumentIdentitiesStory databaseAccess="DatabaseRead" />);
+        const { screen } = rtlRender(<DocumentIdentitiesStory databaseAccess="DatabaseRead" />);
 
         // wait for table load
         expect(await screen.findByText(selectors.documentIdPrefix)).toBeInTheDocument();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21764

### Additional description

Cleaned up test file for DocumentIdentities

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
