### PR TITLE
RavenDB-23683 - Improve the logic for determining when a backup should run

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1405,7 +1405,7 @@ namespace Raven.Server.Documents
                             break;
 
                         case IdleDatabaseActivityType.WakeUpDatabase:
-                            if (_serverStore.ConcurrentBackupsCounter.CanRunBackup == false)
+                            if (_serverStore.ConcurrentBackupsCounter.CanRunBackup(ShardHelper.ToDatabaseName(databaseName)) == false)
                             {
                                 // reached max concurrent backups
                                 var delayInMs = RescheduleDatabaseWakeup();

--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -32,17 +32,6 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
-        public bool CanRunBackup
-        {
-            get
-            {
-                lock (_locker)
-                {
-                    return _runningBackupsPerDatabase.Count - 1 > 0;
-                }
-            }
-        }
-
         public ConcurrentBackupsCounter(BackupConfiguration backupConfiguration, LicenseManager licenseManager)
         {
             _licenseManager = licenseManager;
@@ -63,6 +52,20 @@ namespace Raven.Server.Documents.PeriodicBackup
             _concurrentDatabaseWakeup = new SemaphoreSlim(numberOfCoresToUse);
             _concurrentBackupsDelay = backupConfiguration.ConcurrentBackupsDelay.AsTimeSpan;
             _skipModifications = skipModifications;
+        }
+
+        public bool CanRunBackup(string databaseName)
+        {
+            lock (_locker)
+            {
+                if (_runningBackupsPerDatabase.TryGetValue(databaseName, out _))
+                {
+                    //  allow to backup all shards of the same database concurrently
+                    return true;
+                }
+
+                return MaxNumberOfConcurrentBackups - _runningBackupsPerDatabase.Count >= 1;
+            }
         }
 
         public void StartBackup(string databaseName, string backupName, Logger logger)

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3482,28 +3482,43 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            using (var store = GetDocumentStore())
+            using (var server = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Backup.MaxNumberOfConcurrentBackups)] = 1.ToString()
+                }
+            }))
+            using (var store = GetDocumentStore(new Options
+            {
+                Server = server
+            }))
             {
                 using (var session = store.OpenAsyncSession())
                     await Backup.FillDatabaseWithRandomDataAsync(databaseSizeInMb: 1, session);
 
-                var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 Assert.NotNull(database);
 
                 await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
                     var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
-                    var taskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, opStatus: OperationStatus.InProgress);
+                    var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
 
                     // The backup task is running, and the next backup should be scheduled for the next minute (based on the backup configuration)
                     var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                     Assert.NotNull(taskBackupInfo);
                     Assert.NotNull(taskBackupInfo.OnGoingBackup);
 
-                    using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {
                         AssertNumberOfConcurrentBackups(expectedNumber: 1);
+
+                        Assert.False(server.ServerStore.ConcurrentBackupsCounter.CanRunBackup(database.Name + "_Test"));
+
+                        // checking for the same database name (imitating a different shard for the same database).
+                        Assert.True(server.ServerStore.ConcurrentBackupsCounter.CanRunBackup(database.Name));
 
                         // Let's delay the backup task to 1 hour
                         var delayDuration = TimeSpan.FromHours(1);
@@ -3511,9 +3526,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                         AssertNumberOfConcurrentBackups(expectedNumber: 0);
 
+                        Assert.True(server.ServerStore.ConcurrentBackupsCounter.CanRunBackup(database.Name + "_Test"));
+
                         void AssertNumberOfConcurrentBackups(int expectedNumber)
                         {
-                            int concurrentBackups = WaitForValue(() => Server.ServerStore.ConcurrentBackupsCounter.CurrentNumberOfRunningBackups,
+                            int concurrentBackups = WaitForValue(() => server.ServerStore.ConcurrentBackupsCounter.CurrentNumberOfRunningBackups,
                                 expectedVal: expectedNumber,
                                 timeout: Convert.ToInt32(TimeSpan.FromMinutes(1).TotalMilliseconds),
                                 interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23683/StressTests.Server.Documents.PeriodicBackup.ServerWideBackupStress.ServerWideBackupShouldBackupIdleDatabaseStressrounds-2

### Additional description

- This is a fix to a regression that was introduced here: https://github.com/ravendb/ravendb/pull/20074.
- Allow to run different shards of the same database to run concurrently.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
