### PR TITLE
RavenDB-23809 Leader.PutAsync Keep context valid in case of exceptions

### DIFF
--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -676,7 +676,7 @@ namespace Raven.Server.Rachis
             }
         }
 
-        public class RachisMergedCommand : IDisposable
+        public class RachisMergedCommand : IAsyncDisposable
         {
             private readonly ClusterContextPool _pool;
             private IDisposable _ctxReturn;
@@ -710,10 +710,24 @@ namespace Raven.Server.Rachis
                 var inner = await Tcs.Task;
                 var r = await inner;
                 return BlittableResultWriter == null ? r : (r.Index, BlittableResultWriter.Result);
-            } 
+            }
 
-            public void Dispose()
+            public async ValueTask DisposeAsync()
             {
+                if (Consumed.Raise() == false && Tcs.Task.IsCompleted == false)
+                {
+                    try
+                    {
+                        // If the command has already been dequeued, we must allow it to continue to maintain its context validity.
+                        await Tcs.Task;
+                    }
+                    catch
+                    {
+                        // ignored
+                        // If we reached this point, another exception has already been thrown, and we want it to be the one that gets raised.
+                    }
+                }
+
                 Command.Raw?.Dispose();
                 Command.Raw = null;
                 BlittableResultWriter?.Dispose();
@@ -727,7 +741,7 @@ namespace Raven.Server.Rachis
 
         public async Task<(long Index, object Result)> PutAsync(CommandBase command, TimeSpan timeout)
         {
-            using var rachisMergedCommand = new RachisMergedCommand(_engine.ContextPool, command);
+            await using var rachisMergedCommand = new RachisMergedCommand(_engine.ContextPool, command);
 
             rachisMergedCommand.Initialize();
 
@@ -747,13 +761,7 @@ namespace Raven.Server.Rachis
                     else
                     {
                         if (await waitAsync == false)
-                        {
-                            if (rachisMergedCommand.Consumed.Raise())
-                                throw new TimeoutException($"Waited for {timeout} but the command was not applied in this time.");
-
-                            // if the command is already dequeued we must let it continue to keep its context valid.
-                            await rachisMergedCommand.Tcs.Task;
-                        }
+                            throw new TimeoutException($"Waited for {timeout} but the command was not applied in this time.");
                     }
                 }
                 finally


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23809

### Additional description
To ensure the context remains valid, we catch any exceptions after the command is consumed and before the command task completes. 
Once the command task completes, the Leader has finished handling the command, eliminating the risk of using a released context.


### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
