### PR TITLE
RavenDB-23835 Set password to null after exporting the certificate without password to avoid loading it with password

### DIFF
--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -1097,6 +1097,7 @@ namespace Raven.Server.Web.Authentication
                                 // Exporting with the private key, but without the password
                                 certBytes = cert.Export(X509ContentType.Pkcs12);
                                 certificate.Certificate = Convert.ToBase64String(certBytes);
+                                certificate.Password = null;
                             }
                             catch (Exception e)
                             {

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -24,10 +24,13 @@ using Xunit.Abstractions;
 using Sparrow.Server;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.ServerWide.Context;
 using Raven.Client.Exceptions;
+using Raven.Client.Json;
 
 namespace SlowTests.Authentication
 {
@@ -126,6 +129,43 @@ namespace SlowTests.Authentication
 
             await mre.WaitAsync(TimeSpan.FromSeconds(15));
             Assert.NotEqual(first, Server.Certificate.Certificate.Thumbprint);
+        }
+
+        [RavenFact(RavenTestCategory.Certificates)]
+        public async Task ReplaceCertificateWithPassword()
+        {
+            const string password = "mysecretpassword";
+
+            var (_, leader, certificates) = await CreateRaftClusterWithSsl(1);
+
+            X509Certificate2 certificateWithPassword;
+            using (var store = GetDocumentStore(new Options { Server = leader, CreateDatabase = false, ClientCertificate = certificates.ServerCertificate.Value }))
+            {
+                var rawData = certificates.ServerCertificate.Value.Export(X509ContentType.Pkcs12, password);
+                var certificateDefinition = new CertificateDefinition { Certificate = Convert.ToBase64String(rawData), Password = password };
+
+                var requestExecutor = store.GetRequestExecutor();
+                using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
+                {
+                    var blittable = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(certificateDefinition, context);
+                    var content = new BlittableJsonContent(async stream => await context.WriteAsync(stream, blittable).ConfigureAwait(false));
+                    var response = await requestExecutor.HttpClient.PostAsync($"{leader.WebUrl}/admin/certificates/replace-cluster-cert", content);
+
+                    if (response.IsSuccessStatusCode == false)
+                        Assert.Fail(await response.Content.ReadAsStringAsync());
+                }
+
+                certificateWithPassword = CertificateLoaderUtil.CreateCertificate(rawData, password);
+            }
+
+            using (var store = GetDocumentStore(new Options { Server = leader, CreateDatabase = true, ClientCertificate = certificateWithPassword }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new {Prop = "value"});
+                    await session.SaveChangesAsync();
+                }
+            }
         }
 
         private async Task CanGetLetsEncryptCertificateAndRenewAfterFailure(string acmeUrl)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23835
https://issues.hibernatingrhinos.com/issue/RavenDB-23836

### Additional description
We export the certificate without a password but still attempt to use the password when loading it for validation. 
To prevent this, I set the password to null.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
