### PR TITLE
RavenDB-23775 - Avoid disposing idle database activity timer

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -499,6 +499,9 @@ namespace Raven.Server.Documents
                 var handles = new List<WaitHandle>();
                 foreach (var timer in _wakeupTimers.Values)
                 {
+                    if (timer.IsValueCreated == false)
+                        continue;
+
                     var handle = new ManualResetEvent(false);
                     timer.Value.Dispose(handle);
                     handles.Add(handle);
@@ -581,7 +584,7 @@ namespace Raven.Server.Documents
             IDisposable release = null;
             try
             {
-                if (_wakeupTimers.TryRemove(databaseName.Value, out var timer))
+                if (_wakeupTimers.TryRemove(databaseName.Value, out var timer) && timer.IsValueCreated)
                     timer.Value.Dispose();
 
                 release = EnterReadLockImmediately(databaseName);
@@ -1094,13 +1097,13 @@ namespace Raven.Server.Documents
         {
             // in case the DueTime is negative or zero, the callback will be called immediately and database will be loaded.
             
-            _wakeupTimers.AddOrUpdate(databaseName,
+            _ = _wakeupTimers.AddOrUpdate(databaseName,
                 _ => new Lazy<DatabaseWakeupTimer>(() => new DatabaseWakeupTimer(databaseName, idleDatabaseActivity, NextScheduledActivityCallback)),
                 (_, timer) =>
                 {
                     timer.Value.Update(idleDatabaseActivity);
                     return timer;
-                });
+                }).Value;
         }
 
         private void LogUnloadFailureReason(StringSegment databaseName, string reason)
@@ -1113,7 +1116,7 @@ namespace Raven.Server.Documents
         {
             if (idleDatabaseActivity == null)
             {
-                if (_wakeupTimers.TryRemove(databaseName, out var oldTimer))
+                if (_wakeupTimers.TryRemove(databaseName, out var oldTimer) && oldTimer.IsValueCreated)
                     oldTimer.Value.Dispose();
 
                 return;
@@ -1237,7 +1240,7 @@ namespace Raven.Server.Documents
             if (name == null)
                 return true;
 
-            if (_wakeupTimers.TryRemove(name, out var timer))
+            if (_wakeupTimers.TryRemove(name, out var timer) && timer.IsValueCreated)
                 timer.Value.Dispose();
 
             if (idleDatabaseActivity == null)

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Nito.AsyncEx;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions.Database;
@@ -12,7 +13,6 @@ using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Config;
-using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.NotificationCenter.Notifications.Server;
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents
         public readonly ConcurrentDictionary<StringSegment, DateTime> LastRecentlyUsed =
             new ConcurrentDictionary<StringSegment, DateTime>(StringSegmentComparer.OrdinalIgnoreCase);
 
-        private readonly ConcurrentDictionary<string, Timer> _wakeupTimers = new ConcurrentDictionary<string, Timer>();
+        private readonly ConcurrentDictionary<string, DatabaseWakeupTimer> _wakeupTimers = new ConcurrentDictionary<string, DatabaseWakeupTimer>();
 
         public readonly ResourceCache<DocumentDatabase> DatabasesCache = new ResourceCache<DocumentDatabase>();
         private readonly Logger _logger;
@@ -1093,14 +1093,13 @@ namespace Raven.Server.Documents
         private void AddOrUpdateWakeupTimer(string databaseName, IdleDatabaseActivity idleDatabaseActivity)
         {
             // in case the DueTime is negative or zero, the callback will be called immediately and database will be loaded.
-            var newTimer = new Timer(_ => NextScheduledActivityCallback(databaseName, idleDatabaseActivity), null, idleDatabaseActivity.DueTime, Timeout.Infinite);
-
+            
             _wakeupTimers.AddOrUpdate(databaseName,
-                _ => newTimer,
+                _ => new DatabaseWakeupTimer(databaseName, idleDatabaseActivity, NextScheduledActivityCallback),
                 (_, timer) =>
                 {
-                    timer.Dispose();
-                    return newTimer;
+                    timer.Update(idleDatabaseActivity);
+                    return timer;
                 });
         }
 
@@ -1326,6 +1325,45 @@ namespace Raven.Server.Documents
             {
                 throw new InvalidOperationException($"Cannot delete database {databaseName} from {parentConfiguration.Indexing.TempPath.FullPath}. " +
                                                     $"There is an intersection with database {currentDatabaseName} Temp file located in {currentConfiguration.Indexing.TempPath.FullPath}.");
+            }
+        }
+
+        private sealed class DatabaseWakeupTimer : IDisposable
+        {
+            private IdleDatabaseActivity _activity;
+
+            private readonly string _databaseName;
+            private readonly Action<string, IdleDatabaseActivity> _callback;
+            private readonly Timer _timer;
+
+            public DatabaseWakeupTimer([NotNull] string databaseName, [NotNull] IdleDatabaseActivity activity, [NotNull] Action<string, IdleDatabaseActivity> callback)
+            {
+                _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
+                _activity = activity ?? throw new ArgumentNullException(nameof(activity));
+                _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+
+                _timer = new Timer(TimerCallback, null, _activity.DueTime, Timeout.Infinite);
+            }
+
+            public void Update(IdleDatabaseActivity activity)
+            {
+                _activity = activity;
+                _timer.Change(activity.DueTime, Timeout.Infinite);
+            }
+
+            private void TimerCallback(object state)
+            {
+                _callback(_databaseName, _activity);
+            }
+
+            public void Dispose()
+            {
+                _timer?.Dispose();
+            }
+
+            public void Dispose(WaitHandle notifyObject)
+            {
+                _timer?.Dispose(notifyObject);
             }
         }
     }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents
         public readonly ConcurrentDictionary<StringSegment, DateTime> LastRecentlyUsed =
             new ConcurrentDictionary<StringSegment, DateTime>(StringSegmentComparer.OrdinalIgnoreCase);
 
-        private readonly ConcurrentDictionary<string, DatabaseWakeupTimer> _wakeupTimers = new ConcurrentDictionary<string, DatabaseWakeupTimer>();
+        private readonly ConcurrentDictionary<string, Lazy<DatabaseWakeupTimer>> _wakeupTimers = new();
 
         public readonly ResourceCache<DocumentDatabase> DatabasesCache = new ResourceCache<DocumentDatabase>();
         private readonly Logger _logger;
@@ -500,7 +500,7 @@ namespace Raven.Server.Documents
                 foreach (var timer in _wakeupTimers.Values)
                 {
                     var handle = new ManualResetEvent(false);
-                    timer.Dispose(handle);
+                    timer.Value.Dispose(handle);
                     handles.Add(handle);
                 }
 
@@ -582,7 +582,7 @@ namespace Raven.Server.Documents
             try
             {
                 if (_wakeupTimers.TryRemove(databaseName.Value, out var timer))
-                    timer.Dispose();
+                    timer.Value.Dispose();
 
                 release = EnterReadLockImmediately(databaseName);
 
@@ -1095,10 +1095,10 @@ namespace Raven.Server.Documents
             // in case the DueTime is negative or zero, the callback will be called immediately and database will be loaded.
             
             _wakeupTimers.AddOrUpdate(databaseName,
-                _ => new DatabaseWakeupTimer(databaseName, idleDatabaseActivity, NextScheduledActivityCallback),
+                _ => new Lazy<DatabaseWakeupTimer>(() => new DatabaseWakeupTimer(databaseName, idleDatabaseActivity, NextScheduledActivityCallback)),
                 (_, timer) =>
                 {
-                    timer.Update(idleDatabaseActivity);
+                    timer.Value.Update(idleDatabaseActivity);
                     return timer;
                 });
         }
@@ -1114,7 +1114,7 @@ namespace Raven.Server.Documents
             if (idleDatabaseActivity == null)
             {
                 if (_wakeupTimers.TryRemove(databaseName, out var oldTimer))
-                    oldTimer.Dispose();
+                    oldTimer.Value.Dispose();
 
                 return;
             }
@@ -1238,7 +1238,7 @@ namespace Raven.Server.Documents
                 return true;
 
             if (_wakeupTimers.TryRemove(name, out var timer))
-                timer.Dispose();
+                timer.Value.Dispose();
 
             if (idleDatabaseActivity == null)
                 return true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23775

### Additional description

continuation to https://github.com/ravendb/ravendb/pull/20228
Avoid creating and diposing the timer in every idle database acitivity

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
