### PR TITLE
RavenDB-23888 fixed polarity

### DIFF
--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -42,11 +42,11 @@ namespace Raven.Server.Web.Authentication
     public class AdminCertificatesHandler : ServerRequestHandler
     {
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<AdminCertificatesHandler>("Server");
-        
-        
+
+
         public const string HasTwoFactorFieldName = "HasTwoFactor";
         public const string TwoFactorExpirationDate = "TwoFactorExpirationDate";
-        
+
         [RavenAction("/admin/certificates/2fa/generate", "GET", AuthorizationStatus.Operator)]
         public async Task GenerateSecret()
         {
@@ -64,7 +64,7 @@ namespace Raven.Server.Web.Authentication
                 writer.WriteEndObject();
             }
         }
-        
+
         [RavenAction("/admin/certificates", "POST", AuthorizationStatus.Operator, DisableOnCpuCreditsExhaustion = true)]
         public async Task Generate()
         {
@@ -79,11 +79,11 @@ namespace Raven.Server.Web.Authentication
                     operationId = ServerStore.Operations.GetNextOperationId();
 
                 var stream = TryGetRequestFromStream("Options") ?? RequestBodyStream();
-                
+
                 var certificateJson = await ctx.ReadForDiskAsync(stream, "certificate-generation");
 
                 certificateJson.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationKey), out string twoFactorAuthenticationKey);
-                
+
                 var certificate = JsonDeserializationServer.CertificateDefinition(certificateJson);
 
                 if (certificate.SecurityClearance == SecurityClearance.ClusterAdmin && IsClusterAdmin() == false)
@@ -97,10 +97,10 @@ namespace Raven.Server.Web.Authentication
                 {
                     var permissions = FormatPermissions(certificate);
 
-                    LogAuditFor("Certificates", "GENERATE", 
-                        $"Certificate {certificate?.Name}. Security Clearance: {certificate?.SecurityClearance}. Permissions: {permissions}. TwoFactor: {string.IsNullOrEmpty(twoFactorAuthenticationKey)}");
+                    LogAuditFor("Certificates", "GENERATE",
+                        $"Certificate {certificate?.Name}. Security Clearance: {certificate?.SecurityClearance}. Permissions: {permissions}. TwoFactor: {string.IsNullOrEmpty(twoFactorAuthenticationKey) == false}");
                 }
-                
+
                 byte[] certs = null;
                 await
                     ServerStore.Operations.AddOperation(
@@ -236,10 +236,10 @@ namespace Raven.Server.Web.Authentication
                 {
                     var permissions = FormatPermissions(certificate);
 
-                    LogAuditFor("Certificates", "ADD", 
-                        $"New certificate {certificate?.Name} ['{certificate?.Thumbprint}']. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}. TwoFactor: {string.IsNullOrEmpty(twoFactorAuthenticationKey)}");
+                    LogAuditFor("Certificates", "ADD",
+                        $"New certificate {certificate?.Name} ['{certificate?.Thumbprint}']. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}. TwoFactor: {string.IsNullOrEmpty(twoFactorAuthenticationKey) == false}");
                 }
-                
+
                 try
                 {
                     await PutCertificateCollectionInCluster(certificate, certBytes, certificate.Password, ServerStore, ctx, twoFactorAuthenticationKey, GetRaftRequestIdFromQuery());
@@ -377,7 +377,7 @@ namespace Raven.Server.Web.Authentication
                     if (cert.Value.TryGet(nameof(CertificateDefinition.NotAfter), out DateTime notAfter) && DateTime.UtcNow > notAfter)
                         keysToDelete.Add(cert.Key);
                 }
-                
+
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
                     foreach (string keyToDelete in keysToDelete)
@@ -434,7 +434,7 @@ namespace Raven.Server.Web.Authentication
                 {
                     LogAuditFor("Certificates", "DELETE", $"Certificate '{thumbprint}'.");
                 }
-                
+
                 await DeleteInternal(keysToDelete, GetRaftRequestIdFromQuery());
             }
 
@@ -531,7 +531,7 @@ namespace Raven.Server.Web.Authentication
                         writer.WriteComma();
                         writer.WriteArray("WellKnownAdminCerts", wellKnown);
                         writer.WriteComma();
-                        writer.WriteArray("WellKnownIssuers", Server.WellKnownIssuers?.Select(x=>x.Thumbprint) ?? Array.Empty<string>());
+                        writer.WriteArray("WellKnownIssuers", Server.WellKnownIssuers?.Select(x => x.Thumbprint) ?? Array.Empty<string>());
                         writer.WriteEndObject();
                     }
                 }
@@ -601,27 +601,27 @@ namespace Raven.Server.Web.Authentication
                     // NotBefore will be null if the certificate was generated prior to adding the NotBefore property to class CertificateMetadata
                     // So we are manually extracting this info - See issue RavenDB-18519
                     var tempCertificate = CertificateLoaderUtil.CreateCertificate(Convert.FromBase64String(def.Certificate));
-                    using (tempCertificate) 
+                    using (tempCertificate)
                     {
                         def.NotBefore = tempCertificate.NotBefore;
                     }
-                    
+
                 }
 
                 var certificateRef = certificate;
                 if (metadataOnly)
                 {
                     var defJson = def.ToJson(true);
-                    
+
                     if (HttpContext.Request.IsFromStudio())
                     {
                         var hasTwoFactor = certificate.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationKey), out string _);
-                    
+
                         defJson[HasTwoFactorFieldName] = hasTwoFactor;
                     }
-                    
+
                     certificateRef = context.ReadObject(defJson, "Client/Certificate/Definition");
-                    
+
                     certificate.Dispose();
                 }
                 else
@@ -629,7 +629,7 @@ namespace Raven.Server.Web.Authentication
                     // make sure we don't leak fields like TwoFactorAuthenticationKey
                     certificateRef = context.ReadObject(def.ToJson(false), "Client/Certificate/Definition");
                 }
-                
+
                 certificates.TryAdd(thumbprint, certificateRef);
             }
         }
@@ -689,7 +689,7 @@ namespace Raven.Server.Web.Authentication
                         };
                         certificate = ctx.ReadObject(wellKnownCertDef.ToJson(), "WellKnown/Certificate/Definition");
                     }
-                    else if(Server.CertificateHasWellKnownIssuer(clientCert, out var issuer))
+                    else if (Server.CertificateHasWellKnownIssuer(clientCert, out var issuer))
                     {
                         var wellKnownCertDef = new CertificateDefinition
                         {
@@ -712,13 +712,13 @@ namespace Raven.Server.Web.Authentication
                 {
                     var certificateDefinition = JsonDeserializationServer.CertificateDefinition(certificate);
                     var certificateDJV = certificateDefinition.ToJson(false);
-                    
+
                     var hasTwoFactor = certificate.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationKey), out string _);
                     certificateDJV[HasTwoFactorFieldName] = hasTwoFactor;
-                    
+
                     var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
                     certificateDJV[TwoFactorExpirationDate] = feature?.TwoFactorAuthRegistration?.Expiry;
-                    
+
                     ctx.Write(writer, certificateDJV);
                 }
             }
@@ -730,7 +730,7 @@ namespace Raven.Server.Web.Authentication
             await ServerStore.EnsureNotPassiveAsync();
 
             var deleteTwoFactorConfiguration = GetBoolValueQueryString("deleteTwoFactorConfiguration", required: false) ?? false;
-            
+
             var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
             var clientCert = feature?.Certificate;
 
@@ -738,7 +738,7 @@ namespace Raven.Server.Web.Authentication
             using (var certificateJson = await ctx.ReadForDiskAsync(RequestBodyStream(), "edit-certificate"))
             {
                 var newCertificate = JsonDeserializationServer.CertificateDefinition(certificateJson);
-                
+
                 certificateJson.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationKey), out string newTwoFactorAuthenticationKey);
 
                 ValidateCertificateDefinition(newCertificate, ServerStore);
@@ -750,9 +750,9 @@ namespace Raven.Server.Web.Authentication
                     var existingCertificateJson = ServerStore.Cluster.GetCertificateByThumbprint(ctx, newCertificate.Thumbprint);
                     if (existingCertificateJson == null)
                         throw new InvalidOperationException($"Cannot edit permissions for certificate with thumbprint '{newCertificate.Thumbprint}'. It doesn't exist in the cluster.");
-                    
+
                     existingCertificateJson.TryGet(nameof(PutCertificateCommand.TwoFactorAuthenticationKey), out twoFactorAuthenticationKey);
-                    
+
                     if (deleteTwoFactorConfiguration)
                     {
                         twoFactorAuthenticationKey = null;
@@ -761,7 +761,7 @@ namespace Raven.Server.Web.Authentication
                     {
                         twoFactorAuthenticationKey = newTwoFactorAuthenticationKey;
                     }
-                    
+
                     existingCertificate = JsonDeserializationServer.CertificateDefinition(existingCertificateJson);
 
                     if ((existingCertificate.SecurityClearance == SecurityClearance.ClusterAdmin || existingCertificate.SecurityClearance == SecurityClearance.ClusterNode) && IsClusterAdmin() == false)
@@ -778,13 +778,13 @@ namespace Raven.Server.Web.Authentication
 
                     ServerStore.Cluster.DeleteLocalState(ctx, newCertificate.Thumbprint);
                 }
-                
+
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
                     var permissions = FormatPermissions(newCertificate);
 
-                    LogAuditFor("Certificates", "CHANGE", 
-                        $"Certificate {newCertificate?.Name}. Security Clearance: {newCertificate?.SecurityClearance}. Permissions: {permissions}. TwoFactor: {string.IsNullOrEmpty(twoFactorAuthenticationKey)}");
+                    LogAuditFor("Certificates", "CHANGE",
+                        $"Certificate {newCertificate?.Name}. Security Clearance: {newCertificate?.SecurityClearance}. Permissions: {permissions}. TwoFactor: {string.IsNullOrEmpty(twoFactorAuthenticationKey) == false}");
                 }
 
                 var cmd = new PutCertificateCommand(newCertificate.Thumbprint,
@@ -798,7 +798,8 @@ namespace Raven.Server.Web.Authentication
                         PublicKeyPinningHash = existingCertificate.PublicKeyPinningHash,
                         NotAfter = existingCertificate.NotAfter,
                         NotBefore = existingCertificate.NotBefore
-                    }, GetRaftRequestIdFromQuery()) {TwoFactorAuthenticationKey = twoFactorAuthenticationKey};
+                    }, GetRaftRequestIdFromQuery())
+                { TwoFactorAuthenticationKey = twoFactorAuthenticationKey };
 
                 var putResult = await ServerStore.PutValueInClusterAsync(cmd);
                 await ServerStore.Cluster.WaitForIndexNotification(putResult.Index);
@@ -1013,7 +1014,7 @@ namespace Raven.Server.Web.Authentication
                 {
                     LogAuditFor("Certificates", "RENEW", "Server certificate");
                 }
-                
+
                 try
                 {
                     var success = Server.RefreshClusterCertificate(true, GetRaftRequestIdFromQuery());
@@ -1294,6 +1295,6 @@ namespace Raven.Server.Web.Authentication
                 }
             }
         }
-        
+
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23888

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
