### PR TITLE
RavenDB-23904 - View freezes on refresh in tombstones view

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
@@ -12,7 +12,7 @@ import { useAppSelector } from "components/store";
 import VirtualTable from "components/common/virtualTable/VirtualTable";
 import { useTombstonesStateColumns } from "components/pages/database/settings/tombstones/useTombstonesStateColumns";
 import { LazyLoad } from "components/common/LazyLoad";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useMemo } from "react";
 import { getCoreRowModel, getFilteredRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import SizeGetter from "components/common/SizeGetter";
 
@@ -45,9 +45,17 @@ function TombstonesStateWithSize({ location, width }: TombstonesStateWithSizePro
 
     const { collectionsColumns, subscriptionsColumns, formatEtag } = useTombstonesStateColumns(width);
 
+    const tombstoneStateResults = useMemo(() => {
+        return asyncGetTombstonesState.result?.Results ?? [];
+    }, [asyncGetTombstonesState.result]);
+
+    const tombstoneStatePerSubscriptionInfo = useMemo(() => {
+        return asyncGetTombstonesState.result?.PerSubscriptionInfoExtended ?? [];
+    }, [asyncGetTombstonesState.result]);
+
     const collectionsTable = useReactTable({
         columns: collectionsColumns,
-        data: asyncGetTombstonesState.result?.Results || [],
+        data: tombstoneStateResults,
         columnResizeMode: "onChange",
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
@@ -56,7 +64,7 @@ function TombstonesStateWithSize({ location, width }: TombstonesStateWithSizePro
 
     const subscriptionsTable = useReactTable({
         columns: subscriptionsColumns,
-        data: asyncGetTombstonesState.result?.PerSubscriptionInfoExtended || [],
+        data: tombstoneStatePerSubscriptionInfo,
         columnResizeMode: "onChange",
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
@@ -89,7 +97,7 @@ function TombstonesStateWithSize({ location, width }: TombstonesStateWithSizePro
             <AboutViewHeading title="Tombstones" icon="tombstones" />
             <div className="d-flex align-items-start gap-3 flex-wrap">
                 <ButtonWithSpinner
-                    onClick={() => requestAnimationFrame(async () => asyncGetTombstonesState.execute())}
+                    onClick={asyncGetTombstonesState.execute}
                     variant="primary"
                     isSpinning={asyncGetTombstonesState.loading}
                     icon="refresh"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
@@ -89,7 +89,7 @@ function TombstonesStateWithSize({ location, width }: TombstonesStateWithSizePro
             <AboutViewHeading title="Tombstones" icon="tombstones" />
             <div className="d-flex align-items-start gap-3 flex-wrap">
                 <ButtonWithSpinner
-                    onClick={asyncGetTombstonesState.execute}
+                    onClick={() => requestAnimationFrame(async () => asyncGetTombstonesState.execute())}
                     variant="primary"
                     isSpinning={asyncGetTombstonesState.loading}
                     icon="refresh"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23904

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
