### PR TITLE
RavenDB-20353 - NRE because null result of specific shard Operation (on ShardedMultiOperation)

### DIFF
--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -49,6 +49,7 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
         var operationDescription = operation.Description;
         var operationType = operationDescription.TaskType;
         var operationState = operation.State;
+        var token = operation.Token;
 
         var notification = new OperationStatusChange
         {
@@ -60,16 +61,19 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
         Monitor.Enter(locker);
         try
         {
-            operation.Task = Task.Run(() => taskFactory(ProgressNotification));
-            operation.Task.ContinueWith(ContinuationFunction);
-            Active.TryAdd(id, operation);
-
-            if (operation.Token == null)
-                return operation.Task;
-
-            return operation.Task.ContinueWith(t =>
+            var activeOperation = Active.GetOrAdd(id, key =>
             {
-                operation.Token.Dispose();
+                operation.Task = Task.Run(() => taskFactory(ProgressNotification));
+                operation.Task.ContinueWith(ContinuationFunction);
+                return operation;
+            });
+
+            if (token == null)
+                return activeOperation.Task;
+
+            return activeOperation.Task.ContinueWith(t =>
+            {
+                token.Dispose();
                 return t;
             }).Unwrap();
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20353/FastTests.Server.Documents.Revisions.RevisionsTests.EnforceRevisionsConfigurationoptions-DatabaseMode-Sharded-SearchEngineMode

### Additional description

NRE because null result of specific shard Operation (on ShardedMultiOperation).
I believe in AbstractOperations.AddOperationInternalAsync when we do the 'operation.Task.ContinueWith(ContinuationFunction)' it happens twice even though the operation already exists and one is canceled (so the `operationState.Result` is null and the other is Completed and because `ContinuationFunction` invoked twice in parallel, it can create a `Completed` operation with `null` result.
We didn't succeed in reproducing the failure, but I've added a fix that should prevent it from happening again.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
