### PR TITLE
RavenDB-23820 - Do not show "Pause indexing untill restart" option for a disabled database

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -150,11 +150,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
     const canRestartDatabase = hasDatabaseAdminAccess && !db.isDisabled;
 
     const hasAnyDropdownActions =
-        canPauseAnyIndexing ||
-        canResumeAnyPausedIndexing ||
-        canDisableIndexing ||
-        canEnableIndexing ||
-        isOperatorOrAbove;
+        canPauseAnyIndexing || canResumeAnyPausedIndexing || canDisableIndexing || canEnableIndexing;
 
     const onChangeLockMode = async (lockMode: DatabaseLockMode) => {
         if (db.lockMode === lockMode) {
@@ -418,9 +414,11 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                                         </Dropdown.Item>
                                                     </>
                                                 )}
-                                                <Dropdown.Item onClick={onCompactDatabase}>
-                                                    <Icon icon="compact" /> Compact database
-                                                </Dropdown.Item>
+                                                {!db.isDisabled && (
+                                                    <Dropdown.Item onClick={onCompactDatabase}>
+                                                        <Icon icon="compact" /> Compact database
+                                                    </Dropdown.Item>
+                                                )}
                                             </>
                                         )}
                                     </Dropdown.Menu>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -138,7 +138,8 @@ export function DatabasePanel(props: DatabasePanelProps) {
     const canNavigateToDatabase = !db.isDisabled;
 
     const indexingDisabled = dbState.some((x) => x.status === "success" && x.data.indexingStatus === "Disabled");
-    const canPauseAnyIndexing = dbState.some((x) => x.status === "success" && x.data.indexingStatus === "Running");
+    const canPauseAnyIndexing =
+        dbState.some((x) => x.status === "success" && x.data.indexingStatus === "Running") && !db.isDisabled;
     const canResumeAnyPausedIndexing = dbState.some(
         (x) => x.status === "success" && x.data?.indexingStatus === "Paused"
     );
@@ -147,6 +148,13 @@ export function DatabasePanel(props: DatabasePanelProps) {
     const canEnableIndexing = isOperatorOrAbove && indexingDisabled;
 
     const canRestartDatabase = hasDatabaseAdminAccess && !db.isDisabled;
+
+    const hasAnyDropdownActions =
+        canPauseAnyIndexing ||
+        canResumeAnyPausedIndexing ||
+        canDisableIndexing ||
+        canEnableIndexing ||
+        isOperatorOrAbove;
 
     const onChangeLockMode = async (lockMode: DatabaseLockMode) => {
         if (db.lockMode === lockMode) {
@@ -363,6 +371,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                         <Dropdown.Toggle
                                             data-testid="database-actions-dropdown-toggle"
                                             variant="secondary"
+                                            disabled={!hasAnyDropdownActions}
                                         />
                                     </ButtonGroup>
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23820

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
