### PR TITLE
RavenDB-23852 MultiVectorSearch - merge duplicates

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/SortAndRemoveDuplicates.cs
+++ b/bench/Micro.Benchmark/Benchmarks/SortAndRemoveDuplicates.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+using Sparrow;
+
+namespace Micro.Benchmark.Benchmarks;
+
+public class SortAndRemoveDuplicates
+{
+    [Params(16, 64, 256, 1024, 1024 * 4)]
+    public int ArraySize { get; set; }
+
+    private long[] _sourceArray, _workingArray;
+    private float[] _sourceScoreArray, _workingScoreArray;
+    
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random(125123);
+        var totalElementsNumber = ArraySize;
+        var uniqueElementsNumber = (int)Math.Ceiling(totalElementsNumber * 0.9);
+        
+        _sourceArray = Enumerable.Range(0, uniqueElementsNumber).Select(x => (long)x).ToArray();
+        var repeatedElementsArray = random.GetItems(_sourceArray, totalElementsNumber - uniqueElementsNumber);
+        _sourceArray = _sourceArray.Concat(repeatedElementsArray).ToArray();
+        
+        _sourceScoreArray = Enumerable.Range(0, totalElementsNumber).Select(_ => (float)random.NextDouble()).ToArray();
+        
+        _workingScoreArray = new float[totalElementsNumber];
+        _workingArray = new long[totalElementsNumber];
+    }
+
+    [Benchmark(Baseline = true)]
+    public int SortAndMergeDuplicatesWithBranch()
+    {
+        _sourceArray.AsSpan().CopyTo(_workingArray);
+        _sourceScoreArray.AsSpan().CopyTo(_workingScoreArray);
+        return Sparrow.Server.Utils.Sorting.SortAndMergeDuplicates(_workingArray.AsSpan(), _workingScoreArray.AsSpan());
+    }
+    
+    [Benchmark]
+    public int SortAndMergeDuplicatesBranchless()
+    {
+        _sourceArray.AsSpan().CopyTo(_workingArray);
+        _sourceScoreArray.AsSpan().CopyTo(_workingScoreArray);
+        return SortAndMergeDuplicatesBranchless(_workingArray.AsSpan(), _workingScoreArray.AsSpan());
+    }
+    
+    [Benchmark]
+    public int SortAndRemoveDuplicatesWithBranch()
+    {
+        _sourceArray.AsSpan().CopyTo(_workingArray);
+        _sourceScoreArray.AsSpan().CopyTo(_workingScoreArray);
+        return SortAndRemoveDuplicatesWithBranch(_workingArray.AsSpan(), _workingScoreArray.AsSpan());
+    }
+
+    [Benchmark]
+    public int SortAndRemoveDuplicatesBranchless()
+    {
+        _sourceArray.AsSpan().CopyTo(_workingArray);
+        _sourceScoreArray.AsSpan().CopyTo(_workingScoreArray);
+        return Sparrow.Server.Utils.Sorting.SortAndRemoveDuplicates(_workingArray.AsSpan(), _workingScoreArray.AsSpan());
+    }
+        
+    private static int SortAndRemoveDuplicatesWithBranch<T, W>(Span<T> valuesToDeduplicate, Span<W> itemsAssociated)
+        where T : unmanaged, IBinaryNumber<T>
+    {
+        if (valuesToDeduplicate.Length <= 1)
+            return valuesToDeduplicate.Length;
+            
+        valuesToDeduplicate.Sort(itemsAssociated);
+
+        int outputIdx = 0;
+        for (int i = 1; i < valuesToDeduplicate.Length; i++)
+        {
+            if (valuesToDeduplicate[i] == valuesToDeduplicate[outputIdx])
+            {
+                itemsAssociated[outputIdx] = itemsAssociated[i];
+            }
+            else
+            {
+                outputIdx++;
+                valuesToDeduplicate[outputIdx] = valuesToDeduplicate[i];
+                itemsAssociated[outputIdx] = itemsAssociated[i];
+            }
+        }
+
+        return outputIdx + 1;
+    }
+    
+    private static int SortAndMergeDuplicatesBranchless(Span<long> valuesToDeduplicate, Span<float> itemsAssociated)
+    {
+        if (valuesToDeduplicate.Length <= 1)
+            return valuesToDeduplicate.Length;
+            
+        valuesToDeduplicate.Sort(itemsAssociated);
+
+        // We need to fill in the gaps left by removing deduplication process.
+        // If there are no duplicated the writes at the architecture level will execute
+        // way faster than if there are.
+
+        int nextI = 0;
+        int outputIdx = 0;
+        while (nextI < valuesToDeduplicate.Length - 1)
+        {
+            int i = nextI;
+            nextI++;
+            var nextItemHasSameId = (valuesToDeduplicate[nextI] == valuesToDeduplicate[i]).ToInt32();
+            var nextItemHasDifferentId = nextItemHasSameId ^ 1;
+                
+            // When elements are equal, add previous element to next
+            itemsAssociated[nextI] += nextItemHasSameId * itemsAssociated[outputIdx];
+            outputIdx += nextItemHasDifferentId;
+                
+            valuesToDeduplicate[outputIdx] = valuesToDeduplicate[nextI];
+            itemsAssociated[outputIdx] = itemsAssociated[nextI];
+        }
+
+        outputIdx++;
+        if (outputIdx != valuesToDeduplicate.Length)
+        {
+            valuesToDeduplicate[outputIdx] = valuesToDeduplicate[^1];
+            itemsAssociated[outputIdx] = itemsAssociated[^1];
+        }
+
+        return outputIdx;
+    }
+}

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -21,6 +21,8 @@ public struct MultiVectorSearchMatch : IQueryMatch
     private bool _persisted = false;
     private int _positionOnPersistedValues = 0;
 
+    private const long InitialSize = 16;
+
     public MultiVectorSearchMatch(IndexSearcher searcher, in FieldMetadata metadata, in VectorValue[] vectorsToSearch, in float minimumMatch, in int numberOfCandidates,
         in bool isExact, in bool singleVectorSearchDoNotSortByIds)
     {
@@ -29,6 +31,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _singleVectorSearchDoNotSortByIds = singleVectorSearchDoNotSortByIds;
         _nearestSearches = new Hnsw.NearestSearch[vectorsToSearch.Length];
         _isEmpty = true;
+        
         for (var i = 0; i < vectorsToSearch.Length; ++i)
         {
             var vectorToSearch = vectorsToSearch[i];
@@ -76,8 +79,8 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
     private void FillAndPersistResults()
     {
-        _matches.Init(_searcher.Allocator, 16);
-        _distances.Init(_searcher.Allocator, 16);
+        _matches.Init(_searcher.Allocator, InitialSize);
+        _distances.Init(_searcher.Allocator, InitialSize);
         for (var i = 0; i < _nearestSearches.Length; ++i)
         {
             ref var nearestSearch = ref _nearestSearches[i];
@@ -97,7 +100,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             nearestSearch.Dispose();
         }
 
-        var uniqueCount = Sorting.SortAndRemoveDuplicates(_matches.Results, _distances.Results);
+        var uniqueCount = Sorting.MergeDuplicatesAndSort(_matches.Results, _distances.Results);
         _matches.Truncate(uniqueCount);
         _distances.Truncate(uniqueCount);
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -100,7 +100,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             nearestSearch.Dispose();
         }
 
-        var uniqueCount = Sorting.MergeDuplicatesAndSort(_matches.Results, _distances.Results);
+        var uniqueCount = Sorting.SortAndMergeDuplicates(_matches.Results, _distances.Results);
         _matches.Truncate(uniqueCount);
         _distances.Truncate(uniqueCount);
 

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -125,7 +125,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
              foreach (var (name, field) in props)
              {
                  HashSet<GenerateEmbeddings> hashes = [];
-                 foreach (var  (value,chunking) in field)
+                 foreach (var (value, chunking) in field)
                  {
                      List<string> pending = [];
                      List<ReadOnlyMemory<byte>> cachedEmbeddingsBuffers = [];

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
@@ -281,7 +281,6 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
     {
         const string methodSignature = "text.splitLines(text | [text], maxTokensPerLine)";
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.PlainTextSplitLines);
-
     }
     
     private JsValue SplitPlainTextParagraphs(JsValue self, JsValue[] args)

--- a/src/Sparrow.Server/Utils/Sorting.cs
+++ b/src/Sparrow.Server/Utils/Sorting.cs
@@ -40,7 +40,34 @@ namespace Sparrow.Server.Utils
 
             return outputIdx;
         }
+        
+        public static int MergeDuplicatesAndSort<T, W>(Span<T> values, Span<W> itemsAssociated)
+            where T : unmanaged, IBinaryNumber<T>
+            where W : unmanaged, IAdditionOperators<W, W, W>
+        {
+            if (values.Length <= 1)
+                return values.Length;
+            
+            values.Sort(itemsAssociated);
 
+            int outputIdx = 0;
+            for (int i = 1; i < values.Length; i++)
+            {
+                if (values[i] == values[outputIdx])
+                {
+                    itemsAssociated[outputIdx] += itemsAssociated[i];
+                }
+                else
+                {
+                    outputIdx++;
+                    values[outputIdx] = values[i];
+                    itemsAssociated[outputIdx] = itemsAssociated[i];
+                }
+            }
+
+            return outputIdx + 1;
+        }
+        
         public static unsafe int SortAndRemoveDuplicates<T>(Span<T> values)
             where T : unmanaged, IBinaryNumber<T>
         {

--- a/src/Sparrow.Server/Utils/Sorting.cs
+++ b/src/Sparrow.Server/Utils/Sorting.cs
@@ -7,6 +7,33 @@ namespace Sparrow.Server.Utils
 {
     internal static class Sorting
     {
+        public static int SortAndMergeDuplicates<T, W>(Span<T> values, Span<W> itemsAssociated)
+            where T : unmanaged, IBinaryNumber<T>
+            where W : unmanaged, IAdditionOperators<W, W, W>
+        {
+            if (values.Length <= 1)
+                return values.Length;
+            
+            values.Sort(itemsAssociated);
+
+            int outputIdx = 0;
+            for (int i = 1; i < values.Length; i++)
+            {
+                if (values[i] == values[outputIdx])
+                {
+                    itemsAssociated[outputIdx] += itemsAssociated[i];
+                }
+                else
+                {
+                    outputIdx++;
+                    values[outputIdx] = values[i];
+                    itemsAssociated[outputIdx] = itemsAssociated[i];
+                }
+            }
+
+            return outputIdx + 1;
+        }
+        
         public static int SortAndRemoveDuplicates<T, W>(Span<T> valuesToDeduplicate, Span<W> itemsAssociated)
             where T : unmanaged, IBinaryNumber<T>
         {
@@ -39,33 +66,6 @@ namespace Sparrow.Server.Utils
             }
 
             return outputIdx;
-        }
-        
-        public static int MergeDuplicatesAndSort<T, W>(Span<T> values, Span<W> itemsAssociated)
-            where T : unmanaged, IBinaryNumber<T>
-            where W : unmanaged, IAdditionOperators<W, W, W>
-        {
-            if (values.Length <= 1)
-                return values.Length;
-            
-            values.Sort(itemsAssociated);
-
-            int outputIdx = 0;
-            for (int i = 1; i < values.Length; i++)
-            {
-                if (values[i] == values[outputIdx])
-                {
-                    itemsAssociated[outputIdx] += itemsAssociated[i];
-                }
-                else
-                {
-                    outputIdx++;
-                    values[outputIdx] = values[i];
-                    itemsAssociated[outputIdx] = itemsAssociated[i];
-                }
-            }
-
-            return outputIdx + 1;
         }
         
         public static unsafe int SortAndRemoveDuplicates<T>(Span<T> values)

--- a/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
+++ b/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
@@ -202,12 +202,12 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
     }
 
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
-    public void MergeDuplicatesAndSortShouldWork()
+    public void SortAndMergeDuplicatesShouldWork()
     {
-        Span<int> values = [2, 1, 2, 3];
+        Span<long> values = [2, 1, 2, 3];
         Span<float> itemsAssociated = [0.5f, 0.4f, 0.5f, 0.7f];
 
-        var length = Sorting.MergeDuplicatesAndSort(values, itemsAssociated);
+        var length = Sorting.SortAndMergeDuplicates(values, itemsAssociated);
 
         Assert.Equal(3, length);
     

--- a/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
+++ b/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
@@ -11,6 +11,7 @@ using Nito.Disposables;
 using Raven.Server.Documents.Indexes.VectorSearch;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Tests.Infrastructure;
 using Voron.Data.Graphs;
@@ -151,7 +152,6 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
                 entry.WriteVector(1, "Vector", MemoryMarshal.Cast<float, byte>(vectors[2]));
                 entry.EndWriting();
                 sourceIds[2] = entry.EntryId;
-
             }
             
             indexWriter.Commit();
@@ -199,6 +199,60 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(1L, toAndWith[0]);
             Assert.Equal(3L, toAndWith[1]);
         }        
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void MergeDuplicatesAndSortShouldWork()
+    {
+        Span<int> values = [2, 1, 2, 3];
+        Span<float> itemsAssociated = [0.5f, 0.4f, 0.5f, 0.7f];
+
+        var length = Sorting.MergeDuplicatesAndSort(values, itemsAssociated);
+
+        Assert.Equal(3, length);
+    
+        Assert.Equal(1, values[0]);
+        Assert.Equal(2, values[1]);
+        Assert.Equal(3, values[2]);
+
+        Assert.Equal(0.4f, itemsAssociated[0]);
+        Assert.Equal(1.0f, itemsAssociated[1]);
+        Assert.Equal(0.7f, itemsAssociated[2]);
+    }
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void MultiVectorSearchShouldSumDuplicates()
+    {
+        float[][] vectors = [[1f, 1f], [2f, 0f], [-1f, 3f]];
+        
+        using var _ = GetMappings(out var _, out var mapping, out var getVector);
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            var id = 1;
+            foreach (var vector in vectors)
+            {
+                var idLocal = $"vectors/{id++}";
+                using (var entry = writer.Index(idLocal))
+                {
+                    entry.Write(0, Encodings.Utf8.GetBytes(idLocal));
+                    entry.WriteVector(1, "Vector", MemoryMarshal.Cast<float, byte>(vector));
+                    entry.EndWriting();
+                }
+            }
+
+            writer.Commit();
+        }
+
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            var metadata = mapping.GetByFieldId(1).Metadata;
+            Span<long> ids = stackalloc long[16];
+            
+            var combinedQuery = indexSearcher.MultiVectorSearch(metadata, new[] { getVector(vectors[0]), getVector(vectors[2]) }, 0.0f, 16, false, true);
+            var read = combinedQuery.Fill(ids);
+            Assert.Equal(3, read);
+            Assert.Equal(ids[2], 2);
+        }
     }
 
     private static IDisposable GetMappings(out ByteStringContext bsc, out IndexFieldsMapping mapping, out Func<float[], VectorValue> getVector)

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -379,6 +379,34 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void MultiVectorSearchSumsDuplicates(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration(){ ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Dto() { TextualValue = "pizza" });
+                session.Store(new Dto() { TextualValue = "fruit" });
+                session.SaveChanges();
+
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
+                var multiVectorTextualQueryResult = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
+                    .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask(configuration.Identifier), v => v.ByTexts(["pizza", "pineapple", "cherry", "strawberry", "blueberry"]))
+                    .ToList();
+                
+                Assert.Equal(2, multiVectorTextualQueryResult.Count);
+                Assert.Equal("fruit", multiVectorTextualQueryResult.First().TextualValue);
+            }
+        }
+    }
+    
     private class VectorStaticIndex : AbstractIndexCreationTask<Dto>
     {
         public VectorStaticIndex()

--- a/test/SlowTests/SparrowTests/MergeDuplicatesAndSortTests.cs
+++ b/test/SlowTests/SparrowTests/MergeDuplicatesAndSortTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using FastTests;
+using SlowTests.Utils;
+using Sparrow.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.SparrowTests;
+
+public class MergeDuplicatesAndSortTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenTheory(RavenTestCategory.Memory)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    public void MergeDuplicatesAndSortShouldWork(int seed)
+    {
+        var random = new Random(seed);
+        var totalElementsNumber = random.Next(1, 1024);
+        var uniqueElementsNumber = (int)(totalElementsNumber * 0.9);
+        
+        // Generate elements (indexes)
+        var uniqueElementsArray = Enumerable.Range(0, uniqueElementsNumber).ToArray();
+        var repeatedElementsArray = random.GetItems(uniqueElementsArray, totalElementsNumber - uniqueElementsNumber);
+
+        var arrayWithRepetitions = uniqueElementsArray.Concat(repeatedElementsArray).ToArray();
+        
+        // Generate values (similarities)
+        var values = Enumerable.Range(0, totalElementsNumber).Select(_ => (float)random.NextDouble()).ToArray();
+        
+        // Make copies to perform equivalent calculations using LINQ
+        var arrayWithRepetitionsCopy = (int[])arrayWithRepetitions.Clone();
+        var valuesCopy = (float[])values.Clone();
+        
+        // This works in place
+        var uniqueCount = Sorting.MergeDuplicatesAndSort(arrayWithRepetitions.AsSpan(), values.AsSpan());
+        
+        // Do the same work using LINQ
+        var result = arrayWithRepetitionsCopy.Zip(valuesCopy)
+            .GroupBy(x => x.First)
+            .Select(group => (
+                    Id: group.Key,
+                    Value: group.Sum(x => x.Second)
+                )
+            )
+            .ToArray();
+
+        var resultIds = result.Select(x => x.Id).ToArray();
+        var resultValues = result.Select(x => x.Value).ToArray();
+
+        Assert.Equal(resultIds, arrayWithRepetitions[..uniqueCount]);
+        
+        for (var i = 0; i < uniqueCount; i++)
+        {
+            Assert.Equal(resultValues[i], values[i], 4);
+        }
+    }
+}

--- a/test/SlowTests/SparrowTests/SortAndMergeDuplicatesTests.cs
+++ b/test/SlowTests/SparrowTests/SortAndMergeDuplicatesTests.cs
@@ -9,9 +9,9 @@ using Xunit.Abstractions;
 
 namespace SlowTests.SparrowTests;
 
-public class MergeDuplicatesAndSortTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+public class SortAndMergeDuplicatesTests(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
-    [RavenTheory(RavenTestCategory.Memory)]
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Memory)]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
@@ -19,10 +19,10 @@ public class MergeDuplicatesAndSortTests(ITestOutputHelper output) : NoDisposalN
     {
         var random = new Random(seed);
         var totalElementsNumber = random.Next(1, 1024);
-        var uniqueElementsNumber = (int)(totalElementsNumber * 0.9);
+        var uniqueElementsNumber = (int)Math.Ceiling(totalElementsNumber * 0.9);
         
         // Generate elements (indexes)
-        var uniqueElementsArray = Enumerable.Range(0, uniqueElementsNumber).ToArray();
+        var uniqueElementsArray = Enumerable.Range(0, uniqueElementsNumber).Select(x => (long)x).ToArray();
         var repeatedElementsArray = random.GetItems(uniqueElementsArray, totalElementsNumber - uniqueElementsNumber);
 
         var arrayWithRepetitions = uniqueElementsArray.Concat(repeatedElementsArray).ToArray();
@@ -31,11 +31,11 @@ public class MergeDuplicatesAndSortTests(ITestOutputHelper output) : NoDisposalN
         var values = Enumerable.Range(0, totalElementsNumber).Select(_ => (float)random.NextDouble()).ToArray();
         
         // Make copies to perform equivalent calculations using LINQ
-        var arrayWithRepetitionsCopy = (int[])arrayWithRepetitions.Clone();
+        var arrayWithRepetitionsCopy = (long[])arrayWithRepetitions.Clone();
         var valuesCopy = (float[])values.Clone();
         
         // This works in place
-        var uniqueCount = Sorting.MergeDuplicatesAndSort(arrayWithRepetitions.AsSpan(), values.AsSpan());
+        var uniqueCount = Sorting.SortAndMergeDuplicates(arrayWithRepetitions.AsSpan(), values.AsSpan());
         
         // Do the same work using LINQ
         var result = arrayWithRepetitionsCopy.Zip(valuesCopy)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23852/MultiVectorSearch-merge-scores-of-duplicates-instead-of-performing-OR-operations.

### Additional description

We want to return better MultiVectorSearch query results, with a better approach to cases where some vectors are matched by multiple vector searches.  

Note that it's a breaking change - previously we only took a single value into account.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
