### PR TITLE
RavenDB-23730 - Fix Incoming-Replication recreating revision that has been deleted

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -565,6 +565,10 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 var nonPersistentFlags = GetNonPersistentDocumentFlags();
                                 if (doc.Flags.Contain(DocumentFlags.Revision))
                                 {
+                                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding) == false && 
+                                        database.DocumentsStorage.RevisionsStorage.CheckTombstoneConflictStatus(context, doc.Id, changeVectorVersion)) 
+                                        continue;
+
                                     database.DocumentsStorage.RevisionsStorage.Put(
                                         context,
                                         doc.Id,
@@ -578,6 +582,10 @@ namespace Raven.Server.Documents.Replication.Incoming
 
                                 if (doc.Flags.Contain(DocumentFlags.DeleteRevision))
                                 {
+                                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding) == false && 
+                                        database.DocumentsStorage.RevisionsStorage.CheckTombstoneConflictStatus(context, doc.Id, changeVectorVersion))
+                                        continue;
+
                                     database.DocumentsStorage.RevisionsStorage.Delete(
                                         context,
                                         doc.Id,

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -566,7 +566,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 if (doc.Flags.Contain(DocumentFlags.Revision))
                                 {
                                     if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding) == false && 
-                                        database.DocumentsStorage.RevisionsStorage.CheckTombstoneConflictStatus(context, doc.Id, changeVectorVersion)) 
+                                        database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion)) 
                                         continue;
 
                                     database.DocumentsStorage.RevisionsStorage.Put(
@@ -583,7 +583,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 if (doc.Flags.Contain(DocumentFlags.DeleteRevision))
                                 {
                                     if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding) == false && 
-                                        database.DocumentsStorage.RevisionsStorage.CheckTombstoneConflictStatus(context, doc.Id, changeVectorVersion))
+                                        database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion))
                                         continue;
 
                                     database.DocumentsStorage.RevisionsStorage.Delete(

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -565,9 +565,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 var nonPersistentFlags = GetNonPersistentDocumentFlags();
                                 if (doc.Flags.Contain(DocumentFlags.Revision))
                                 {
-                                    if (database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion)) 
-                                        continue;
-
                                     database.DocumentsStorage.RevisionsStorage.Put(
                                         context,
                                         doc.Id,
@@ -581,9 +578,6 @@ namespace Raven.Server.Documents.Replication.Incoming
 
                                 if (doc.Flags.Contain(DocumentFlags.DeleteRevision))
                                 {
-                                    if (database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion))
-                                        continue;
-
                                     database.DocumentsStorage.RevisionsStorage.Delete(
                                         context,
                                         doc.Id,

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -565,8 +565,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 var nonPersistentFlags = GetNonPersistentDocumentFlags();
                                 if (doc.Flags.Contain(DocumentFlags.Revision))
                                 {
-                                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding) == false && 
-                                        database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion)) 
+                                    if (database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion)) 
                                         continue;
 
                                     database.DocumentsStorage.RevisionsStorage.Put(
@@ -582,8 +581,7 @@ namespace Raven.Server.Documents.Replication.Incoming
 
                                 if (doc.Flags.Contain(DocumentFlags.DeleteRevision))
                                 {
-                                    if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding) == false && 
-                                        database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion))
+                                    if (database.DocumentsStorage.RevisionsStorage.IsExistingTombstoneIsNewer(context, doc.Id, changeVectorVersion))
                                         continue;
 
                                     database.DocumentsStorage.RevisionsStorage.Delete(

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -302,7 +302,7 @@ namespace Raven.Server.Documents.Revisions
 
         public bool IsExistingNewerTombstone(DocumentsOperationContext context, string docId, ChangeVector revisionChangeVector, DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags, long lastModifiedTicks)
         {
-            if(nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation)) // creation of the ForceCreated revision after deletion of old revision with the same cv 
+            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation)) // creation of the ForceCreated revision after deletion of old revision with the same cv 
                 return false;
 
             using (DocumentIdWorker.GetSliceFromId(context, docId, out var revisionIdSlice))

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -17,7 +17,6 @@ using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
-using Raven.Server.Utils.Enumerators;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Json;
@@ -32,6 +31,7 @@ using Voron.Exceptions;
 using Voron.Impl;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Revisions;
+using static Raven.Server.Documents.Schemas.Tombstones;
 using static Voron.Data.Tables.Table;
 using Constants = Raven.Client.Constants;
 using Size = Sparrow.Size;
@@ -298,6 +298,25 @@ namespace Raven.Server.Documents.Revisions
             }
 
             return true;
+        }
+
+        public bool CheckTombstoneConflictStatus(DocumentsOperationContext context, string docId, ChangeVector revisionChangeVector)
+        {
+            using (DocumentIdWorker.GetSliceFromId(context, docId, out var revisionIdSlice))
+            using (CreateRevisionTombstoneKeySlice(context, revisionIdSlice, revisionChangeVector.Version.ToString(), out _, out var tombstoneKeySlice))
+            {
+                var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(_documentsStorage.TombstonesSchema, RevisionsTombstonesSlice);
+                if (tombstoneTable.ReadByKey(tombstoneKeySlice, out var tvr))
+                {
+                    var tombstoneChangeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref tvr);
+                    var status = ChangeVectorUtils.GetConflictStatus(revisionChangeVector, tombstoneChangeVector);
+
+                    if (status is ConflictStatus.AlreadyMerged)
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         public unsafe bool Put(DocumentsOperationContext context, string id, BlittableJsonReaderObject document,

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -308,6 +308,10 @@ namespace Raven.Server.Documents.Revisions
                 var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(_documentsStorage.TombstonesSchema, RevisionsTombstonesSlice);
                 if (tombstoneTable.ReadByKey(tombstoneKeySlice, out var tvr))
                 {
+                    var tombstoneFlags = TableValueToFlags((int)TombstoneTable.Flags, ref tvr);
+                    if (tombstoneFlags.Contain(DocumentFlags.Artificial) && tombstoneFlags.Contain(DocumentFlags.FromResharding))
+                        return false;
+
                     var tombstoneChangeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref tvr);
                     var status = ChangeVectorUtils.GetConflictStatus(revisionChangeVector, tombstoneChangeVector);
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -300,7 +300,7 @@ namespace Raven.Server.Documents.Revisions
             return true;
         }
 
-        public bool CheckTombstoneConflictStatus(DocumentsOperationContext context, string docId, ChangeVector revisionChangeVector)
+        public bool IsExistingTombstoneIsNewer(DocumentsOperationContext context, string docId, ChangeVector revisionChangeVector)
         {
             using (DocumentIdWorker.GetSliceFromId(context, docId, out var revisionIdSlice))
             using (CreateRevisionTombstoneKeySlice(context, revisionIdSlice, revisionChangeVector.Version.ToString(), out _, out var tombstoneKeySlice))

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -300,8 +300,11 @@ namespace Raven.Server.Documents.Revisions
             return true;
         }
 
-        public bool IsExistingTombstoneIsNewer(DocumentsOperationContext context, string docId, ChangeVector revisionChangeVector)
+        public bool IsExistingNewerTombstone(DocumentsOperationContext context, string docId, ChangeVector revisionChangeVector, DocumentFlags flags, NonPersistentDocumentFlags nonPersistentFlags, long lastModifiedTicks)
         {
+            if(nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation)) // creation of the ForceCreated revision after deletion of old revision with the same cv 
+                return false;
+
             using (DocumentIdWorker.GetSliceFromId(context, docId, out var revisionIdSlice))
             using (CreateRevisionTombstoneKeySlice(context, revisionIdSlice, revisionChangeVector.Version.ToString(), out _, out var tombstoneKeySlice))
             {
@@ -309,14 +312,18 @@ namespace Raven.Server.Documents.Revisions
                 if (tombstoneTable.ReadByKey(tombstoneKeySlice, out var tvr))
                 {
                     var tombstoneFlags = TableValueToFlags((int)TombstoneTable.Flags, ref tvr);
-                    if (tombstoneFlags.Contain(DocumentFlags.Artificial) && tombstoneFlags.Contain(DocumentFlags.FromResharding))
+                    if (tombstoneFlags.Contain(DocumentFlags.Artificial | DocumentFlags.FromResharding))
                         return false;
 
-                    var tombstoneChangeVector = TableValueToChangeVector(context, (int)TombstoneTable.ChangeVector, ref tvr);
-                    var status = ChangeVectorUtils.GetConflictStatus(revisionChangeVector, tombstoneChangeVector);
+                    if (flags.Contain(DocumentFlags.ForceCreated) &&
+                        nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) &&
+                        TableValueToDateTime((int)TombstoneTable.LastModified, ref tvr).Ticks < lastModifiedTicks)
+                    {
+                        // The force-created revision created after deletion of old revision with the same cv, and then got by replication
+                        return false;
+                    }
 
-                    if (status is ConflictStatus.AlreadyMerged)
-                        return true;
+                    return true;
                 }
             }
 
@@ -329,6 +336,9 @@ namespace Raven.Server.Documents.Revisions
         {
             Debug.Assert(changeVector != null, "Change vector must be set");
             Debug.Assert(lastModifiedTicks != DateTime.MinValue.Ticks, "last modified ticks must be set");
+
+            if (IsExistingNewerTombstone(context, id, changeVector, flags, nonPersistentFlags, lastModifiedTicks)) 
+                return false;
 
             BlittableJsonReaderObject.AssertNoModifications(document, id, assertChildren: true);
 
@@ -1260,7 +1270,7 @@ namespace Raven.Server.Documents.Revisions
             });
         }
 
-        public void DeleteRevision(DocumentsOperationContext context, Slice key, string collection, string changeVector, long lastModifiedTicks, Slice changeVectorSlice, bool fromReplication)
+        public void DeleteRevision(DocumentsOperationContext context, Slice key, string collection, string changeVector, long lastModifiedTicks, Slice changeVectorSlice, bool fromReplication, DocumentFlags flags = DocumentFlags.None)
         {
             var collectionName = _documentsStorage.ExtractCollectionName(context, collection);
             var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
@@ -1292,7 +1302,7 @@ namespace Raven.Server.Documents.Revisions
                 revisionEtag = _documentsStorage.GenerateNextEtagForReplicatedTombstoneMissingDocument(context);
             }
 
-            CreateTombstone(context, key, revisionEtag, collectionName, changeVector, lastModifiedTicks, fromReplication);
+            CreateTombstone(context, key, revisionEtag, collectionName, changeVector, lastModifiedTicks, fromReplication, flags);
         }
 
         private unsafe void CreateTombstone(DocumentsOperationContext context, Slice keySlice, long revisionEtag,
@@ -1370,6 +1380,9 @@ namespace Raven.Server.Documents.Revisions
             long lastModifiedTicks, NonPersistentDocumentFlags nonPersistentFlags, DocumentFlags flags)
         {
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.SkipRevisionCreation))
+                return;
+
+            if (IsExistingNewerTombstone(context, id, changeVector, flags, nonPersistentFlags, lastModifiedTicks)) 
                 return;
 
             Debug.Assert(changeVector != null, "Change vector must be set");

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -657,7 +657,7 @@ namespace Raven.Server.Smuggler.Documents
                                 case Tombstone.TombstoneType.Revision:
                                     using (RevisionTombstoneReplicationItem.TryExtractChangeVectorSliceFromKey(context.Allocator, tombstone.LowerId, out var changeVectorSlice))
                                     {
-                                        _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, key, tombstone.Collection, tombstone.ChangeVector, tombstone.LastModified.Ticks, changeVectorSlice, fromReplication: false);
+                                        _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, key, tombstone.Collection, tombstone.ChangeVector, tombstone.LastModified.Ticks, changeVectorSlice, fromReplication: false, tombstone.Flags);
                                     }
                                     break;
 

--- a/test/SlowTests/Issues/RavenDB-23730.cs
+++ b/test/SlowTests/Issues/RavenDB-23730.cs
@@ -14,9 +14,6 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
 using Raven.Server;
 using Raven.Server.Config;
-using Raven.Server.Documents.Sharding;
-using Raven.Server.Rachis;
-using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -55,7 +52,6 @@ namespace SlowTests.Issues
 
             var oldLocation = await Sharding.GetShardNumberForAsync(src, id);
             await Sharding.Resharding.MoveShardForId(src, id, toShard: Math.Abs(oldLocation - 1));
-            // Now "Users/1" in shard 0.
 
             var nodes = new List<RavenServer>() { Server };
             var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(nodes, src.Database);
@@ -69,17 +65,12 @@ namespace SlowTests.Issues
 
             var restoredDatabaseName = $"restored_{Guid.NewGuid()}-{src.Database}";
             using (Sharding.Backup.ReadOnly(backupPath))
-            using (Backup.RestoreDatabase(src, new RestoreBackupConfiguration
-                   {
-                       DatabaseName = restoredDatabaseName,
-                       ShardRestoreSettings = settings
-                   }, timeout: TimeSpan.FromSeconds(60)))
+            using (Backup.RestoreDatabase(src, new RestoreBackupConfiguration { DatabaseName = restoredDatabaseName, ShardRestoreSettings = settings },
+                       timeout: TimeSpan.FromSeconds(60)))
             {
-                // Get the shards with the 'Artificial | FromResharding' revisions tombstones
-                var shardDb = await GetShardWithTombstones(restoredDatabaseName);
-
                 // Wait until 'shardDb' success to perform 'ExecuteMoveDocumentsAsync'
-                await WaitForShardsMigration(shardDb);
+                var bucket = await Sharding.GetBucketAsync(src, id, restoredDatabaseName);
+                await Sharding.Resharding.WaitForMigrationComplete(src, bucket, restoredDatabaseName);
 
                 using (var session = src.OpenAsyncSession(restoredDatabaseName))
                 {
@@ -92,38 +83,6 @@ namespace SlowTests.Issues
                     Assert.Equal(2, user1Revisions.Count);
                 }
             }
-        }
-
-        private async Task<ShardedDocumentDatabase> GetShardWithTombstones(string databaseName)
-        {
-            await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(databaseName))
-            {
-                using (shard.ShardedDocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-                using (ctx.OpenReadTransaction())
-                {
-                    if (shard.ShardedDocumentsStorage.RevisionsStorage.GetNumberOfRevisionTombstones(ctx) > 0)
-                        return shard;
-                }
-            }
-
-            return null;
-        }
-
-        private Task WaitForShardsMigration(ShardedDocumentDatabase shardDb)
-        {
-            return WaitAndAssertForValueAsync<Exception>(async () =>
-            {
-                try
-                {
-                    await shardDb.DocumentsMigrator.ExecuteMoveDocumentsAsync();
-                    return null;
-                }
-                catch (RachisApplyException ex) when (ex.Message.Contains("Failed to update database record."))
-                {
-                    // Shard isn't initialized yet
-                    return ex;
-                }
-            }, null);
         }
 
         [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
@@ -278,7 +237,7 @@ namespace SlowTests.Issues
 
             using var store = GetDocumentStore(new Options()
             {
-                Server = leader, 
+                Server = leader,
                 ReplicationFactor = 3,
                 ModifyDatabaseRecord = record =>
                 {

--- a/test/SlowTests/Issues/RavenDB-23730.cs
+++ b/test/SlowTests/Issues/RavenDB-23730.cs
@@ -1,13 +1,22 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
+using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.Documents.Sharding;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,6 +27,103 @@ namespace SlowTests.Issues
     {
         public RavenDB_23730(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Revisions)]
+        public async Task ReshardingBeforeBackupTest()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            using var src = Sharding.GetDocumentStore();
+
+            await RevisionsHelper.SetupRevisionsAsync(src, modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
+
+            const string id = "Users/1";
+            using (var session = src.OpenSession())
+            {
+                session.Store(new User { Name = "Old" }, id);
+                session.SaveChanges();
+            }
+
+            using (var session = src.OpenSession())
+            {
+                var user = session.Load<User>(id);
+                Assert.NotNull(user);
+                user.Name = "New";
+                session.SaveChanges();
+            }
+
+            var oldLocation = await Sharding.GetShardNumberForAsync(src, id);
+            await Sharding.Resharding.MoveShardForId(src, id, toShard: Math.Abs(oldLocation - 1));
+            // Now "Users/1" in shard 0.
+
+            var nodes = new List<RavenServer>() { Server };
+            var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(nodes, src.Database);
+            var config = Backup.CreateBackupConfiguration(backupPath);
+            await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(nodes, src, config);
+            Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+            var dirs = Directory.GetDirectories(backupPath);
+            var sharding = await Sharding.GetShardingConfigurationAsync(src);
+            var settings = Sharding.Backup.GenerateShardRestoreSettings(dirs, sharding);
+
+            var restoredDatabaseName = $"restored_{Guid.NewGuid()}-{src.Database}";
+            using (Sharding.Backup.ReadOnly(backupPath))
+            using (Backup.RestoreDatabase(src, new RestoreBackupConfiguration
+                   {
+                       DatabaseName = restoredDatabaseName,
+                       ShardRestoreSettings = settings
+                   }, timeout: TimeSpan.FromSeconds(60)))
+            {
+                // Get the shards with the 'Artificial | FromResharding' revisions tombstones
+                var shardDb = await GetShardWithTombstones(restoredDatabaseName);
+
+                // Wait until 'shardDb' success to perform 'ExecuteMoveDocumentsAsync'
+                await WaitForShardsMigration(shardDb);
+
+                using (var session = src.OpenAsyncSession(restoredDatabaseName))
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.Equal("New", user.Name);
+                    var revCount = await session.Advanced.Revisions.GetCountForAsync(id);
+                    Assert.Equal(2, revCount);
+
+                    var user1Revisions = await GetRevisionsCvs(session, id);
+                    Assert.Equal(2, user1Revisions.Count);
+                }
+            }
+        }
+
+        private async Task<ShardedDocumentDatabase> GetShardWithTombstones(string databaseName)
+        {
+            await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(databaseName))
+            {
+                using (shard.ShardedDocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    if (shard.ShardedDocumentsStorage.RevisionsStorage.GetNumberOfRevisionTombstones(ctx) > 0)
+                        return shard;
+                }
+            }
+
+            return null;
+        }
+
+        private Task WaitForShardsMigration(ShardedDocumentDatabase shardDb)
+        {
+            return WaitAndAssertForValueAsync<Exception>(async () =>
+            {
+                try
+                {
+                    await shardDb.DocumentsMigrator.ExecuteMoveDocumentsAsync();
+                    return null;
+                }
+                catch (RachisApplyException ex) when (ex.Message.Contains("Failed to update database record."))
+                {
+                    // Shard isn't initialized yet
+                    return ex;
+                }
+            }, null);
         }
 
         [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
@@ -165,9 +271,77 @@ namespace SlowTests.Issues
             }
         }
 
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        public async Task CanRecreateForceCreatedRevisionAndReplicate()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3);
+
+            using var store = GetDocumentStore(new Options()
+            {
+                Server = leader, 
+                ReplicationFactor = 3,
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            });
+
+            List<string> revisions;
+
+            var user1 = new User { Id = "Users/1-A", Name = "Shahar_old" };
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: user1.Id);
+                await session.SaveChangesAsync();
+
+                revisions = await GetRevisionsCvs(session, user1.Id);
+                Assert.Equal(1, revisions.Count);
+            }
+
+            await store.Maintenance.SendAsync(new DeleteRevisionsOperation(user1.Id, revisions, removeForceCreatedRevisions: true));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var revisions2 = await GetRevisionsCvs(session, user1.Id);
+                Assert.Empty(revisions2);
+
+                session.Advanced.WaitForReplicationAfterSaveChanges(TimeSpan.FromSeconds(15));
+
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: user1.Id);
+                await session.SaveChangesAsync();
+            }
+
+            foreach (var n in nodes)
+            {
+                using var nodeStore = GetStoreForServer(n, store.Database);
+                // Wait for (force-created) revision replication
+                await WaitForValueAsync(async () =>
+                {
+                    using (var session = nodeStore.OpenAsyncSession())
+                    {
+                        return (await GetRevisionsCvs(session, user1.Id)).Count;
+                    }
+                }, 1);
+            }
+
+            IDocumentStore GetStoreForServer(RavenServer server, string database)
+            {
+                return new DocumentStore
+                    {
+                        Database = database, 
+                        Urls = new[] { server.WebUrl }, 
+                        Conventions = new DocumentConventions { DisableTopologyUpdates = true }
+                    }
+                    .Initialize();
+            }
+        }
+
         private async Task ModifyExternalReplication(DocumentStore from, DocumentStore to, long ongoingTaskId, bool disable)
         {
-            var external = new ExternalReplication(from.Database, $"ConnectionString-{to.Identifier}") { TaskId = ongoingTaskId, Disabled = true };
+            var external = new ExternalReplication(from.Database, $"ConnectionString-{to.Identifier}") { TaskId = ongoingTaskId, Disabled = disable };
             await from.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
         }
 

--- a/test/SlowTests/Issues/RavenDB-23730.cs
+++ b/test/SlowTests/Issues/RavenDB-23730.cs
@@ -1,0 +1,191 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23730 : ReplicationTestBase
+    {
+        public RavenDB_23730(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Revisions)]
+        public async Task IncomingReplicationRecreateRevisionAltoughtHavingTombstoneForIt()
+        {
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            };
+            using var store1 = GetDocumentStore(options);
+            using var store2 = GetDocumentStore(options);
+            using var store3 = GetDocumentStore(options);
+
+            var revisionsConfig = new RevisionsConfiguration
+            {
+                Collections = new Dictionary<string, RevisionsCollectionConfiguration>() { ["Users"] = new RevisionsCollectionConfiguration() { Disabled = false } }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store1, store1.Database, revisionsConfig);
+            await RevisionsHelper.SetupRevisionsAsync(store2, store2.Database, revisionsConfig);
+            await RevisionsHelper.SetupRevisionsAsync(store3, store3.Database, revisionsConfig);
+
+            List<string> user1Revisions;
+            var user1 = new User { Id = "Users/1-A", Name = "Shahar_old" };
+            using (var session = store1.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+
+                user1Revisions = await GetRevisionsCvs(session, user1.Id);
+                Assert.Equal(1, user1Revisions.Count);
+            }
+
+            var ongoingTaskId12 = (await SetupReplicationAsync(store1, store2)).First().TaskId;
+            await EnsureReplicatingAsync(store1, store2);
+            // 'Shahar_old' revision is now on store1 and store2, store3 still has nothing
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                (await session.LoadAsync<User>(user1.Id)).Name = "Shahar_new";
+                await session.SaveChangesAsync();
+            }
+
+            await EnsureReplicatingAsync(store1, store2);
+            // 'Shahar_old' and 'Shahar_new' revisions are now on store1 and store2, store3 still has nothing
+
+            await ModifyExternalReplication(from: store1, to: store2, ongoingTaskId12, disable: true);
+
+            await store1.Maintenance.SendAsync(new DeleteRevisionsOperation(user1.Id, user1Revisions));
+            // store1 now has revision 'Shahar_new' and 'Shahar_old' revision-tombstone, store2 has revisions 'Shahar_old' and 'Shahar_new', store3 still has nothing
+            var stats = await GetDatabaseStatisticsAsync(store1, store1.Database);
+            Assert.Equal(1, stats.CountOfTombstones);
+            Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+            // 1=>3
+            await SetupReplicationAsync(store1, store3);
+            await EnsureReplicatingAsync(store1, store3);
+            // store3 now has revision 'Shahar_new' and 'Shahar_old' revision-tombstone (got it from store1), store1 now has revision 'Shahar_new' and 'Shahar_old' revision-tombstone, store2 has revisions 'Shahar_old' and 'Shahar_new'.
+            stats = await GetDatabaseStatisticsAsync(store3, store3.Database);
+            Assert.Equal(1, stats.CountOfTombstones);
+            Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+            // 2=>3
+            await SetupReplicationAsync(store2, store3);
+            await EnsureReplicatingAsync(store2, store3);
+            // [Before the fix]
+            // store3 now has revision 'Shahar_new' , 'Shahar_old' revision-tombstone and 'Shahar_old' revision (got it from store2)
+            // store1 now has revision 'Shahar_new' and 'Shahar_old' revision-tombstone,
+            // store2 has revisions 'Shahar_old' and 'Shahar_new'.
+
+            // 2=>1
+            await SetupReplicationAsync(store2, store1);
+            await EnsureReplicatingAsync(store2, store1);
+            // [Before the fix]
+            // store3 now has revision 'Shahar_new' , 'Shahar_old' revision-tombstone and 'Shahar_old' revision (got it from store2)
+            // store2 has revisions 'Shahar_old' and 'Shahar_new'.
+            // store1 now has revision 'Shahar_new' , 'Shahar_old' revision-tombstone and 'Shahar_old' revision
+
+            // 1=>2 (enable)
+            await ModifyExternalReplication(from: store1, to: store2, ongoingTaskId12, disable: false);
+            // 3=>1
+            await SetupReplicationAsync(store3, store1);
+            await EnsureReplicatingAsync(store3, store1);
+            // 3=>2
+            await SetupReplicationAsync(store3, store2);
+            await EnsureReplicatingAsync(store3, store2);
+
+            // Replication: 1=>3, 1=>2, 2=>3, 2=>1, 3=>1, 3=>2
+
+            stats = await GetDatabaseStatisticsAsync(store1, store1.Database);
+            Assert.Equal(1, stats.CountOfTombstones);
+            Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+            stats = await GetDatabaseStatisticsAsync(store2, store2.Database);
+            Assert.Equal(1, stats.CountOfTombstones);
+            Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+            stats = await GetDatabaseStatisticsAsync(store3, store3.Database);
+            Assert.Equal(1, stats.CountOfTombstones);
+            Assert.Equal(1, stats.CountOfRevisionDocuments);
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task CanRecreateForceCreatedRevision()
+        {
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+                }
+            };
+            using var store1 = GetDocumentStore(options);
+
+            List<string> revisions;
+
+            var user1 = new User { Id = "Users/1-A", Name = "Shahar_old" };
+            using (var session = store1.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: user1.Id);
+                await session.SaveChangesAsync();
+
+                revisions = await GetRevisionsCvs(session, user1.Id);
+                Assert.Equal(1, revisions.Count);
+            }
+
+            await store1.Maintenance.SendAsync(new DeleteRevisionsOperation(user1.Id, revisions, removeForceCreatedRevisions: true));
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                var revisions2 = await GetRevisionsCvs(session, user1.Id);
+                Assert.Empty(revisions2);
+
+                session.Advanced.Revisions.ForceRevisionCreationFor(id: user1.Id);
+                await session.SaveChangesAsync();
+
+                var revisions3 = await GetRevisionsCvs(session, user1.Id);
+                Assert.Equal(1, revisions3.Count);
+                Assert.Equal(revisions.First(), revisions3.First());
+            }
+        }
+
+        private async Task ModifyExternalReplication(DocumentStore from, DocumentStore to, long ongoingTaskId, bool disable)
+        {
+            var external = new ExternalReplication(from.Database, $"ConnectionString-{to.Identifier}") { TaskId = ongoingTaskId, Disabled = true };
+            await from.Maintenance.SendAsync(new UpdateExternalReplicationOperation(external));
+        }
+
+        private async Task<List<string>> GetRevisionsCvs(IAsyncDocumentSession session, string id)
+        {
+            var cvs = (await session
+                .Advanced
+                .Revisions
+                .GetMetadataForAsync(id)).Select(m => m.GetString(Constants.Documents.Metadata.ChangeVector));
+
+            return cvs.ToList();
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.ReshardingTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ReshardingTestBase.cs
@@ -81,15 +81,16 @@ public partial class RavenTestBase
             return bucket;
         }
 
-        public async Task WaitForMigrationComplete(IDocumentStore store, int bucket, TimeSpan? timeout = null)
+        public async Task WaitForMigrationComplete(IDocumentStore store, int bucket, string database = null, TimeSpan? timeout = null)
         {
+            database ??= store.Database;
             using (var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(30)))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database), cts.Token);
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database), cts.Token);
                 while (record.Sharding.BucketMigrations.ContainsKey(bucket))
                 {
                     await Task.Delay(250, cts.Token);
-                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database), cts.Token);
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database), cts.Token);
                 }
             }
         }
@@ -100,7 +101,7 @@ public partial class RavenTestBase
             {
                 servers ??= _parent.GetServers();
                 var bucket = await StartMovingShardForId(store, id, toShard, servers);
-                await WaitForMigrationComplete(store, bucket, timeout ?? TimeSpan.FromSeconds(30));
+                await WaitForMigrationComplete(store, bucket, timeout: timeout ?? TimeSpan.FromSeconds(30));
             }
             catch (Exception e)
             {

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -185,9 +185,9 @@ public partial class RavenTestBase
                 return ShardHelper.GetBucketFor(config, allocator, id);
         }
 
-        public async Task<int> GetBucketAsync(IDocumentStore store, string id)
+        public async Task<int> GetBucketAsync(IDocumentStore store, string id, string database = null)
         {
-            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database ?? store.Database));
             return GetBucket(record.Sharding, id);
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -337,7 +337,7 @@ public partial class RavenTestBase
         {
             var shardingConfiguration = record != null ? record.Sharding : await GetShardingConfigurationAsync(store, database);
             DatabaseStatistics combined = new DatabaseStatistics();
-            var essential = await store.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            var essential = await store.Maintenance.ForDatabase(database ?? store.Database).SendAsync(new GetEssentialStatisticsOperation());
 
             combined.CountOfConflicts = essential.CountOfConflicts;
             combined.CountOfCounterEntries = essential.CountOfCounterEntries;

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -92,7 +92,7 @@ namespace FastTests
             if (dbRecord.IsSharded)
                 return await Sharding.GetDatabaseStatisticsAsync(store, database ?? store.Database, dbRecord, servers);
 
-            return await store.Maintenance.SendAsync(new GetStatisticsOperation());
+            return await store.Maintenance.ForDatabase(database ?? store.Database).SendAsync(new GetStatisticsOperation());
         }
 
         public bool WaitForDocument<T>(IDocumentStore store,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23730/SlowTests.Issues.RavenDB21326.RevisionsBinCleanerClusterTestoptions-DatabaseMode-Single-SearchEngineMode-Lucene

### Additional description

Fixing recreating revision that was already deleted (its tombstone already exists) because of replication timings (reproduced by a test)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
