### PR TITLE
RavenDB-23929 VectorSearch - set default minimum similarity to 0.

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -598,8 +598,8 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.Static.ComplexFieldIndexingBehavior", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public CoraxComplexFieldIndexingBehavior CoraxStaticIndexComplexFieldIndexingBehavior { get; protected set; }
 
-        [Description("The default minimum similarity for vector search (0.0f - 1.0f, default is 0.75f)")]
-        [DefaultValue(0.75f)]
+        [Description("The default minimum similarity for vector search (0.0f - 1.0f, default is 0f)")]
+        [DefaultValue(0f)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.Corax.VectorSearch.DefaultMinimumSimilarity", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public float CoraxVectorSearchDefaultMinimumSimilarity { get; protected set; }

--- a/test/SlowTests/Issues/RavenDB-23509.cs
+++ b/test/SlowTests/Issues/RavenDB-23509.cs
@@ -34,7 +34,7 @@ public class RavenDB_23509 : RavenTestBase
         using var session = store.OpenSession();
         var results = session.Query<Result, TIndex>()
             .VectorSearch(f => f.WithField(s => s.Vector),
-                v => v.ByText("dog"))
+                v => v.ByText("dog"), minimumSimilarity: 0.75f)
             .ToList();
         
         Assert.Equal(1, results.Count);
@@ -59,7 +59,7 @@ public class RavenDB_23509 : RavenTestBase
         using var session = store.OpenSession();
         var results = session.Query<Result, TIndex>()
             .VectorSearch(f => f.WithField(s => s.Vector),
-                v => v.ByEmbedding([-0.1f, -0.2f]))
+                v => v.ByEmbedding([-0.1f, -0.2f]), minimumSimilarity: 0.75f)
             .ToList();
         
         Assert.Equal(1, results.Count);

--- a/test/SlowTests/Issues/RavenDB-23524.cs
+++ b/test/SlowTests/Issues/RavenDB-23524.cs
@@ -27,10 +27,10 @@ public class RavenDB_23524(ITestOutputHelper output) : RavenTestBase(output)
         var results = await session.Advanced.AsyncDocumentQuery<Product>()
             .WaitForNonStaleResults()
             .VectorSearch(f => f.WithText(p => p.Name),
-                v => v.ByText("italian"))
+                v => v.ByText("italian"), minimumSimilarity: 0.75f)
             .OrElse()
             .VectorSearch(f => f.WithText(p => p.Name),
-                v => v.ByText("food"))
+                v => v.ByText("food"), minimumSimilarity: 0.75f)
             .ToListAsync();
 
         Assert.Equal(3, results.Count);

--- a/test/SlowTests/Issues/RavenDB-23658.cs
+++ b/test/SlowTests/Issues/RavenDB-23658.cs
@@ -32,7 +32,7 @@ public class RavenDB_23658(ITestOutputHelper output) : RavenTestBase(output)
                 field => field
                     .WithField(x => x.VectorFromSingle),
                 searchTerm => searchTerm
-                    .ByEmbedding(new RavenVector<float>([6.599999904632568f, 7.699999809265137f])))
+                    .ByEmbedding(new RavenVector<float>([6.599999904632568f, 7.699999809265137f])), minimumSimilarity: 0.75f)
             .ProjectInto<Item>()
             .ToList();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23929

### Additional description

VectorSearch - set default minimum similarity to 0.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
