### PR TITLE
RavenDB-23661: Caller should decide prefetching or not.

### DIFF
--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -31,6 +31,7 @@ namespace Voron.Data.Tables
         internal readonly Transaction _tx;
         private readonly EventHandler<InvalidOperationException> _onCorruptedDataHandler;
         private readonly Tree _tableTree;
+        private readonly bool _prefetch;
 
         private ActiveRawDataSmallSection _activeDataSmallSection;
         private FixedSizeTree _inactiveSections;
@@ -132,7 +133,7 @@ namespace Voron.Data.Tables
         /// Using this constructor WILL NOT register the Table for commit in
         /// the Transaction, and hence changes WILL NOT be committed.
         /// </summary>
-        public Table(TableSchema schema, Slice name, Transaction tx, Tree tableTree, TableSchemaStatsReference stats, byte tableType, bool doSchemaValidation = false)
+        public Table(TableSchema schema, Slice name, Transaction tx, Tree tableTree, TableSchemaStatsReference stats, byte tableType, bool doSchemaValidation = false, bool prefetch = false)
         {
             Name = name;
 
@@ -140,6 +141,7 @@ namespace Voron.Data.Tables
             _tx = tx;
             _tableType = tableType;
             _stats = stats;
+            _prefetch = prefetch;
 
             _tableTree = tableTree;
             if (_tableTree == null)
@@ -159,13 +161,14 @@ namespace Voron.Data.Tables
         /// this overload is meant to be used for global reads only, when want to use
         /// a global index to find data, without touching the actual table.
         /// </summary>
-        public Table(TableSchema schema, Transaction tx, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
+        public Table(TableSchema schema, Transaction tx, EventHandler<InvalidOperationException> onCorruptedDataHandler = null, bool prefetch = false)
         {
             _schema = schema;
             _tx = tx;
             _forGlobalReadsOnly = true;
             _tableType = 0;
             _onCorruptedDataHandler = onCorruptedDataHandler;
+            _prefetch = prefetch;
         }
 
         public bool ReadByKey(Slice key, out TableValueReader reader)
@@ -189,7 +192,7 @@ namespace Voron.Data.Tables
             {
                 if (read.HasValue == false)
                 {
-                    reader = default(TableValueReader);
+                    reader = default;
                     return false;
                 }
 
@@ -1311,7 +1314,7 @@ namespace Voron.Data.Tables
             try
             {
                 var fstIndex = GetFixedSizeTree(tree, value, 0, index.IsGlobal);
-                using (var it = fstIndex.Iterate())
+                using (var it = fstIndex.Iterate(_prefetch))
                 {
                     if (it.SeekToLast() == false)
                         yield break;
@@ -1356,7 +1359,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 yield break;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (startsWith)
                     it.SetRequiredPrefix(value);
@@ -1390,7 +1393,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 yield break;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 it.SetRequiredPrefix(prefix);
 
@@ -1423,7 +1426,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 return null;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 it.SetRequiredPrefix(value);
 
@@ -1448,7 +1451,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 yield break;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
                     yield break;
@@ -1490,7 +1493,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 yield break;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
                     yield break;
@@ -1528,7 +1531,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 return null;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
                     return null;
@@ -1569,7 +1572,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 yield break;
             
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 it.SetRequiredPrefix(requiredPrefix);
 
@@ -1600,7 +1603,7 @@ namespace Voron.Data.Tables
 
             var pk = _schema.Key;
             var tree = GetTree(pk);
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 it.SetRequiredPrefix(requiredPrefix);
 
@@ -1631,7 +1634,7 @@ namespace Voron.Data.Tables
             if (tree == null)
                 yield break;
 
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(value) == false)
                     yield break;
@@ -1653,7 +1656,7 @@ namespace Voron.Data.Tables
         {
             var pk = _schema.Key;
             var tree = GetTree(pk);
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(value) == false)
                     yield break;
@@ -1676,7 +1679,7 @@ namespace Voron.Data.Tables
             reader = default;
             var pk = _schema.Key;
             var tree = GetTree(pk);
-            using (var it = tree.Iterate(true))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(value) == false)
                 {
@@ -1714,7 +1717,7 @@ namespace Voron.Data.Tables
             {
                 while (true)
                 {
-                    using (var it = tree.Iterate(true))
+                    using (var it = tree.Iterate(_prefetch))
                     {
                         if (it.Seek(value) == false)
                             return;
@@ -1750,7 +1753,7 @@ namespace Voron.Data.Tables
         {
             var fst = GetFixedSizeTree(index);
 
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.Seek(0) == false)
                     return null;
@@ -1767,7 +1770,7 @@ namespace Voron.Data.Tables
 
             var pk = _schema.Key;
             var tree = GetTree(pk);
-            using (var it = tree.Iterate(false))
+            using (var it = tree.Iterate(_prefetch))
             {
                 if (it.Seek(slice) == false)
                 {
@@ -1786,7 +1789,7 @@ namespace Voron.Data.Tables
 
             var pk = _schema.Key;
             var tree = GetTree(pk);
-            using (var it = tree.Iterate(false))
+            using (var it = tree.Iterate(_prefetch))
             {
                 it.SetRequiredPrefix(slice);
 
@@ -1805,7 +1808,7 @@ namespace Voron.Data.Tables
         {
             var pk = _schema.Key;
             var tree = GetTree(pk);
-            using (var it = tree.Iterate(false))
+            using (var it = tree.Iterate(_prefetch))
             {
                 it.SetRequiredPrefix(prefix);
 
@@ -1865,7 +1868,7 @@ namespace Voron.Data.Tables
             // in IO deprived setups.
             // https://issues.hibernatingrhinos.com/issue/RavenDB-21106
 
-            // If we page fault on every page (specially in cold scenarios) we would be wasting a lot. Therefore we should
+            // If we page fault on every page (specially in cold scenarios) we would be wasting a lot. Therefore, we should
             // iterate with prefetching enabled.
             using var it = fst.Iterate(prefetch: true);
             if (it.Seek(seek) == false)
@@ -1972,7 +1975,7 @@ namespace Voron.Data.Tables
         {
             var fst = GetFixedSizeTree(index);
 
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.Seek(key) == false)
                     yield break;
@@ -2016,7 +2019,7 @@ namespace Voron.Data.Tables
         {
             var fst = GetFixedSizeTree(index);
 
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.SeekToLast() == false)
                     return null;
@@ -2030,7 +2033,7 @@ namespace Voron.Data.Tables
         public IEnumerable<TableValueHolder> SeekBackwardFromLast(TableSchema.FixedSizeKeyIndexDef index, long skip = 0)
         {
             var fst = GetFixedSizeTree(index);
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.SeekToLast() == false)
                     yield break;
@@ -2050,7 +2053,7 @@ namespace Voron.Data.Tables
         public IEnumerable<TableValueHolder> SeekBackwardFrom(TableSchema.FixedSizeKeyIndexDef index, long key, long skip = 0)
         {
             var fst = GetFixedSizeTree(index);
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.Seek(key) == false &&
                     it.SeekToLast() == false)
@@ -2075,7 +2078,7 @@ namespace Voron.Data.Tables
         {
             var fst = GetFixedSizeTree(index);
 
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.Seek(start) == false)
                     return false;
@@ -2138,7 +2141,7 @@ namespace Voron.Data.Tables
             // them one at a time
             while (deleted < numberOfEntriesToDelete)
             {
-                using (var it = fst.Iterate())
+                using (var it = fst.Iterate(_prefetch))
                 {
                     if (it.Seek(long.MinValue) == false)
                         return deleted;
@@ -2159,7 +2162,7 @@ namespace Voron.Data.Tables
             reader = default;
             var fst = GetFixedSizeTree(index);
 
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.Seek(value) == false)
                     return false;
@@ -2178,7 +2181,7 @@ namespace Voron.Data.Tables
 
             var fst = GetFixedSizeTree(index);
 
-            using (var it = fst.Iterate())
+            using (var it = fst.Iterate(_prefetch))
             {
                 if (it.Seek(value) == false)
                     return false;
@@ -2201,7 +2204,7 @@ namespace Voron.Data.Tables
             TableValueHolder tableValueHolder = null;
             while (true)
             {
-                using (var it = tree.Iterate(true))
+                using (var it = tree.Iterate(_prefetch))
                 {
                     it.SetRequiredPrefix(startSlice);
                     if (it.Seek(it.RequiredPrefix) == false)
@@ -2247,7 +2250,7 @@ namespace Voron.Data.Tables
             {
                 // deleting from a table can shift things around, so we delete 
                 // them one at a time
-                using (var it = tree.Iterate(true))
+                using (var it = tree.Iterate(_prefetch))
                 {
                     if (startsWith)
                         it.SetRequiredPrefix(value);
@@ -2298,7 +2301,7 @@ namespace Voron.Data.Tables
             TableValueHolder tableValueHolder = null;
             while (deleted < numberOfEntriesToDelete)
             {
-                using (var it = pkTree.Iterate(true))
+                using (var it = pkTree.Iterate(_prefetch))
                 {
                     it.SetRequiredPrefix(startSlice);
                     if (it.Seek(it.RequiredPrefix) == false)
@@ -2473,7 +2476,7 @@ namespace Voron.Data.Tables
 
             foreach (var section in new[] { inactiveSections, activeCandidateSection })
             {
-                using (var it = section.Iterate())
+                using (var it = section.Iterate(_prefetch))
                 {
                     if (it.Seek(0))
                     {

--- a/src/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/src/Voron/Impl/Compaction/StorageCompaction.cs
@@ -486,7 +486,7 @@ namespace Voron.Impl.Compaction
                 {
                     long transactionSize = 0L;
 
-                    Table inputTable = innerTxr.OpenTable(schema, treeName);
+                    Table inputTable = innerTxr.OpenTable(schema, treeName, prefetch: true);
                     var outputTable = txw.OpenTable(schema, treeName);
 
                     if (schema.Key == null || schema.Key.IsGlobal) 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -230,15 +230,15 @@ namespace Voron.Impl
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public Table OpenTable(TableSchema schema, string name)
+        public Table OpenTable(TableSchema schema, string name, bool prefetch = false)
         {
             using (Slice.From(Allocator, name, ByteStringType.Immutable, out Slice nameSlice))
             {
-                return OpenTable(schema, nameSlice);
+                return OpenTable(schema, nameSlice, prefetch);
             }
         }
 
-        public Table OpenTable(TableSchema schema, Slice name)
+        public Table OpenTable(TableSchema schema, Slice name, bool prefetch = false)
         {
             _tables ??= new Dictionary<TableKey, Table>();
 
@@ -269,7 +269,7 @@ namespace Voron.Impl
                 };
             }
 
-            value = new Table(schema, clonedName, this, tableTree, tableStatsRef, schema.TableType);
+            value = new Table(schema, clonedName, this, tableTree, tableStatsRef, schema.TableType, prefetch: prefetch);
             _tables[key] = value;
             return value;
         }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23661

### Additional description

In the case of Time Series it was clear that the prefetching have to be disabled because rollups are maintenance tasks and therefore they shouldn't monopolize the IO system. The problem spawn from the caller not having the ability to decide if it make sense to use prefetching or not based on what's the nature of the access. 

Voron Tables has been extended to allow the creator of the accessor to decide if prefetching is enabled or not. Since most of the relevant operations had prefetching already disabled and from those where it was enabled they were non critical operations; the default has been set to false. 

If future QA testing shows regressions they will be analyzed in a case-by-case basis. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
