### PR TITLE
RavenDB-23774 - SlowTests.Server.Documents.OngoingTasks.ReplicationOn…

### DIFF
--- a/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
@@ -155,8 +155,8 @@ namespace SlowTests.Server.Documents.OngoingTasks
             // continue the replication and let the items replicate to the sink
 
             replication.Mend();
-            Assert.NotNull(await WaitForDocumentToReplicateAsync<User>(sink1, UserId, TimeSpan.FromSeconds(10)));
-            Assert.NotNull(await WaitForDocumentToReplicateAsync<User>(sink2, UserId, TimeSpan.FromSeconds(10)));
+            Assert.NotNull(await WaitForDocumentToReplicateAsync<User>(sink1, UserId, TimeSpan.FromSeconds(15)));
+            Assert.NotNull(await WaitForDocumentToReplicateAsync<User>(sink2, UserId, TimeSpan.FromSeconds(15)));
 
             await VerifyPullAsHubReplicationProgress(hub, hubDatabase, isCompleted: true);
 
@@ -413,8 +413,20 @@ namespace SlowTests.Server.Documents.OngoingTasks
         private async Task VerifyPullAsHubReplicationProgress(DocumentStore store, DocumentDatabase database,
             bool isCompleted = false, bool hasTombstones = false, RavenServer server = null)
         {
-            var results = await GetReplicationProgress(store, database.Name, server);
+            IReplicationTaskProgress[] results = null;
+            await WaitForValueAsync(async () =>
+            {
+                results = await GetReplicationProgress(store, database.Name, server);
+                if (results.Length != 1)
+                    return false;
 
+                if (results[0].ProcessesProgress.Count != 2)
+                    return false;
+
+                return true;
+            }, true);
+
+            Assert.NotNull(results);
             var result = Assert.Single(results);
             var processesProgress = result.ProcessesProgress;
             Assert.Equal(2, processesProgress.Count); // we should have 2 results, one per each sink


### PR DESCRIPTION
…goingTaskProgressTests.GetPullReplicationAsHubTaskProgressShouldWork_TwoSinks

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23774/SlowTests.Server.Documents.OngoingTasks.ReplicationOngoingTaskProgressTests.GetPullReplicationAsHubTaskProgressShouldWorkTwoSink

### Additional description

* Increased `WaitForDocumentToReplicateAsync` wait time.
* Added wait for results in `VerifyPullAsHubReplicationProgress` (in failures, we initially get 1 result, but shortly after, there are 2—so waiting should stabilize it).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
