### PR TITLE
RavenDB-23903 Test certs with duplicate attributes check

### DIFF
--- a/src/Raven.Client/Util/CertificateHelper.cs
+++ b/src/Raven.Client/Util/CertificateHelper.cs
@@ -5,26 +5,12 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Raven.Client.Util;
 
 internal static class CertificateHelper
 {
-#if FEATURE_X509CERTIFICATELOADER_SUPPORT
-    private static readonly Pkcs12LoaderLimits AllowDuplicateAttributes;
-
-    static CertificateHelper()
-    {
-        AllowDuplicateAttributes = new Pkcs12LoaderLimits(Pkcs12LoaderLimits.Defaults);
-
-        var allowDuplicateAttributesProperty = AllowDuplicateAttributes.GetType().GetProperty(nameof(AllowDuplicateAttributes), BindingFlags.Instance | BindingFlags.NonPublic);
-        Debug.Assert(allowDuplicateAttributesProperty != null, $"{nameof(allowDuplicateAttributesProperty)} != null");
-        allowDuplicateAttributesProperty.SetValue(AllowDuplicateAttributes, true);
-    }
-#endif
-
     public static X509Certificate2 CreateCertificateFromCert(byte[] rawData)
     {
         ValidateContentType(rawData, X509ContentType.Cert);
@@ -58,7 +44,7 @@ internal static class CertificateHelper
         ValidateContentType(rawData, X509ContentType.Pfx);
 
 #if FEATURE_X509CERTIFICATELOADER_SUPPORT
-        var certificate = X509CertificateLoader.LoadPkcs12(rawData, password, keyStorageFlags, AllowDuplicateAttributes);
+        var certificate = X509CertificateLoader.LoadPkcs12(rawData, password, keyStorageFlags);
 #else
         var certificate = new X509Certificate2(rawData, password, keyStorageFlags);
 #endif


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23903

### Additional description

PR with duplicate attributes check to run tests.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
