### PR TITLE
RavenDB-23785 Skip pebble tests

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Authentication
         {
         }
         
-        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000)]
+        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000, Skip = "RavenDB-23795")]
         public async Task CanGetPebbleCertificate()
         {
             var acmeUrl = Environment.GetEnvironmentVariable("RAVEN_PEBBLE_URL") ?? string.Empty;
@@ -78,7 +78,7 @@ namespace SlowTests.Authentication
             }
         }
 
-        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000)]
+        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000, Skip = "RavenDB-23795")]
         public async Task CanGetLetsEncryptCertificateAndRenewAfterFailurePebble()
         {
             var acmeUrl = Environment.GetEnvironmentVariable("RAVEN_PEBBLE_URL") ?? string.Empty;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23785

### Additional description

Root programs are [moving towards requiring “single-purpose” issuance hierarchies](https://www.chromium.org/Home/chromium-security/root-ca-policy/moving-forward-together/#focusing-on-simplicity), where every certificate has only a single EKU. For now we should skip pebble tests and enable them after [RavenDB-23795](https://issues.hibernatingrhinos.com/issue/RavenDB-23795/Root-CAs-single-EKU-requirement-by-June-2026) is handled.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
