### PR TITLE
RavenDB-23796 avoid creating sample data in the auth tests - it is a heavy endpoint

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -798,6 +798,7 @@ namespace SlowTests.Authentication
                 var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
                 {
                     ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                    ("POST", "/databases/*/studio/sample-data") // heavy
                 };
 
                 using (var httpClientHandler = new HttpClientHandler())
@@ -918,6 +919,7 @@ namespace SlowTests.Authentication
                 var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
                 {
                     ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                    ("POST", "/databases/*/studio/sample-data") // heavy
                 };
 
                 using (var httpClientHandler = new HttpClientHandler())
@@ -1032,6 +1034,7 @@ namespace SlowTests.Authentication
                 var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
                 {
                     ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                    ("POST", "/databases/*/studio/sample-data") // heavy
                 };
 
                 using (var httpClientHandler = new HttpClientHandler())
@@ -1143,6 +1146,7 @@ namespace SlowTests.Authentication
                 var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
                 {
                     ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                    ("POST", "/databases/*/studio/sample-data") // heavy
                 };
 
                 using (var httpClientHandler = new HttpClientHandler())
@@ -1249,6 +1253,7 @@ namespace SlowTests.Authentication
                 var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
                 {
                     ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                    ("POST", "/databases/*/studio/sample-data") // heavy
                 };
 
                 using (var httpClientHandler = new HttpClientHandler())

--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -26,6 +26,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
@@ -78,7 +79,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CanGetDocWithValidPermission()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
@@ -106,7 +107,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CanGetAttachmentWithValidPermission()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
@@ -134,7 +135,7 @@ namespace SlowTests.Authentication
         {
             var version = httpVersion != null ? new Version(httpVersion) : null;
 
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
@@ -163,7 +164,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CanReachOperatorEndpointWithOperatorPermission()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
@@ -183,7 +184,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CannotReachOperatorEndpointWithoutOperatorPermission()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
@@ -209,7 +210,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CanReachDatabaseAdminEndpointWithDatabaseAdminPermission()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
@@ -242,7 +243,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CannotReachDatabaseAdminEndpointWithoutDatabaseAdminPermission()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
             var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
@@ -274,7 +275,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CanOnlyGetRelevantDbsAccordingToPermissions()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var dbName = GetDatabaseName();
             var dbName1 = GetDatabaseName();
             var dbName2 = GetDatabaseName();
@@ -316,7 +317,7 @@ namespace SlowTests.Authentication
         [Fact]
         public void CannotGetDocWithoutCertificate()
         {
-            Certificates.SetupServerAuthentication();
+            SetupServerAuthentication();
 
             Assert.Throws<AuthorizationException>(() =>
             {
@@ -1202,7 +1203,7 @@ namespace SlowTests.Authentication
         [NightlyBuildMultiplatformFact(RavenArchitecture.AllX64)]
         public void Routes_ClusterAdmin()
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = SetupServerAuthentication();
             var databaseName1 = GetDatabaseName();
             var databaseName2 = GetDatabaseName();
             var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
@@ -1301,6 +1302,16 @@ namespace SlowTests.Authentication
                     });
                 }
             }
+        }
+
+        private TestCertificatesHolder SetupServerAuthentication()
+        {
+            return Certificates.SetupServerAuthentication(customSettings: new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Licensing.CanActivate), "false" },
+                { RavenConfiguration.GetKey(x => x.Licensing.CanForceUpdate), "false" },
+                { RavenConfiguration.GetKey(x => x.Licensing.CanRenew), "false" }
+            });
         }
 
         private static void AssertServerRoutes(IEnumerable<RouteInformation> routes, HashSet<(string Method, string Path)> endpointsToIgnore, HttpClient httpClient, Action<RouteInformation, HttpStatusCode> assert)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23796 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
