### PR TITLE
RavenDB-7070 Making the RabbitMQ connection infrastructure used in the test consistent with others so it won't throw InvalidOperationException when debugging if there is no relevant env variable is defined

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTestBase.cs
@@ -105,7 +105,7 @@ loadToOrders" + ExchangeSuffix + @"(orderData);
             {
                 Name = connectionStringName,
                 BrokerType = QueueBrokerType.RabbitMq,
-                RabbitMqConnectionSettings = new RabbitMqConnectionSettings(){ConnectionString = connectionString ?? RabbitMqConnectionString.Instance.VerifiedConnectionString}
+                RabbitMqConnectionSettings = new RabbitMqConnectionSettings(){ConnectionString = connectionString ?? RabbitMqConnectionString.Instance.VerifiedUrl.Value}
             });
         return config;
     }

--- a/test/Tests.Infrastructure/ConnectionString/RabbitMqConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/RabbitMqConnectionString.cs
@@ -14,14 +14,22 @@ public class RabbitMqConnectionString : IDisposable
     
     private IConnection _connection;
 
-    private readonly Lazy<string> _initialized;
+    private readonly Lazy<bool> _canConnect;
+    
+    private Lazy<string> Url { get; }
+
+    public Lazy<string> VerifiedUrl { get; }
 
     private RabbitMqConnectionString()
     {
-        _initialized = new Lazy<string>(EnsureInitialize);
+        VerifiedUrl = new Lazy<string>(VerifiedNodesValueFactory);
+
+        Url = new Lazy<string>(() => Environment.GetEnvironmentVariable(EnvironmentVariable) ?? string.Empty);
+        
+        _canConnect = new Lazy<bool>(CanConnectInternal);
     }
 
-    private string EnsureInitialize()
+    protected virtual string VerifiedNodesValueFactory()
     {
         var localConnectionString = "amqp://guest:guest@localhost:5672/";
 
@@ -29,15 +37,14 @@ public class RabbitMqConnectionString : IDisposable
         if (_connection != null)
             return localConnectionString;
 
-        var envConnectionString = Environment.GetEnvironmentVariable(EnvironmentVariable) ?? string.Empty;
-        if (envConnectionString.Length == 0)
+        if (Url.Value.Length == 0)
             throw new InvalidOperationException($"Environment variable {EnvironmentVariable} is empty");
 
-        _connection = CreateConnection(envConnectionString, out var ex);
+        _connection = CreateConnection(Url.Value, out var ex);
         if (_connection != null)
-            return envConnectionString;
+            return Url.Value;
 
-        throw new InvalidOperationException($"Can't create connection for Kafka instance. Provided url: {envConnectionString}", ex);
+        throw new InvalidOperationException($"Can't create connection for Rabbit MQ instance. Provided url: {Url.Value}", ex);
 
         IConnection CreateConnection(string connectionString, out Exception exception)
         {
@@ -72,11 +79,9 @@ public class RabbitMqConnectionString : IDisposable
 
     public IModel CreateModel()
     {
-        _ = _initialized.Value;
+        _ = _canConnect.Value;
         return _connection.CreateModel();
     }
-
-    public string VerifiedConnectionString => _initialized.Value;
 
     public bool CanConnect => CanConnectInternal();
 
@@ -84,7 +89,11 @@ public class RabbitMqConnectionString : IDisposable
     {
         try
         {
-            _ = _initialized.Value;
+            var url = Url.Value;
+            if (string.IsNullOrEmpty(url))
+                return false;
+
+            VerifiedNodesValueFactory();
             return true;
         }
         catch (Exception)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-7070

### Additional description

Enhancing debugging experience

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
