### PR TITLE
RavenDB-23683 - Improve the logic for determining when a backup should run

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
-        public bool CanRunBackup => _concurrentBackups - 1 > 0;
+        public bool CanRunBackup => _concurrentBackups >= 1;
 
         public ConcurrentBackupsCounter(BackupConfiguration backupConfiguration, LicenseManager licenseManager)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23683/StressTests.Server.Documents.PeriodicBackup.ServerWideBackupStress.ServerWideBackupShouldBackupIdleDatabaseStressrounds-2

### Additional description

This is a fix to a regression that was introduced here: https://github.com/ravendb/ravendb/pull/20074.
When we have only one concurrent backup allowed, we won't be able to wakeup the database for backup.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
