### PR TITLE
RavenDB-7070 - move tests to FastTests

### DIFF
--- a/test/FastTests/TestsInheritanceFastTests.cs
+++ b/test/FastTests/TestsInheritanceFastTests.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Tests.Infrastructure;
+using Voron.Util.Settings;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests
+{
+    public class TestsInheritanceFastTests : RavenLowLevelTestBase
+    {
+        public TestsInheritanceFastTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [NonLinuxFact]
+        public void AllTestsShouldUseRavenFactOrRavenTheoryAttributes()
+        {
+            var assemblies = new HashSet<Assembly>();
+            string projectPath = FindSlowTestsDirectory();
+            string outputDir = NewDataPath(suffix: "BuildOutput", forceCreateDir: true); // Temporary directory
+
+            var projectCsProj = PathUtil.ToFullPath(Path.Combine(projectPath, "SlowTests.csproj"));
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    Arguments = $"publish \"{projectCsProj}\" --configuration Debug --output \"{outputDir}\" --no-restore",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            var exited = process.WaitForExit(TimeSpan.FromMinutes(5));
+            Assert.True(exited, "Process timeout!");
+            Assert.True(process.ExitCode == 0, $"Build failed! Output:{Environment.NewLine}{output}{Environment.NewLine}Error:{Environment.NewLine}{error}");
+
+            var outputDll = Directory.GetDirectories(PathUtil.ToFullPath(Path.Combine(projectPath, "bin", "Debug"))).FirstOrDefault();
+            Assert.NotNull(outputDll);
+
+            outputDll = PathUtil.ToFullPath(Path.Combine(outputDll, "SlowTests.dll"));
+            Assert.True(File.Exists(outputDll), $"DLL not found: {outputDll}");
+
+            var loaded = Assembly.LoadFrom(outputDll);
+            var types = from assembly in GetAssemblies(assemblies, loaded)
+                from test in GetAssemblyTypes(assembly)
+                from method in test.GetMethods()
+                where Filter(method)
+                select method;
+
+            var array = types.ToArray();
+            const int numberToTolerate = 6346;
+            if (array.Length == numberToTolerate)
+                return;
+
+            var userMessage = $"We have detected '{array.Length}' test(s) that do not have {nameof(RavenFactAttribute)} or {nameof(RavenTheoryAttribute)} attribute. Please check if tests that you have added have those attributes. List of test files:{Environment.NewLine}{string.Join(Environment.NewLine, array.Select(x => GetTestName(x)))}";
+            throw new Exception(userMessage);
+
+            static string GetTestName(MethodInfo method)
+            {
+                return $"{method.DeclaringType?.FullName}.{method.Name}";
+            }
+
+            static bool Filter(MethodInfo method)
+            {
+                var factAttribute = method.GetCustomAttribute(typeof(FactAttribute), false);
+                if (factAttribute != null)
+                {
+                    if (ValidNamespace(factAttribute.GetType().Namespace))
+                        return false;
+
+                    return true;
+                }
+
+                var theoryAttribute = method.GetCustomAttribute(typeof(TheoryAttribute), false);
+                if (theoryAttribute != null)
+                {
+                    if (ValidNamespace(theoryAttribute.GetType().Namespace))
+                        return false;
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool ValidNamespace(string @namespace)
+            {
+                return @namespace == null || @namespace.StartsWith("FastTests") || @namespace.StartsWith("SlowTests") || @namespace.StartsWith("Tests.Infrastructure");
+            }
+        }
+
+        internal static IEnumerable<Assembly> GetAssemblies(HashSet<Assembly> assemblies, Assembly assemblyToScan)
+        {
+            if (assemblies.Add(assemblyToScan) == false)
+                yield break;
+
+            yield return assemblyToScan;
+
+            foreach (var asm in assemblyToScan.GetReferencedAssemblies())
+            {
+
+                Assembly load;
+                try
+                {
+                    load = Assembly.Load(asm);
+                }
+                catch
+                {
+                    continue;
+                }
+                foreach (var assembly in GetAssemblies(assemblies, load))
+                    yield return assembly;
+            }
+        }
+
+        internal static Type[] GetAssemblyTypes(Assembly assemblyToScan)
+        {
+            try
+            {
+                return assemblyToScan.GetTypes();
+            }
+            catch
+            {
+                return Array.Empty<Type>();
+            }
+        }
+
+        private static string FindSlowTestsDirectory()
+        {
+            for (int i = 1; i < 10; i++)
+            {
+                var dir = string.Concat(Enumerable.Repeat("../", i)) + "test/SlowTests/";
+                var fullPath = PathUtil.ToFullPath(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, dir)));
+                if (Directory.Exists(fullPath))
+                    return fullPath;
+            }
+
+            throw new FileNotFoundException("Unable to find Studio directory");
+        }
+    }
+}

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -30,8 +30,8 @@ namespace SlowTests.Tests
         [NonLinuxFact]
         public void NonDisposableTestShouldNotExist()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
-                        from test in GetAssemblyTypes(assembly)
+            var types = from assembly in TestsInheritanceFastTests.GetAssemblies(_assemblies, typeof(TestsInheritanceTests).Assembly)
+                        from test in TestsInheritanceFastTests.GetAssemblyTypes(assembly)
                         where test.GetMethods().Any(x => x.GetCustomAttributes(typeof(FactAttribute), true).Count() != 0 || x.GetCustomAttributes(typeof(TheoryAttribute), true).Count() != 0)
                         where typeof(IDisposable).IsAssignableFrom(test) == false
                         select test;
@@ -47,8 +47,8 @@ namespace SlowTests.Tests
         [NonLinuxFact]
         public void TestsShouldInheritFromRightBaseClasses()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
-                        from test in GetAssemblyTypes(assembly)
+            var types = from assembly in TestsInheritanceFastTests.GetAssemblies(_assemblies, typeof(TestsInheritanceTests).Assembly)
+                        from test in TestsInheritanceFastTests.GetAssemblyTypes(assembly)
                         where test.GetMethods().Any(x => x.GetCustomAttributes(typeof(FactAttribute), true).Count() != 0 || x.GetCustomAttributes(typeof(TheoryAttribute), true).Count() != 0)
                         where test.IsSubclassOf(typeof(ParallelTestBase)) == false && test.IsSubclassOf(typeof(RavenTestDriver)) == false && test.Namespace.StartsWith("EmbeddedTests") == false
                         select test;
@@ -64,8 +64,8 @@ namespace SlowTests.Tests
         [NonLinuxFact]
         public void HandlersShouldNotInheritStraightFromRequestHandler()
         {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
-                        from handler in GetAssemblyTypes(assembly)
+            var types = from assembly in TestsInheritanceFastTests.GetAssemblies(_assemblies, typeof(TestsInheritanceTests).Assembly)
+                        from handler in TestsInheritanceFastTests.GetAssemblyTypes(assembly)
                         where handler != typeof(DatabaseRequestHandler) && handler != typeof(ServerRequestHandler)
                         where handler.IsSubclassOf(typeof(RequestHandler)) && handler.IsSubclassOf(typeof(ServerRequestHandler)) == false && handler.IsSubclassOf(typeof(DatabaseRequestHandler)) == false
                         select handler;
@@ -76,93 +76,6 @@ namespace SlowTests.Tests
 
             var userMessage = string.Join(Environment.NewLine, array.Select(x => x.FullName));
             throw new Exception(userMessage);
-        }
-
-        [Fact]
-        public void AllTestsShouldUseRavenFactOrRavenTheoryAttributes()
-        {
-            var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
-                        from test in GetAssemblyTypes(assembly)
-                        from method in test.GetMethods()
-                        where Filter(method)
-                        select method;
-
-            var array = types.ToArray();
-            const int numberToTolerate = 6392;
-            if (array.Length == numberToTolerate)
-                return;
-
-            var userMessage = $"We have detected '{array.Length}' test(s) that do not have {nameof(RavenFactAttribute)} or {nameof(RavenTheoryAttribute)} attribute. Please check if tests that you have added have those attributes. List of test files:{Environment.NewLine}{string.Join(Environment.NewLine, array.Select(x => GetTestName(x)))}";
-            throw new Exception(userMessage);
-
-            static string GetTestName(MethodInfo method)
-            {
-                return $"{method.DeclaringType?.FullName}.{method.Name}";
-            }
-
-            static bool Filter(MethodInfo method)
-            {
-                var factAttribute = method.GetCustomAttribute(typeof(FactAttribute), false);
-                if (factAttribute != null)
-                {
-                    if (ValidNamespace(factAttribute.GetType().Namespace))
-                        return false;
-
-                    return true;
-                }
-
-                var theoryAttribute = method.GetCustomAttribute(typeof(TheoryAttribute), false);
-                if (theoryAttribute != null)
-                {
-                    if (ValidNamespace(theoryAttribute.GetType().Namespace))
-                        return false;
-
-                    return true;
-                }
-
-                return false;
-            }
-
-            static bool ValidNamespace(string @namespace)
-            {
-                return @namespace == null || @namespace.StartsWith("FastTests") || @namespace.StartsWith("SlowTests") || @namespace.StartsWith("Tests.Infrastructure");
-            }
-        }
-
-        private IEnumerable<Assembly> GetAssemblies(Assembly assemblyToScan)
-        {
-            if (_assemblies.Add(assemblyToScan) == false)
-                yield break;
-
-            yield return assemblyToScan;
-
-            foreach (var asm in assemblyToScan.GetReferencedAssemblies())
-            {
-
-                Assembly load;
-                try
-                {
-                    load = Assembly.Load(asm);
-                }
-                catch
-                {
-                    continue;
-                }
-                foreach (var assembly in GetAssemblies(load))
-                    yield return assembly;
-            }
-        }
-
-        private static Type[] GetAssemblyTypes(Assembly assemblyToScan)
-        {
-            try
-            {
-                return assemblyToScan.GetTypes();
-            }
-            catch
-            {
-                return Array.Empty<Type>();
-            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-7070

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
