### PR TITLE
RavenDB-23556 Fixing tests after changing the default min similarity from 0.75 to 0

### DIFF
--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
@@ -64,7 +64,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
 
             var byVector = session.Query<Dto, TIndex>()
                 .VectorSearch(f => f.WithField(s => s.Vector),
-                    v => v.ByText("joe"))
+                    v => v.ByText("joe"), minimumSimilarity: 0.75f)
                 .ToList();
 
             Assert.Single(byVector);
@@ -92,7 +92,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
 
             var byVector = session.Query<Dto, TIndex>()
                 .VectorSearch(f => f.WithField(s => s.Vector),
-                    v => v.ByText("Joe"))
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
                 .ToList();
 
             Assert.Empty(byVector);
@@ -144,7 +144,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
             Assert.Equal(0, nullElements);
 
             var byVector = session.Query<Dto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector),
-                    v => v.ByText("Joe"))
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
                 .ToList();
 
             Assert.Single(byVector);
@@ -172,7 +172,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
 
             var byVector = session.Query<Dto, TIndex>()
                 .VectorSearch(f => f.WithField(s => s.Vector),
-                    v => v.ByText("Joe"))
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
                 .ToList();
 
             Assert.Empty(byVector);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23556

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/20273

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
