### PR TITLE
RavenDB-23371 Corax: RangeQuery optimizations for big datasets.

### DIFF
--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -251,14 +251,15 @@ namespace Corax.Querying.Matches
                     var termType = (TermIdMask)_itBuffer[i] & TermIdMask.EnsureIsSingleMask;
                     if (termType == TermIdMask.SmallPostingList)
                     {
-                        var smallSetId = EntryIdEncodings.GetContainerId(_itBuffer[i]);
-                        _smallPostListIds.Add(smallSetId);
+                        // Always has sufficient capacity due to the BufferSize constraint
+                        _smallPostListIds.AddByRefUnsafe() = EntryIdEncodings.GetContainerId(_itBuffer[i]);
                     }
                 }
-
+                
                 _smallPostingListIndex = 0;
                 if (_smallPostListIds.Count == 0)
                     return;
+                
                 Container.GetAll(_searcher._transaction.LowLevelTransaction, _smallPostListIds.ToSpan(), _containerItems, long.MinValue, _pageLocator);
             }
 

--- a/src/Sparrow/Compression/VariableSizeEncoding.cs
+++ b/src/Sparrow/Compression/VariableSizeEncoding.cs
@@ -14,11 +14,12 @@ namespace Sparrow.Compression
 
 
             ref var bufferRef = ref MemoryMarshal.GetReference(buffer);
-
+            ref var outputBufferRef = ref MemoryMarshal.GetReference(output);
+            
             int pos = 0;
             for (int i = 0; i < count; i++)
             {
-                ref var outputRef = ref Unsafe.Add(ref MemoryMarshal.GetReference(output), i);
+                ref var outputRef = ref Unsafe.Add(ref outputBufferRef, i);
                 if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
                 {
                     

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -23,7 +23,7 @@ public unsafe struct NativeList<T>
 
     public T* RawItems => Capacity > 0 ? (T*)_storage.Ptr : null;
 
-    public int Capacity => _storage.Length / sizeof(T);
+    public int Capacity = 0;
     public int Count;
 
     public readonly Span<T> ToSpan() => Count == 0 ? Span<T>.Empty : new Span<T>(_storage.Ptr, Count);
@@ -121,6 +121,7 @@ public unsafe struct NativeList<T>
     {
         var capacity = count == 1 ? 1 : Math.Max(1, Bits.PowerOf2(count));
         ctx.Allocate(capacity * sizeof(T), out _storage);
+        Capacity = _storage.Length / sizeof(T);
     }
     
     public void Grow(ByteStringContext ctx, int addition)
@@ -135,6 +136,7 @@ public unsafe struct NativeList<T>
         }
 
         _storage = mem;
+        Capacity = _storage.Length / sizeof(T);
     }
 
     public readonly void Sort()
@@ -196,6 +198,7 @@ public unsafe struct NativeList<T>
     {
         if(_storage.HasValue)
             ctx.Release(ref _storage);
+        Capacity = 0;
     }
 
     public void Clear()

--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -109,6 +109,8 @@ public unsafe struct FastPForDecoder : IDisposable
         bigDeltaOffsets.Initialize(_allocator);
         var buffer = stackalloc uint[256];
         int read = 0;
+        Span<long> outputSpan = new Span<long>(output, outputCount);
+        
         while (_metadata < _end && read < outputCount)
         {
             Debug.Assert(read + 256 <= outputCount, "We assume a minimum of 256 free spaces");
@@ -127,12 +129,14 @@ public unsafe struct FastPForDecoder : IDisposable
                 case FastPForEncoder.VarIntBatchMarker:
                     var countOfVarIntBatch = *_metadata++;
                     var prevScalar = _prev.GetElement(3);
+                    var offset = VariableSizeEncoding.ReadMany(new ReadOnlySpan<byte>(_input, (int)(_end - _input)), countOfVarIntBatch, outputSpan[read..]);
+                    _input += offset;
+                    
                     for (int i = 0; i < countOfVarIntBatch; i++)
                     {
-                        var cur = VariableSizeEncoding.Read<long>(_input, out var offset);
-                        _input += offset;
+                        var cur = outputSpan[read];
                         cur += prevScalar;
-                        output[read++] = cur << _prefixShiftAmount | _sharedPrefix;
+                        outputSpan[read++] = cur << _prefixShiftAmount | _sharedPrefix;
                         prevScalar = cur;
                     }
                     _prev = Vector256.Create(prevScalar);

--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -26,6 +26,7 @@ public unsafe struct FastPForDecoder : IDisposable
     private ByteStringContext<ByteStringMemoryCache>.InternalScope _exceptionsScope;
     private Vector256<long> _prev;
     private ByteString _buffer;
+    private NativeList<long> _bigDeltaOffsets;
     private int NumberOfIntegersInBuffer => _buffer.Length / sizeof(uint);
 
     public FastPForDecoder(ByteStringContext allocator)
@@ -34,6 +35,7 @@ public unsafe struct FastPForDecoder : IDisposable
         const int initialExceptionsSize = 1024;
         _exceptionsScope = allocator.Allocate(initialExceptionsSize * sizeof(uint), out _buffer);
         _exceptions = (uint*)_buffer.Ptr;
+        _bigDeltaOffsets.Initialize(allocator);
     }
 
     public void MarkInvalid()
@@ -105,8 +107,8 @@ public unsafe struct FastPForDecoder : IDisposable
         var sharedPrefixMask = Vector256.Create<long>(_sharedPrefix);
 
         var bigDeltaStart = 0;
-        var bigDeltaOffsets = new NativeList<long>();
-        bigDeltaOffsets.Initialize(_allocator);
+        ref var bigDeltaOffsets = ref _bigDeltaOffsets;
+        bigDeltaOffsets.ResetAndEnsureCapacity(_allocator, outputCount);
         var buffer = stackalloc uint[256];
         int read = 0;
         Span<long> outputSpan = new Span<long>(output, outputCount);
@@ -119,7 +121,7 @@ public unsafe struct FastPForDecoder : IDisposable
             switch (numOfBits)
             {
                 case FastPForEncoder.BiggerThanMaxMarker:
-                    bigDeltaOffsets.Add(_allocator, (long)_metadata);
+                    bigDeltaOffsets.AddByRefUnsafe() = (long)_metadata;
                     // we don't need to worry about block fit, because we are ensured that we have at least
                     // 256 items to read into the output here, and these marker are for the next blcok
                     
@@ -186,12 +188,12 @@ public unsafe struct FastPForDecoder : IDisposable
                 var (a, b) = Vector256.Widen(Vector256.Load(buffer + i));
                 if (expectedBufferIndex == i)
                 {
-                    a |= GetDeltaHighBits(ref bigDeltaStart);
+                    a |= GetDeltaHighBits(ref bigDeltaOffsets, ref bigDeltaStart);
                 }
                 PrefixSumAndStoreToOutput(a, ref _prev);
                 if (expectedBufferIndex == i + 4)
                 {
-                    b |= GetDeltaHighBits(ref bigDeltaStart);
+                    b |= GetDeltaHighBits(ref bigDeltaOffsets, ref bigDeltaStart);
                 }
                 PrefixSumAndStoreToOutput(b, ref _prev);
             }
@@ -199,7 +201,7 @@ public unsafe struct FastPForDecoder : IDisposable
             bigDeltaStart = 0;
             bigDeltaOffsets.Clear();
 
-            Vector256<ulong> GetDeltaHighBits(ref int index)
+            Vector256<ulong> GetDeltaHighBits(ref NativeList<long> bigDeltaOffsets, ref int index)
             {
                 var ptr = (byte*)bigDeltaOffsets.RawItems[index] + 1;
                 index++;
@@ -243,6 +245,7 @@ public unsafe struct FastPForDecoder : IDisposable
     public void Dispose()
     {
         _exceptionsScope.Dispose();
+        _bigDeltaOffsets.Dispose(_allocator);
     }
 
     public static long ReadStart(byte* p)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23371
### Additional description

This PR introduces micro-optimizations in `PForDecoder` and `MultiTermMatch`, focusing on batching operations and minimizing unnecessary allocations.

Dataset: 400M, unbounded float range query:
![image](https://github.com/user-attachments/assets/c511dedb-8904-42fe-923a-b40b8742622f)


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
