### PR TITLE
RavenDB-23907 Can't test SQL Connection String conectivity

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -8,6 +8,10 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using Microsoft.Data.SqlClient;
+using MySqlConnector;
+using Npgsql;
+using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Extensions.Streams;
@@ -110,6 +114,11 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
 
     public static void TestConnection(string factoryName, string connectionString)
     {
+        DbProviderFactories.RegisterFactory("Microsoft.Data.SqlClient", SqlClientFactory.Instance);
+        DbProviderFactories.RegisterFactory("MySqlConnector.MySqlConnectorFactory", MySqlConnectorFactory.Instance);
+        DbProviderFactories.RegisterFactory("Npgsql", NpgsqlFactory.Instance);
+        DbProviderFactories.RegisterFactory("Oracle.ManagedDataAccess.Client", OracleClientFactory.Instance);
+        
         var providerFactory = DbProviderFactories.GetFactory(factoryName);
         var connection = providerFactory.CreateConnection();
         connection.ConnectionString = connectionString;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23907/Cant-test-SQL-Connection-String-conectivity
### Additional description

Factories weren't registered to test the connectivity. Added the registration in the test method but didn't do that in Program.cs for less probability of future side effects.
https://github.com/ravendb/ravendb/issues/20325

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
