### PR TITLE
RavenDB-23863

### DIFF
--- a/src/Sparrow/RecyclableMemoryStreamFactory.cs
+++ b/src/Sparrow/RecyclableMemoryStreamFactory.cs
@@ -7,17 +7,16 @@ namespace Sparrow;
 
 internal class RecyclableMemoryStreamFactory
 {
-    private static readonly RecyclableMemoryStreamManager Manager = new()
+    private static readonly RecyclableMemoryStreamManager Manager = new(new RecyclableMemoryStreamManager.Options
     {
-        Settings =
-        {
-            AggressiveBufferReturn = true,
-            MaximumBufferSize = Constants.Size.Megabyte,
-            MaximumSmallPoolFreeBytes = 256 * Constants.Size.Megabyte,
-            MaximumLargePoolFreeBytes = 128 * Constants.Size.Megabyte,
-            ThrowExceptionOnToArray = true
-        }
-    };
+        AggressiveBufferReturn = true,
+        MaximumBufferSize = Constants.Size.Megabyte,
+        MaximumSmallPoolFreeBytes = 256 * Constants.Size.Megabyte,
+        MaximumLargePoolFreeBytes = 128 * Constants.Size.Megabyte,
+        ThrowExceptionOnToArray = true,
+        LargeBufferMultiple = 64 * Constants.Size.Kilobyte,
+        BlockSize = 32 * Constants.Size.Kilobyte
+    });
 
     public static RecyclableMemoryStream GetRecyclableStream()
     {


### PR DESCRIPTION
- RecyclableMemoryStreamManager needs to be configured via ctor with Options parameter
- set LargeBufferMultiple to 64 kb from 1 mb, this will create 16 size slots in the large buffer pool
- set BlockSize to 32 kb from 128kb for small buffer pool

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23863

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
