### PR TITLE
RavenDB-23842 More massive ETL logs to Debug

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseEtlBase.cs
@@ -114,19 +114,19 @@ public abstract class RelationalDatabaseEtlBase<TRelationalEtlConfiguration, TRe
     {
         if (table.Inserts.Count > 0)
         {
-            if (Logger.IsInfoEnabled)
+            if (Logger.IsDebugEnabled)
             {
-                Logger.Info($"[{Name}] Inserted {stats.InsertedRecordsCount} (out of {table.Inserts.Count}) records to '{table.TableName}' table " +
+                Logger.Debug($"[{Name}] Inserted {stats.InsertedRecordsCount} (out of {table.Inserts.Count}) records to '{table.TableName}' table " +
                             $"from the following documents: {string.Join(", ", table.Inserts.Select(x => x.DocumentId))}");
             }
         }
 
         if (table.Deletes.Count > 0)
         {
-            if (Logger.IsInfoEnabled)
+            if (Logger.IsDebugEnabled)
             {
-                Logger.Info($"[{Name}] Deleted {stats.DeletedRecordsCount} (out of {table.Deletes.Count}) records from '{table.TableName}' table " +
-                            $"for the following documents: {string.Join(", ", table.Inserts.Select(x => x.DocumentId))}");
+                Logger.Debug($"[{Name}] Deleted {stats.DeletedRecordsCount} (out of {table.Deletes.Count}) records from '{table.TableName}' table " +
+                             $"for the following documents: {string.Join(", ", table.Inserts.Select(x => x.DocumentId))}");
             }
         }
     }

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -186,8 +186,8 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
 
                     var elapsedMilliseconds = sp.ElapsedMilliseconds;
 
-                    if (Logger.IsInfoEnabled && token.IsCancellationRequested == false)
-                        Logger.Info($"Insert took: {elapsedMilliseconds:#,#;;0}ms, statement: {cmd.CommandText}");
+                    if (Logger.IsDebugEnabled && token.IsCancellationRequested == false)
+                        Logger.Debug($"Insert took: {elapsedMilliseconds:#,#;;0}ms, statement: {cmd.CommandText}");
 
                     var tableMetrics = _sqlMetrics.GetTableMetrics(tableName);
                     tableMetrics.InsertActionsMeter.MarkSingleThreaded(1);
@@ -271,8 +271,8 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
 
                     var elapsedMilliseconds = sp.ElapsedMilliseconds;
 
-                    if (Logger.IsInfoEnabled && token.IsCancellationRequested == false)
-                        Logger.Info($"Delete took: {elapsedMilliseconds:#,#;;0}ms, statement: {cmd.CommandText}");
+                    if (Logger.IsDebugEnabled && token.IsCancellationRequested == false)
+                        Logger.Debug($"Delete took: {elapsedMilliseconds:#,#;;0}ms, statement: {cmd.CommandText}");
 
                     var tableMetrics = _sqlMetrics.GetTableMetrics(tableName);
                     tableMetrics.DeleteActionsMeter.MarkSingleThreaded(1);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23842

### Additional description
Those logs create massive logs in the log file so I moved them to be Debug instead of Info, which is the default now.


### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
