### PR TITLE
RavenDB-22491 - Show the revision size in document size tooltip

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/documents/getDocumentRevisionPhysicalSizeCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/getDocumentRevisionPhysicalSizeCommand.ts
@@ -1,0 +1,28 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+
+type DocumentRevisionPhysicalSizeCommandResult = Raven.Server.Documents.Handlers.SizeDetails & {
+    ChangeVector: string;
+  };
+
+class getDocumentRevisionsPhysicalSizeCommand extends commandBase {
+  
+  constructor(private changeVectors: string, private db: database) {
+    super();
+  }
+  
+  execute(): JQueryPromise<DocumentRevisionPhysicalSizeCommandResult> {
+    const args = {
+      changeVector: this.changeVectors,
+    };
+    
+    const url = endpoints.databases.revisions.revisionsSize + this.urlEncodeArgs(args);
+    
+    return this.query<DocumentRevisionPhysicalSizeCommandResult>(url, null, this.db)
+      .fail((response: JQueryXHR) => this.reportError("Failed to get the revision physical size", response.responseText, response.statusText));
+  }
+}
+
+export = getDocumentRevisionsPhysicalSizeCommand;

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -45,8 +45,8 @@ import globalSettings = require("common/settings/globalSettings");
 import fileDownloader = require("common/fileDownloader");
 import moment = require("moment");
 import generalUtils = require("common/generalUtils");
-import getDocumentRevisionsPhysicalSizeCommand
-    from "commands/database/documents/getDocumentRevisionPhysicalSizeCommand";
+import getDocumentRevisionsPhysicalSizeCommand = require("commands/database/documents/getDocumentRevisionPhysicalSizeCommand");
+
 
 class editDocument extends viewModelBase {
 

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -45,6 +45,8 @@ import globalSettings = require("common/settings/globalSettings");
 import fileDownloader = require("common/fileDownloader");
 import moment = require("moment");
 import generalUtils = require("common/generalUtils");
+import getDocumentRevisionsPhysicalSizeCommand
+    from "commands/database/documents/getDocumentRevisionPhysicalSizeCommand";
 
 class editDocument extends viewModelBase {
 
@@ -238,7 +240,7 @@ class editDocument extends viewModelBase {
         (ace as any).config.loadModule("ace/mode/raven_document_newline_friendly");
 
         this.connectedDocuments.compositionComplete();
-        
+
         studioSettings.default.globalSettings()
             .done((settings: globalSettings) => {
                 if (settings.collapseDocsWhenOpening.getValue()) {
@@ -539,11 +541,11 @@ class editDocument extends viewModelBase {
         });
 
         this.documentSizeHtml = ko.computed(() => {
-            if (this.isClone() || this.isCreatingNewDocument() || this.inReadOnlyMode()) {
+            if (this.isClone() || this.isCreatingNewDocument()) {
                 return `Computed Size: ${this.computedDocumentSize()} KB`;
             }
-            
-            const text = `<div class="margin-top-sm margin-bottom-sm"><strong>Document Size on Disk</strong></div> Actual Size: ${this.sizeOnDiskActual()} <br/> Allocated Size: ${this.sizeOnDiskAllocated()} <br/> Compressed: ${this.isCompressed() ? "Yes" : "No"}`;
+
+            const text = `<div class="margin-top-sm margin-bottom-sm"><strong>${this.inReadOnlyMode() ? "Revision" : "Document"} Size on Disk</strong></div> Actual Size: ${this.sizeOnDiskActual()} <br/> Allocated Size: ${this.sizeOnDiskAllocated()} <br/> Compressed: ${this.isCompressed() ? "Yes" : "No"}`;
             const hugeSizeText = this.isHugeDocument() ? `<br /><div class="text-warning bg-warning margin-top margin-bottom">Document is huge</div>` : "";
             
             return text + hugeSizeText;
@@ -1235,13 +1237,21 @@ class editDocument extends viewModelBase {
                 
                 this.document(doc);
                 this.displayDocumentChange(false);
-
+                this.getRevisionPhysicalSize(changeVector)
                 this.revisionChangeVector(changeVector);
 
                 this.dirtyFlag().reset();
             })
             .fail(() => messagePublisher.reportError("Could not find requested revision. Redirecting to latest version"))
             .always(() => this.isBusy(false));
+    }
+
+    private getRevisionPhysicalSize(changeVector: string): JQueryPromise<Raven.Server.Documents.Handlers.SizeDetails> {
+        return new getDocumentRevisionsPhysicalSizeCommand(changeVector, this.activeDatabase()).execute().done((response) => {
+            this.sizeOnDiskActual(response.HumaneActualSize);
+            this.sizeOnDiskAllocated(response.HumaneAllocatedSize);
+            this.isCompressed(response.IsCompressed);
+        });
     }
 
     refreshDocument() {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22491

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
