### PR TITLE
RavenDB-23957 - Improve the low memory detection on Windows

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -183,19 +183,18 @@ namespace Raven.Server.Documents.Handlers.Debugging
             if (PlatformDetails.RunningOnLinux == false)
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                using (var process = Process.GetCurrentProcess())
                 {
-                    var sharedClean = MemoryInformation.GetSharedCleanInBytes(process);
+                    var sharedClean = MemoryInformation.GetSharedCleanInBytes(out var workingSet, out _);
                     var rc = Win32MemoryQueryMethods.GetMaps();
                     var djv = new DynamicJsonValue
                     {
                         ["Totals"] = new DynamicJsonValue
                         {
-                            ["WorkingSet"] = process.WorkingSet64,
+                            ["WorkingSet"] = workingSet,
                             ["SharedClean"] = Sizes.Humane(sharedClean),
                             ["PrivateClean"] = "N/A",
                             ["TotalClean"] = rc.ProcessClean,
-                            ["RssHumanly"] = Sizes.Humane(process.WorkingSet64),
+                            ["RssHumanly"] = Sizes.Humane(workingSet),
                             ["SharedCleanHumanly"] = Sizes.Humane(sharedClean),
                             ["PrivateCleanHumanly"] = "N/A",
                             ["TotalCleanHumanly"] = Sizes.Humane(rc.ProcessClean)
@@ -324,6 +323,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 [nameof(MemoryInfo.PhysicalMemory)] = memInfo.TotalPhysicalMemory.ToString(),
                 [nameof(MemoryInfo.WorkingSet)] = memInfo.WorkingSet.ToString(),
+                [nameof(MemoryInfo.SharedClean)] = memInfo.SharedCleanMemory.ToString(),
                 [nameof(MemoryInfo.ManagedAllocations)] = Size.Humane(managedMemoryInBytes),
                 [nameof(MemoryInfo.ManagedHeapsAfterLastGC)] = ManagedHeapsInfo(gcInfo),
                 [nameof(MemoryInfo.UnmanagedAllocations)] = Size.Humane(totalUnmanagedAllocations),
@@ -571,6 +571,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         {
             public string PhysicalMemory { get; set; }
             public string WorkingSet { get; set; }
+            public string SharedClean { get; set; }
             
             public string Remarks { get; set; }
             public string ManagedAllocations { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -185,7 +185,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {
                     var sharedClean = MemoryInformation.GetSharedCleanInBytes(out var workingSet, out _);
-                    var rc = Win32MemoryQueryMethods.GetMaps();
+                    var rc = Win32MemoryMethods.GetMaps();
                     var djv = new DynamicJsonValue
                     {
                         ["Totals"] = new DynamicJsonValue

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -592,7 +592,7 @@ namespace Sparrow.LowMemory
             workingSet = workingSetInBytes;
             pageFileUsage = pageFileUsageInBytes;
 
-            return workingSet - privateUsage - sharedDirty;
+            return Math.Max(0, workingSet - privateUsage - sharedDirty);
         }
 
         private static (long WorkingSetInBytes, long PageFileUsageInBytes, long? PrivateUsageInBytes) GetProcessMemoryInfoForWindows()

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -85,20 +85,6 @@ namespace Sparrow.LowMemory
             InstalledMemory = new Size(256, SizeUnit.Megabytes)
         };
 
-        [StructLayout(LayoutKind.Sequential)]
-        public struct MemoryStatusEx
-        {
-            public uint dwLength;
-            public uint dwMemoryLoad;
-            public ulong ullTotalPhys;
-            public ulong ullAvailPhys;
-            public ulong ullTotalPageFile;
-            public ulong ullAvailPageFile;
-            public ulong ullTotalVirtual;
-            public ulong ullAvailVirtual;
-            public ulong ullAvailExtendedVirtual;
-        }
-
         public static bool DisableEarlyOutOfMemoryCheck =
             string.Equals(Environment.GetEnvironmentVariable("RAVEN_DISABLE_EARLY_OOM"), "true", StringComparison.OrdinalIgnoreCase);
 
@@ -214,95 +200,6 @@ namespace Sparrow.LowMemory
                                                 MemoryUtils.GetExtendedMemoryInfo(memInfo, GetDirtyMemoryState()), memInfo);
 
         }
-
-        public enum JOBOBJECTINFOCLASS
-        {
-            AssociateCompletionPortInformation = 7,
-            BasicLimitInformation = 2,
-            BasicUIRestrictions = 4,
-            EndOfJobTimeInformation = 6,
-            ExtendedLimitInformation = 9,
-            SecurityLimitInformation = 5,
-            GroupInformation = 11
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        struct JOBOBJECT_BASIC_LIMIT_INFORMATION
-        {
-            public Int64 PerProcessUserTimeLimit;
-            public Int64 PerJobUserTimeLimit;
-            public JOBOBJECTLIMIT LimitFlags;
-            public UIntPtr MinimumWorkingSetSize;
-            public UIntPtr MaximumWorkingSetSize;
-            public UInt32 ActiveProcessLimit;
-            public Int64 Affinity;
-            public UInt32 PriorityClass;
-            public UInt32 SchedulingClass;
-        }
-
-        [Flags]
-        public enum JOBOBJECTLIMIT : uint
-        {
-            // Basic Limits
-            Workingset = 0x00000001,
-            ProcessTime = 0x00000002,
-            JobTime = 0x00000004,
-            ActiveProcess = 0x00000008,
-            Affinity = 0x00000010,
-            PriorityClass = 0x00000020,
-            PreserveJobTime = 0x00000040,
-            SchedulingClass = 0x00000080,
-
-            // Extended Limits
-            ProcessMemory = 0x00000100,
-            JobMemory = 0x00000200,
-            DieOnUnhandledException = 0x00000400,
-            BreakawayOk = 0x00000800,
-            SilentBreakawayOk = 0x00001000,
-            KillOnJobClose = 0x00002000,
-            SubsetAffinity = 0x00004000,
-
-            // Notification Limits
-            JobReadBytes = 0x00010000,
-            JobWriteBytes = 0x00020000,
-            RateControl = 0x00040000,
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
-        {
-            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
-            public IO_COUNTERS IoInfo;
-            public UIntPtr ProcessMemoryLimit;
-            public UIntPtr JobMemoryLimit;
-            public UIntPtr PeakProcessMemoryUsed;
-            public UIntPtr PeakJobMemoryUsed;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        struct IO_COUNTERS
-        {
-            public UInt64 ReadOperationCount;
-            public UInt64 WriteOperationCount;
-            public UInt64 OtherOperationCount;
-            public UInt64 ReadTransferCount;
-            public UInt64 WriteTransferCount;
-            public UInt64 OtherTransferCount;
-        }
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool IsProcessInJob(IntPtr hProcess, IntPtr hJob, out bool isInJob);
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [DllImport("kernel32.dll")]
-        public static extern unsafe bool QueryInformationJobObject(IntPtr hJob, JOBOBJECTINFOCLASS JobObjectInformationClass, void* lpJobObjectInformation,
-            int cbJobObjectInformationLength, out int lpReturnLength);
-
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern unsafe bool GlobalMemoryStatusEx(MemoryStatusEx* lpBuffer);
 
         public static (long Rss, long Swap) GetMemoryUsageFromProcStatus()
         {
@@ -611,12 +508,12 @@ namespace Sparrow.LowMemory
         private static unsafe MemoryInfoResult GetMemoryInfoWindows()
         {
             // windows
-            var memoryStatus = new MemoryStatusEx
+            var memoryStatus = new Win32MemoryMethods.MemoryStatusEx
             {
-                dwLength = (uint)sizeof(MemoryStatusEx)
+                dwLength = (uint)sizeof(Win32MemoryMethods.MemoryStatusEx)
             };
 
-            if (GlobalMemoryStatusEx(&memoryStatus) == false)
+            if (Win32MemoryMethods.GlobalMemoryStatusEx(&memoryStatus) == false)
             {
                 if (Logger.IsInfoEnabled)
                     Logger.Info("Failure when trying to read memory info from Windows, error code is: " + Marshal.GetLastWin32Error());
@@ -630,20 +527,20 @@ namespace Sparrow.LowMemory
             var availableMemoryForProcessingInBytes = memoryStatusUllAvailPhys + sharedCleanInBytes;
 
             string remarks = null;
-            if (IsProcessInJob(ProcessHandle, IntPtr.Zero, out var isInJob) && isInJob)
+            if (Win32MemoryMethods.IsProcessInJob(ProcessHandle, IntPtr.Zero, out var isInJob) && isInJob)
             {
-                JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = default;
-                if (QueryInformationJobObject(IntPtr.Zero,
-                        JOBOBJECTINFOCLASS.ExtendedLimitInformation, (void*)&limits,
-                        sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
+                Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = default;
+                if (Win32MemoryMethods.QueryInformationJobObject(IntPtr.Zero,
+                        Win32MemoryMethods.JOBOBJECTINFOCLASS.ExtendedLimitInformation, (void*)&limits,
+                        sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
                         out int limitsOutputSize) == false ||
-                    limitsOutputSize != sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
+                    limitsOutputSize != sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
                 {
                     if (_reportedQueryJobObjectFailure == false && Logger.IsInfoEnabled)
                     {
                         _reportedQueryJobObjectFailure = true;
                         Logger.Info(
-                            $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
+                            $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
                     }
                 }
                 else

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -585,7 +585,21 @@ namespace Sparrow.LowMemory
             // of it resides in physical memory, this approach provides a highly reliable approximation of the shared
             // dirty memory footprint.
             var sharedDirty = GetTotalScratchAllocatedMemoryInBytes();
-            long privateUsage;
+
+            (long workingSetInBytes, long pageFileUsageInBytes, long? privateUsageInBytes) = GetProcessMemoryInfoForWindows();
+            var privateUsage = privateUsageInBytes ?? AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes() + AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
+
+            workingSet = workingSetInBytes;
+            pageFileUsage = pageFileUsageInBytes;
+
+            return workingSet - privateUsage - sharedDirty;
+        }
+
+        private static (long WorkingSetInBytes, long PageFileUsageInBytes, long? PrivateUsageInBytes) GetProcessMemoryInfoForWindows()
+        {
+            long workingSet;
+            long pageFileUsage;
+            long? privateUsage;
 
             if (WindowsSupportsMemoryCountersEx2)
             {
@@ -607,10 +621,10 @@ namespace Sparrow.LowMemory
 
                 workingSet = (long)memCounters.WorkingSetSize;
                 pageFileUsage = (long)memCounters.PagefileUsage;
-                privateUsage = AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes() + AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
+                privateUsage = null;
             }
 
-            return workingSet - privateUsage - sharedDirty;
+            return (workingSet, pageFileUsage, privateUsage);
         }
 
         public static long GetWorkingSetInBytes()
@@ -620,12 +634,8 @@ namespace Sparrow.LowMemory
 
             if (PlatformDetails.RunningOnWindows)
             {
-                if (Win32MemoryMethods.GetProcessMemoryInfoLegacy(ProcessHandle, out Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX))) == false)
-                {
-                    throw new InvalidOperationException("Failure when trying to read memory using the legacy GetProcessMemoryInfo, error code is: " + Marshal.GetLastWin32Error());
-                }
-
-                return (long)memCounters.WorkingSetSize;
+                (long workingSetInBytes, _, _) = GetProcessMemoryInfoForWindows();
+                return workingSetInBytes;
             }
 
             using (var currentProcess = Process.GetCurrentProcess())

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -29,7 +29,8 @@ namespace Sparrow.LowMemory
         private static readonly byte[] Committed_AS = Encoding.UTF8.GetBytes("Committed_AS:");
 
         private static readonly int ProcessId;
-        private static readonly bool SupportsMemoryCountersEx2;
+        private static readonly bool WindowsSupportsMemoryCountersEx2;
+        private static readonly Size? WindowsInstalledMemory;
         private static readonly IntPtr ProcessHandle = IntPtr.Zero;
         public static readonly Size TotalPhysicalMemory;
 
@@ -49,13 +50,23 @@ namespace Sparrow.LowMemory
 
                     try
                     {
-                        // Windows 10 22H2 with September 2023 cumulative update or Windows 11 22H2 with September 2023 cumulative update
-                        SupportsMemoryCountersEx2 = Win32MemoryMethods.GetProcessMemoryInfo(process.Handle, out memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2)));
+                        // supported only on Windows 10 22H2 with September 2023 cumulative update or Windows 11 22H2 with September 2023 cumulative update
+                        WindowsSupportsMemoryCountersEx2 = Win32MemoryMethods.GetProcessMemoryInfo(process.Handle, out memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2)));
                     }
                     catch
                     {
                         // not supported on this OS
                     }
+
+                    if (Win32MemoryMethods.GetPhysicallyInstalledSystemMemory(out var installedMemoryInKb))
+                    {
+                        // The amount of physical memory retrieved by the GetPhysicallyInstalledSystemMemory function
+                        // must be equal to or greater than the amount reported by the GlobalMemoryStatusEx function
+                        // if it is less, the SMBIOS data is malformed and the function fails with ERROR_INVALID_DATA.
+                        // Malformed SMBIOS data may indicate a problem with the user's computer.
+                        WindowsInstalledMemory = new Size(installedMemoryInKb, SizeUnit.Kilobytes);
+                    }
+
                 }
             }
 
@@ -292,10 +303,6 @@ namespace Sparrow.LowMemory
         [return: MarshalAs(UnmanagedType.Bool)]
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern unsafe bool GlobalMemoryStatusEx(MemoryStatusEx* lpBuffer);
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool GetPhysicallyInstalledSystemMemory(out long totalMemoryInKb);
 
         public static (long Rss, long Swap) GetMemoryUsageFromProcStatus()
         {
@@ -616,12 +623,6 @@ namespace Sparrow.LowMemory
                 return FailedResult;
             }
 
-            // The amount of physical memory retrieved by the GetPhysicallyInstalledSystemMemory function
-            // must be equal to or greater than the amount reported by the GlobalMemoryStatusEx function
-            // if it is less, the SMBIOS data is malformed and the function fails with ERROR_INVALID_DATA.
-            // Malformed SMBIOS data may indicate a problem with the user's computer.
-            var fetchedInstalledMemory = GetPhysicallyInstalledSystemMemory(out var installedMemoryInKb);
-
             var sharedCleanInBytes = GetSharedCleanInBytes(out long workingSet, out long pageFileUsage);
             long memoryStatusUllAvailPhys = (long)memoryStatus.ullAvailPhys;
             long totalPageFile = (long)memoryStatus.ullTotalPageFile;
@@ -683,9 +684,7 @@ namespace Sparrow.LowMemory
                 AvailableMemoryForProcessing = new Size(availableMemoryForProcessingInBytes, SizeUnit.Bytes),
                 SharedCleanMemory = new Size(sharedCleanInBytes, SizeUnit.Bytes),
                 TotalPhysicalMemory = new Size((long)memoryStatus.ullTotalPhys, SizeUnit.Bytes),
-                InstalledMemory = fetchedInstalledMemory ?
-                    new Size(installedMemoryInKb, SizeUnit.Kilobytes) :
-                    new Size((long)memoryStatus.ullTotalPhys, SizeUnit.Bytes),
+                InstalledMemory = WindowsInstalledMemory ?? new Size((long)memoryStatus.ullTotalPhys, SizeUnit.Bytes),
                 WorkingSet = new Size(workingSet, SizeUnit.Bytes),
                 IsExtended = true,
                 TotalSwapUsage = new Size(pageFileUsage, SizeUnit.Bytes)
@@ -694,7 +693,7 @@ namespace Sparrow.LowMemory
 
         public static long GetSharedCleanInBytes(out long workingSet, out long pageFileUsage)
         {
-            if (SupportsMemoryCountersEx2)
+            if (WindowsSupportsMemoryCountersEx2)
             {
                 if (Win32MemoryMethods.GetProcessMemoryInfo(ProcessHandle, out Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2 memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2))) == false)
                 {

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -581,6 +581,12 @@ namespace Sparrow.LowMemory
 
         public static long GetSharedCleanInBytes(out long workingSet, out long pageFileUsage)
         {
+            // The used space in scratch buffers represents dirty memory. While we cannot precisely determine how much
+            // of it resides in physical memory, this approach provides a highly reliable approximation of the shared
+            // dirty memory footprint.
+            var sharedDirty = GetTotalScratchAllocatedMemoryInBytes();
+            long privateUsage;
+
             if (WindowsSupportsMemoryCountersEx2)
             {
                 if (Win32MemoryMethods.GetProcessMemoryInfo(ProcessHandle, out Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2 memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2))) == false)
@@ -590,7 +596,7 @@ namespace Sparrow.LowMemory
 
                 workingSet = (long)memCounters.WorkingSetSize;
                 pageFileUsage = (long)memCounters.PagefileUsage;
-                return workingSet - (long)memCounters.PrivateWorkingSetSize;
+                privateUsage = (long)memCounters.PrivateWorkingSetSize;
             }
             else
             {
@@ -601,54 +607,10 @@ namespace Sparrow.LowMemory
 
                 workingSet = (long)memCounters.WorkingSetSize;
                 pageFileUsage = (long)memCounters.PagefileUsage;
-                return GetLegacySharedClean(workingSet);
-            }
-        }
-
-        private static long GetLegacySharedClean(long workingSet)
-        {
-            var mappedDirty = 0L;
-            foreach (var mapping in NativeMemory.FileMapping)
-            {
-                var fileMappingInfo = mapping.Value.Value;
-                var fileType = fileMappingInfo.FileType;
-                if (fileType == NativeMemory.FileType.Data)
-                    continue;
-
-                var totalMapped = GetTotalMapped(fileMappingInfo);
-                if (fileType == NativeMemory.FileType.ScratchBuffer)
-                {
-                    // for scratch buffers we have the allocated size
-                    var allocated = fileMappingInfo.GetAllocatedSizeFunc?.Invoke() ?? totalMapped;
-                    if (allocated < totalMapped / 2)
-                    {
-                        // using less than half of the size of the scratch buffer
-                        mappedDirty += allocated;
-                        continue;
-                    }
-                }
-
-                // we are counting the total mapped size of all the other buffers
-                mappedDirty += totalMapped;
+                privateUsage = AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes() + AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
             }
 
-            var sharedClean = workingSet - AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes() - AbstractLowMemoryMonitor.GetManagedMemoryInBytes() - mappedDirty;
-
-            // the shared dirty can be larger than the size of the working set
-            // this can happen when some of the buffers were paged out
-            return Math.Max(0, sharedClean);
-        }
-
-        private static long GetTotalMapped(NativeMemory.FileMappingInfo fileMappingInfo)
-        {
-            var totalMapped = 0L;
-
-            foreach (var singleMapping in fileMappingInfo.Info)
-            {
-                totalMapped += singleMapping.Value;
-            }
-
-            return totalMapped;
+            return workingSet - privateUsage - sharedDirty;
         }
 
         public static long GetWorkingSetInBytes()

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -618,6 +618,16 @@ namespace Sparrow.LowMemory
             if (PlatformDetails.RunningOnLinux)
                 return GetMemoryUsageFromProcStatus().Rss;
 
+            if (PlatformDetails.RunningOnWindows)
+            {
+                if (Win32MemoryMethods.GetProcessMemoryInfoLegacy(ProcessHandle, out Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX))) == false)
+                {
+                    throw new InvalidOperationException("Failure when trying to read memory using the legacy GetProcessMemoryInfo, error code is: " + Marshal.GetLastWin32Error());
+                }
+
+                return (long)memCounters.WorkingSetSize;
+            }
+
             using (var currentProcess = Process.GetCurrentProcess())
             {
                 return currentProcess.WorkingSet64;

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -29,18 +29,36 @@ namespace Sparrow.LowMemory
         private static readonly byte[] Committed_AS = Encoding.UTF8.GetBytes("Committed_AS:");
 
         private static readonly int ProcessId;
-
+        private static readonly bool SupportsMemoryCountersEx2;
         private static readonly IntPtr ProcessHandle = IntPtr.Zero;
-
         public static readonly Size TotalPhysicalMemory;
 
         static MemoryInformation()
         {
             using (var process = Process.GetCurrentProcess())
+            {
                 ProcessId = process.Id;
 
-            if (PlatformDetails.RunningOnWindows)
-                ProcessHandle = Win32MemoryQueryMethods.GetCurrentProcess();
+                if (PlatformDetails.RunningOnWindows)
+                {
+                    ProcessHandle = Win32MemoryQueryMethods.GetCurrentProcess();
+
+                    var memCounters = new PROCESS_MEMORY_COUNTERS_EX2
+                    {
+                        cb = (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX2))
+                    };
+
+                    try
+                    {
+                        // Windows 10 22H2 with September 2023 cumulative update or Windows 11 22H2 with September 2023 cumulative update
+                        SupportsMemoryCountersEx2 = GetProcessMemoryInfo(process.Handle, out memCounters, (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX2)));
+                    }
+                    catch
+                    {
+                        // not supported on this OS
+                    }
+                }
+            }
 
             TotalPhysicalMemory = GetMemoryInfo().TotalPhysicalMemory;
         }
@@ -408,12 +426,12 @@ namespace Sparrow.LowMemory
                 extended &= PlatformDetails.RunningOnLinux == false;
 
                 MemoryInfoResult result;
-                using (var process = extended ? Process.GetCurrentProcess() : null)
                 {
                     if (PlatformDetails.RunningOnPosix == false)
-                        result = GetMemoryInfoWindows(process, extended);
+                        result = GetMemoryInfoWindows();
                     else if (PlatformDetails.RunningOnMacOsx)
-                        result = GetMemoryInfoMacOs(process, extended);
+                        using (var process = extended ? Process.GetCurrentProcess() : null)
+                            result = GetMemoryInfoMacOs(process, extended);
                     else
                         result = GetMemoryInfoLinux(smapsReader, extended);
                 }
@@ -423,8 +441,8 @@ namespace Sparrow.LowMemory
             }
             catch (Exception e)
             {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info("Error while trying to get available memory, will stop trying and report that there is 256MB free only from now on", e);
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Error while trying to get available memory, will stop trying and report that there is 256MB free only from now on", e);
                 _failedToGetAvailablePhysicalMemory = true;
                 return FailedResult;
             }
@@ -584,7 +602,7 @@ namespace Sparrow.LowMemory
 
         private static bool _reportedQueryJobObjectFailure = false;
 
-        private static unsafe MemoryInfoResult GetMemoryInfoWindows(Process process, bool extended)
+        private static unsafe MemoryInfoResult GetMemoryInfoWindows()
         {
             // windows
             var memoryStatus = new MemoryStatusEx
@@ -605,7 +623,7 @@ namespace Sparrow.LowMemory
             // Malformed SMBIOS data may indicate a problem with the user's computer.
             var fetchedInstalledMemory = GetPhysicallyInstalledSystemMemory(out var installedMemoryInKb);
 
-            var sharedCleanInBytes = GetSharedCleanInBytes(process);
+            var sharedCleanInBytes = GetSharedCleanInBytes(out long workingSet, out long pageFileUsage);
             long memoryStatusUllAvailPhys = (long)memoryStatus.ullAvailPhys;
             long totalPageFile = (long)memoryStatus.ullTotalPageFile;
             long availPageFile = (long)(memoryStatus.ullTotalPageFile - memoryStatus.ullAvailPageFile);
@@ -648,21 +666,8 @@ namespace Sparrow.LowMemory
 
                     if (maxSize != long.MaxValue)
                     {
-                        long workingSet64;
-                        if (process == null)
-                        {
-                            using (var p = Process.GetCurrentProcess())
-                            {
-                                workingSet64 = p.WorkingSet64;
-                            }
-                        }
-                        else
-                        {
-                            workingSet64 = process.WorkingSet64;
-                        }
-
-                        availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSet64, 0);
-                        availPageFile = Math.Max(maxSize - workingSet64, 0);
+                        availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSet, 0);
+                        availPageFile = Math.Max(maxSize - workingSet, 0);
                         totalPageFile = maxSize;
                         memoryStatusUllAvailPhys = Math.Min(availableMemoryForProcessingInBytes, memoryStatusUllAvailPhys);
                         remarks = "Memory limited by Job Object limits";
@@ -682,17 +687,82 @@ namespace Sparrow.LowMemory
                 InstalledMemory = fetchedInstalledMemory ?
                     new Size(installedMemoryInKb, SizeUnit.Kilobytes) :
                     new Size((long)memoryStatus.ullTotalPhys, SizeUnit.Bytes),
-                WorkingSet = new Size(process?.WorkingSet64 ?? 0, SizeUnit.Bytes),
-                IsExtended = extended,
-                TotalSwapUsage = new Size(process?.PagedMemorySize64 ?? 0, SizeUnit.Bytes)
+                WorkingSet = new Size(workingSet, SizeUnit.Bytes),
+                IsExtended = true,
+                TotalSwapUsage = new Size(pageFileUsage, SizeUnit.Bytes)
             };
         }
 
-        public static long GetSharedCleanInBytes(Process process)
+        //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex2
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROCESS_MEMORY_COUNTERS_EX2
         {
-            if (process == null)
-                return 0;
+            public uint cb;
+            public uint PageFaultCount;
+            public ulong PeakWorkingSetSize;
+            public ulong WorkingSetSize;
+            public ulong QuotaPeakPagedPoolUsage;
+            public ulong QuotaPagedPoolUsage;
+            public ulong QuotaPeakNonPagedPoolUsage;
+            public ulong QuotaNonPagedPoolUsage;
+            public ulong PagefileUsage;
+            public ulong PeakPagefileUsage;
+            public ulong PrivateUsage;
+            public ulong PrivateWorkingSetSize;
+            public ulong SharedCommitUsage;
+        }
 
+        //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROCESS_MEMORY_COUNTERS_EX
+        {
+            public uint cb;
+            public uint PageFaultCount;
+            public ulong PeakWorkingSetSize;
+            public ulong WorkingSetSize;
+            public ulong QuotaPeakPagedPoolUsage;
+            public ulong QuotaPagedPoolUsage;
+            public ulong QuotaPeakNonPagedPoolUsage;
+            public ulong QuotaNonPagedPoolUsage;
+            public ulong PagefileUsage;
+            public ulong PeakPagefileUsage;
+            public ulong PrivateUsage;
+        }
+
+        [DllImport("psapi.dll", SetLastError = true)]
+        private static extern bool GetProcessMemoryInfo(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX2 counters, uint size);
+
+        [DllImport("psapi.dll", SetLastError = true, EntryPoint = "GetProcessMemoryInfo")]
+        private static extern bool GetProcessMemoryInfoLegacy(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX counters, uint size);
+
+        public static long GetSharedCleanInBytes(out long workingSet, out long pageFileUsage)
+        {
+            if (SupportsMemoryCountersEx2)
+            {
+                if (GetProcessMemoryInfo(ProcessHandle, out PROCESS_MEMORY_COUNTERS_EX2 memCounters, (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX2))) == false)
+                {
+                    throw new InvalidOperationException("Failure when trying to read memory using GetProcessMemoryInfo, error code is: " + Marshal.GetLastWin32Error());
+                }
+
+                workingSet = (long)memCounters.WorkingSetSize;
+                pageFileUsage = (long)memCounters.PagefileUsage;
+                return workingSet - (long)memCounters.PrivateWorkingSetSize;
+            }
+            else
+            {
+                if (GetProcessMemoryInfoLegacy(ProcessHandle, out PROCESS_MEMORY_COUNTERS_EX memCounters, (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX))) == false)
+                {
+                    throw new InvalidOperationException("Failure when trying to read memory using the legacy GetProcessMemoryInfo, error code is: " + Marshal.GetLastWin32Error());
+                }
+
+                workingSet = (long)memCounters.WorkingSetSize;
+                pageFileUsage = (long)memCounters.PagefileUsage;
+                return GetLegacySharedClean(workingSet);
+            }
+        }
+
+        private static long GetLegacySharedClean(long workingSet)
+        {
             var mappedDirty = 0L;
             foreach (var mapping in NativeMemory.FileMapping)
             {
@@ -718,7 +788,7 @@ namespace Sparrow.LowMemory
                 mappedDirty += totalMapped;
             }
 
-            var sharedClean = process.WorkingSet64 - AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes() - AbstractLowMemoryMonitor.GetManagedMemoryInBytes() - mappedDirty;
+            var sharedClean = workingSet - AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes() - AbstractLowMemoryMonitor.GetManagedMemoryInBytes() - mappedDirty;
 
             // the shared dirty can be larger than the size of the working set
             // this can happen when some of the buffers were paged out

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -41,17 +41,16 @@ namespace Sparrow.LowMemory
 
                 if (PlatformDetails.RunningOnWindows)
                 {
-                    ProcessHandle = Win32MemoryQueryMethods.GetCurrentProcess();
-
-                    var memCounters = new PROCESS_MEMORY_COUNTERS_EX2
+                    ProcessHandle = Win32MemoryMethods.GetCurrentProcess();
+                    var memCounters = new Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2
                     {
-                        cb = (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX2))
+                        cb = (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2))
                     };
 
                     try
                     {
                         // Windows 10 22H2 with September 2023 cumulative update or Windows 11 22H2 with September 2023 cumulative update
-                        SupportsMemoryCountersEx2 = GetProcessMemoryInfo(process.Handle, out memCounters, (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX2)));
+                        SupportsMemoryCountersEx2 = Win32MemoryMethods.GetProcessMemoryInfo(process.Handle, out memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2)));
                     }
                     catch
                     {
@@ -693,53 +692,11 @@ namespace Sparrow.LowMemory
             };
         }
 
-        //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex2
-        [StructLayout(LayoutKind.Sequential)]
-        public struct PROCESS_MEMORY_COUNTERS_EX2
-        {
-            public uint cb;
-            public uint PageFaultCount;
-            public ulong PeakWorkingSetSize;
-            public ulong WorkingSetSize;
-            public ulong QuotaPeakPagedPoolUsage;
-            public ulong QuotaPagedPoolUsage;
-            public ulong QuotaPeakNonPagedPoolUsage;
-            public ulong QuotaNonPagedPoolUsage;
-            public ulong PagefileUsage;
-            public ulong PeakPagefileUsage;
-            public ulong PrivateUsage;
-            public ulong PrivateWorkingSetSize;
-            public ulong SharedCommitUsage;
-        }
-
-        //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex
-        [StructLayout(LayoutKind.Sequential)]
-        public struct PROCESS_MEMORY_COUNTERS_EX
-        {
-            public uint cb;
-            public uint PageFaultCount;
-            public ulong PeakWorkingSetSize;
-            public ulong WorkingSetSize;
-            public ulong QuotaPeakPagedPoolUsage;
-            public ulong QuotaPagedPoolUsage;
-            public ulong QuotaPeakNonPagedPoolUsage;
-            public ulong QuotaNonPagedPoolUsage;
-            public ulong PagefileUsage;
-            public ulong PeakPagefileUsage;
-            public ulong PrivateUsage;
-        }
-
-        [DllImport("psapi.dll", SetLastError = true)]
-        private static extern bool GetProcessMemoryInfo(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX2 counters, uint size);
-
-        [DllImport("psapi.dll", SetLastError = true, EntryPoint = "GetProcessMemoryInfo")]
-        private static extern bool GetProcessMemoryInfoLegacy(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX counters, uint size);
-
         public static long GetSharedCleanInBytes(out long workingSet, out long pageFileUsage)
         {
             if (SupportsMemoryCountersEx2)
             {
-                if (GetProcessMemoryInfo(ProcessHandle, out PROCESS_MEMORY_COUNTERS_EX2 memCounters, (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX2))) == false)
+                if (Win32MemoryMethods.GetProcessMemoryInfo(ProcessHandle, out Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2 memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2))) == false)
                 {
                     throw new InvalidOperationException("Failure when trying to read memory using GetProcessMemoryInfo, error code is: " + Marshal.GetLastWin32Error());
                 }
@@ -750,7 +707,7 @@ namespace Sparrow.LowMemory
             }
             else
             {
-                if (GetProcessMemoryInfoLegacy(ProcessHandle, out PROCESS_MEMORY_COUNTERS_EX memCounters, (uint)Marshal.SizeOf(typeof(PROCESS_MEMORY_COUNTERS_EX))) == false)
+                if (Win32MemoryMethods.GetProcessMemoryInfoLegacy(ProcessHandle, out Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX))) == false)
                 {
                     throw new InvalidOperationException("Failure when trying to read memory using the legacy GetProcessMemoryInfo, error code is: " + Marshal.GetLastWin32Error());
                 }

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -43,20 +43,11 @@ namespace Sparrow.LowMemory
                 if (PlatformDetails.RunningOnWindows)
                 {
                     ProcessHandle = Win32MemoryMethods.GetCurrentProcess();
-                    var memCounters = new Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2
-                    {
-                        cb = (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2))
-                    };
 
-                    try
-                    {
-                        // supported only on Windows 10 22H2 with September 2023 cumulative update or Windows 11 22H2 with September 2023 cumulative update
-                        WindowsSupportsMemoryCountersEx2 = Win32MemoryMethods.GetProcessMemoryInfo(process.Handle, out memCounters, (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2)));
-                    }
-                    catch
-                    {
-                        // not supported on this OS
-                    }
+                    // supported only on Windows 10 22H2 with September 2023 cumulative update or Windows 11 22H2 with September 2023 cumulative update and above
+                    var expectedSize = (uint)Marshal.SizeOf(typeof(Win32MemoryMethods.PROCESS_MEMORY_COUNTERS_EX2));
+                    Win32MemoryMethods.GetProcessMemoryInfo(process.Handle, out var memCounters, expectedSize);
+                    WindowsSupportsMemoryCountersEx2 = expectedSize == memCounters.cb;
 
                     if (Win32MemoryMethods.GetPhysicallyInstalledSystemMemory(out var installedMemoryInKb))
                     {

--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -22,7 +22,7 @@ namespace Sparrow.Server.Platform
                 return CheckPageFileOnHdd.WindowsIsSwappingOnHddInsteadOfSsd();
             }
 
-            public static bool WillCauseHardPageFault(byte* address, long length) => PlatformDetails.RunningOnPosix ? PosixMemoryQueryMethods.WillCauseHardPageFault(address, length) : Win32MemoryQueryMethods.WillCauseHardPageFault(address, length);
+            public static bool WillCauseHardPageFault(byte* address, long length) => PlatformDetails.RunningOnPosix ? PosixMemoryQueryMethods.WillCauseHardPageFault(address, length) : Win32MemoryMethods.WillCauseHardPageFault(address, length);
         }
 
         public static class NativeMemory

--- a/src/Sparrow.Server/Platform/Win32/Win32MemoryMethods.cs
+++ b/src/Sparrow.Server/Platform/Win32/Win32MemoryMethods.cs
@@ -7,8 +7,6 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Utils;
 
-// ReSharper disable InconsistentNaming
-
 namespace Sparrow.Server.Platform.Win32
 {
     public static unsafe class Win32MemoryMethods
@@ -17,11 +15,24 @@ namespace Sparrow.Server.Platform.Win32
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool GetPhysicallyInstalledSystemMemory(out long totalMemoryInKb);
 
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GlobalMemoryStatusEx(MemoryStatusEx* lpBuffer);
+
         [DllImport("psapi.dll", SetLastError = true)]
         public static extern bool GetProcessMemoryInfo(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX2 counters, uint size);
 
         [DllImport("psapi.dll", SetLastError = true, EntryPoint = "GetProcessMemoryInfo")]
         public static extern bool GetProcessMemoryInfoLegacy(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX counters, uint size);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool IsProcessInJob(IntPtr hProcess, IntPtr hJob, out bool isInJob);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll")]
+        public static extern bool QueryInformationJobObject(IntPtr hJob, JOBOBJECTINFOCLASS JobObjectInformationClass, void* lpJobObjectInformation,
+            int cbJobObjectInformationLength, out int lpReturnLength);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern IntPtr GetCurrentProcess();
@@ -29,6 +40,20 @@ namespace Sparrow.Server.Platform.Win32
         [DllImport("psapi.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool QueryWorkingSetEx(IntPtr hProcess, byte* pv, uint cb);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MemoryStatusEx
+        {
+            public uint dwLength;
+            public uint dwMemoryLoad;
+            public ulong ullTotalPhys;
+            public ulong ullAvailPhys;
+            public ulong ullTotalPageFile;
+            public ulong ullAvailPageFile;
+            public ulong ullTotalVirtual;
+            public ulong ullAvailVirtual;
+            public ulong ullAvailExtendedVirtual;
+        }
 
         //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex2
         [StructLayout(LayoutKind.Sequential)]
@@ -64,6 +89,81 @@ namespace Sparrow.Server.Platform.Win32
             public ulong PagefileUsage;
             public ulong PeakPagefileUsage;
             public ulong PrivateUsage;
+        }
+
+        public enum JOBOBJECTINFOCLASS
+        {
+            AssociateCompletionPortInformation = 7,
+            BasicLimitInformation = 2,
+            BasicUIRestrictions = 4,
+            EndOfJobTimeInformation = 6,
+            ExtendedLimitInformation = 9,
+            SecurityLimitInformation = 5,
+            GroupInformation = 11
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public Int64 PerProcessUserTimeLimit;
+            public Int64 PerJobUserTimeLimit;
+            public JOBOBJECTLIMIT LimitFlags;
+            public UIntPtr MinimumWorkingSetSize;
+            public UIntPtr MaximumWorkingSetSize;
+            public UInt32 ActiveProcessLimit;
+            public Int64 Affinity;
+            public UInt32 PriorityClass;
+            public UInt32 SchedulingClass;
+        }
+
+        [Flags]
+        public enum JOBOBJECTLIMIT : uint
+        {
+            // Basic Limits
+            Workingset = 0x00000001,
+            ProcessTime = 0x00000002,
+            JobTime = 0x00000004,
+            ActiveProcess = 0x00000008,
+            Affinity = 0x00000010,
+            PriorityClass = 0x00000020,
+            PreserveJobTime = 0x00000040,
+            SchedulingClass = 0x00000080,
+
+            // Extended Limits
+            ProcessMemory = 0x00000100,
+            JobMemory = 0x00000200,
+            DieOnUnhandledException = 0x00000400,
+            BreakawayOk = 0x00000800,
+            SilentBreakawayOk = 0x00001000,
+            KillOnJobClose = 0x00002000,
+            SubsetAffinity = 0x00004000,
+
+            // Notification Limits
+            JobReadBytes = 0x00010000,
+            JobWriteBytes = 0x00020000,
+            RateControl = 0x00040000,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public UIntPtr ProcessMemoryLimit;
+            public UIntPtr JobMemoryLimit;
+            public UIntPtr PeakProcessMemoryUsed;
+            public UIntPtr PeakJobMemoryUsed;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct IO_COUNTERS
+        {
+            public UInt64 ReadOperationCount;
+            public UInt64 WriteOperationCount;
+            public UInt64 OtherOperationCount;
+            public UInt64 ReadTransferCount;
+            public UInt64 WriteTransferCount;
+            public UInt64 OtherTransferCount;
         }
 
         // ReSharper disable once InconsistentNaming

--- a/src/Sparrow.Server/Platform/Win32/Win32MemoryMethods.cs
+++ b/src/Sparrow.Server/Platform/Win32/Win32MemoryMethods.cs
@@ -11,14 +11,56 @@ using Sparrow.Utils;
 
 namespace Sparrow.Server.Platform.Win32
 {
-    public static unsafe class Win32MemoryQueryMethods
+    public static unsafe class Win32MemoryMethods
     {
+        [DllImport("psapi.dll", SetLastError = true)]
+        public static extern bool GetProcessMemoryInfo(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX2 counters, uint size);
+
+        [DllImport("psapi.dll", SetLastError = true, EntryPoint = "GetProcessMemoryInfo")]
+        public static extern bool GetProcessMemoryInfoLegacy(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX counters, uint size);
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern IntPtr GetCurrentProcess();
 
         [DllImport("psapi.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool QueryWorkingSetEx(IntPtr hProcess, byte* pv, uint cb);
+
+        //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex2
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROCESS_MEMORY_COUNTERS_EX2
+        {
+            public uint cb;
+            public uint PageFaultCount;
+            public ulong PeakWorkingSetSize;
+            public ulong WorkingSetSize;
+            public ulong QuotaPeakPagedPoolUsage;
+            public ulong QuotaPagedPoolUsage;
+            public ulong QuotaPeakNonPagedPoolUsage;
+            public ulong QuotaNonPagedPoolUsage;
+            public ulong PagefileUsage;
+            public ulong PeakPagefileUsage;
+            public ulong PrivateUsage;
+            public ulong PrivateWorkingSetSize;
+            public ulong SharedCommitUsage;
+        }
+
+        //https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROCESS_MEMORY_COUNTERS_EX
+        {
+            public uint cb;
+            public uint PageFaultCount;
+            public ulong PeakWorkingSetSize;
+            public ulong WorkingSetSize;
+            public ulong QuotaPeakPagedPoolUsage;
+            public ulong QuotaPagedPoolUsage;
+            public ulong QuotaPeakNonPagedPoolUsage;
+            public ulong QuotaNonPagedPoolUsage;
+            public ulong PagefileUsage;
+            public ulong PeakPagefileUsage;
+            public ulong PrivateUsage;
+        }
 
         // ReSharper disable once InconsistentNaming
         struct PPSAPI_WORKING_SET_EX_INFORMATION

--- a/src/Sparrow.Server/Platform/Win32/Win32MemoryMethods.cs
+++ b/src/Sparrow.Server/Platform/Win32/Win32MemoryMethods.cs
@@ -13,6 +13,10 @@ namespace Sparrow.Server.Platform.Win32
 {
     public static unsafe class Win32MemoryMethods
     {
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetPhysicallyInstalledSystemMemory(out long totalMemoryInKb);
+
         [DllImport("psapi.dll", SetLastError = true)]
         public static extern bool GetProcessMemoryInfo(IntPtr hProcess, out PROCESS_MEMORY_COUNTERS_EX2 counters, uint size);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23957/Low-memory-detection-on-Windows

### Additional description

- Improve the low memory detection on Windows by using the Windows API and not the expensive call to `Process.GetCurrentProcess()`.
- Accurate calculation of shared clean memory by using the extended API.
- Call `GetPhysicallyInstalledSystemMemory` only once.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
