### PR TITLE
RavenDB-23579 Tombstones for counters and time-series will not be cle…

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -985,8 +985,18 @@ namespace Raven.Server.Documents.ETL
                 var state = EtlProcess.GetProcessState(_database, config.Name, transform.Name);
                 var etag = ChangeVectorUtils.GetEtagById(state.ChangeVector, _database.DbBase64Id);
 
-                AddOrUpdate(lastProcessedTombstones, Constants.TimeSeries.All, etag);
-                AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.TimeSeries.All, etag, type);
+                if (transform.ApplyToAllDocuments)
+                {
+                    AddOrUpdate(lastProcessedTombstones, Constants.TimeSeries.All, etag);
+                    AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.TimeSeries.All, etag, type);
+                    continue;
+                }
+
+                foreach (var collection in transform.Collections)
+                {
+                    AddOrUpdate(lastProcessedTombstones, collection, etag);
+                    AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, collection, etag, type);
+                }
             }
         }
 
@@ -998,8 +1008,18 @@ namespace Raven.Server.Documents.ETL
                 var state = EtlProcess.GetProcessState(_database, config.Name, transform.Name);
                 var etag = ChangeVectorUtils.GetEtagById(state.ChangeVector, _database.DbBase64Id);
 
-                AddOrUpdate(lastProcessedTombstones, Constants.Counters.All, etag);
-                AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.Counters.All, etag, type);
+                if (transform.ApplyToAllDocuments)
+                {
+                    AddOrUpdate(lastProcessedTombstones, Constants.Counters.All, etag);
+                    AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.Counters.All, etag, type);
+                    continue;
+                }
+
+                foreach (var collection in transform.Collections)
+                {
+                    AddOrUpdate(lastProcessedTombstones, collection, etag);
+                    AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, collection, etag, type);
+                }
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-23579.cs
+++ b/test/SlowTests/Issues/RavenDB-23579.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23579 : EtlTestBase
+    {
+        public RavenDB_23579(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        const string script = """
+                              loadToUsers(this);
+                              function loadTimeSeriesOfUsersBehavior(doc, ts)
+                              {
+                                  if (ts.startsWith("INC")){
+                                      return false;
+                                  }
+                                  return true;
+                              }
+                              """;
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Counters)]
+        public async void TombstoneAfterCounterDeletionWithEtl()
+        {
+            var (src, _, _) = CreateSrcDestAndAddEtl("Users", script);
+
+            var user = new User();
+            var order = new Order();
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(order);
+                session.CountersFor(order.Id).Increment("AA", 3);
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = src.OpenAsyncSession())
+            {
+                session.CountersFor(order.Id).Delete("AA");
+                await session.SaveChangesAsync();
+            }
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(src);
+            var tombstoneCleaner = database.TombstoneCleaner;
+            var deletedTombstonesCount = await tombstoneCleaner.ExecuteCleanup();
+            Assert.Equal(2, deletedTombstonesCount ); //This should be changed to 1 after issue RavenDB-23874 is fixed.
+        }
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.TimeSeries)]
+        public async void TombstoneAfterTsDeletionWithEtl()
+        {
+            var (src, _, _) = CreateSrcDestAndAddEtl("Users", script);
+
+            var user = new User();
+            var order = new Order();
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(order);
+                session.TimeSeriesFor<FilteredReplicationTests.HeartRateMeasure>(order.Id).Append(DateTime.UtcNow, new FilteredReplicationTests.HeartRateMeasure
+                {
+                    HeartRate = 34
+                });
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = src.OpenAsyncSession())
+            {
+                session.TimeSeriesFor<FilteredReplicationTests.HeartRateMeasure>(order.Id).Delete();
+                await session.SaveChangesAsync();
+            }
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(src);
+            var tombstoneCleaner = database.TombstoneCleaner;
+            var deletedTombstonesCount = await tombstoneCleaner.ExecuteCleanup();
+            Assert.Equal(1, deletedTombstonesCount );
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23579

### Additional description

When we had an ETL for a collection, it did not take into account the calculation of the minimum etag for counter and time series tombstones.
Now, we will take it into account, just as we do for documents.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
