### PR TITLE
RavenDB-22794 - Add comments for operations that implements IMaintenanceOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
@@ -5,17 +5,59 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
+    /// <summary>
+    /// The backup configuration settings.
+    /// </summary>
     public class BackupConfiguration : IDynamicJson
     {
+        /// <summary>
+        /// The type of backup (e.g., snapshot or incremental).
+        /// </summary>
         public BackupType BackupType { get; set; }
+
+        /// <summary>
+        /// The upload mode for the backup.
+        /// </summary>
         public BackupUploadMode BackupUploadMode { get; set; }
+
+        /// <summary>
+        /// Settings related to snapshot backups.
+        /// </summary>
         public SnapshotSettings SnapshotSettings { get; set; }
+
+        /// <summary>
+        /// Encryption settings for the backup.
+        /// </summary>
         public BackupEncryptionSettings BackupEncryptionSettings { get; set; }
+
+        /// <summary>
+        /// Settings for local storage backup.
+        /// </summary>
         public LocalSettings LocalSettings { get; set; }
+
+        /// <summary>
+        /// Settings for Amazon S3 backup.
+        /// </summary>
         public S3Settings S3Settings { get; set; }
+
+        /// <summary>
+        /// Settings for Amazon Glacier backup.
+        /// </summary>
         public GlacierSettings GlacierSettings { get; set; }
+
+        /// <summary>
+        /// Settings for Azure backup.
+        /// </summary>
         public AzureSettings AzureSettings { get; set; }
+
+        /// <summary>
+        /// Settings for FTP-based backup.
+        /// </summary>
         public FtpSettings FtpSettings { get; set; }
+
+        /// <summary>
+        /// Settings for Google Cloud backup.
+        /// </summary>
         public GoogleCloudSettings GoogleCloudSettings { get; set; }
 
         internal bool HasBackup()

--- a/src/Raven.Client/Documents/Operations/Backups/BackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupOperation.cs
@@ -9,10 +9,19 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
+    /// <summary>
+    /// Operation to start a one-time backup using the specified backup configuration.
+    /// </summary>
     public sealed class BackupOperation : IMaintenanceOperation<OperationIdResult<StartBackupOperationResult>>
     {
         private readonly BackupConfiguration _backupConfiguration;
-        
+
+        /// <inheritdoc cref="BackupOperation"/>
+        /// <param name="backupConfiguration">The backup configuration defining the backup settings.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="backupConfiguration"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the provided backup configuration does not specify any backup destinations.
+        /// </exception>
         public BackupOperation(BackupConfiguration backupConfiguration)
         {
             _backupConfiguration = backupConfiguration ?? throw new ArgumentNullException(nameof(backupConfiguration));

--- a/src/Raven.Client/Documents/Operations/Backups/DelayBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/DelayBackupOperation.cs
@@ -6,11 +6,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups;
 
+/// <summary>
+/// Operation to delay the execution of a running backup task in the database.
+/// </summary>
 public sealed class DelayBackupOperation : IMaintenanceOperation<OperationState>
 {
     private readonly long _runningBackupTaskId;
     private readonly TimeSpan _duration;
 
+    /// <inheritdoc cref="DelayBackupOperation"/>
+    /// <param name="runningBackupTaskId">The identifier of the running backup task to delay.</param>
+    /// <param name="duration">The duration for which the backup task should be delayed.</param>
     public DelayBackupOperation(long runningBackupTaskId, TimeSpan duration)
     {
         _runningBackupTaskId = runningBackupTaskId;

--- a/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.cs
@@ -8,10 +8,15 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
+    /// <summary>
+    /// Operation to retrieve the status of a periodic backup task in the database.
+    /// </summary>
     public sealed class GetPeriodicBackupStatusOperation : IMaintenanceOperation<GetPeriodicBackupStatusOperationResult>
     {
         private readonly long _taskId;
 
+        /// <inheritdoc cref="GetPeriodicBackupStatusOperation"/>
+        /// <param name="taskId">The identifier of the periodic backup task to retrieve the status for.</param>
         public GetPeriodicBackupStatusOperation(long taskId)
         {
             _taskId = taskId;

--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
@@ -12,14 +12,45 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
+    /// <summary>
+    /// Defines the configuration for periodic backup tasks.
+    /// Supports full and incremental backups with configurable frequencies, retention policies, and mentor node assignments.
+    /// </summary>
     public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJsonValueConvertible
     {
+        /// <summary>
+        /// The name of the periodic backup task.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The unique identifier for the backup task.
+        /// </summary>
         public long TaskId { get; set; }
+
+        /// <summary>
+        /// Indicates whether the backup task is disabled.
+        /// </summary>
         public bool Disabled { get; set; }
+
+        /// <summary>
+        /// The mentor node responsible for executing the backup task.
+        /// </summary>
         public string MentorNode { get; set; }
+
+        /// <summary>
+        /// Determines if the backup task should always run on the mentor node.
+        /// </summary>
         public bool PinToMentorNode { get; set; }
+
+        /// <summary>
+        /// The retention policy associated with the backup task.
+        /// </summary>
         public RetentionPolicy RetentionPolicy { get; set; }
+
+        /// <summary>
+        /// The timestamp when the backup task was created.
+        /// </summary>
         public DateTime? CreatedAt { get; set; }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Operations/Backups/Sharding/GetShardedPeriodicBackupStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/Sharding/GetShardedPeriodicBackupStatusOperation.cs
@@ -8,10 +8,15 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups.Sharding
 {
+    /// <summary>
+    /// Operation to retrieve the status of a periodic backup task in a sharded database.
+    /// </summary>
     public sealed class GetShardedPeriodicBackupStatusOperation : IMaintenanceOperation<GetShardedPeriodicBackupStatusOperationResult>
     {
         private readonly long _taskId;
 
+        /// <inheritdoc cref="GetShardedPeriodicBackupStatusOperation"/>
+        /// <param name="taskId">The identifier of the periodic backup task to retrieve the status for.</param>
         public GetShardedPeriodicBackupStatusOperation(long taskId)
         {
             _taskId = taskId;

--- a/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
@@ -8,11 +8,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
+    /// <summary>
+    /// Operation to start a backup task in the database.
+    /// </summary>
     public sealed class StartBackupOperation : IMaintenanceOperation<OperationIdResult<StartBackupOperationResult>>
     {
         private readonly bool _isFullBackup;
         private readonly long _taskId;
 
+        /// <inheritdoc cref="StartBackupOperation"/>
+        /// <param name="isFullBackup">Determines whether the backup is a full backup (<c>true</c>) or an incremental backup (<c>false</c>).</param>
+        /// <param name="taskId">The identifier of the backup task to start.</param>
         public StartBackupOperation(bool isFullBackup, long taskId)
         {
             _isFullBackup = isFullBackup;

--- a/src/Raven.Client/Documents/Operations/Backups/UpdatePeriodicBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/UpdatePeriodicBackupOperation.cs
@@ -9,10 +9,15 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Backups
 {
+    /// <summary>
+    /// Operation to update the configuration of a periodic backup task in the database.
+    /// </summary>
     public sealed class UpdatePeriodicBackupOperation : IMaintenanceOperation<UpdatePeriodicBackupOperationResult>
     {
         private readonly PeriodicBackupConfiguration _configuration;
 
+        /// <inheritdoc cref="UpdatePeriodicBackupOperation"/>
+        /// <param name="configuration">The periodic backup configuration to apply.</param>
         public UpdatePeriodicBackupOperation(PeriodicBackupConfiguration configuration)
         {
             _configuration = configuration;

--- a/src/Raven.Client/Documents/Operations/Configuration/GetClientConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Configuration/GetClientConfigurationOperation.cs
@@ -6,6 +6,9 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Configuration
 {
+    /// <summary>
+    /// Operation to retrieve the client configuration settings for the database.
+    /// </summary>
     public sealed class GetClientConfigurationOperation : IMaintenanceOperation<GetClientConfigurationOperation.Result>
     {
         public RavenCommand<Result> GetCommand(DocumentConventions conventions, JsonOperationContext context)

--- a/src/Raven.Client/Documents/Operations/Configuration/GetStudioConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Configuration/GetStudioConfigurationOperation.cs
@@ -6,6 +6,9 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Configuration
 {
+    /// <summary>
+    /// Operation to retrieve the studio configuration settings for the database.
+    /// </summary>
     internal sealed class GetStudioConfigurationOperation : IMaintenanceOperation<StudioConfiguration>
     {
         public RavenCommand<StudioConfiguration> GetCommand(DocumentConventions conventions, JsonOperationContext context)

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/GetConnectionStringsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/GetConnectionStringsOperation.cs
@@ -14,18 +14,25 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ConnectionStrings
 {
+    /// <summary>
+    /// Operation to retrieve connection strings from the database.
+    /// </summary>
     public sealed class GetConnectionStringsOperation: IMaintenanceOperation<GetConnectionStringsResult> 
     {
         private readonly string _connectionStringName;
 
         private readonly ConnectionStringType _type;
 
+        /// <inheritdoc cref="GetConnectionStringsOperation"/>
+        /// <param name="connectionStringName">The name of the connection string to retrieve.</param>
+        /// <param name="type">The type of the connection string.</param>
         public GetConnectionStringsOperation(string connectionStringName, ConnectionStringType type)
         {
             _connectionStringName = connectionStringName;
             _type = type;
         }
 
+        /// <inheritdoc cref="GetConnectionStringsOperation"/>
         public GetConnectionStringsOperation()
         {
             // get them all

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/PutConnectionStringOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/PutConnectionStringOperation.cs
@@ -9,10 +9,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.ConnectionStrings
 {
+    /// <summary>
+    /// Operation to add or update a connection string in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the connection string.</typeparam>
     public sealed class PutConnectionStringOperation<T> : IMaintenanceOperation<PutConnectionStringResult> where T : ConnectionString
     {
         private readonly T _connectionString;
 
+        /// <inheritdoc cref="PutConnectionStringOperation{T}"/>
+        /// <param name="connectionString">The connection string to add or update.</param>
         public PutConnectionStringOperation(T connectionString)
         {
             _connectionString = connectionString;

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/RemoveConnectionStringOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/RemoveConnectionStringOperation.cs
@@ -8,10 +8,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.ConnectionStrings
 {
+    /// <summary>
+    /// Operation to remove a connection string from the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the connection string to remove.</typeparam>
     public sealed class RemoveConnectionStringOperation<T> : IMaintenanceOperation<RemoveConnectionStringResult> where T : ConnectionString
     {
         private readonly T _connectionString;
 
+        /// <inheritdoc cref="RemoveConnectionStringOperation{T}"/>
+        /// <param name="connectionString">The connection string to remove.</param>
         public RemoveConnectionStringOperation(T connectionString)
         {
             _connectionString = connectionString;

--- a/src/Raven.Client/Documents/Operations/DataArchival/ConfigureDataArchivalOperation.cs
+++ b/src/Raven.Client/Documents/Operations/DataArchival/ConfigureDataArchivalOperation.cs
@@ -9,10 +9,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.DataArchival
 {
+    /// <summary>
+    /// Operation to configure data archival settings in the database.
+    /// </summary>
     public class ConfigureDataArchivalOperation : IMaintenanceOperation<ConfigureDataArchivalOperationResult>
     {
         private readonly DataArchivalConfiguration _configuration;
 
+        /// <inheritdoc cref="ConfigureDataArchivalOperation"/>
+        /// <param name="configuration">The data archival configuration to apply.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="configuration"/> is null.</exception>
         public ConfigureDataArchivalOperation(DataArchivalConfiguration configuration)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));

--- a/src/Raven.Client/Documents/Operations/DataArchival/DataArchivalConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/DataArchival/DataArchivalConfiguration.cs
@@ -2,12 +2,27 @@
 
 namespace Raven.Client.Documents.Operations.DataArchival
 {
+    /// <summary>
+    /// The configuration for data archival in RavenDB.
+    /// Allows setting archive frequency, maximum items to process, and enabling/disabling the feature.
+    /// </summary>
     public class DataArchivalConfiguration : IDynamicJson
     {
+        /// <summary>
+        ///  Indicates whether data archival is disabled.
+        /// </summary>
         public bool Disabled { get; set; }
 
+        /// <summary>
+        /// The frequency of archival operations in seconds.
+        /// If null, the default frequency is used.
+        /// </summary>
         public long? ArchiveFrequencyInSec { get; set; }
 
+        /// <summary>
+        /// The maximum number of items to process in each archival operation.
+        /// If null, it defaults to <see cref="int.MaxValue"/>.
+        /// </summary>
         public long? MaxItemsToProcess { get; set; }
 
         public override int GetHashCode()

--- a/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
@@ -10,10 +10,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.ETL
 {
+    /// <summary>
+    /// Operation to add a new ETL task to the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the connection string used for the ETL configuration.</typeparam>
     public sealed class AddEtlOperation<T> : IMaintenanceOperation<AddEtlOperationResult> where T : ConnectionString
     {
         private readonly EtlConfiguration<T> _configuration;
 
+        /// <inheritdoc cref="AddEtlOperation{T}"/>
+        /// <param name="configuration">The ETL configuration to add.</param>
         public AddEtlOperation(EtlConfiguration<T> configuration)
         {
             _configuration = configuration;

--- a/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
@@ -10,11 +10,18 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.ETL
 {
+    /// <summary>
+    /// Operation to update an existing ETL task in the database.
+    /// </summary>
+    /// <typeparam name="T">The type of the connection string used for the ETL configuration.</typeparam>
     public sealed class UpdateEtlOperation<T> : IMaintenanceOperation<UpdateEtlOperationResult> where T : ConnectionString
     {
         private readonly long _taskId;
         private readonly EtlConfiguration<T> _configuration;
 
+        /// <inheritdoc cref="UpdateEtlOperation{T}"/>
+        /// <param name="taskId">The identifier of the ETL task to update.</param>
+        /// <param name="configuration">The new ETL configuration to apply.</param>
         public UpdateEtlOperation(long taskId, EtlConfiguration<T> configuration)
         {
             _taskId = taskId;

--- a/src/Raven.Client/Documents/Operations/Expiration/ConfigureExpirationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ConfigureExpirationOperation.cs
@@ -9,10 +9,15 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Expiration
 {
+    /// <summary>
+    /// Operation to configure the expiration settings for documents in the database.
+    /// </summary>
     public sealed class ConfigureExpirationOperation : IMaintenanceOperation<ConfigureExpirationOperationResult>
     {
         private readonly ExpirationConfiguration _configuration;
 
+        /// <inheritdoc cref="ConfigureExpirationOperation"/>
+        /// <param name="configuration">The expiration configuration settings to apply.</param>
         public ConfigureExpirationOperation(ExpirationConfiguration configuration)
         {
             _configuration = configuration;

--- a/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
@@ -2,12 +2,27 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Expiration
 {
+    /// <summary>
+    /// The configuration for document expiration feature.
+    /// Allows setting deletion frequency, maximum items to process, and enabling/disabling expiration.
+    /// </summary>
     public sealed class ExpirationConfiguration : IDynamicJson
     {
+        /// <summary>
+        /// Indicates whether document expiration is disabled.
+        /// </summary>
         public bool Disabled { get; set; }
 
+        /// <summary>
+        /// The frequency of document deletion operations in seconds.
+        /// If null, the default frequency is used.
+        /// </summary>
         public long? DeleteFrequencyInSec { get; set; }
 
+        /// <summary>
+        /// The maximum number of items to process in each expiration operation.
+        /// If null, it defaults to <see cref="int.MaxValue"/>.
+        /// </summary>
         public long? MaxItemsToProcess { get; set; }
 
         public override int GetHashCode()

--- a/src/Raven.Client/Documents/Operations/Identities/GetIdentitiesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Identities/GetIdentitiesOperation.cs
@@ -6,6 +6,9 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Identities
 {
+    /// <summary>
+    /// Operation to retrieve all identities and their current values from the database.
+    /// </summary>
     public sealed class GetIdentitiesOperation : IMaintenanceOperation<Dictionary<string, long>>
     {
         public RavenCommand<Dictionary<string, long>> GetCommand(DocumentConventions conventions, JsonOperationContext context)

--- a/src/Raven.Client/Documents/Operations/Identities/NextIdentityForOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Identities/NextIdentityForOperation.cs
@@ -6,10 +6,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Identities
 {
+    /// <summary>
+    /// Operation to generate the next identity value for a specified identity name in the database.
+    /// </summary>
     public sealed class NextIdentityForOperation : IMaintenanceOperation<long>
     {
         private readonly string _identityName;
 
+        /// <inheritdoc cref="NextIdentityForOperation"/>
+        /// <param name="name">The name of the identity for which to generate the next value.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name"/> is null or whitespace.</exception>
         public NextIdentityForOperation(string name)
         {
             if (string.IsNullOrWhiteSpace(name))

--- a/src/Raven.Client/Documents/Operations/Identities/SeedIdentityForOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Identities/SeedIdentityForOperation.cs
@@ -6,12 +6,22 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Identities
 {
+    /// <summary>
+    /// Operation to seed an identity value for a specified identity name in the database.
+    /// </summary>
     public sealed class SeedIdentityForOperation : IMaintenanceOperation<long>
     {
         private readonly string _identityName;
         private readonly long _identityValue;
         private readonly bool _forceUpdate;
 
+        /// <inheritdoc cref="SeedIdentityForOperation"/>
+        /// <param name="name">The name of the identity to seed.</param>
+        /// <param name="value">The value to set for the identity.</param>
+        /// <param name="forceUpdate">
+        /// If <c>true</c>, forces an update even if the current identity value is greater than the provided value.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="name"/> is null or whitespace.</exception>
         public SeedIdentityForOperation(string name, long value, bool forceUpdate = false)
         {
             if (string.IsNullOrWhiteSpace(name))

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexErrorsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexErrorsOperation.cs
@@ -8,20 +8,29 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve indexing errors for all or specific indexes in the database.
+    /// </summary>
     public sealed class GetIndexErrorsOperation : IMaintenanceOperation<IndexErrors[]>
     {
         private readonly string[] _indexNames;
         private readonly string _nodeTag;
 
+        /// <inheritdoc cref="GetIndexErrorsOperation"/>
         public GetIndexErrorsOperation()
         {
         }
 
+        /// <inheritdoc cref="GetIndexErrorsOperation"/>
+        /// <param name="indexNames">The names of the indexes to retrieve errors for.</param>
         public GetIndexErrorsOperation(string[] indexNames)
         {
             _indexNames = indexNames;
         }
 
+        /// <inheritdoc cref="GetIndexErrorsOperation"/>
+        /// <param name="indexNames">The names of the indexes to retrieve errors for.</param>
+        /// <param name="nodeTag">The specific node from which to fetch index errors.</param>
         internal GetIndexErrorsOperation(string[] indexNames, string nodeTag)
         {
             _indexNames = indexNames;

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexNamesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexNamesOperation.cs
@@ -6,11 +6,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve the names of indexes from the database.
+    /// </summary>
     public sealed class GetIndexNamesOperation : IMaintenanceOperation<string[]>
     {
         private readonly int _start;
         private readonly int _pageSize;
 
+        /// <inheritdoc cref="GetIndexNamesOperation"/>
+        /// <param name="start">The starting position of the index names list.</param>
+        /// <param name="pageSize">The maximum number of index names to retrieve.</param>
         public GetIndexNamesOperation(int start, int pageSize)
         {
             _start = start;

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexOperation.cs
@@ -8,10 +8,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve the definition of a specific index.
+    /// </summary>
     public sealed class GetIndexOperation : IMaintenanceOperation<IndexDefinition>
     {
         private readonly string _indexName;
 
+        /// <inheritdoc cref="GetIndexOperation"/>
+        /// <param name="indexName">The name of the index to retrieve.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="indexName"/> is null.</exception>
         public GetIndexOperation(string indexName)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexesOperation.cs
@@ -8,11 +8,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve the definitions of multiple indexes from the database.
+    /// </summary>
     public sealed class GetIndexesOperation : IMaintenanceOperation<IndexDefinition[]>
     {
         private readonly int _start;
         private readonly int _pageSize;
 
+        /// <inheritdoc cref="GetIndexesOperation"/>
+        /// <param name="start">The starting position of the indexes list.</param>
+        /// <param name="pageSize">The maximum number of index definitions to retrieve.</param>
         public GetIndexesOperation(int start, int pageSize)
         {
             _start = start;

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexesStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexesStatisticsOperation.cs
@@ -7,8 +7,12 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve statistics for all indexes in the database.
+    /// </summary>
     public sealed class GetIndexesStatisticsOperation : IMaintenanceOperation<IndexStats[]>
     {
+        /// <inheritdoc cref="GetIndexesStatisticsOperation"/>
         public GetIndexesStatisticsOperation()
         {
             

--- a/src/Raven.Client/Documents/Operations/Indexes/GetIndexingStatusOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/GetIndexingStatusOperation.cs
@@ -7,6 +7,9 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Indexes
 {
+    /// <summary>
+    /// Operation to retrieve the current indexing status of the database.
+    /// </summary>
     public sealed class GetIndexingStatusOperation : IMaintenanceOperation<IndexingStatus>
     {
         public RavenCommand<IndexingStatus> GetCommand(DocumentConventions conventions, JsonOperationContext context)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22794/Add-comments-for-operations-that-implements-IMaintenanceOperationT

### Additional description

Operations in this PR:

- `GetIndexOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetIndexNamesOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetShardedPeriodicBackupStatusOperation (in Raven.Client.Documents.Operations.Backups.Sharding)`
- `BackupOperation (in Raven.Client.Documents.Operations.Backups)`
- `DelayBackupOperation (in Raven.Client.Documents.Operations.Backups)`
- `GetPeriodicBackupStatusOperation (in Raven.Client.Documents.Operations.Backups)`
- `StartBackupOperation (in Raven.Client.Documents.Operations.Backups)`
- `UpdatePeriodicBackupOperation (in Raven.Client.Documents.Operations.Backups)`
- `GetClientConfigurationOperation (in Raven.Client.Documents.Operations.Configuration)`
- `GetStudioConfigurationOperation (in Raven.Client.Documents.Operations.Configuration)`
- `GetConnectionStringsOperation (in Raven.Client.Documents.Operations.ConnectionStrings)`
- `PutConnectionStringOperation<T> (in Raven.Client.Documents.Operations.ConnectionStrings)`
- `RemoveConnectionStringOperation<T> (in Raven.Client.Documents.Operations.ConnectionStrings)`
- `ConfigureDataArchivalOperation (in Raven.Client.Documents.Operations.DataArchival)`
- `AddEtlOperation<T> (in Raven.Client.Documents.Operations.ETL)`
- `UpdateEtlOperation<T> (in Raven.Client.Documents.Operations.ETL)`
- `ConfigureExpirationOperation (in Raven.Client.Documents.Operations.Expiration)`
- `GetIdentitiesOperation (in Raven.Client.Documents.Operations.Identities)`
- `NextIdentityForOperation (in Raven.Client.Documents.Operations.Identities)`
- `SeedIdentityForOperation (in Raven.Client.Documents.Operations.Identities)`
- `GetIndexErrorsOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetIndexesOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetIndexesStatisticsOperation (in Raven.Client.Documents.Operations.Indexes)`
- `GetIndexingStatusOperation (in Raven.Client.Documents.Operations.Indexes)`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
