### PR TITLE
RavenDB-23556 Renaming collection name and changing the format of ID for embedding docs

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
@@ -53,12 +53,12 @@ public static class EmbeddingsHelper
     
     public static string GetEmbeddingDocumentId(string documentId)
     {
-        return $"{documentId}/embeddings";
+        return $"embeddings/{documentId}";
     }
 
     public static string GetEmbeddingDocumentCollectionName(string sourceCollectionName)
     {
-        return $"{sourceCollectionName}/embeddings";
+        return $"@embeddings/{sourceCollectionName}";
     }
 
     public static string GetEmbeddingCacheDocumentId(AiConnectionStringIdentifier id, string valueHash, VectorEmbeddingType targetQuantization)


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23556

### Additional description

We'll have `@embeddings/{collection}` as the collection name and `embeddings/{docId}` as IDs. This way all embedding collections will have the same prefix and be visible together at the top in the studio (also @embeddings-cache). The new format of embedding docs ID will make that operations like streaming of documents with a collection prefix (e.g. orders/) won't return embedding documents.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
