### PR TITLE
RavenDB-23768 CPU usage calculation fix

### DIFF
--- a/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
@@ -85,6 +85,16 @@ namespace Raven.Server.Utils.Cpu
                 //overflow
                 return LastCpuUsage?.ProcessCpuUsage ?? 0;
             }
+            // If processorTimeDiff is negative (can happen when switching processors or affinity groups),
+            // use the last valid CPU usage value.
+            if (processorTimeDiff < 0)
+            {
+                if (Logger.IsInfoEnabled)
+                {
+                    Logger.Info($"processorTimeDiff == {processorTimeDiff}, OS: {RuntimeInformation.OSDescription}");
+                }
+                return LastCpuUsage?.ProcessCpuUsage ?? 0;
+            }
 
             if (currentInfo.ActiveCores <= 0)
             {
@@ -104,7 +114,15 @@ namespace Raven.Server.Utils.Cpu
                 processCpuUsage = Math.Min(processCpuUsage, machineCpuUsage);
             }
 
-            return Math.Min(100, processCpuUsage);
+            if (processCpuUsage < 0 && Logger.IsInfoEnabled)
+            {
+                Logger.Info($"processCpuUsage == {processCpuUsage}, OS: {RuntimeInformation.OSDescription}");
+            }
+
+            // final value will be between 0 and 100%.
+            processCpuUsage = Math.Max(0, Math.Min(100, processCpuUsage));
+
+            return processCpuUsage;
         }
 
         public void Dispose()
@@ -160,14 +178,14 @@ namespace Raven.Server.Utils.Cpu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong GetTime(FileTime fileTime)
         {
-            return ((ulong)fileTime.dwHighDateTime << 32) | (uint)fileTime.dwLowDateTime;
+            return ((ulong)fileTime.dwHighDateTime << 32) | fileTime.dwLowDateTime;
         }
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct FileTime
         {
-            public int dwLowDateTime;
-            public int dwHighDateTime;
+            public uint dwLowDateTime;
+            public uint dwHighDateTime;
         }
     }
 

--- a/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
@@ -89,10 +89,6 @@ namespace Raven.Server.Utils.Cpu
             // use the last valid CPU usage value.
             if (processorTimeDiff < 0)
             {
-                if (Logger.IsInfoEnabled)
-                {
-                    Logger.Info($"processorTimeDiff == {processorTimeDiff}, OS: {RuntimeInformation.OSDescription}");
-                }
                 return LastCpuUsage?.ProcessCpuUsage ?? 0;
             }
 
@@ -113,7 +109,7 @@ namespace Raven.Server.Utils.Cpu
                 // min as sometimes +-1% due to time sampling
                 processCpuUsage = Math.Min(processCpuUsage, machineCpuUsage);
             }
-
+            // shouldn't happen
             if (processCpuUsage < 0 && Logger.IsInfoEnabled)
             {
                 Logger.Info($"processCpuUsage == {processCpuUsage}, OS: {RuntimeInformation.OSDescription}");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23768

### Additional description

On dual-processor machines, our CPU usage calculation sometimes produces a "min int" or otherwise weird percentage. This is likely because when a process switches between processors (or affinity groups), the unsynchronized per-core timers can cause the computed processorTimeDiff to be negative.

Fix:

We clamp the final CPU usage result so that it always falls between 0 and 100%.
If processorTimeDiff is negative, we log the negative value and fall back to the last valid CPU usage.
We also updated our FileTime structure to use uint instead of int to ensure a proper 64‑bit conversion from FILETIME.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
