### PR TITLE
RavenDB-23704 - Prevent memory fragmenation by moving allocation pointer back when releasing memory at current allocation boundary

### DIFF
--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -671,6 +671,7 @@ namespace Sparrow.Server
         public const int MaxAllocationBlockSizeInBytes = 256 * MinBlockSizeInBytes;
         public const int DefaultAllocationBlockSizeInBytes = 1 * MinBlockSizeInBytes;
         public const int MinReusableBlockSizeInBytes = 8;
+        public const int MaxAllocatedBlockSize = 2 * Sparrow.Global.Constants.Size.Megabyte;
 
         static unsafe ByteStringContext()
         {
@@ -1040,7 +1041,7 @@ namespace Sparrow.Server
             {
                 if (_externalCurrentLeft == 0)
                 {
-                    var tmp = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, AllocationBlockSize * 2);
+                    var tmp = Math.Min(ByteStringContext.MaxAllocatedBlockSize, AllocationBlockSize * 2);
                     AllocateExternalSegment(tmp);
                     AllocationBlockSize = tmp;
                 }
@@ -1184,7 +1185,7 @@ namespace Sparrow.Server
             }
             else
             {
-                AllocationBlockSize = Math.Min(2 * Sparrow.Global.Constants.Size.Megabyte, AllocationBlockSize * 2);
+                AllocationBlockSize = Math.Min(ByteStringContext.MaxAllocatedBlockSize, AllocationBlockSize * 2);
                 var toAllocate = Math.Max(AllocationBlockSize, allocationUnit);
                 _internalCurrent = AllocateSegment(toAllocate);
                 Debug.Assert(_internalCurrent.SizeLeft >= allocationUnit, $"{_internalCurrent.SizeLeft} >= {allocationUnit}");

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -750,7 +750,7 @@ namespace Sparrow.Server
         /// </summary>
         private readonly List<SegmentInformation> _wholeSegments;
         private readonly int _initialAllocationBlockSize;
-        public int AllocationBlockSize { get; private set; }
+        internal int AllocationBlockSize { get; private set; }
 
         internal long _totalAllocated, _currentlyAllocated;
 

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -1336,7 +1336,11 @@ namespace Sparrow.Server
 
             int reusablePoolIndex = GetPoolIndexForReuse(value._pointer->Size);
 
-            if (value._pointer->Size <= ByteStringContext.MinBlockSizeInBytes)
+            if (value._pointer == _internalCurrent.Current - value._pointer->Size)
+            {
+                _internalCurrent.Current -= value._pointer->Size;
+            }
+            else if (value._pointer->Size <= ByteStringContext.MinBlockSizeInBytes)
             {
                 FastStack<IntPtr> pool = _internalReusableStringPool[reusablePoolIndex];
                 if (pool == null)

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -671,7 +671,7 @@ namespace Sparrow.Server
         public const int MaxAllocationBlockSizeInBytes = 256 * MinBlockSizeInBytes;
         public const int DefaultAllocationBlockSizeInBytes = 1 * MinBlockSizeInBytes;
         public const int MinReusableBlockSizeInBytes = 8;
-        public const int MaxAllocatedBlockSize = 2 * Sparrow.Global.Constants.Size.Megabyte;
+        public const int MaxSegmentSizeInBytes = 2 * Sparrow.Global.Constants.Size.Megabyte;
 
         static unsafe ByteStringContext()
         {
@@ -1041,7 +1041,7 @@ namespace Sparrow.Server
             {
                 if (_externalCurrentLeft == 0)
                 {
-                    var tmp = Math.Min(ByteStringContext.MaxAllocatedBlockSize, AllocationBlockSize * 2);
+                    var tmp = Math.Min(ByteStringContext.MaxSegmentSizeInBytes, AllocationBlockSize * 2);
                     AllocateExternalSegment(tmp);
                     AllocationBlockSize = tmp;
                 }
@@ -1185,7 +1185,7 @@ namespace Sparrow.Server
             }
             else
             {
-                AllocationBlockSize = Math.Min(ByteStringContext.MaxAllocatedBlockSize, AllocationBlockSize * 2);
+                AllocationBlockSize = Math.Min(ByteStringContext.MaxSegmentSizeInBytes, AllocationBlockSize * 2);
                 var toAllocate = Math.Max(AllocationBlockSize, allocationUnit);
                 _internalCurrent = AllocateSegment(toAllocate);
                 Debug.Assert(_internalCurrent.SizeLeft >= allocationUnit, $"{_internalCurrent.SizeLeft} >= {allocationUnit}");

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using Sparrow.Global;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Tests.Infrastructure;
@@ -192,6 +192,38 @@ namespace FastTests.Sparrow
                 context.Reset();
 
                 Assert.Equal(blockSizeInBytes, context.AllocationBlockSize);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Memory)]
+        public void CanReuseMemory()
+        {
+            using (var context = new ByteStringContext<ByteStringDirectAllocator>(SharedMultipleUseFlag.None))
+            {
+                while (context.AllocationBlockSize != 2 * Constants.Size.Megabyte)
+                {
+                    context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2, out _);
+                }
+
+                Assert.Equal(2 * Constants.Size.Megabyte, context.AllocationBlockSize);
+
+                const int toAllocate = ByteStringContext.MinBlockSizeInBytes * 5;
+                context.Allocate(toAllocate, out var first);
+                var ptrLocation = (long)first._pointer;
+                var allocatedBefore = context._totalAllocated;
+                context.Release(ref first);
+
+                for (var i = 0; i < 512; i++)
+                {
+                    var allocation = i % 2 == 0 ? toAllocate / 2 : toAllocate;
+                    context.Allocate(allocation, out var byteString);
+
+                    Assert.Equal(ptrLocation, (long)byteString._pointer);
+
+                    context.Release(ref byteString);
+                }
+
+                Assert.Equal(allocatedBefore, context._totalAllocated);
             }
         }
 

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -125,7 +125,10 @@ namespace FastTests.Sparrow
                 context.Allocate(2 * ByteStringContext.MinBlockSizeInBytes - sizeof(ByteStringStorage), out var byteStringInFirst);
 
                 long ptrLocation = (long)byteStringInFirst._pointer;
-                long nextPtrLocation = ptrLocation + byteStringInFirst._pointer->Size;
+
+                // we need to allocate this since we want the first block to be released as a new segment
+                context.Allocate(1, out var byteStringInSecond);
+                long nextPtrLocation = (long)byteStringInSecond._pointer + byteStringInSecond._pointer->Size;
 
                 context.Release(ref byteStringInFirst); // After the release the block should be reserved as a new segment. 
 
@@ -135,9 +138,9 @@ namespace FastTests.Sparrow
                 Assert.InRange((long)byteStringReused._pointer, ptrLocation, ptrLocation + allocationBlockSize);
                 Assert.Equal(ptrLocation, (long)byteStringReused._pointer); // We are the first in the segment.
 
-                // This allocation will have an allocation unit size of 128 and fit into the rest of the initial segment, which should be 
+                // This allocation will have an allocation unit size of 64 and fit into the rest of the initial segment, which should be 
                 // available for an exact reuse bucket allocation. 
-                context.Allocate(64, out var byteStringReusedFromBucket);
+                context.Allocate(32, out var byteStringReusedFromBucket);
 
                 Assert.Equal((long)byteStringReusedFromBucket._pointer, nextPtrLocation);
             }

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -202,12 +202,12 @@ namespace FastTests.Sparrow
         {
             using (var context = new ByteStringContext<ByteStringDirectAllocator>(SharedMultipleUseFlag.None))
             {
-                while (context.AllocationBlockSize != ByteStringContext.MaxAllocatedBlockSize)
+                while (context.AllocationBlockSize != ByteStringContext.MaxSegmentSizeInBytes)
                 {
                     context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2, out _);
                 }
 
-                Assert.Equal(ByteStringContext.MaxAllocatedBlockSize, context.AllocationBlockSize);
+                Assert.Equal(ByteStringContext.MaxSegmentSizeInBytes, context.AllocationBlockSize);
 
                 const int toAllocate = ByteStringContext.MinBlockSizeInBytes * 5;
                 context.Allocate(toAllocate, out var first);

--- a/test/FastTests/Sparrow/ByteStringTests.cs
+++ b/test/FastTests/Sparrow/ByteStringTests.cs
@@ -1,5 +1,4 @@
-﻿using Sparrow.Global;
-using Sparrow.Server;
+﻿using Sparrow.Server;
 using Sparrow.Threading;
 using Tests.Infrastructure;
 using Xunit;
@@ -200,12 +199,12 @@ namespace FastTests.Sparrow
         {
             using (var context = new ByteStringContext<ByteStringDirectAllocator>(SharedMultipleUseFlag.None))
             {
-                while (context.AllocationBlockSize != 2 * Constants.Size.Megabyte)
+                while (context.AllocationBlockSize != ByteStringContext.MaxAllocatedBlockSize)
                 {
                     context.Allocate(ByteStringContext.MinBlockSizeInBytes / 2, out _);
                 }
 
-                Assert.Equal(2 * Constants.Size.Megabyte, context.AllocationBlockSize);
+                Assert.Equal(ByteStringContext.MaxAllocatedBlockSize, context.AllocationBlockSize);
 
                 const int toAllocate = ByteStringContext.MinBlockSizeInBytes * 5;
                 context.Allocate(toAllocate, out var first);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23704/Unmanaged-memory-growing-up-to-OOM-during-backup

### Additional description

The change adds an optimization to the Release method by checking if the memory being released is at the top of the current allocation area.
In the original code, all released memory would be handled in one of two ways:

1. Small blocks (≤ `MinBlockSizeInBytes`) would be added to the reusable string pool
2. Large blocks would be added to the ready-to-use memory segments

The new code introduces a third case that's checked first:
```
if (value._pointer == _internalCurrent.Current - value._pointer->Size)
{
    _internalCurrent.Current -= value._pointer->Size;
}
```
This checks if the memory being released is exactly at the end of the current allocation area. If it is, instead of adding it to a pool, we simply move the allocation pointer back by the size of the block. This effectively "unwraps" the last allocation, making that memory immediately available for the next allocation without going through the pool mechanism.
This change improves allocation performance by avoiding the overhead of pool management when releasing memory that's at the top of the allocation stack. It also helps prevent memory fragmentation since consecutive allocations and releases at the top of the stack will maintain contiguous memory, as demonstrated in the test case.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
