### PR TITLE
RavenDB-23752 Skip terms filtered by analyzer in Lucene query building

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -884,8 +884,9 @@ namespace Raven.Server.Documents.Queries
                 if (type != LuceneTermType.String)
                     throw new InvalidQueryException("Proximity search works only on simple string terms, not wildcard or prefix ones", metadata.QueryText, parameters);
 
-                var pq = LuceneQueryHelper.AnalyzedTerm(fieldName, valueAsString, type, analyzer) as PhraseQuery; // this will return PQ, unless there is a single term
-                if (pq == null)
+                // this will return PQ, unless there is a single term
+                // note that TryGetAnalyzedTerm skips tokens filtered by analyzer (e.g. stopwords)
+                if (LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, valueAsString, type, analyzer, out var t) == false || t is not PhraseQuery pq)
                     throw new InvalidQueryException("Proximity search works only on multiple search terms", metadata.QueryText, parameters);
 
                 pq.Slop = proximity.Value;
@@ -898,7 +899,9 @@ namespace Raven.Server.Documents.Queries
             Lucene.Net.Search.Query firstQuery = null;
             foreach (var v in GetValues())
             {
-                var t = LuceneQueryHelper.AnalyzedTerm(fieldName, v, GetTermType(v), analyzer);
+                if (LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, v, GetTermType(v), analyzer, out var t) == false)
+                    continue;
+                
                 if (firstQuery == null && q == null)
                 {
                     firstQuery = t;

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -885,8 +885,8 @@ namespace Raven.Server.Documents.Queries
                     throw new InvalidQueryException("Proximity search works only on simple string terms, not wildcard or prefix ones", metadata.QueryText, parameters);
 
                 // this will return PQ, unless there is a single term
-                // note that TryGetAnalyzedTerm skips tokens filtered by analyzer (e.g. stopwords)
-                if (LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, valueAsString, type, analyzer, out var t) == false || t is not PhraseQuery pq)
+                LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, valueAsString, type, analyzer, out var t);
+                if (t is not PhraseQuery pq)
                     throw new InvalidQueryException("Proximity search works only on multiple search terms", metadata.QueryText, parameters);
 
                 pq.Slop = proximity.Value;

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -170,7 +170,7 @@ namespace Raven.Server.Documents.Queries
         }
 
         private static ThreadLocal<LowerCaseKeywordAnalyzer> WildcardAnalyzer = new ThreadLocal<LowerCaseKeywordAnalyzer>(() => new());
-        public static Query AnalyzedTerm(string fieldName, string term, LuceneTermType type, Analyzer analyzer, float? boost = null, float? similarity = null)
+        public static bool TryGetAnalyzedTerm(string fieldName, string term, LuceneTermType type, Analyzer analyzer, out Query query, float? boost = null, float? similarity = null)
         {
             if (type != LuceneTermType.String && type != LuceneTermType.Prefix && type != LuceneTermType.WildCard)
                 throw new InvalidOperationException("Analyzed terms can be only created from string values.");
@@ -213,24 +213,33 @@ namespace Raven.Server.Documents.Queries
             {
                 case LuceneTermType.Prefix:
                 {
-                    return new PrefixQuery(new Term(fieldName, terms[0].TrimEnd(AsteriskChar)))
+                    query = new PrefixQuery(new Term(fieldName, terms[0].TrimEnd(AsteriskChar)))
                     {
                         Boost = boost.Value
                     };
+                    return true;
                 }
                 case LuceneTermType.WildCard:
-                    return new WildcardQuery(new Term(fieldName, terms[0]))
+                    query = new WildcardQuery(new Term(fieldName, terms[0]))
                     {
                         Boost = boost.Value
                     };
+                    return true;
+            }
+
+            if (terms.Count == 0)
+            {
+                query = null;
+                return false;
             }
 
             if (terms.Count == 1)
             {
-                return new TermQuery(new Term(fieldName, terms[0]))
+                query = new TermQuery(new Term(fieldName, terms[0]))
                 {
                     Boost = boost.Value
                 };
+                return true;
             }
 
             var pq = new PhraseQuery
@@ -241,7 +250,8 @@ namespace Raven.Server.Documents.Queries
             foreach (var t in terms)
                 pq.Add(new Term(fieldName, t));
 
-            return pq;
+            query = pq;
+            return true;
         }
 
         public static unsafe string GetTermValue(string value, LuceneTermType type, bool exact)

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -233,7 +233,7 @@ namespace Raven.Server.Documents.Queries
                 query = new PhraseQuery
                 {
                     Boost = boost.Value
-                };;
+                };
                 return false;
             }
 

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -229,7 +229,11 @@ namespace Raven.Server.Documents.Queries
 
             if (terms.Count == 0)
             {
-                query = null;
+                // Backward compatibility for proximity search
+                query = new PhraseQuery
+                {
+                    Boost = boost.Value
+                };;
                 return false;
             }
 

--- a/test/SlowTests/Issues/RavenDB-23752.cs
+++ b/test/SlowTests/Issues/RavenDB-23752.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23752 : RavenTestBase
+{
+    public RavenDB_23752(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void StopwordsAreSkippedInQueryBuilding(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { Name = "test a car" };
+                session.Store(dto);
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+                index.Execute(store);
+                Indexes.WaitForIndexing(store);
+                
+                var queryResults = session
+                    .Query<DummyIndex.IndexEntry, DummyIndex>()
+                    .Search(x => x.SearchedText, "test a car", @operator: SearchOperator.And)
+                    .ProjectInto<Dto>()
+                    .ToList();
+                
+                Assert.Single(queryResults);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+    
+    private class DummyIndex : AbstractIndexCreationTask<Dto, DummyIndex.IndexEntry>
+    {
+        public class IndexEntry
+        {
+            public string SearchedText { get; set; }
+        }
+
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexEntry() { SearchedText = dto.Name };
+            
+            Index(x => x.SearchedText, FieldIndexing.Search);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23752.cs
+++ b/test/SlowTests/Issues/RavenDB-23752.cs
@@ -3,6 +3,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -38,6 +39,27 @@ public class RavenDB_23752 : RavenTestBase
                     .ToList();
                 
                 Assert.Single(queryResults);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ProximitySearchWithOnlyStopwords(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { Name = "of and" };
+                session.Store(dto);
+                session.SaveChanges();
+                
+                Assert.Throws<InvalidQueryException>(() => session.Advanced
+                    .DocumentQuery<Dto>()
+                    .Search(x => x.Name,"of and")
+                    .Proximity(0)
+                    .ToList());
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-23752.cs
+++ b/test/SlowTests/Issues/RavenDB-23752.cs
@@ -3,7 +3,6 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
-using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,8 +23,10 @@ public class RavenDB_23752 : RavenTestBase
         {
             using (var session = store.OpenSession())
             {
-                var dto = new Dto() { Name = "test a car" };
-                session.Store(dto);
+                var dto1 = new Dto() { Name = "test a car" };
+                var dto2 = new Dto() { Name = "test car" };
+                session.Store(dto1);
+                session.Store(dto2);
                 session.SaveChanges();
 
                 var index = new DummyIndex();
@@ -38,28 +39,32 @@ public class RavenDB_23752 : RavenTestBase
                     .ProjectInto<Dto>()
                     .ToList();
                 
-                Assert.Single(queryResults);
+                Assert.Equal(2, queryResults.Count);
             }
         }
     }
 
     [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-    public void ProximitySearchWithOnlyStopwords(Options options)
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void ProximitySearchWithOnlyStopwordsReturnsEmptySet(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
-                var dto = new Dto() { Name = "of and" };
-                session.Store(dto);
+                var dto1 = new Dto() { Name = "of and" };
+                var dto2 = new Dto() { Name = "of thisisnotastopword and" };
+                session.Store(dto1);
+                session.Store(dto2);
                 session.SaveChanges();
-                
-                Assert.Throws<InvalidQueryException>(() => session.Advanced
+
+                var result = session.Advanced
                     .DocumentQuery<Dto>()
-                    .Search(x => x.Name,"of and")
-                    .Proximity(0)
-                    .ToList());
+                    .Search(x => x.Name, "of and")
+                    .Proximity(3)
+                    .ToList();
+                
+                Assert.Empty(result);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23752/Investigate-stop-word-behavior-in-FullTextSearch-and-the-AND-operator

### Additional description

When building Lucene query, if analyzer filters all terms in `LuceneQueryHelper.AnalyzedTerm`, we want to ignore it in query building instead of adding default `PhraseQuery`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
