### PR TITLE
RavenDB-23556: Cleaning up unused embeddings generation workers on DatabaseRecordChange

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -681,6 +682,8 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         if (record is null)
             return;
 
+        HashSet<EmbeddingsGenerationTaskIdentifier> taskIdsToRetain = [];
+
         foreach (EmbeddingsGenerationConfiguration configuration in record.EmbeddingsGenerations)
         {
             var identifier = new EmbeddingsGenerationTaskIdentifier(configuration.Identifier);
@@ -693,7 +696,9 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
                 continue;
             }
-            
+
+            taskIdsToRetain.Add(identifier);
+
             if (_workers.TryGetValue(identifier, out var existing) is false)
             {
                 _ = _workers.GetOrAdd(identifier, CreateAiWorker).RunAsync();
@@ -709,6 +714,14 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                     _ = toDispose.ShutdownAsync();
                 }
                 _ = _workers.GetOrAdd(identifier, CreateAiWorker).RunAsync();
+            }
+        }
+
+        foreach (var taskIdToRemove in _workers.Keys.Except(taskIdsToRetain))
+        {
+            if (_workers.TryRemove(taskIdToRemove, out var toDispose))
+            {
+                _ = toDispose.ShutdownAsync();
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23556

### Additional description

Workers remained in memory on disable or delete a task.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
