### PR TITLE
RavenDB-23556 Using Base64 instead of Hex to have shorter hashes since they will be part of a document id

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
@@ -48,7 +48,7 @@ public static class EmbeddingsHelper
 
         Sodium.GenericHash(valueSpan, hashBuffer);
 
-        return Convert.ToHexString(hashBuffer);
+        return Convert.ToBase64String(hashBuffer);
     }
     
     public static string GetEmbeddingDocumentId(string documentId)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23556 

### Additional description

We'll have smaller hash outputs from the chunks.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
