### PR TITLE
RavenDB-23620 In tests, wait on the backup operation before starting a new one

### DIFF
--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -344,7 +344,7 @@ namespace RachisTests.DatabaseCluster
                 // start backup
                 var backupPath = NewDataPath(suffix: "BackupFolder");
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 0 1 1 *");
-                long taskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config, isFullBackup: true);
+                var (taskId, _) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config, isFullBackup: true);
 
                 var backupShard0 = database.PeriodicBackupRunner.PeriodicBackups.Single(x => x.Configuration.TaskId == taskId);
                 

--- a/test/SlowTests/Issues/RavenDB-21050.cs
+++ b/test/SlowTests/Issues/RavenDB-21050.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
@@ -78,17 +77,8 @@ public class RavenDB_21050 : RavenTestBase
     private async Task<long> WaitAndAssertForBackup(DocumentStore source, RavenDatabaseMode databaseMode, long backupTaskId, TimeSpan? timeout = null)
     {
         timeout ??= TimeSpan.FromMinutes(5);
-
-        WaitHandle[] backupsDone = null;
-        if (databaseMode == RavenDatabaseMode.Sharded)
-            backupsDone = await Sharding.Backup.WaitForBackupToComplete(source);
-        else
-            backupsDone = await Backup.WaitForBackupToComplete(source);
-
         var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
-
-        Assert.True(WaitHandle.WaitAll(backupsDone, timeout.Value));
-
+        await backupStatus.WaitForCompletionAsync(timeout);
         return backupStatus.Id;
     }
 

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -126,12 +126,9 @@ namespace SlowTests.Sharding.Backup
                     await session.SaveChangesAsync();
                 }
 
-                var waitHandles = await Sharding.Backup.WaitForBackupToComplete(store1);
-
-                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "* * * * *");
-                long taskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store1, config);
-
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: BackupTestBase.GetCronForFarFuture());
+                var (taskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store1, config);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 // import
                 var dirs = Directory.GetDirectories(backupPath);
@@ -163,11 +160,8 @@ namespace SlowTests.Sharding.Backup
                     await session.SaveChangesAsync();
                 }
 
-                waitHandles = await Sharding.Backup.WaitForBackupToComplete(store1);
-                
-                await Sharding.Backup.RunBackupAsync(store1, taskId, isFullBackup: false);
-
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                runBackupOperation = await Sharding.Backup.RunBackupAsync(store1, taskId, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 // import
 
@@ -547,8 +541,8 @@ namespace SlowTests.Sharding.Backup
 
                 var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
 
-                var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config);
+                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                var (backupTaskId, op) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config);
 
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(backupTaskId + 3, TimeSpan.FromSeconds(10));
@@ -587,17 +581,17 @@ namespace SlowTests.Sharding.Backup
 
                 var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
 
-                var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config);
+                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                var (backupTaskId, op) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config);
 
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                 var dirs = Directory.GetDirectories(backupPath).ToList();
                 Assert.Equal(cluster.Nodes.Count, dirs.Count);
 
-                var op = store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(backupTaskId));
+                var opResult = store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(backupTaskId));
 
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await op);
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await opResult);
 
                 Assert.Contains($"Database is sharded, can't use {nameof(GetPeriodicBackupStatusOperation)}, " +
                                 $"use {nameof(GetShardedPeriodicBackupStatusOperation)} instead", ex.Message);

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -422,15 +422,11 @@ namespace SlowTests.Sharding.Backup
                     session.SaveChanges();
                 }
 
-                var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
-
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 // add more data
-                waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 0; i < 10; i++)
@@ -442,8 +438,8 @@ namespace SlowTests.Sharding.Backup
                     await session.SaveChangesAsync();
                 }
 
-                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 var dirs = Directory.GetDirectories(backupPath);
                 Assert.Equal(cluster.Nodes.Count, dirs.Length);
@@ -583,20 +579,16 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    var waitHandles = await Sharding.Backup.WaitForBackupToComplete(store);
-
-                    var config = Backup.CreateBackupConfiguration(s3Settings: s3Settings, fullBackupFrequency: null, incrementalBackupFrequency: "0 */6 * * *", 
+                    var config = Backup.CreateBackupConfiguration(s3Settings: s3Settings, fullBackupFrequency: null, incrementalBackupFrequency: BackupTestBase.GetCronForFarFuture(), 
                         backupEncryptionSettings: new BackupEncryptionSettings
                         {
                             EncryptionMode = EncryptionMode.UseDatabaseKey
                         });
 
-                    var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config);
-
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     // add more data
-                    waitHandles = await Sharding.Backup.WaitForBackupToComplete(store);
                     using (var session = store.OpenAsyncSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -608,8 +600,8 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
 
@@ -1172,15 +1164,11 @@ namespace SlowTests.Sharding.Backup
                     session.SaveChanges();
                 }
 
-                var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
-
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 // add counters
-                waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 0; i < 10; i++)
@@ -1191,11 +1179,10 @@ namespace SlowTests.Sharding.Backup
                     await session.SaveChangesAsync();
                 }
 
-                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 // add more docs
-                waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                 using (var session = store.OpenSession())
                 {
                     for (int i = 0; i < 10; i++)
@@ -1206,8 +1193,8 @@ namespace SlowTests.Sharding.Backup
                     session.SaveChanges();
                 }
 
-                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 var dirs = Directory.GetDirectories(backupPath);
                 Assert.Equal(cluster.Nodes.Count, dirs.Length);
@@ -1302,15 +1289,11 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                    var config = Backup.CreateBackupConfiguration(s3Settings: s3Settings);
-                    var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
-
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    var config = Backup.CreateBackupConfiguration(s3Settings: s3Settings, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                    var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     // add counters
-                    waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                     using (var session = store.OpenAsyncSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -1321,11 +1304,10 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
-
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
+                    
                     // add more docs
-                    waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                     using (var session = store.OpenSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -1336,8 +1318,8 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
                     ShardedRestoreSettings settings;
@@ -1435,15 +1417,11 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                    var config = Backup.CreateBackupConfiguration(azureSettings: azureSettings);
-                    var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
-
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    var config = Backup.CreateBackupConfiguration(azureSettings: azureSettings, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                    var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     // add counters
-                    waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                     using (var session = store.OpenAsyncSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -1454,11 +1432,10 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     // add more docs
-                    waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                     using (var session = store.OpenSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -1469,8 +1446,8 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
                     ShardedRestoreSettings settings;
@@ -1568,15 +1545,11 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                    var config = Backup.CreateBackupConfiguration(googleCloudSettings: googleCloudSettings);
-                    var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
-
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    var config = Backup.CreateBackupConfiguration(googleCloudSettings: googleCloudSettings, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                    var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     // add counters
-                    waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                     using (var session = store.OpenAsyncSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -1587,11 +1560,10 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     // add more docs
-                    waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
                     using (var session = store.OpenSession())
                     {
                         for (int i = 0; i < 10; i++)
@@ -1602,8 +1574,8 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                    Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                    runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                    await runBackupOperation.WaitForCompletionAsync();
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
                     var dirs = new HashSet<string>();

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -996,12 +996,9 @@ namespace SlowTests.Sharding.Cluster
                     session.SaveChanges();
                 }
 
-                var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
-
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                var (backupTaskId, runBackupOperation) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 // migrate bucket
                 const string id = $"users/1${suffix}";
@@ -1035,10 +1032,8 @@ namespace SlowTests.Sharding.Cluster
                 }
 
                 // run backup again
-                waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
-
-                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
-                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+                runBackupOperation = await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 var dirs = Directory.GetDirectories(backupPath);
                 Assert.Equal(cluster.Nodes.Count, dirs.Length);

--- a/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
@@ -727,8 +727,8 @@ namespace SlowTests.Sharding.Cluster
                 await TriggerAClusterTransactionToForceCheckTombstonesAsync(store);
                 
                 //run periodic backup on all shards
-                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 * *");
-                var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(leader, store, config, isFullBackup: false);
+                var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency:BackupTestBase.GetCronForFarFuture());
+                var (backupTaskId, _) = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(leader, store, config, isFullBackup: false);
                 
                 //wait till all shards finish backing up the 2 tombstones
                 foreach (var node in nodes)

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -199,7 +199,8 @@ namespace FastTests
                     TryGetBackupStatusFromPeriodicBackupAndPrint(OperationStatus.Completed, OperationStatus.Completed, opId, periodicBackupRunner, status, backupResult);
                 }
             }
-
+            public static string GetCronForFarFuture() => $"* {DateTime.Now.AddHours(12).Hour} * * *"; 
+            
             public PeriodicBackupConfiguration CreateBackupConfiguration(string backupPath = null, BackupType backupType = BackupType.Backup, bool disabled = false, string fullBackupFrequency = "0 0 1 1 *",
                 string incrementalBackupFrequency = null, long? taskId = null, string mentorNode = null, BackupEncryptionSettings backupEncryptionSettings = null, AzureSettings azureSettings = null,
                 GoogleCloudSettings googleCloudSettings = null, S3Settings s3Settings = null, FtpSettings ftpSettings = null, RetentionPolicy retentionPolicy = null, string name = null, BackupUploadMode backupUploadMode = BackupUploadMode.Default, bool pinToMentorNode = false)
@@ -358,9 +359,8 @@ namespace FastTests
                 if (mode == RavenDatabaseMode.Single)
                     return await UpdateConfigAndRunBackupAsync(_parent.Server, config, store);
 
-                var backupCompleted = await _parent.Sharding.Backup.WaitForBackupToComplete(store);
-                var backupTaskId = await _parent.Sharding.Backup.UpdateConfigurationAndRunBackupAsync(_parent.Server, store, config);
-                Assert.True(WaitHandle.WaitAll(backupCompleted, TimeSpan.FromSeconds(10)));
+                var (backupTaskId, runBackupOperation) = await _parent.Sharding.Backup.UpdateConfigurationAndRunBackupAsync(_parent.Server, store, config);
+                await runBackupOperation.WaitForCompletionAsync();
 
                 return backupTaskId;
             }

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Backups.Sharding;
@@ -351,20 +352,19 @@ public partial class RavenTestBase
             return waitHandles.ToArray();
         }
 
-        public Task<long> UpdateConfigurationAndRunBackupAsync(RavenServer server, IDocumentStore store, PeriodicBackupConfiguration config, bool isFullBackup = false)
+        public Task<(long TaskId, Operation runBackupOperation)> UpdateConfigurationAndRunBackupAsync(RavenServer server, IDocumentStore store, PeriodicBackupConfiguration config, bool isFullBackup = false)
         {
             return UpdateConfigurationAndRunBackupAsync(new List<RavenServer> { server }, store, config, isFullBackup);
         }
 
-        public async Task<long> UpdateConfigurationAndRunBackupAsync(List<RavenServer> servers, IDocumentStore store, PeriodicBackupConfiguration config, bool isFullBackup = false)
+        public async Task<(long TaskId, Operation runBackupOperation)> UpdateConfigurationAndRunBackupAsync(List<RavenServer> servers, IDocumentStore store, PeriodicBackupConfiguration config, bool isFullBackup = false)
         {
             var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
             WaitForResponsibleNodeUpdateInCluster(store, servers, result.TaskId);
 
-            await RunBackupAsync(store, result.TaskId, isFullBackup);
-
-            return result.TaskId;
+            var runBackupOperation = await RunBackupAsync(store, result.TaskId, isFullBackup);
+            return (result.TaskId, runBackupOperation);
         }
 
         public async Task<long> UpdateConfigAsync(RavenServer server, PeriodicBackupConfiguration config, DocumentStore store)
@@ -405,17 +405,9 @@ public partial class RavenTestBase
             }
         }
 
-        public async Task RunBackupAsync(IDocumentStore store, long taskId, bool isFullBackup)
+        public async Task<Operation> RunBackupAsync(IDocumentStore store, long taskId, bool isFullBackup)
         {
-            try
-            {
-                await store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup, taskId));
-                
-            }
-            catch (BackupAlreadyRunningException)
-            {
-                // backup may have started independently due to timer
-            }
+            return await store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup, taskId));
         }
 
         public IDisposable ReadOnly(string path)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23620

### Additional description
The original wait for backup doesn't wait for the operation to finish.
In practice, the schedule function is not yet executed, and PeriodicBackup.RunningTask is still set.
That means that potentially the new backup can start before this function is executed and cause BackupAlreadyRunningException.

I really don't like all the "ForTestPurpose," and I think we should minimize our use of that.

Anyway, I rely on the production code Operation.WaitForCompletionAsync to wait before the next backup run is executed.

There is an issue that potentially the backup can be running due to the backup schedule.
To avoid that, I created a function to set the backup time for much later.

I didn't touch tests that are not triggering more backup runs.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
