### PR TITLE
RavenDB-23941 - Allow the backup task to complete before concluding the test

### DIFF
--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -289,10 +289,10 @@ namespace RachisTests.DatabaseCluster
         {
             using (var store = GetDocumentStore(options))
             {
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new User(), "users/1");
-                    session.SaveChanges();
+                    await session.StoreAsync(new User(), "users/1");
+                    await session.SaveChangesAsync();
                 }
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
@@ -312,6 +312,8 @@ namespace RachisTests.DatabaseCluster
                 // call StartBackupOperation - this will not start a new backup task for that id since we already have one running
                 var error = await Assert.ThrowsAnyAsync<BackupAlreadyRunningException>(() => store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId)));
                 Assert.Equal(error.OperationId, backup.RunningTask.Id);
+                
+                mre.Set();
             }
         }
 
@@ -322,10 +324,10 @@ namespace RachisTests.DatabaseCluster
             options.ReplicationFactor = 1;
             using (var store = GetDocumentStore(options))
             {
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new User(), "users/1");
-                    session.SaveChanges();
+                    await session.StoreAsync(new User(), "users/1");
+                    await session.SaveChangesAsync();
                 }
 
                 var database = await Sharding.GetAnyShardDocumentDatabaseInstanceFor(ShardHelper.ToShardName(store.Database, 0));
@@ -362,6 +364,8 @@ namespace RachisTests.DatabaseCluster
                 // call StartBackupOperation - this should throw since we the backup is still running on shard 0
                 var error = await Assert.ThrowsAnyAsync<BackupAlreadyRunningException>(() => store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId)));
                 Assert.Equal(error.OperationId, backupShard0.RunningTask.Id);
+
+                mreShard0.Set();
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23941/HangingTest-CallingStartBackupOperationWhileBackupRunningShouldThrow

### Additional description

Allow the backup task to complete before concluding the test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
