### PR TITLE
RavenDB-23908 - Restore the subscription name when restoring a database from a snapshot

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -537,11 +537,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             if (filesToRestore.Count > 0)
                 return;
 
-            foreach (var (name, state) in subscription)
+            foreach (var (_, state) in subscription)
             {
                 var command = new PutSubscriptionCommand(databaseName, state.Query, state.MentorNode, RaftIdGenerator.DontCareId)
                 {
                     Disabled = state.Disabled,
+                    SubscriptionName = state.SubscriptionName,
                     InitialChangeVector = state.ChangeVectorForNextBatchStartingPoint,
                 };
                 //There's no need to wait for the execution of this command at this point since we will wait for subsequent commands later.

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3811,6 +3811,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     subscriptionsConfig = await destination.Subscriptions.GetSubscriptionsAsync(0, 10);
                     Assert.Equal(1, subscriptionsConfig.Count);
+                    Assert.Equal(subscriptionName, subscriptionsConfig[0].SubscriptionName);
                     Assert.Equal(snapshotCv.Split("-")[0], subscriptionsConfig[0].ChangeVectorForNextBatchStartingPoint.Split("-")[0]);
                 }
             }
@@ -3833,7 +3834,10 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
 
             var lastCv = "";
-            var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+            var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>
+            {
+                Name = Guid.NewGuid().ToString()
+            });
 
             using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subscriptionName)
             {
@@ -3885,6 +3889,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     subscriptionsConfig = await destination.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                     Assert.Equal(1, subscriptionsConfig.Count);
+                    Assert.Equal(subscriptionName, subscriptionsConfig[0].SubscriptionName);
                     Assert.Equal(snapshotCv.Split("-")[0], subscriptionsConfig[0].ChangeVectorForNextBatchStartingPoint.Split("-")[0]);
                 }
             }
@@ -3914,7 +3919,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             var subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
             Assert.Equal(1, subscriptionsConfig.Count);
 
-            await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Order>
+            var name2 = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Order>
             {
                 Name = "sub2"
             });
@@ -3932,7 +3937,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
             Assert.Equal(1, subscriptionsConfig.Count);
 
-            await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Order>
+            var name3 = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Order>
             {
                 Name = "sub3"
             });
@@ -3961,8 +3966,12 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var users = await session.LoadAsync<User>(ids);
                     Assert.All(users.Values, Assert.NotNull);
                 }
-                subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+                subscriptionsConfig = await destination.Subscriptions.GetSubscriptionsAsync(0, 10);
                 Assert.Equal(2, subscriptionsConfig.Count);
+
+                var names = subscriptionsConfig.Select(x => x.SubscriptionName).ToList();
+                Assert.Contains(name2, names);
+                Assert.Contains(name3, names);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23908/Restoring-snapshot-backup-causes-subscriptions-to-be-labelled-with-numbers-instead-of-original-names

### Additional description

Restore the subscription name when restoring a database from a snapshot.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
