### PR TITLE
RavenDB-23789 - SlowTests.Server.Documents.OngoingTasks.ReplicationOngoingTaskProgressTests.GetPullReplicationAsHubTaskProgressShouldWork

### DIFF
--- a/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
@@ -51,7 +51,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             // since we broke replication, we expect incomplete results with items to process
 
-            await VerifyReplicationProgress(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: false);
+            await VerifyReplicationProgressAsync(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: false);
 
             // continue the replication and let the items replicate to the destination
 
@@ -60,7 +60,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             // now we should have values for the last sent Etag and change vectors, so we retrieve them to verify they are correct
 
-            await VerifyReplicationProgress(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: true);
+            await VerifyReplicationProgressAsync(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: true);
 
             // break the replication again to perform deletion and check tombstone items
 
@@ -68,7 +68,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             await DeleteUserDocument(source);
 
-            await VerifyReplicationProgress(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: false, hasTombstones: true);
+            await VerifyReplicationProgressAsync(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: false, hasTombstones: true);
 
             // continue the replication and check if all tombstones are processed
 
@@ -76,7 +76,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             Assert.True(WaitForDocumentDeletion(destination, UserId));
 
-            await VerifyReplicationProgress(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: true, hasTombstones: true);
+            await VerifyReplicationProgressAsync(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: true, hasTombstones: true);
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
@@ -100,7 +100,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             var hubDatabase = await GetDocumentDatabaseInstanceForAsync(hub.Database);
 
-            await VerifyReplicationProgress(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: false);
+            await VerifyReplicationProgressAsync(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: false);
 
             // continue the replication and let the items replicate to the sink
 
@@ -109,7 +109,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             // now we should have values for the last sent Etag and change vectors, so we retrieve them to verify they are correct
 
-            await VerifyReplicationProgress(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: true);
+            await VerifyReplicationProgressAsync(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: true);
 
             // break the replication again to perform deletion and check tombstone items
 
@@ -117,14 +117,14 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             await DeleteUserDocument(hub);
 
-            await VerifyReplicationProgress(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: false, hasTombstones: true);
+            await VerifyReplicationProgressAsync(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: false, hasTombstones: true);
 
             // continue the replication and check if all tombstones are processed
 
             replication.Mend();
             Assert.True(WaitForDocumentDeletion(sink, UserId));
 
-            await VerifyReplicationProgress(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: true, hasTombstones: true);
+            await VerifyReplicationProgressAsync(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: true, hasTombstones: true);
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
@@ -240,12 +240,12 @@ namespace SlowTests.Server.Documents.OngoingTasks
 
             var sinkDatabase = await GetDatabase(leader, sink.Database);
 
-            await VerifyReplicationProgress(sink, sinkDatabase, ReplicationNode.ReplicationType.PullAsSink, isCompleted: true, server: leader);
+            await VerifyReplicationProgressAsync(sink, sinkDatabase, ReplicationNode.ReplicationType.PullAsSink, isCompleted: true, server: leader);
 
             await DeleteUserDocument(sink);
             Assert.True(WaitForDocumentDeletion(hub, UserId));
 
-            await VerifyReplicationProgress(sink, sinkDatabase, ReplicationNode.ReplicationType.PullAsSink, isCompleted: true, hasTombstones: true, server: leader);
+            await VerifyReplicationProgressAsync(sink, sinkDatabase, ReplicationNode.ReplicationType.PullAsSink, isCompleted: true, hasTombstones: true, server: leader);
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio | RavenTestCategory.Cluster)]
@@ -381,17 +381,24 @@ namespace SlowTests.Server.Documents.OngoingTasks
             }
         }
 
-        private async Task VerifyReplicationProgress(DocumentStore store, DocumentDatabase database, ReplicationNode.ReplicationType replicationType,
+        private async Task VerifyReplicationProgressAsync(DocumentStore store, DocumentDatabase database, ReplicationNode.ReplicationType replicationType,
             bool isCompleted = false, bool hasTombstones = false, RavenServer server = null)
         {
-            var results = await GetReplicationProgress(store, database.Name, server);
+            IReplicationTaskProgress[] results = null;
+            await WaitForValueAsync(async () =>
+            {
+                results = await GetReplicationProgress(store, database.Name, server);
+                if (results == null || results.Length != 1)
+                    return false;
+
+                return true;
+            }, true);
 
             if (isCompleted)
             {
                 if (replicationType != ReplicationNode.ReplicationType.PullAsSink)
                 {
-                    var (lastSentEtag, sourceChangeVector, destinationChangeVector) = GetReplicationHandlerState(database);
-                    AssertReplicationBatchCompleted(results, lastSentEtag, sourceChangeVector, destinationChangeVector);
+                    await AssertReplicationBatchCompletedAsync(store, database, server);
                 }
 
                 if (hasTombstones)
@@ -486,12 +493,30 @@ namespace SlowTests.Server.Documents.OngoingTasks
             Assert.False(progress.ProcessesProgress[0].Completed);
         }
 
-        private void AssertReplicationBatchCompleted(IReplicationTaskProgress[] result, long lastSentEtag, string sourceChangeVector, string destinationChangeVector)
+        private async Task AssertReplicationBatchCompletedAsync(DocumentStore store, DocumentDatabase database, RavenServer server)
         {
-            Assert.NotEmpty(result);
-            Assert.Single(result);
+            var (lastSentEtag, sourceChangeVector, destinationChangeVector) = GetReplicationHandlerState(database);
 
-            var processProgress = result[0].ProcessesProgress[0];
+            IReplicationTaskProgress[] results = null;
+            await WaitForValueAsync(async () =>
+            {
+                results = await GetReplicationProgress(store, database.Name, server);
+                if (results == null || results.Length != 1)
+                    return false;
+
+                var result = results[0];
+                if (result.ProcessesProgress.Count != 1)
+                    return false;
+
+                if (result.ProcessesProgress[0].LastSentEtag != lastSentEtag)
+                    return false;
+
+                return true;
+            }, true);
+
+            Assert.NotEmpty(results);
+            var result = Assert.Single(results);
+            var processProgress = Assert.Single(result.ProcessesProgress);
 
             Assert.Equal(lastSentEtag, processProgress.LastSentEtag);
             Assert.Equal(sourceChangeVector, processProgress.SourceChangeVector);

--- a/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task GetExternalReplicationTaskProgressShouldWork(Options options)
         {
             using var source = GetDocumentStore(options);
@@ -79,12 +79,11 @@ namespace SlowTests.Server.Documents.OngoingTasks
             await VerifyReplicationProgressAsync(source, sourceDb, ReplicationNode.ReplicationType.External, isCompleted: true, hasTombstones: true);
         }
 
-        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.All)]
-        public async Task GetPullReplicationAsHubTaskProgressShouldWork(Options options)
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Studio)]
+        public async Task GetPullReplicationAsHubTaskProgressShouldWork()
         {
-            using var hub = GetDocumentStore(options);
-            using var sink = GetDocumentStore(options);
+            using var hub = GetDocumentStore();
+            using var sink = GetDocumentStore();
 
             // we want the first result to show unprocessed items
             // so, we define pull replication task and break it immediately
@@ -127,13 +126,12 @@ namespace SlowTests.Server.Documents.OngoingTasks
             await VerifyReplicationProgressAsync(hub, hubDatabase, ReplicationNode.ReplicationType.PullAsHub, isCompleted: true, hasTombstones: true);
         }
 
-        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.All)]
-        public async Task GetPullReplicationAsHubTaskProgressShouldWork_TwoSinks(Options options)
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Studio)]
+        public async Task GetPullReplicationAsHubTaskProgressShouldWork_TwoSinks()
         {
-            using var hub = GetDocumentStore(new Options(options) { ModifyDatabaseName = _ => "HubDB" });
-            using var sink1 = GetDocumentStore(new Options(options) { ModifyDatabaseName = _ => "Sink1DB" });
-            using var sink2 = GetDocumentStore(new Options(options) { ModifyDatabaseName = _ => "Sink2DB" });
+            using var hub = GetDocumentStore(new Options() { ModifyDatabaseName = _ => "HubDB" });
+            using var sink1 = GetDocumentStore(new Options() { ModifyDatabaseName = _ => "Sink1DB" });
+            using var sink2 = GetDocumentStore(new Options() { ModifyDatabaseName = _ => "Sink2DB" });
 
             // we want the first result to show unprocessed items
             // so, we define pull replication task and break it immediately
@@ -177,13 +175,12 @@ namespace SlowTests.Server.Documents.OngoingTasks
             await VerifyPullAsHubReplicationProgress(hub, hubDatabase, isCompleted: true, hasTombstones: true);
         }
 
-        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.All)]
-        public async Task GetPullReplicationAsSinkTaskProgressShouldWork(Options options)
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Studio)]
+        public async Task GetPullReplicationAsSinkTaskProgressShouldWork()
         {
             var (_, leader, certificates) = await CreateRaftClusterWithSsl(1);
 
-            using var hub = GetDocumentStore(new Options(options)
+            using var hub = GetDocumentStore(new Options()
             {
                 Server = leader,
                 AdminCertificate = certificates.ServerCertificate.Value,
@@ -192,7 +189,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
                 CreateDatabase = true
             });
 
-            using var sink = GetDocumentStore(new Options(options)
+            using var sink = GetDocumentStore(new Options()
             {
                 Server = leader,
                 AdminCertificate = certificates.ServerCertificate.Value,
@@ -249,7 +246,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio | RavenTestCategory.Cluster)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task GetInternalReplicationProgressShouldWork(Options options)
         {
             var (nodes, leader) = await CreateRaftCluster(3);
@@ -284,7 +281,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ShouldGetErrorForExternalReplicationTask(Options options)
         {
             using var source = GetDocumentStore(options);
@@ -305,7 +302,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
         }
 
         [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Studio)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public async Task ShouldGetErrorForPullReplicationAsSinkTask(Options options)
         {
             using var hub = GetDocumentStore(options);


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-23789/SlowTests.Server.Documents.OngoingTasks.ReplicationOngoingTaskProgressTests.GetPullReplicationAsHubTaskProgressShouldWorkoptions
- https://issues.hibernatingrhinos.com/issue/RavenDB-23841/SlowTests.Server.Documents.OngoingTasks.ReplicationOngoingTaskProgressTests.GetPullReplicationAsHubTaskProgressShouldWorkoptions

### Additional description

* Added wait for results in `VerifyReplicationProgressAsync` 
* Removed `SearchEngineMode = RavenSearchEngineMode.All` from tests


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
