### PR TITLE
RavenDB-23894 - Index Errors: Disable dropdown and display disclaimer instead of empty dropdown

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/SelectIndexErrorsDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/SelectIndexErrorsDropdown.tsx
@@ -11,6 +11,7 @@ import { useIndexErrorsDropdown } from "components/pages/database/indexes/errors
 import { ColumnFiltersState, Updater } from "@tanstack/react-table";
 import Dropdown from "react-bootstrap/Dropdown";
 import { CustomDropdownToggle } from "components/common/Dropdown";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
 
 interface SelectIndexErrorsDropdownProps {
     indexesList: NameAndCount[];
@@ -45,15 +46,22 @@ export function SelectIndexErrorsDropdown({
 
     return (
         <Dropdown className="select-index-errors-dropdown">
-            <Dropdown.Toggle
-                as={CustomDropdownToggle}
-                variant="secondary"
-                disabled={isLoading}
-                className="select-index-errors-toggle d-flex align-items-center"
-                isCaretHidden
+            <ConditionalPopover
+                conditions={{
+                    isActive: indexesList.length === 0,
+                    message: `No ${dropdownTypeLabelText} with indexing errors available`,
+                }}
             >
-                <div className="flex-grow d-flex align-items-center">{labelText}</div>
-            </Dropdown.Toggle>
+                <Dropdown.Toggle
+                    as={CustomDropdownToggle}
+                    variant="secondary"
+                    disabled={isLoading || indexesList.length === 0}
+                    className="select-index-errors-toggle d-flex align-items-center"
+                    isCaretHidden
+                >
+                    <div className="flex-grow d-flex align-items-center">{labelText}</div>
+                </Dropdown.Toggle>
+            </ConditionalPopover>
             <Dropdown.Menu className="p-3 custom-dropdown-menu">
                 <div className="vstack gap-2">
                     <div className="hstack lh-1 gap-3">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23894


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
