### PR TITLE
RavenDB-22246: Fix tests for Embedded Server for ThrowOnInvalidOrMissingLicense default value

### DIFF
--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -246,91 +246,27 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
-    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldWork()
     {
-        ServerOptions options = new();
-        var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
-
-        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
-        expectedMessageBuilder.AppendLicenseMissingMessage();
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
-        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
-        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
-        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
-
-        expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
-
-        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+        StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
-    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_ServerOptionLicense_ShouldThrow()
+    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_ServerOptionLicense_ShouldWork()
     {
-        ServerOptions options = null;
-        var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
-
-        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
-        expectedMessageBuilder.AppendLicenseMissingMessage();
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
-        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
-        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
-        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
-
-        expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
-
-        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+        StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
-    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldWork()
     {
-        var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
-
-        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
-        expectedMessageBuilder.AppendLicenseMissingMessage();
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
-        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
-        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
-
-        expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
-
-        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+        StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
-    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
+    public void VerifyLicense_EnforceDefaultValue_InvalidLicense_ServerOptionLicensePath_ShouldWork()
     {
-        var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
-
-        var expectedMessageBuilder = new LicenseVerificationErrorBuilderForTestingPurposes();
-        expectedMessageBuilder.AppendLicenseMissingMessage();
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
-        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
-
-        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
-        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
-
-        expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
-
-        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+        StartEmbeddedServerLicenseOptionTestWithDefaultThrowOnInvalidOrMissingLicenseValue(LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     private void StartEmbeddedServerLicenseOptionTest(bool throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22246

### Additional description

For the Embedded Server, we [set](https://github.com/ravendb/ravendb/commit/8de73ae18b6afa9c7657ed1e3cfe0b889a07a81c#diff-d5ea6f295a84f4d8c6e51eab723f939325ea63cfac09690e99d5f3da59180176R110-L110) `Licensing.ThrowOnInvalidOrMissingLicense` = `false` by default. This pull request brings the tests into compliance with this change.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
