### PR TITLE
RavenDB-23556 Fixing references of embeddings docs collection in auto indexes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client;
+using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Server.Config.Categories;
+using Raven.Server.Documents.AI.Embeddings;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
 using Raven.Server.ServerWide.Context;
@@ -13,6 +16,8 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     internal sealed class AutoMapIndex : MapIndexBase<AutoMapIndexDefinition, AutoIndexField>
     {
+        private readonly HashSet<string> _referencedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         private AutoMapIndex(AutoMapIndexDefinition definition)
             : base(IndexType.AutoMap, IndexSourceType.Documents, definition, compiled: null)
         {
@@ -41,6 +46,14 @@ namespace Raven.Server.Documents.Indexes.Auto
             return new AutoIndexDocsEnumerator(items, stats, collection);
         }
 
+        protected override void HandleDocumentChange(DocumentChange change)
+        {
+            if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false && _referencedCollections.Contains(change.CollectionName) == false)
+                return;
+            
+            _mre.Set();
+        }
+
         protected override IIndexingWork[] CreateIndexWorkExecutors()
         {
             var workers = new List<IIndexingWork>
@@ -54,11 +67,14 @@ namespace Raven.Server.Documents.Indexes.Auto
             if (usesEmbeddingsGenerationTask)
             {
                 // We only have a single collection for auto map index
-                var collection = Collections.First();
-                
+                string collection = Collections.First();
+                var referencedEmbeddingsCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collection);
+
+                _referencedCollections.Add(referencedEmbeddingsCollection);
+
                 var referencedCollections = new Dictionary<string, HashSet<CollectionName>>();
                 
-                referencedCollections.Add(collection, new HashSet<CollectionName>() { new CollectionName(collection) });
+                referencedCollections.Add(collection, new HashSet<CollectionName>() { new CollectionName(referencedEmbeddingsCollection) });
                 
                 workers.Add(new HandleDocumentReferences(this, referencedCollections, DocumentDatabase.DocumentsStorage, _indexStorage, Configuration));
             }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -337,7 +338,49 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             }
         }
     }
-    
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void WillFindUpdatedEmbeddingValues(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto() { TextualValue = "asdsdfsdf" }, "dto/1");
+            session.SaveChanges();
+
+            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
+            var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
+                .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f).ToList();
+            Assert.Equal(0, multiVectorTextualQuery.Count);
+        }
+
+        aiTaskDone.Reset();
+        
+        using (var session = store.OpenSession())
+        {
+            WaitForUserToContinueTheTest(store);
+
+            session.Store(new Dto() { TextualValue = "pizza" }, "dto/1");
+            session.SaveChanges();
+
+            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
+            WaitForUserToContinueTheTest(store);
+
+            Thread.Sleep(2000); // TODO - auto index staleness need to take into account referenced embeddings collections
+            
+            var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
+                .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f).ToList();
+            Assert.Equal(1, multiVectorTextualQuery.Count);
+        }
+    }
+
     private class VectorStaticIndex : AbstractIndexCreationTask<Dto>
     {
         public VectorStaticIndex()


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23556

### Additional description

Fixing the collection names and `HandleDocumentChange` implementation so an auto index will get updated upon update of the related embeddings collection

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
