### PR TITLE
RavenDB-21964 - fix concurrent usage of hashmap in subscription tests [v5.4]

### DIFF
--- a/src/Sparrow/Collections/ConcurrentSet.cs
+++ b/src/Sparrow/Collections/ConcurrentSet.cs
@@ -109,10 +109,7 @@ namespace Sparrow.Collections
 
             foreach (T item in other)
             {
-                if (_inner.TryAdd(item, null))
-                {
-                    Interlocked.Increment(ref _innerCountForEmpty);
-                }
+                TryAdd(item);
             }
         }
     }

--- a/src/Sparrow/Collections/ConcurrentSet.cs
+++ b/src/Sparrow/Collections/ConcurrentSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -97,6 +98,22 @@ namespace Sparrow.Collections
         public override string ToString()
         {
             return Count.ToString("#,#", CultureInfo.InvariantCulture);
+        }
+
+        public void UnionWith(IEnumerable<T> other)
+        {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            foreach (T item in other)
+            {
+                if (_inner.TryAdd(item, null))
+                {
+                    Interlocked.Increment(ref _innerCountForEmpty);
+                }
+            }
         }
     }
 }

--- a/test/FastTests/Sparrow/ConcurrentSetTests.cs
+++ b/test/FastTests/Sparrow/ConcurrentSetTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Sparrow.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public class ConcurrentSetTests : NoDisposalNeeded
+    {
+        public ConcurrentSetTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void UnionWith_AddsAllElementsFromOtherCollection()
+        {
+            // Arrange
+            var set = new ConcurrentSet<int> { 1, 2, 3 };
+            var other = new List<int> { 4, 5, 6 };
+
+            // Act
+            set.UnionWith(other);
+
+            // Assert
+            Assert.Equal(6, set.Count);
+            Assert.Contains(1, set);
+            Assert.Contains(2, set);
+            Assert.Contains(3, set);
+            Assert.Contains(4, set);
+            Assert.Contains(5, set);
+            Assert.Contains(6, set);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void UnionWith_DoesNotAddDuplicates()
+        {
+            // Arrange
+            var set = new ConcurrentSet<int> { 1, 2, 3 };
+            var other = new List<int> { 3, 4, 5 };
+
+            // Act
+            set.UnionWith(other);
+
+            // Assert
+            Assert.Equal(5, set.Count);
+            Assert.Contains(1, set);
+            Assert.Contains(2, set);
+            Assert.Contains(3, set);
+            Assert.Contains(4, set);
+            Assert.Contains(5, set);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void UnionWith_ThrowsArgumentNullException_WhenOtherIsNull()
+        {
+            // Arrange
+            var set = new ConcurrentSet<int>();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => set.UnionWith(null));
+        }
+    }
+}

--- a/test/InterversionTests/RavenDB-21028.cs
+++ b/test/InterversionTests/RavenDB-21028.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Indexing.Benchmark.Entities;
 using Raven.Client.Documents.Subscriptions;
+using Sparrow.Collections;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -50,7 +51,7 @@ namespace InterversionTests
                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1)
                        }))
                 {
-                    var items = new HashSet<string>();
+                    var items = new ConcurrentSet<string>();
                     subscription.AfterAcknowledgment += batch =>
                     {
                         foreach (var item in batch.Items)

--- a/test/RachisTests/SubscriptionFailoverWIthWaitingChains.cs
+++ b/test/RachisTests/SubscriptionFailoverWIthWaitingChains.cs
@@ -19,6 +19,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Collections;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -108,7 +109,7 @@ namespace RachisTests
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16)
                 });
 
-                HashSet<string> redirects = new HashSet<string>();
+                ConcurrentSet<string> redirects = new ConcurrentSet<string>();
                 var mre = new AsyncManualResetEvent();
                 var processedItems = new List<string>();
                 subsWorker.AfterAcknowledgment += batch =>

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -24,6 +24,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -797,7 +798,7 @@ namespace RachisTests
                     Assert.NotNull(tag);
 
                     var redirects = new Dictionary<string, string>();
-                    var processedIds = new HashSet<string>();
+                    var processedIds = new ConcurrentSet<string>();
                     var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(name)
                     {
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16),

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -17,6 +17,7 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Commands.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow.Collections;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Server;
@@ -101,7 +102,7 @@ namespace SlowTests.Client.Subscriptions
             {
                 var id = store.Subscriptions.Create<User>();
 
-                var workerToDocsAmount = new Dictionary<SubscriptionWorker<User>, HashSet<string>>();
+                var workerToDocsAmount = new Dictionary<SubscriptionWorker<User>, ConcurrentSet<string>>();
 
                 for (int i = 0; i < workersAmount; i++)
                 {
@@ -110,7 +111,7 @@ namespace SlowTests.Client.Subscriptions
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
                         Strategy = SubscriptionOpeningStrategy.Concurrent,
                         MaxDocsPerBatch = 1
-                    }), new HashSet<string>());
+                    }), new ConcurrentSet<string>());
                 }
 
                 using (var session = store.OpenSession())
@@ -984,7 +985,7 @@ namespace SlowTests.Client.Subscriptions
             using (var store = GetDocumentStore())
             {
                 var id = await store.Subscriptions.CreateAsync<User>();
-                var docs = new HashSet<string>();
+                var docs = new ConcurrentSet<string>();
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -1044,7 +1045,7 @@ namespace SlowTests.Client.Subscriptions
                     Filter = user => user.Age == 0
                 });
 
-                var docs = new HashSet<string>();
+                var docs = new ConcurrentSet<string>();
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -1119,7 +1120,7 @@ where predicate.call(doc)"
                     Filter = user => user.Age == 0
                 });
 
-                var docs = new HashSet<string>();
+                var docs = new ConcurrentSet<string>();
                 var workers = new List<SubscriptionWorker<User>>();
                 var subscriptionLog = new List<(string WorkerId, DateTime Date, string Message)>();
                 try
@@ -1298,7 +1299,7 @@ where predicate.call(doc)"
                 var id = await store.Subscriptions.CreateAsync<User>();
 
                 //responsible node processes doc
-                HashSet<string> docs = await RunSubscriptionWorkerAndProcessOneDocumentAsync(store, id);
+                ConcurrentSet<string> docs = await RunSubscriptionWorkerAndProcessOneDocumentAsync(store, id);
 
                 var node1 = string.Empty;
                 Assert.True(await WaitForValueAsync(async () =>
@@ -1375,9 +1376,9 @@ where predicate.call(doc)"
             }
         }
 
-        private static async Task<HashSet<string>> RunSubscriptionWorkerAndProcessOneDocumentAsync(DocumentStore store, string id)
+        private static async Task<ConcurrentSet<string>> RunSubscriptionWorkerAndProcessOneDocumentAsync(DocumentStore store, string id)
         {
-            var docs = new HashSet<string>();
+            var docs = new ConcurrentSet<string>();
             await using var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
             {
                 TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),

--- a/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
@@ -6,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
@@ -545,7 +547,8 @@ select {
                 {
                     Query = query
                 });
-                var revisions = new ConcurrentSet<MyRevision>();
+                var concurrentDictionary = new ConcurrentDictionary<int, MyRevision>();
+                var index = 0;
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
@@ -555,15 +558,15 @@ select {
                     {
                         foreach (var item in x.Items)
                         {
-                            revisions.Add(item.Result);
+                            concurrentDictionary[Interlocked.Increment(ref index)] = item.Result;
                         }
                     });
 
                     dynamic resultsObj1 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
 
                     List<dynamic> results = resultsObj1.RevisionDocuments;
-                    Assert.Equal(8, await WaitForValueAsync(() => revisions.Count, 8));
-
+                    Assert.Equal(8, await WaitForValueAsync(() => concurrentDictionary.Count, 8));
+                    List<MyRevision> revisions = concurrentDictionary.OrderBy(kvp => kvp.Key).Select(x => x.Value).ToList();
                     var f = revisions.First();
                     IDictionary<string, object> metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[0])["@metadata"];
 
@@ -669,7 +672,8 @@ select {
                 }
 
                 var subscriptionId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = query });
-                var revisions = new ConcurrentSet<MyRevision>();
+                var concurrentDictionary = new ConcurrentDictionary<int, MyRevision>();
+                var index = 0;
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
                        {
                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
@@ -679,15 +683,15 @@ select {
                     {
                         foreach (var item in x.Items)
                         {
-                            revisions.Add(item.Result);
+                            concurrentDictionary[Interlocked.Increment(ref index)] = item.Result;
                         }
                     });
 
                     dynamic resultsObj1 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
 
                     List<dynamic> results = resultsObj1.RevisionDocuments;
-                    Assert.Equal(1, await WaitForValueAsync(() => revisions.Count, 1));
-
+                    Assert.Equal(1, await WaitForValueAsync(() => concurrentDictionary.Count, 1));
+                    List<MyRevision> revisions = concurrentDictionary.OrderBy(kvp => kvp.Key).Select(x => x.Value).ToList();
                     var f = revisions.First();
                     IDictionary<string, object> metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[results.Count - 2])["@metadata"];
 
@@ -778,7 +782,8 @@ select {
                 {
                     Query = query
                 });
-                var revisions = new ConcurrentSet<MyRevision>();
+                var concurrentDictionary = new ConcurrentDictionary<int,MyRevision>();
+                var index = 0;
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
@@ -788,15 +793,15 @@ select {
                     {
                         foreach (var item in x.Items)
                         {
-                            revisions.Add(item.Result);
+                            concurrentDictionary[Interlocked.Increment(ref index)] = item.Result;
                         }
                     });
 
                     dynamic resultsObj1 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
 
                     List<dynamic> results = resultsObj1.RevisionDocuments;
-                    Assert.Equal(7, await WaitForValueAsync(() => revisions.Count, 7));
-
+                    Assert.Equal(7, await WaitForValueAsync(() => concurrentDictionary.Count, 7));
+                    List<MyRevision> revisions = concurrentDictionary.OrderBy(kvp => kvp.Key).Select(x => x.Value).ToList();
                     var f = revisions.First();
                     IDictionary<string, object> metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[0])["@metadata"];
 

--- a/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
@@ -17,6 +17,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -544,7 +545,7 @@ select {
                 {
                     Query = query
                 });
-                var revisions = new HashSet<MyRevision>();
+                var revisions = new ConcurrentSet<MyRevision>();
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
@@ -668,7 +669,7 @@ select {
                 }
 
                 var subscriptionId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = query });
-                var revisions = new HashSet<MyRevision>();
+                var revisions = new ConcurrentSet<MyRevision>();
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
                        {
                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
@@ -777,7 +778,7 @@ select {
                 {
                     Query = query
                 });
-                var revisions = new HashSet<MyRevision>();
+                var revisions = new ConcurrentSet<MyRevision>();
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21964

PR v6.2: https://github.com/ravendb/ravendb/pull/20243

### Additional description

Concurrent usage of HashMap could lead to unexpected results in test assert

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
