### PR TITLE
RavenDB-23807 - Long GC pauses due to low memory handler

### DIFF
--- a/src/Raven.Server/Indexing/LuceneCleaner.cs
+++ b/src/Raven.Server/Indexing/LuceneCleaner.cs
@@ -70,7 +70,7 @@ public class LuceneCleaner : ILowMemoryHandler
         if (sp != null && sp.ElapsedMilliseconds > 100)
         {
             Logger.Info($"Purged Lucene caches, took: {sp.ElapsedMilliseconds}ms, " +
-                        $"cleaned: {new Size(NativeMemory.TotalLuceneUnmanagedAllocationsForSorting - unmanagedUsedBeforeInBytes, SizeUnit.Bytes)}");
+                        $"cleaned: {new Size(unmanagedUsedBeforeInBytes - NativeMemory.TotalLuceneUnmanagedAllocationsForSorting, SizeUnit.Bytes)}");
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23807/Long-GC-pauses-due-to-low-memory-handler

### Additional description

When the `LuceneCleaner` low memory handler is triggered, it executes only once while the system remains in a low memory state. This approach mirrors our allocation strategy in context - we perform a comprehensive cleanup of existing memory, then permit new allocations to proceed.
This single-execution design prevents the system from falling into an inefficient cycle of constant allocation and deallocation during memory-constrained periods. By cleaning memory once and then allowing controlled allocation, we maintain system stability while working toward normal memory conditions.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
