### PR TITLE
RavenDB-23872 Merge `Reuse` with `Initialize` in `CompactKey`, since `Reuse` has only one usage, to avoid double allocations.

### DIFF
--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -60,18 +60,7 @@ public sealed unsafe class CompactKey : IDisposable
     public void Initialize(LowLevelTransaction tx)
     {
         _owner = tx;
-        
-        StoragePool ??= ArrayPool<byte>.Create();
-        KeyMappingPool ??= ArrayPool<long>.Create();
 
-        _storage = StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
-        _keyMappingCache = KeyMappingPool.Rent(2 * MappingTableMask);
-        
-        Reuse();
-    }
-
-    public void Reuse()
-    {
         Dictionary = Invalid;
         _currentKeyIdx = Invalid;
         _decodedKeyIdx = Invalid;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23872

### Additional description

The reuse mechanism was used only in `Initialize`, so there is no need to keep it as separate method for now.

However, in the previous version we accidentally allocated memory twice (via ArrayPool), which resulted in longer GC pauses and increased latency in queries.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
