### PR TITLE
RavenDB-23167 - fix SeekBackward giving greater keys than the last key that passed

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1509,15 +1509,21 @@ namespace Raven.Server.Documents.Revisions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, Slice lowerId, out Slice prefixSlice)
+        internal unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, Slice lowerId, out Slice prefixSlice)
         {
-            return GetKeyPrefix(context, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
+            return GetKeyPrefix(context.Allocator, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, out Slice prefixSlice)
+        internal static unsafe ByteStringContext.InternalScope GetKeyPrefix(ByteStringContext allocator, Slice lowerId, out Slice prefixSlice)
         {
-            var scope = context.Allocator.Allocate(lowerIdSize + 1, out ByteString keyMem);
+            return GetKeyPrefix(allocator, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe ByteStringContext.InternalScope GetKeyPrefix(ByteStringContext allocator, byte* lowerId, int lowerIdSize, out Slice prefixSlice)
+        {
+            var scope = allocator.Allocate(lowerIdSize + 1, out ByteString keyMem);
 
             Memory.Copy(keyMem.Ptr, lowerId, lowerIdSize);
             keyMem.Ptr[lowerIdSize] = SpecialChars.RecordSeparator;
@@ -1532,9 +1538,15 @@ namespace Raven.Server.Documents.Revisions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
+        internal static ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
         {
-            var scope = context.Allocator.Allocate(lowerId.Size + 1 + sizeof(long), out ByteString keyMem);
+            return GetKeyWithEtag(context.Allocator, lowerId, etag, out prefixSlice);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(ByteStringContext allocator, Slice lowerId, long etag, out Slice prefixSlice)
+        {
+            var scope = allocator.Allocate(lowerId.Size + 1 + sizeof(long), out ByteString keyMem);
 
             Memory.Copy(keyMem.Ptr, lowerId.Content.Ptr, lowerId.Size);
             keyMem.Ptr[lowerId.Size] = SpecialChars.RecordSeparator;

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -719,11 +719,11 @@ namespace Voron.Data.BTrees
             return SearchForPage(key, out node);
         }
 
-        internal TreePage FindPageFor(Slice key, out TreeNodeHeader* node, out TreeCursorConstructor cursor, bool allowCompressed = false)
+        internal TreePage FindPageFor(Slice key, out TreeNodeHeader* node, out TreeCursorConstructor cursor, bool allowCompressed = false, bool backward = false)
         {
             TreePage p;
 
-            if (TryUseRecentTransactionPage(key, out cursor, out p, out node))
+            if (TryUseRecentTransactionPage(key, out cursor, out p, out node, backward))
             {
                 if (allowCompressed == false && p.IsCompressed)
                     ThrowOnCompressedPage(p);
@@ -731,7 +731,7 @@ namespace Voron.Data.BTrees
                 return p;
             }
 
-            return SearchForPage(key, allowCompressed, out cursor, out node);
+            return SearchForPage(key, allowCompressed, out cursor, out node, backward: backward);
         }
 
         [ThreadStatic]
@@ -816,7 +816,7 @@ namespace Voron.Data.BTrees
             return p.LastSearchPosition;
         }
 
-        private TreePage SearchForPage(Slice key, bool allowCompressed, out TreeCursorConstructor cursorConstructor, out TreeNodeHeader* node, bool addToRecentlyFoundPages = true)
+        private TreePage SearchForPage(Slice key, bool allowCompressed, out TreeCursorConstructor cursorConstructor, out TreeNodeHeader* node, bool addToRecentlyFoundPages = true, bool backward = false)
         {
             var p = GetReadOnlyTreePage(State.Header.RootPageNumber);
 
@@ -859,7 +859,7 @@ namespace Voron.Data.BTrees
             if (allowCompressed == false && p.IsCompressed)
                 ThrowOnCompressedPage(p);
 
-            node = p.Search(_llt, key); // will set the LastSearchPosition
+            node = p.Search(_llt, key, backward); // will set the LastSearchPosition
 
             if (p.NumberOfEntries > 0 && addToRecentlyFoundPages) // compressed page can have no ordinary entries
                 AddToRecentlyFoundPages(cursor, p, leftmostPage, rightmostPage);
@@ -977,7 +977,7 @@ namespace Voron.Data.BTrees
             return true;
         }
 
-        private bool TryUseRecentTransactionPage(Slice key, out TreeCursorConstructor cursor, out TreePage page, out TreeNodeHeader* node)
+        private bool TryUseRecentTransactionPage(Slice key, out TreeCursorConstructor cursor, out TreePage page, out TreeNodeHeader* node, bool backward)
         {
             if (_recentlyFoundPages == null || _recentlyFoundPages.TryFind(key, out var foundPage) == false)
             {
@@ -1003,7 +1003,7 @@ namespace Voron.Data.BTrees
             if (page.IsLeaf == false)
                 VoronUnrecoverableErrorException.Raise(_llt, "Index points to a non leaf page");
 
-            node = page.Search(_llt, key); // will set the LastSearchPosition
+            node = page.Search(_llt, key, backward); // will set the LastSearchPosition
 
             cursor = new TreeCursorConstructor(_llt, this, page, foundPage.Cursor.ToArray(), lastFoundPageNumber);
             return true;

--- a/src/Voron/Data/BTrees/TreeIterator.cs
+++ b/src/Voron/Data/BTrees/TreeIterator.cs
@@ -41,18 +41,28 @@ namespace Voron.Data.BTrees
             return _tree.GetDataSize(Current);
         }
 
+        public bool SeekBackward(Slice key)
+        {
+            return SeekInternal(key, backward: true);
+        }
+
         public bool Seek(Slice key)
+        {
+            return SeekInternal(key, backward: false);
+        }
+
+        private bool SeekInternal(Slice key, bool backward)
         {
             if (_disposed)
                 throw new ObjectDisposedException("TreeIterator " + _tree.Name);
 
             TreeNodeHeader* node;
             TreeCursorConstructor constructor;
-            _currentPage = _tree.FindPageFor(key, node: out node, cursor: out constructor, allowCompressed: _tree.IsLeafCompressionSupported);
+            _currentPage = _tree.FindPageFor(key, node: out node, cursor: out constructor, allowCompressed: _tree.IsLeafCompressionSupported, backward: backward);
             if (_currentPage.IsCompressed)
             {
                 DecompressedCurrentPage();
-                node = _currentPage.Search(_tx, key);
+                node = _currentPage.Search(_tx, key, backward: backward);
             }
 
             _cursor = constructor.Build(key);
@@ -69,12 +79,20 @@ namespace Voron.Data.BTrees
                 return true;
             }
 
-            // The key is not found in the db, but we are Seek()ing for equals or starts with.
-            // We know that the exact value isn't there, but it is possible that the next page has values 
-            // that is actually greater than the key, so we need to check it as well.
-
-            _currentPage.LastSearchPosition = _currentPage.NumberOfEntries; // force next MoveNext to move to the next _page_.
-            return MoveNext();
+            if (backward)
+            {
+                // We know that the exact value isn't there, but it is possible that the previous page has values 
+                // that is actually less than the key, so we need to check it as well.
+                _currentPage.LastSearchPosition = -1; // force next MovePrev to move to the previous _page_.
+                return MovePrev();
+            }
+            else
+            {
+                // We know that the exact value isn't there, but it is possible that the next page has values 
+                // that is actually greater than the key, so we need to check it as well.
+                _currentPage.LastSearchPosition = _currentPage.NumberOfEntries; // force next MoveNext to move to the next _page_.
+                return MoveNext();
+            }
         }
 
         public Slice CurrentKey

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -105,7 +105,7 @@ namespace Voron.Data.BTrees
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public TreeNodeHeader* Search(LowLevelTransaction tx, Slice key)
+        public TreeNodeHeader* Search(LowLevelTransaction tx, Slice key, bool backward = false)
         {
             int numberOfEntries = NumberOfEntries;
             if (numberOfEntries == 0)
@@ -134,7 +134,11 @@ namespace Voron.Data.BTrees
                         lastMatch = Memory.Compare(keyPtr, pageKey, Math.Min(keySize, pageKeyLength));
                         LastMatch = lastMatch != 0 ? lastMatch : keySize - pageKeyLength;
 
-                        LastSearchPosition = LastMatch > 0 ? 1 : 0;
+                        if (backward)
+                            LastSearchPosition = LastMatch < 0 ? -1 : 0;
+                        else
+                            LastSearchPosition = LastMatch > 0 ? 1 : 0;
+                        
                         return LastSearchPosition == 0 ? node : null;
                     }
 
@@ -164,12 +168,19 @@ namespace Voron.Data.BTrees
                             high = position - 1;
                     }
 
-                    if (lastMatch > 0) // found entry less than key
+                    if (backward)
                     {
-                        position++; // move to the smallest entry larger than the key
+                        if (lastMatch < 0)  // found entry greater than key
+                            position--; // move to the largest entry smaller than the key
+                    }
+                    else
+                    {
+                        if (lastMatch > 0) // found entry less than key
+                            position++; // move to the smallest entry larger than the key
+
+                        Debug.Assert(position < ushort.MaxValue);
                     }
 
-                    Debug.Assert(position < ushort.MaxValue);
                     lastSearchPosition = position;
                     break;
                 }
@@ -193,7 +204,15 @@ namespace Voron.Data.BTrees
             LastMatch = lastMatch;
             LastSearchPosition = lastSearchPosition;
 
-            return lastSearchPosition >= numberOfEntries ? null : GetNode(lastSearchPosition);
+            if (backward)
+            {
+                if (lastSearchPosition <= -1)
+                    return null;
+            }
+            else if (lastSearchPosition >= numberOfEntries)
+                return null;
+
+            return GetNode(lastSearchPosition);
         }
 
         [DoesNotReturn]

--- a/src/Voron/Data/BTrees/TreePageIterator.cs
+++ b/src/Voron/Data/BTrees/TreePageIterator.cs
@@ -39,11 +39,21 @@ namespace Voron.Data.BTrees
             OnDisposal?.Invoke(this);
         }
 
+        public bool SeekBackward(Slice key)
+        {
+            return SeekInternal(key, backward: true);
+        }
+
         public bool Seek(Slice key)
+        {
+            return SeekInternal(key, backward: false);
+        }
+
+        private bool SeekInternal(Slice key, bool backward)
         {
             if (_disposed)
                 throw new ObjectDisposedException("PageIterator");
-            var current = _page.Search(_tx, key);
+            var current = _page.Search(_tx, key, backward);
             if (current == null)
                 return false;
 

--- a/src/Voron/Data/EmptyIterator.cs
+++ b/src/Voron/Data/EmptyIterator.cs
@@ -11,6 +11,11 @@ namespace Voron.Data
             return false;
         }
 
+        public bool SeekBackward(Slice key)
+        {
+            return false;
+        }
+
         public bool DoRequireValidation
         {
             get { throw new InvalidOperationException("No current page"); }

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -17,6 +17,7 @@ namespace Voron.Data.Fixed
         {
             bool SeekToLast();
             bool Seek(TVal key);
+            bool SeekBackward(TVal key);
             TVal CurrentKey { get; }
             byte* ValuePtr(out int valueSize);
             ByteStringContext.Scope Value(out Slice slice);
@@ -37,6 +38,11 @@ namespace Voron.Data.Fixed
             }
 
             public bool Seek(TVal key)
+            {
+                return false;
+            }
+
+            public bool SeekBackward(TVal key)
             {
                 return false;
             }
@@ -116,6 +122,17 @@ namespace Voron.Data.Fixed
                 if (_fst._lastMatch > 0)
                     _pos++; // We didn't find the key.
                 return _pos != _header->NumberOfEntries;
+            }
+
+            public bool SeekBackward(TVal key)
+            {
+                if (_header == null)
+                    return false;
+                _pos = _fst.BinarySearch(_dataStart, _header->NumberOfEntries, key, _fst._entrySize);
+                if (_fst._lastMatch < 0)
+                    _pos--; // We didn't find the key.
+
+                return _pos != -1;
             }
 
             public TVal CurrentKey
@@ -226,6 +243,12 @@ namespace Voron.Data.Fixed
             {
                 _currentPage = _parent.FindPageFor(key);
                 return _currentPage.LastMatch <= 0 || MoveNext();
+            }
+
+            public bool SeekBackward(TVal key)
+            {
+                _currentPage = _parent.FindPageFor(key);
+                return _currentPage.LastMatch >= 0 || MovePrev();
             }
 
             public bool SeekToLast()

--- a/src/Voron/Data/IIterator.cs
+++ b/src/Voron/Data/IIterator.cs
@@ -11,6 +11,7 @@ namespace Voron.Data
         Slice MaxKey { get; set; }
 
         bool Seek(Slice key);
+        bool SeekBackward(Slice key);
         bool MoveNext();
         bool MovePrev();
         bool Skip(long count);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1442,7 +1442,7 @@ namespace Voron.Data.Tables
             return null;
         }
 
-        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice? prefix, Slice last, long skip)
+        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice? prefix, Slice last, long skip) // V4
         {
             var tree = GetTree(index);
             if (tree == null)
@@ -1450,7 +1450,7 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     yield break;
 
                 if (prefix != null)
@@ -1484,7 +1484,7 @@ namespace Voron.Data.Tables
             }
         }
 
-        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice prefix, Slice last)
+        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice prefix, Slice last) // V1 V3
         {
             var tree = GetTree(index);
             if (tree == null)
@@ -1492,17 +1492,11 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     yield break;
 
                 it.SetRequiredPrefix(prefix);
                 if (SliceComparer.StartWith(it.CurrentKey, it.RequiredPrefix) == false)
-                {
-                    if (it.MovePrev() == false)
-                        yield break;
-                }
-
-                if (SliceComparer.CompareInline(it.CurrentKey, last) > 0)
                 {
                     if (it.MovePrev() == false)
                         yield break;
@@ -1530,7 +1524,7 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     return null;
 
                 it.SetRequiredPrefix(prefix);
@@ -2047,13 +2041,12 @@ namespace Voron.Data.Tables
             }
         }
 
-        public IEnumerable<TableValueHolder> SeekBackwardFrom(TableSchema.FixedSizeKeyIndexDef index, long key, long skip = 0)
+        public IEnumerable<TableValueHolder> SeekBackwardFrom(TableSchema.FixedSizeKeyIndexDef index, long key, long skip = 0) // V2
         {
             var fst = GetFixedSizeTree(index);
             using (var it = fst.Iterate())
             {
-                if (it.Seek(key) == false &&
-                    it.SeekToLast() == false)
+                if (it.SeekBackward(key) == false)
                     yield break;
 
                 if (it.Skip(-skip) == false)
@@ -2062,8 +2055,6 @@ namespace Voron.Data.Tables
                 var result = new TableValueHolder();
                 do
                 {
-                    if (it.CurrentKey > key)
-                        continue;
 
                     GetTableValueReader(it, out result.Reader);
                     yield return result;

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1442,7 +1442,7 @@ namespace Voron.Data.Tables
             return null;
         }
 
-        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice? prefix, Slice last, long skip) // V4
+        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice? prefix, Slice last, long skip)
         {
             var tree = GetTree(index);
             if (tree == null)
@@ -1484,7 +1484,7 @@ namespace Voron.Data.Tables
             }
         }
 
-        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice prefix, Slice last) // V1 V3
+        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice prefix, Slice last)
         {
             var tree = GetTree(index);
             if (tree == null)
@@ -2041,7 +2041,7 @@ namespace Voron.Data.Tables
             }
         }
 
-        public IEnumerable<TableValueHolder> SeekBackwardFrom(TableSchema.FixedSizeKeyIndexDef index, long key, long skip = 0) // V2
+        public IEnumerable<TableValueHolder> SeekBackwardFrom(TableSchema.FixedSizeKeyIndexDef index, long key, long skip = 0)
         {
             var fst = GetFixedSizeTree(index);
             using (var it = fst.Iterate())

--- a/test/SlowTests/Issues/RavenDB-23167-Voron.cs
+++ b/test/SlowTests/Issues/RavenDB-23167-Voron.cs
@@ -1,0 +1,337 @@
+﻿using System;
+using System.Linq;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Sparrow.Server;
+using Sparrow.Server.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+using Voron.Impl;
+using static Voron.Data.Tables.TableSchema;
+using Sparrow.Binary;
+using Sparrow.Threading;
+using FastTests.Voron;
+using FastTests.Voron.FixedSize;
+using Sparrow.Json;
+using System.Collections.Generic;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23167_Voron : StorageTest
+    {
+        public RavenDB_23167_Voron(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void SeekBackwardFrom_VoronOverloads()
+        {
+            RequireFileBasedPager();
+
+            using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
+            using (Slice.From(allocator, "PK", out var pk))
+            using (Slice.From(allocator, "Etags", out var etagsSlice))
+            using (Slice.From(allocator, "RevisionsIdAndEtag", out var idAndEtagSlice))
+            using (Slice.From(allocator, "Table", out var tableName))
+            {
+                var etagsIndex = new FixedSizeKeyIndexDef { Name = etagsSlice, IsGlobal = false, StartIndex = 0 };
+                var idAndEtagIndex = new IndexDef { StartIndex = 1, Count = 3, Name = idAndEtagSlice };
+                var schema = new TableSchema()
+                    .DefineKey(new IndexDef { Name = pk, IsGlobal = false, StartIndex = 0, Count = 1 })
+                    .DefineFixedSizeIndex(etagsIndex)
+                    .DefineIndex(idAndEtagIndex);
+
+                using (var tx = Env.WriteTransaction())
+                {
+                    schema.Create(tx, tableName, null);
+                    tx.Commit();
+                }
+
+                using (var tx = Env.WriteTransaction())
+                {
+                    var table = tx.OpenTable(schema, tableName);
+
+                    InsertToTable(tx, table, 2, "foo/bar");
+                    InsertToTable(tx, table, 4, "foo/bar1");
+                    InsertToTable(tx, table, 6, "foo/bar");
+
+                    tx.Commit();
+                }
+
+                using (var tx = Env.ReadTransaction())
+                {
+                    var table = tx.OpenTable(schema, tableName);
+
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: 3, empty: false, expectedEtag: 2);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: 0, empty: true);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: 10, empty: false, expectedEtag: 6);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: long.MaxValue, empty: false, expectedEtag: 6);
+
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 3, empty: false, expectedEtag: 2);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 0, empty: true);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 10, empty: false, expectedEtag: 6);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: long.MaxValue, empty: false, expectedEtag: 6);
+
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 5, empty: false, expectedEtag: 2);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar1", endEtag: 5, empty: false, expectedEtag: 4);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/ba", endEtag: 5, empty: true);
+
+                    AssertSeekBackwardAfterAllKeys(tx.Allocator, table, idAndEtagIndex, "foo/bar", empty: false, expectedEtag: 6);
+                    AssertSeekBackwardAfterAllKeys(tx.Allocator, table, idAndEtagIndex, "foo/ba", empty: true);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(10)]
+        [InlineDataWithRandomSeed(100)]
+        public void SeekBackwardFrom_VoronOverloads_Random(int numberOfEntities, int seed)
+        {
+            RequireFileBasedPager();
+
+            var random = new Random(seed);
+
+            using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
+            using (Slice.From(allocator, "PK", out var pk))
+            using (Slice.From(allocator, "Etags", out var etagsSlice))
+            using (Slice.From(allocator, "RevisionsIdAndEtag", out var idAndEtagSlice))
+            using (Slice.From(allocator, "Table", out var tableName))
+            {
+                var etagsIndex = new FixedSizeKeyIndexDef { Name = etagsSlice, IsGlobal = false, StartIndex = 0 }; // Index key: [KeyEtag = 0]
+                var idAndEtagIndex = new IndexDef { StartIndex = 1, Count = 3, Name = idAndEtagSlice }; // Index key: [LowerId = 1, RecordSeparator = 2, Etag = 3]
+                var schema = new TableSchema() // Schema: KeyEtag = 0, LowerId = 1, RecordSeparator = 2, Etag = 3
+                    .DefineKey(new IndexDef { Name = pk, IsGlobal = false, StartIndex = 0, Count = 1 })
+                    .DefineFixedSizeIndex(etagsIndex)
+                    .DefineIndex(idAndEtagIndex);
+
+                using (var tx = Env.WriteTransaction())
+                {
+                    schema.Create(tx, tableName, null);
+                    tx.Commit();
+                }
+
+                List<(string Id, long Etag)> entities = new List<(string Id, long Etag)>();
+                List<(string Id, long Etag)> users;
+                List<(string Id, long Etag)> companies;
+
+                using (var tx = Env.WriteTransaction())
+                {
+                    var usedEtags = new HashSet<long>();
+
+                    var table = tx.OpenTable(schema, tableName);
+
+                    for (int i = 1; i < numberOfEntities; i++)
+                    {
+                        var id = i % 2 == 0 ? $"users/{i}" : $"companies/{i}";
+                        var etag = GetUniqueEtag(); // Get etag that isn't exist in 'usedEtags'
+                        usedEtags.Add(etag); // Add the unique etag to the HashSet
+                        entities.Add((id, etag));
+                        InsertToTable(tx, table, etag, id);
+                    }
+
+                    tx.Commit();
+
+                    long GetUniqueEtag()
+                    {
+                        long etag;
+                        do
+                        {
+                            etag = random.NextInt64(1, numberOfEntities * 10);
+                        } while (usedEtags.Contains(etag)); // Keep generating until a unique etag is found
+                        return etag;
+                    }
+                }
+
+                entities = entities.OrderBy(entity => entity.Etag).ToList();
+                users = entities.Where(x => x.Id.StartsWith("users/")).ToList();
+                companies = entities.Where(x => x.Id.StartsWith("companies/")).ToList();
+
+                using (var tx = Env.ReadTransaction())
+                {
+                    var table = tx.OpenTable(schema, tableName);
+
+                    // Entities:
+                    var entity = entities.First();
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag - 1, empty: true);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag, empty: false, entity.Etag);
+
+                    int mid = entities.Count / 2;
+                    entity = entities[mid];
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag, empty: false, expectedEtag: entity.Etag);
+                    var expectedEtag = entities[mid].Etag;
+                    if (entities[mid + 1].Etag == entities[mid].Etag + 1)
+                        expectedEtag = entities[mid].Etag + 1;
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag + 1, empty: false, expectedEtag: expectedEtag);
+
+                    entity = entities.Last();
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag, empty: false, expectedEtag: entity.Etag);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: entity.Etag + 1, empty: false, expectedEtag: entity.Etag);
+
+                    // Users:
+                    var user = users.First();
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag - 1, empty: true);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag, empty: false, expectedEtag: user.Etag);
+
+                    mid = users.Count / 2;
+                    user = users[mid];
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag, empty: false, expectedEtag: user.Etag);
+                    var userExpectedEtag = users[mid].Etag;
+                    if (users[mid + 1].Etag == users[mid].Etag + 1 && users[mid + 1].Id == users[mid].Id)
+                        userExpectedEtag = users[mid].Etag + 1;
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag + 1, empty: false, expectedEtag: userExpectedEtag); //
+
+                    user = users.Last();
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag, empty: false, expectedEtag: user.Etag);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag + 1, empty: false, expectedEtag: user.Etag);
+
+                    // Companies:
+                    var company = companies.First();
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag - 1, empty: true);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag, empty: false, expectedEtag: company.Etag);
+
+                    mid = companies.Count / 2;
+                    company = companies[mid];
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag, empty: false, expectedEtag: company.Etag);
+                    var companyExpectedEtag = companies[mid].Etag;
+                    if (companies[mid + 1].Etag == companies[mid].Etag + 1 && companies[mid + 1].Id == companies[mid].Id)
+                        companyExpectedEtag = companies[mid].Etag + 1;
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag + 1, empty: false, expectedEtag: companyExpectedEtag);
+
+                    company = companies.Last();
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag, empty: false, expectedEtag: company.Etag);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, company.Id, endEtag: company.Etag + 1, empty: false, expectedEtag: company.Etag);
+                }
+            }
+        }
+
+        private static void AssertSeekBackwardForFixedSizeTrees(Table table, FixedSizeKeyIndexDef voronIndex, long endEtag, bool empty, long? expectedEtag = null)
+        {
+            var tvhs = table.SeekBackwardFrom(voronIndex, endEtag);
+            var keys = tvhs.Select(tvh => DocumentsStorage.TableValueToEtag((int)TestTable.KeyEtag, ref tvh.Reader)).ToList();
+
+            if (empty)
+            {
+                Assert.Empty(keys);
+                if (expectedEtag.HasValue)
+                    throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+            }
+            else
+            {
+                Assert.NotEmpty(keys);
+                var lastLocalKey = keys[0];
+
+                if (expectedEtag.HasValue)
+                {
+                    if (expectedEtag.Value != lastLocalKey)
+                    {
+
+                    }
+                    Assert.Equal(expectedEtag.Value, lastLocalKey);
+                }
+                else
+                    Assert.True(endEtag >= lastLocalKey, $"endEtag {endEtag}, lastLocalEtag: {lastLocalKey}");
+            }
+        }
+
+        private static void AssertSeekBackward(ByteStringContext allocator, Table table, IndexDef voronIndex,
+            string id, long endEtag, bool empty, long? expectedEtag = null)
+        {
+            using (Slice.From(allocator, id, out var idSlice))
+            using (RevisionsStorage.GetKeyPrefix(allocator, idSlice, out Slice prefixSlice))
+            using (RevisionsStorage.GetKeyWithEtag(allocator, idSlice, endEtag, out var compoundPrefix))
+            {
+                var seekResults = table.SeekBackwardFrom(voronIndex, prefixSlice, compoundPrefix, 0).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(seekResults);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(seekResults);
+                    using var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None);
+
+                    var tvr = seekResults[0].Result.Reader;
+
+                    var lastLocalEtag = DocumentsStorage.TableValueToEtag((int)TestTable.Etag, ref tvr);
+
+                    if (expectedEtag.HasValue)
+                    {
+                        if (expectedEtag.Value != lastLocalEtag)
+                        {
+
+                        }
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                    }
+                    else
+                        Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
+
+
+                    var lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr);
+                    Assert.Equal(id, lastLocalId);
+
+                }
+            }
+        }
+
+        private static void AssertSeekBackwardAfterAllKeys(ByteStringContext allocator, Table table, IndexDef voronIndex, string id, bool empty = false, long? expectedEtag = null)
+        {
+            using (Slice.From(allocator, id, out var idSlice))
+            using (RevisionsStorage.GetKeyPrefix(allocator, idSlice, out Slice prefixSlice))
+            {
+                var seekResults = table.SeekBackwardFrom(voronIndex, prefixSlice, Slices.AfterAllKeys, 0).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(seekResults);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(seekResults);
+                    using var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None);
+
+                    var tvr = seekResults[0].Result.Reader;
+
+                    if (expectedEtag.HasValue)
+                    {
+                        var lastLocalEtag = DocumentsStorage.TableValueToEtag((int)TestTable.Etag, ref tvr);
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                    }
+
+                    string lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr).ToString();
+                    Assert.Equal(id, lastLocalId);
+                }
+            }
+        }
+
+        private static void InsertToTable(Transaction tx, Table table, long etag, string id)
+        {
+            using (Slice.From(tx.Allocator, id, ByteStringType.Immutable, out var idSlice))
+            using (table.Allocate(out TableValueBuilder tvb))
+            {
+                tvb.Add(Bits.SwapBytes(etag));
+                tvb.Add(idSlice); // Adding the same slice as the value for simplicity
+                tvb.Add(SpecialChars.RecordSeparator);
+                tvb.Add(Bits.SwapBytes(etag));
+                table.Insert(tvb);
+            }
+        }
+
+        private enum TestTable
+        {
+            KeyEtag = 0,
+            LowerId = 1,
+            RecordSeparator = 2,
+            Etag = 3
+        }
+
+    }
+}
+

--- a/test/SlowTests/Issues/RavenDB-23167-Voron.cs
+++ b/test/SlowTests/Issues/RavenDB-23167-Voron.cs
@@ -181,7 +181,7 @@ namespace SlowTests.Issues
                     var userExpectedEtag = users[mid].Etag;
                     if (users[mid + 1].Etag == users[mid].Etag + 1 && users[mid + 1].Id == users[mid].Id)
                         userExpectedEtag = users[mid].Etag + 1;
-                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag + 1, empty: false, expectedEtag: userExpectedEtag); //
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag + 1, empty: false, expectedEtag: userExpectedEtag);
 
                     user = users.Last();
                     AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, user.Id, endEtag: user.Etag, empty: false, expectedEtag: user.Etag);

--- a/test/SlowTests/Issues/RavenDB_23167.cs
+++ b/test/SlowTests/Issues/RavenDB_23167.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.Schemas;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23167 : RavenTestBase
+    {
+        public RavenDB_23167(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task SeekBackwardGivingGreaterKeysThanTheLastKeyThatPassed()
+        {
+            using var store = GetDocumentStore();
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // Create a doc with 2 revisions
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name1"
+                };
+                await session.StoreAsync(person, "foo/bar");
+                await session.SaveChangesAsync();
+                // cv: A:1, (local) etag: 2
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name2"
+                };
+                await session.StoreAsync(person, "foo/bar1");
+                await session.SaveChangesAsync();
+                // cv: A:3, etag: 4
+            }
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name3"
+                };
+                await session.StoreAsync(person, "foo/bar");
+                await session.SaveChangesAsync();
+                // cv: A:5, etag: 6
+            }
+
+            AssertSeekBackwardForFixedSizeTrees(db, endEtag: 3, empty: false, expectedEtag: 2);
+            AssertSeekBackwardForFixedSizeTrees(db, endEtag: 0, empty: true);
+            AssertSeekBackwardForFixedSizeTrees(db, endEtag: 10, empty: false, expectedEtag: 6);
+
+            AssertSeekBackward(db, "foo/bar", endEtag: 3, empty: false, expectedEtag: 2);
+            AssertSeekBackward(db, "foo/bar", endEtag: 0, empty: true);
+            AssertSeekBackward(db, "foo/bar", endEtag: 10, empty: false, expectedEtag: 6);
+            AssertSeekBackward(db, "foo/bar", endEtag: long.MaxValue, empty: false, expectedEtag: 6);
+
+            AssertSeekBackward(db, "foo/bar", endEtag: 5, empty: false, expectedEtag: 2);
+            AssertSeekBackward(db, "foo/bar1", endEtag: 5, empty: false, expectedEtag: 4);
+            AssertSeekBackward(db, "foo/ba", endEtag: 5, empty: true);
+
+            AssertSeekBackwardAfterAllKeys(db, "foo/bar", empty: false, expectedEtag: 6);
+            AssertSeekBackwardAfterAllKeys(db, "foo/ba", empty: true);
+        }
+
+        private static void AssertSeekBackwardForFixedSizeTrees(DocumentDatabase db, long endEtag, bool empty, long? expectedEtag = null)
+        {
+            var revisionsStorage = db.DocumentsStorage.RevisionsStorage;
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var table = new Table(revisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);
+                var voronIndex = revisionsStorage.RevisionsSchema.FixedSizeIndexes[Revisions.AllRevisionsEtagsSlice];
+                var tvhs = table.SeekBackwardFrom(voronIndex, endEtag);
+                var revisions = tvhs.Select(tvh => RevisionsStorage.TableValueToRevision(context, ref tvh.Reader, DocumentFields.ChangeVector)).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(revisions);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(revisions);
+                    var lastLocalEtag = revisions[0].Etag;
+                    Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
+
+                    if (expectedEtag.HasValue)
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                }
+            }
+        }
+
+        private static void AssertSeekBackward(DocumentDatabase db, string id, long endEtag, bool empty, long? expectedEtag = null)
+        {
+            var revisionsStorage = db.DocumentsStorage.RevisionsStorage;
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, id, out var idSlice))
+            using (db.DocumentsStorage.RevisionsStorage.GetKeyPrefix(context, idSlice, out Slice prefixSlice))
+            using (RevisionsStorage.GetKeyWithEtag(context, idSlice, endEtag, out var compoundPrefix))
+            {
+                var table = new Table(revisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);
+                var voronIndex = revisionsStorage.RevisionsSchema.Indexes[Revisions.IdAndEtagSlice];
+                var trvs = table.SeekBackwardFrom(voronIndex, prefixSlice, compoundPrefix, 0);
+                var revisions = trvs.Select(tvr => RevisionsStorage.TableValueToRevision(context, ref tvr.Result.Reader, DocumentFields.ChangeVector)).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(revisions);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(revisions);
+                    var lastLocalEtag = revisions[0].Etag;
+                    Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
+
+                    if (expectedEtag.HasValue)
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                }
+            }
+        }
+
+        private static void AssertSeekBackwardAfterAllKeys(DocumentDatabase db, string id, bool empty = false, long? expectedEtag = null)
+        {
+            var revisionsStorage = db.DocumentsStorage.RevisionsStorage;
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, id, out var idSlice))
+            using (db.DocumentsStorage.RevisionsStorage.GetKeyPrefix(context, idSlice, out Slice prefixSlice))
+            {
+                var table = new Table(revisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);
+                var voronIndex = revisionsStorage.RevisionsSchema.Indexes[Revisions.IdAndEtagSlice];
+                var trvs = table.SeekBackwardFrom(voronIndex, prefixSlice, Slices.AfterAllKeys, 0);
+                var revisions = trvs.Select(tvr => RevisionsStorage.TableValueToRevision(context, ref tvr.Result.Reader, DocumentFields.ChangeVector)).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(revisions);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(revisions);
+
+                    if (expectedEtag.HasValue)
+                    {
+                        var lastLocalEtag = revisions[0].Etag;
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                    }
+                }
+            }
+        }
+
+        private class Person
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string AddressId { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23167/SeekBackwardFrom-with-last-parameter-not-seeking-properly

### Additional description

Merge https://github.com/ravendb/ravendb/pull/19695 and https://github.com/ravendb/ravendb/pull/20182 to 6.0: https://github.com/ravendb/ravendb/pull/20200
The original issue:
Some SeekBackwardFrom() functions such as
public IEnumerable SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice prefix, Slice last)
are seeking the 'last' key parameter and start iterating backwards from the wrong adjacent value.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
