### PR TITLE
RavenDB-23380 Add index definition validation to test index

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
@@ -66,7 +66,9 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
             query = query.Replace(providedIndexName, testIndexName);
             
             testIndexDefinition.Name = testIndexName;
-                
+
+            ValidateIndexDefinition(testIndexDefinition);
+            
             var djv = new DynamicJsonValue() { [nameof(IndexQueryServerSide.Query)] = query, [nameof(IndexQueryServerSide.QueryParameters)] = queryParameters };
 
             var queryAsBlittable = context.ReadObject(djv, "test-index-query");
@@ -88,7 +90,7 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
                 using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
                 using (var queryContext = QueryOperationContext.Allocate(RequestHandler.Database))
                 {
-                    // we don't wait for non stale results because
+                    // we don't wait for non-stale results because
                     // it's handled by WaitForProcessingOfSampleDocs
                     indexQueryServerSide.WaitForNonStaleResults = false;
 
@@ -112,6 +114,20 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
                     await result.WriteTestIndexResultAsync(RequestHandler.ResponseBodyStream(), context);
                 }
             }
+        }
+
+        return;
+
+        void ValidateIndexDefinition(IndexDefinition definition)
+        {
+            if (IndexStore.IsValidIndexName(definition.Name, true, out var errorMessage) == false)
+            {
+                throw new ArgumentException(errorMessage);
+            }
+            
+            definition.RemoveDefaultValues();
+            AbstractIndexCreateController.ValidateAnalyzers(definition, RequestHandler.DatabaseName);
+            AbstractIndexCreateController.ValidateConfiguration(definition);
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
@@ -67,7 +67,7 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
             
             testIndexDefinition.Name = testIndexName;
 
-            ValidateIndexDefinition(testIndexDefinition);
+            RequestHandler.Database.IndexStore.Create.ValidateTestStaticIndex(testIndexDefinition);
             
             var djv = new DynamicJsonValue() { [nameof(IndexQueryServerSide.Query)] = query, [nameof(IndexQueryServerSide.QueryParameters)] = queryParameters };
 
@@ -114,20 +114,6 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
                     await result.WriteTestIndexResultAsync(RequestHandler.ResponseBodyStream(), context);
                 }
             }
-        }
-
-        return;
-
-        void ValidateIndexDefinition(IndexDefinition definition)
-        {
-            if (IndexStore.IsValidIndexName(definition.Name, true, out var errorMessage) == false)
-            {
-                throw new ArgumentException(errorMessage);
-            }
-            
-            definition.RemoveDefaultValues();
-            AbstractIndexCreateController.ValidateAnalyzers(definition, RequestHandler.DatabaseName);
-            AbstractIndexCreateController.ValidateConfiguration(definition);
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -196,7 +196,7 @@ public abstract class AbstractIndexCreateController
         return new IndexBatchScope(this, ServerStore, ServerStore.LicenseManager.GetNumberOfUtilizedCores(), onBatchSaved);
     }
 
-    private void ValidateAnalyzers(IndexDefinition definition)
+    internal static void ValidateAnalyzers(IndexDefinition definition, string databaseName)
     {
         if (definition.Fields == null)
             return;
@@ -208,7 +208,7 @@ public abstract class AbstractIndexCreateController
 
             try
             {
-                LuceneIndexingExtensions.GetAnalyzerType(kvp.Key, kvp.Value.Analyzer, GetDatabaseName());
+                LuceneIndexingExtensions.GetAnalyzerType(kvp.Key, kvp.Value.Analyzer, databaseName);
             }
             catch (Exception e)
             {
@@ -216,8 +216,10 @@ public abstract class AbstractIndexCreateController
             }
         }
     }
+
+    private void ValidateAnalyzers(IndexDefinition definition) => ValidateAnalyzers(definition, GetDatabaseName());
     
-    private static void ValidateConfiguration(IndexDefinition definition)
+    internal static void ValidateConfiguration(IndexDefinition definition)
     {
         if (definition.Configuration == null)
             return;

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -50,42 +50,20 @@ public abstract class AbstractIndexCreateController
 
     protected virtual async ValueTask ValidateStaticIndexAsync(IndexDefinition definition)
     {
-        if (IndexStore.IsValidIndexName(definition.Name, true, out var errorMessage) == false)
-        {
-            throw new ArgumentException(errorMessage);
-        }
-
-        ServerStore.LicenseManager.AssertCanAddAdditionalAssembliesFromNuGet(definition);
-
-        definition.RemoveDefaultValues();
-        ValidateAnalyzers(definition);
-        
-        ValidateConfiguration(definition);
-
-        var databaseConfiguration = GetDatabaseConfiguration();
-        var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion); // pre-compile it and validate
+        ValidateStaticIndexInternal(definition);
 
         if (definition.Type == IndexType.MapReduce)
         {
+            var databaseConfiguration = GetDatabaseConfiguration();
+            // pre-compile it and validate
+            var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
+        
             await MapReduceIndex.ValidateReduceResultsCollectionNameAsync(
                 definition,
                 instance,
                 GetIndexes,
                 GetCollectionCountAsync,
                 NeedToCheckIfCollectionEmpty(definition, databaseConfiguration));
-
-            if (string.IsNullOrEmpty(definition.PatternForOutputReduceToCollectionReferences) == false)
-                OutputReferencesPattern.ValidatePattern(definition.PatternForOutputReduceToCollectionReferences, out _);
-        }
-
-        if (definition.SourceType != IndexSourceType.Documents)
-        {
-            if (definition.ArchivedDataProcessingBehavior != null && definition.ArchivedDataProcessingBehavior != ArchivedDataProcessingBehavior.IncludeArchived)
-            {
-                throw new ArgumentException(
-                    $"{nameof(ArchivedDataProcessingBehavior)} other than '{ArchivedDataProcessingBehavior.IncludeArchived}' can be set only for document indexes,  not for indexes with {nameof(IndexSourceType)} '{definition.SourceType}' .");
-            }
-            definition.ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior.IncludeArchived;
         }
     }
 
@@ -99,14 +77,35 @@ public abstract class AbstractIndexCreateController
 
     internal virtual void ValidateTestStaticIndex(IndexDefinition definition)
     {
+        ValidateStaticIndexInternal(definition);
+    }
+    
+    private void ValidateStaticIndexInternal(IndexDefinition definition)
+    {
         if (IndexStore.IsValidIndexName(definition.Name, true, out var errorMessage) == false)
         {
             throw new ArgumentException(errorMessage);
         }
-            
+
+        ServerStore.LicenseManager.AssertCanAddAdditionalAssembliesFromNuGet(definition);
+
         definition.RemoveDefaultValues();
         ValidateAnalyzers(definition);
+        
         ValidateConfiguration(definition);
+        
+        if (definition.SourceType != IndexSourceType.Documents)
+        {
+            if (definition.ArchivedDataProcessingBehavior != null && definition.ArchivedDataProcessingBehavior != ArchivedDataProcessingBehavior.IncludeArchived)
+            {
+                throw new ArgumentException(
+                    $"{nameof(ArchivedDataProcessingBehavior)} other than '{ArchivedDataProcessingBehavior.IncludeArchived}' can be set only for document indexes,  not for indexes with {nameof(IndexSourceType)} '{definition.SourceType}' .");
+            }
+            definition.ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior.IncludeArchived;
+        }
+        
+        if (string.IsNullOrEmpty(definition.PatternForOutputReduceToCollectionReferences) == false)
+            OutputReferencesPattern.ValidatePattern(definition.PatternForOutputReduceToCollectionReferences, out _);
     }
 
     public async ValueTask<long> CreateIndexAsync(IndexDefinition definition, string raftRequestId, string source = null)

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -97,6 +97,18 @@ public abstract class AbstractIndexCreateController
         }
     }
 
+    internal virtual void ValidateTestStaticIndex(IndexDefinition definition)
+    {
+        if (IndexStore.IsValidIndexName(definition.Name, true, out var errorMessage) == false)
+        {
+            throw new ArgumentException(errorMessage);
+        }
+            
+        definition.RemoveDefaultValues();
+        ValidateAnalyzers(definition);
+        ValidateConfiguration(definition);
+    }
+
     public async ValueTask<long> CreateIndexAsync(IndexDefinition definition, string raftRequestId, string source = null)
     {
         if (definition == null)
@@ -196,7 +208,7 @@ public abstract class AbstractIndexCreateController
         return new IndexBatchScope(this, ServerStore, ServerStore.LicenseManager.GetNumberOfUtilizedCores(), onBatchSaved);
     }
 
-    internal static void ValidateAnalyzers(IndexDefinition definition, string databaseName)
+    private void ValidateAnalyzers(IndexDefinition definition)
     {
         if (definition.Fields == null)
             return;
@@ -208,7 +220,7 @@ public abstract class AbstractIndexCreateController
 
             try
             {
-                LuceneIndexingExtensions.GetAnalyzerType(kvp.Key, kvp.Value.Analyzer, databaseName);
+                LuceneIndexingExtensions.GetAnalyzerType(kvp.Key, kvp.Value.Analyzer, GetDatabaseName());
             }
             catch (Exception e)
             {
@@ -216,10 +228,8 @@ public abstract class AbstractIndexCreateController
             }
         }
     }
-
-    private void ValidateAnalyzers(IndexDefinition definition) => ValidateAnalyzers(definition, GetDatabaseName());
     
-    internal static void ValidateConfiguration(IndexDefinition definition)
+    private static void ValidateConfiguration(IndexDefinition definition)
     {
         if (definition.Configuration == null)
             return;

--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -52,12 +52,12 @@ public abstract class AbstractIndexCreateController
     {
         ValidateStaticIndexInternal(definition);
 
+        var databaseConfiguration = GetDatabaseConfiguration();
+        // pre-compile it and validate
+        var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
+        
         if (definition.Type == IndexType.MapReduce)
         {
-            var databaseConfiguration = GetDatabaseConfiguration();
-            // pre-compile it and validate
-            var instance = IndexCompilationCache.GetIndexInstance(definition, databaseConfiguration, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
-        
             await MapReduceIndex.ValidateReduceResultsCollectionNameAsync(
                 definition,
                 instance,

--- a/test/SlowTests/Issues/RavenDB-23380.cs
+++ b/test/SlowTests/Issues/RavenDB-23380.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents.Compilation;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Server.Documents.Indexes.Test;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23380 : RavenTestBase
+{
+    public RavenDB_23380(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    private class PutTestIndexCommand : RavenCommand<object>
+    {
+        private readonly TestIndexParameters _payload;
+        private readonly int _shardNumber;
+        private readonly bool _isSharded;
+        
+        public PutTestIndexCommand(TestIndexParameters payload, bool isSharded = false, int shardNumber = 0)
+        {
+            _payload = payload;
+            _isSharded = isSharded;
+            _shardNumber = shardNumber;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            if (_isSharded)
+            {
+                url = $"{node.Url}/databases/{node.Database}/indexes/test?nodeTag={node.ClusterTag}&shardNumber={_shardNumber}";
+            }
+            else
+            {
+                url = $"{node.Url}/databases/{node.Database}/indexes/test";
+            }
+
+            var payloadJson = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_payload, ctx);
+
+            var documentConventions = new DocumentConventions();
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await ctx.WriteAsync(stream, payloadJson);
+                }, documentConventions)
+            };
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void IncorrectAnalyzerNameShouldThrowSharded(Options options) => IncorrectAnalyzerNameShouldThrow(options, isSharded: true);
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+    public void IncorrectAnalyzerNameShouldThrowSingle(Options options) => IncorrectAnalyzerNameShouldThrow(options, isSharded: false);
+    
+    private void IncorrectAnalyzerNameShouldThrow(Options options, bool isSharded)
+    {
+        var payload = new TestIndexParameters()
+        {
+            IndexDefinition = new IndexDefinition() { Maps = new HashSet<string> { "from dto in docs.Dtos select new { Name = dto.Name }" }, Fields = new Dictionary<string, IndexFieldOptions> { { "Name", new IndexFieldOptions { Analyzer = "NonExistingAnalyzer", Indexing = FieldIndexing.Search } } } },
+            Query = "from index '<TestIndexName>' select Name"
+        };
+        
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Name = "Name1" };
+                var dto2 = new Dto() { Name = "Name2" };
+
+                session.Store(dto1);
+                session.Store(dto2);
+
+                session.SaveChanges();
+            }
+            
+            using (var commands = store.Commands())
+            {
+                var cmd = isSharded ? new PutTestIndexCommand(payload, isSharded: true, shardNumber: 0) : new PutTestIndexCommand(payload);
+
+                var ex = Assert.Throws<IndexCompilationException>(() => commands.Execute(cmd));
+                
+                Assert.Contains("Cannot find analyzer type 'NonExistingAnalyzer' for field: Name", ex.Message);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void InvalidDefinitionShouldThrowSharded(Options options) => InvalidDefinitionShouldThrow(options, isSharded: true);
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+    public void InvalidDefinitionShouldThrowSingle(Options options) => InvalidDefinitionShouldThrow(options, isSharded: false);
+    
+    private void InvalidDefinitionShouldThrow(Options options, bool isSharded)
+    {
+        var payload = new TestIndexParameters()
+        {
+            IndexDefinition = new IndexDefinition() { Maps = new HashSet<string> { "from dto in docs.Dtos select new { Value = dto.Value / (dto.Value - dto.Value) }" } },
+            Query = "from index '<TestIndexName>' select Value"
+        };
+        
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Value = 21 };
+                session.Store(dto1);
+                session.SaveChanges();
+                
+                using (var commands = store.Commands())
+                {
+                    PutTestIndexCommand cmd;
+                    
+                    if (isSharded)
+                    {
+                        var shardNumber = Sharding.GetShardNumberForAsync(store, dto1.Id).GetAwaiter().GetResult();
+                        cmd = new PutTestIndexCommand(payload, isSharded: true, shardNumber: shardNumber);
+                    }
+                    else
+                        cmd = new PutTestIndexCommand(payload);
+
+                    Assert.Throws<RavenException>(() => commands.Execute(cmd));
+                }
+            }
+        }
+    }
+    
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int Value { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23380/Infinite-Loop-on-Run-Test-Due-to-Invalid-Analyzer-Field-in-Indexing

### Additional description

Test index should have its definition validated in request handler

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
