### PR TITLE
RavenDB-23938 IndexErrors tests took too long

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrors.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrors.spec.tsx
@@ -1,5 +1,4 @@
 import { rtlRender } from "test/rtlTestUtils";
-import React from "react";
 import { composeStories } from "@storybook/react";
 import * as stories from "./IndexErrors.stories";
 import { within } from "@testing-library/dom";
@@ -41,7 +40,7 @@ describe("IndexErrors", function () {
 
         expect(await screen.findByRole("heading", { name: textSelectors.title })).toBeInTheDocument();
         expect(await screen.findAllByClassName(classSelectors.nodePanel)).toHaveLength(6);
-    }, 10000);
+    });
 
     it("renders a single non-sharded node with errors and displays total count", async () => {
         const { screen } = rtlRender(<IndexErrorsStory hasErrors databaseAccess="DatabaseAdmin" isSharded={false} />);

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrors.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrors.stories.tsx
@@ -1,6 +1,10 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React from "react";
-import { databaseAccessArgType, withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import {
+    databaseAccessArgType,
+    withBootstrap5,
+    withForceRerender,
+    withStorybookContexts,
+} from "test/storybookTestUtils";
 import { mockServices } from "test/mocks/services/MockServices";
 import { mockStore } from "test/mocks/store/MockStore";
 import IndexErrors from "components/pages/database/indexes/errors/IndexErrors";
@@ -8,7 +12,7 @@ import { IndexesStubs } from "test/stubs/IndexesStubs";
 
 export default {
     title: "Pages/Indexes/Index Errors",
-    decorators: [withStorybookContexts, withBootstrap5],
+    decorators: [withStorybookContexts, withBootstrap5, withForceRerender],
 } satisfies Meta;
 
 interface IndexErrorsStoryArgs {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanel.tsx
@@ -243,20 +243,22 @@ function IndexErrorsPanelDetailsStatus({
                         </PopoverWithHoverWrapper>
                     </LazyLoad>
                 </RichPanelDetails>
-                <Collapse unmountOnExit mountOnEnter in={!panelCollapsed}>
-                    <RichPanelDetails>
-                        <div ref={ref} className="w-100">
-                            <IndexErrorsPanelTable
-                                status={asyncFetchErrorDetails.status}
-                                refresh={asyncFetchErrorDetails.execute}
-                                indexErrors={mappedIndexErrors}
-                                isLoading={asyncFetchErrorDetails.loading}
-                                width={width}
-                                table={table}
-                            />
-                        </div>
-                    </RichPanelDetails>
-                </Collapse>
+                <div ref={ref}>
+                    <Collapse in={!panelCollapsed} mountOnEnter unmountOnExit>
+                        <RichPanelDetails>
+                            <div className="w-100">
+                                <IndexErrorsPanelTable
+                                    status={asyncFetchErrorDetails.status}
+                                    refresh={asyncFetchErrorDetails.execute}
+                                    indexErrors={mappedIndexErrors}
+                                    isLoading={asyncFetchErrorDetails.loading}
+                                    width={width}
+                                    table={table}
+                                />
+                            </div>
+                        </RichPanelDetails>
+                    </Collapse>
+                </div>
             </>
         );
     }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanelTable.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanelTable.tsx
@@ -3,6 +3,7 @@ import { Table, useReactTable } from "@tanstack/react-table";
 import { LoadError } from "components/common/LoadError";
 import VirtualTable from "components/common/virtualTable/VirtualTable";
 import { AsyncStateStatus } from "react-async-hook";
+import { useMemo } from "react";
 
 interface IndexErrorsPanelTableProps {
     status: AsyncStateStatus;
@@ -23,9 +24,11 @@ export function IndexErrorsPanelTable({
 }: IndexErrorsPanelTableProps) {
     const { indexErrorsPanelColumns } = useIndexErrorsPanelColumns(width);
 
+    const data = useMemo(() => indexErrors ?? [], [indexErrors]);
+
     const indexErrorsPanelTable = useReactTable<IndexErrorPerDocument>({
         ...table.options,
-        data: indexErrors ?? [],
+        data,
         columns: indexErrorsPanelColumns,
     });
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23938/IndexErrors-tests-took-too-long

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
