### PR TITLE
[7.1] RavenDB-22986 - Free space searching improvements

### DIFF
--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -20,6 +20,18 @@ namespace Voron.Impl.FreeSpace
         private readonly FreeSpaceRecursiveCallGuard _guard;
         private const int NumberOfFreePagesForSparseConsideration = NumberOfPagesInSection/4;
 
+        private readonly Dictionary<long, SectionMetadata> _maxConsecutiveRangePerSection = new();
+
+        [StructLayout(LayoutKind.Sequential, Size = 8)]
+        public struct SectionMetadata()
+        {
+            public ushort Max = NumberOfPagesInSection;
+            public ushort StartBits = NumberOfPagesInSection;
+            public ushort EndBits = NumberOfPagesInSection;
+
+            private ushort Reserved = 0;
+        }
+
         static FreeSpaceHandling()
         {
             using (StorageEnvironment.GetStaticContext(out var ctx))
@@ -195,14 +207,44 @@ namespace Voron.Impl.FreeSpace
         {
             do
             {
-                var current = new StreamBitArray(it.CreateReaderForCurrent().Base);
+                long currentSectionId = it.CurrentKey;
+                long? page;
 
-                if (current.SetCount >= num &&
-                    TryFindContinuousRange(freeSpaceTree, it, num, current, it.CurrentKey, out long? page))
+                if (_maxConsecutiveRangePerSection.TryGetValue(currentSectionId, out var known) && known.Max <= num)
+                {
+                    if (_maxConsecutiveRangePerSection.TryGetValue(currentSectionId + 1, out var knownNext))
+                    {
+                        if (known.EndBits + knownNext.StartBits < num)
+                            continue;
+                    }
+
+                    // current section's maximum continuous range is insufficient for the requested size.
+                    // while we can skip searching within this section alone, we still need to check
+                    // if merging with the following section could provide enough space
+                    var currentBitArray = new StreamBitArray(it.CreateReaderForCurrent().Base);
+                    if (TryFindSmallValueMergingTwoSections(freeSpaceTree, currentSectionId, num, currentBitArray, out page))
+                        return page;
+
+                    continue;
+                }
+
+                var current = new StreamBitArray(it.CreateReaderForCurrent().Base);
+                if (current.SetCount >= num
+                    && TryFindContinuousRange(freeSpaceTree, num, current, currentSectionId, out page))
                     return page;
 
-                //could not find a continuous so trying to merge
-                if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, it.CurrentKey, num, current, out page))
+                ref var metadata = ref CollectionsMarshal.GetValueRefOrAddDefault(_maxConsecutiveRangePerSection, currentSectionId, out var exists);
+                if (exists == false)
+                    metadata = new SectionMetadata();
+
+                if (num < metadata.Max)
+                {
+                    // here we _know_ it can't fit anything larger, so we mark it for the next time
+                    metadata.Max = (ushort)Math.Min(num, current.SetCount);
+                }
+
+                // could not find a continuous so trying to merge two consecutive sections
+                if (TryFindSmallValueMergingTwoSections(freeSpaceTree, currentSectionId, num, current, out page))
                     return page;
             }
             while (it.MoveNext());
@@ -210,8 +252,7 @@ namespace Voron.Impl.FreeSpace
             return null;
         }
 
-        private bool TryFindContinuousRange(FixedSizeTree freeSpaceTree, FixedSizeTree.IFixedSizeIterator it, int num,
-            StreamBitArray current, long currentSectionId, out long? page)
+        private bool TryFindContinuousRange(FixedSizeTree freeSpaceTree, int num, StreamBitArray current, long currentSectionId, out long? page)
         {
             page = -1;
             var start = current.GetContinuousRangeStart(num);
@@ -222,7 +263,7 @@ namespace Voron.Impl.FreeSpace
 
             if (current.SetCount == num)
             {
-                freeSpaceTree.Delete(it.CurrentKey);
+                freeSpaceTree.Delete(currentSectionId);
             }
             else
             {
@@ -231,52 +272,73 @@ namespace Voron.Impl.FreeSpace
                     current.Set(i + start.Value, false);
                 }
 
-                current.Write(freeSpaceTree, it.CurrentKey);
+                current.Write(freeSpaceTree, currentSectionId);
             }
 
             return true;
         }
 
-        private static bool TryFindSmallValueMergingTwoSections(LowLevelTransaction tx, FixedSizeTree freeSpacetree, long currentSectionId, int num,
-            StreamBitArray current, out long? result)
+        private bool TryFindSmallValueMergingTwoSections(FixedSizeTree freeSpaceTree, long currentSectionId, int num, StreamBitArray current, out long? result)
         {
             result = -1;
             var currentEndRange = current.GetEndRangeCount();
-            if (currentEndRange == 0)
-                return false;
 
             var nextSectionId = currentSectionId + 1;
-
-            StreamBitArray next;
-            using (freeSpacetree.Read(nextSectionId, out Slice read))
+            StreamBitArray? next = null;
+            int nextRangeStart = 0;
+            using (freeSpaceTree.Read(nextSectionId, out Slice read))
             {
-                if (!read.HasValue)
-                    return false;
+                if (read.HasValue)
+                {
+                    next = new StreamBitArray(read.CreateReader().Base);
+                    nextRangeStart = next.Value.GetStartRangeCount();
+                }
+            }
 
-                next = new StreamBitArray(read.CreateReader().Base);
+            if (currentEndRange == 0 || next == null || currentEndRange + nextRangeStart < num)
+            {
+                // we update the cache in any of the following cases:
+                // - the current section has no more available space at its end
+                // - the next section does not exist
+                // - even when combining the current and next sections, the total space is insufficient
+
+                ref var metadata = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                    _maxConsecutiveRangePerSection, currentSectionId, out var exists);
+
+                if (exists == false)
+                    metadata = new SectionMetadata();
+
+                metadata.EndBits = (ushort)currentEndRange;
+
+                ref var nextMetadata = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                    _maxConsecutiveRangePerSection, nextSectionId, out exists);
+
+                if (exists == false)
+                    nextMetadata = new SectionMetadata();
+
+                nextMetadata.StartBits = (ushort)nextRangeStart;
+
+                return false;
             }
 
             var nextRange = num - currentEndRange;
-            if (next.HasStartRangeCount(nextRange) == false)
-                return false;
-
-            if (next.SetCount == nextRange)
+            if (next.Value.SetCount == nextRange)
             {
-                freeSpacetree.Delete(nextSectionId);
+                freeSpaceTree.Delete(nextSectionId);
             }
             else
             {
                 for (int i = 0; i < nextRange; i++)
                 {
-                    next.Set(i, false);
+                    next.Value.Set(i, false);
                 }
 
-                next.Write(freeSpacetree, nextSectionId);
+                next.Value.Write(freeSpaceTree, nextSectionId);
             }
 
             if (current.SetCount == currentEndRange)
             {
-                freeSpacetree.Delete(currentSectionId);
+                freeSpaceTree.Delete(currentSectionId);
             }
             else
             {
@@ -285,7 +347,7 @@ namespace Voron.Impl.FreeSpace
                     current.Set(NumberOfPagesInSection - 1 - i, false);
                 }
 
-                current.Write(freeSpacetree, currentSectionId);
+                current.Write(freeSpaceTree, currentSectionId);
             }
 
 
@@ -420,6 +482,9 @@ namespace Voron.Impl.FreeSpace
                 var freeSpaceTree = GetFreeSpaceTree(tx);
                 StreamBitArray sba;
                 var section = pageNumber / NumberOfPagesInSection;
+
+                _maxConsecutiveRangePerSection.Remove(section);
+
                 using (freeSpaceTree.Read(section, out Slice result))
                 {
                     sba = !result.HasValue ? new StreamBitArray() : new StreamBitArray(result.CreateReader().Base);
@@ -451,6 +516,16 @@ namespace Voron.Impl.FreeSpace
                 yield return page;
             }
         }
+
+        public Dictionary<long, SectionMetadata> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx)
+        {
+            if (tx.Transaction.IsWriteTransaction == false)
+                throw new InvalidOperationException($"{nameof(GetMaxConsecutiveRangePerSection)} must be called with an open write transaction");
+
+            return new Dictionary<long, SectionMetadata>(_maxConsecutiveRangePerSection);
+        }
+
+        public void OnRollback() => _maxConsecutiveRangePerSection.Clear();
 
         public FreeSpaceHandlingDisabler Disable()
         {

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -214,27 +214,11 @@ namespace Voron.Impl.FreeSpace
             StreamBitArray current, long currentSectionId, out long? page)
         {
             page = -1;
-            var start = -1;
-            while (true)
-            {
-                start = current.FirstSetBit(start + 1);
-                if (start == -1 ||
-                    start + num > NumberOfPagesInSection)
-                    return false;
+            var start = current.GetContinuousRangeStart(num);
+            if (start == null)
+                return false;
 
-                if (num > 1)
-                {
-                    var nextUnsetBit = current.NextUnsetBits(start + 1);
-                    if (nextUnsetBit != -1 && (nextUnsetBit - start) < num)
-                    {
-                        start = nextUnsetBit;
-                        continue;
-                    }
-                }
-
-                page = currentSectionId * NumberOfPagesInSection + start;
-                break;
-            }
+            page = currentSectionId * NumberOfPagesInSection + start;
 
             if (current.SetCount == num)
             {
@@ -244,7 +228,7 @@ namespace Voron.Impl.FreeSpace
             {
                 for (int i = 0; i < num; i++)
                 {
-                    current.Set(i + start, false);
+                    current.Set(i + start.Value, false);
                 }
 
                 current.Write(freeSpaceTree, it.CurrentKey);

--- a/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -13,6 +13,8 @@ namespace Voron.Impl.FreeSpace
         void FreePage(LowLevelTransaction tx, long pageNumber);
         long GetFreePagesOverhead(LowLevelTransaction tx);
         IEnumerable<long> GetFreePagesOverheadPages(LowLevelTransaction tx);
+        Dictionary<long, FreeSpaceHandling.SectionMetadata> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx);
+        void OnRollback();
         FreeSpaceHandlingDisabler Disable();
         List<(long Start, long Count)> GetSparseRegions(LowLevelTransaction tx, HashSet<long> sparseRangeCandidate);
     }

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using Sparrow.Json.Parsing;
 using Voron.Data.Fixed;
@@ -358,29 +359,61 @@ public unsafe struct StreamBitArray
 
     public int GetEndRangeCount()
     {
-        int count = 0;
-        for (int i = CountOfWords - Vector256<uint>.Count; i >= 0; i -= Vector256<uint>.Count)
+        var count = 0;
+        fixed (uint* ptr = _inner)
         {
-            var a = Vector256.LoadUnsafe(ref _inner[i]);
-            if (a == Vector256<uint>.AllBitsSet)
-            {
-                count += 256;
-                continue;
-            }
+            long* span = (long*)ptr;
+            const int length = CountOfWords / 2;
 
-            for (int j = i + Vector256<uint>.Count - 1; j >= 0; j--)
+            for (var i = length - 1; i >= 0; i--)
             {
-                if (_inner[j] == uint.MaxValue)
+                long current = span[i];
+                if (current == 0)
+                    break;
+
+                if (current == -1)
                 {
-                    count += 32;
+                    count += BitsInWord * 2;
                     continue;
                 }
 
-                count += BitOperations.LeadingZeroCount(~_inner[j]);
+                int numberOfSetBits = BitOperations.LeadingZeroCount(~(ulong)current);
+                count += numberOfSetBits;
+
+                // we won't find any more continuous bits after this.
                 break;
             }
+        }
+        return count;
+    }
 
-            break;
+    public int GetStartRangeCount()
+    {
+        var count = 0;
+
+        fixed (uint* ptr = _inner)
+        {
+            long* span = (long*)ptr;
+
+            for (var i = 0; i < CountOfWords / 2; i++)
+            {
+                long current = span[i];
+
+                if (current == 0)
+                    break;
+
+                if (current == -1)
+                {
+                    count += BitsInWord * 2;
+                    continue;
+                }
+
+                int numberOfSetBits = BitOperations.TrailingZeroCount(~current);
+                count += numberOfSetBits;
+
+                // we won't find any more continuous bits after this.
+                return count;
+            }
         }
 
         return count;
@@ -388,38 +421,36 @@ public unsafe struct StreamBitArray
 
     public bool HasStartRangeCount(int max)
     {
-        Debug.Assert(max <= 2048, "max <= 2048 - maximum range inside the bit array");
+        var count = 0;
 
-        int count = 0;
-        for (int i = 0; i < CountOfWords; i += Vector256<uint>.Count)
+        fixed (uint* ptr = _inner)
         {
-            var a = Vector256.LoadUnsafe(ref _inner[i]);
-            if (a == Vector256<uint>.AllBitsSet)
-            {
-                count += 256;
-                if (count >= max)
-                    return true;
-                continue;
-            }
+            long* span = (long*)ptr;
 
-            for (int j = i; j < i + Vector256<uint>.Count; j++)
+            for (var i = 0; i < CountOfWords / 2; i++)
             {
-                if (_inner[j] == uint.MaxValue)
+                long current = span[i];
+
+                if (current == 0)
+                    break;
+
+                if (current == -1)
                 {
-                    count += 32;
+                    count += BitsInWord * 2;
                     if (count >= max)
                         return true;
                     continue;
                 }
 
-                count += BitOperations.TrailingZeroCount(~_inner[j]);
+                int numberOfSetBits = BitOperations.TrailingZeroCount(~current);
+                count += numberOfSetBits;
+
+                // we won't find any more continuous bits after this.
                 return count >= max;
             }
-
-            break;
         }
 
-        return count >= max;
+        return false;
     }
 
     public DynamicJsonValue ToJson(long key, bool hex)

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.Intrinsics;
@@ -8,9 +9,11 @@ namespace Voron.Impl.FreeSpace;
 
 public unsafe struct StreamBitArray
 {
-    private const int CountOfItems = 64;
+    private const int CountOfWords = 64;
+    private const int BitsInWord = 32;
+    private const int TotalBits = CountOfWords * BitsInWord;
 
-    private fixed uint _inner[CountOfItems];
+    private fixed uint _inner[CountOfWords];
     public int SetCount;
 
     public StreamBitArray()
@@ -49,7 +52,7 @@ public unsafe struct StreamBitArray
         h.StoreUnsafe(ref _inner[56]);
     }
 
-    public unsafe void Write(FixedSizeTree freeSpaceTree, long sectionId)
+    public void Write(FixedSizeTree freeSpaceTree, long sectionId)
     {
         using (freeSpaceTree.DirectAdd(sectionId, out _, out var ptr))
         {
@@ -80,6 +83,183 @@ public unsafe struct StreamBitArray
         h.StoreUnsafe(ref ints[57]);
     }
 
+    public int? GetContinuousRangeStart(int num)
+    {
+        return num switch
+        {
+            1 => FirstSetBit(),
+            < BitsInWord => FindSmallRange(num),
+            < 64 => FindLargeRange<int>(num),
+            _ => FindLargeRange<long>(num)
+        };
+    }
+
+    private int? FirstSetBit()
+    {
+        for (int i = 0; i < CountOfWords; i += Vector256<uint>.Count)
+        {
+            var a = Vector256.LoadUnsafe(ref _inner[i]);
+            var gt = Vector256.GreaterThan(a, Vector256<uint>.Zero);
+            if (gt == Vector256<uint>.Zero)
+                continue;
+
+            var mask = gt.ExtractMostSignificantBits();
+            var idx = BitOperations.TrailingZeroCount(mask) + i;
+            var item = _inner[idx];
+            return idx * 32 + BitOperations.TrailingZeroCount(item);
+        }
+
+        return null;
+    }
+
+    private int? FindSmallRange(int num)
+    {
+        // finding sequences up to 32 bits
+        for (var i = 0; i < CountOfWords; i++)
+        {
+            uint current = _inner[i];
+            if (current == 0)
+                continue;
+
+            if (current == uint.MaxValue)
+                return i * BitsInWord;
+
+            var currentCopy = current;
+            int numCopy = num - 1;
+
+            // find consecutive range: https://stackoverflow.com/a/37903049/6366
+            // perform AND operations with shifted versions of the number
+            // this will leave 1s only where there were n consecutive 1s
+            while (currentCopy != 0 && numCopy-- > 0)
+            {
+                currentCopy &= (currentCopy << 1);
+            }
+
+            if (currentCopy != 0)
+            {
+                int position = BitOperations.TrailingZeroCount(currentCopy);
+                return i * BitsInWord + position - (num - 1);
+            }
+
+            if (i == CountOfWords - 1)
+            {
+                // this is the last word, no next word to check with
+                break;
+            }
+
+            // we didn't find the sequence in the word, let's check it between words
+            int numberOfSetBitsCurrent = BitOperations.LeadingZeroCount((uint)~current);
+            var nextWord = _inner[i + 1];
+            var numberOfSetBitsNext = BitOperations.TrailingZeroCount(~nextWord);
+
+            if (numberOfSetBitsCurrent + numberOfSetBitsNext >= num)
+                return (i * BitsInWord) + (BitsInWord - numberOfSetBitsCurrent);
+        }
+
+        return null;
+    }
+
+    private int? FindLargeRange<T>(int num)
+        where T : unmanaged, INumber<T>
+    {
+        // finding sequences larger than 32 bits
+        // the idea is that we look for sequences that bridge across words using leading/trailing zero counts
+        var start = -1;
+        var count = 0;
+
+        int currentBitsInWord = sizeof(T) * 8;
+        int spanLength = CountOfWords * sizeof(uint) / sizeof(T);
+
+        fixed (void* p = &_inner[0])
+        {
+            var span = new Span<T>(p, spanLength);
+
+            for (var i = 0; i < span.Length; i++)
+            {
+                T current = span[i];
+                if (current == T.Zero)
+                {
+                    start = -1;
+                    count = 0;
+                    continue;
+                }
+
+                if (current == -T.One)
+                {
+                    if (start == -1)
+                    {
+                        start = i * currentBitsInWord;
+                    }
+
+                    count += currentBitsInWord;
+                    if (count >= num)
+                        return start;
+
+                    continue;
+                }
+
+                if (start == -1)
+                {
+                    // find trailing ones at the end of the word if no sequence has started
+                    CheckTrailingSequence();
+                }
+                else
+                {
+                    if (count + (TotalBits - i * currentBitsInWord) < num)
+                    {
+                        // impossible to satisfy the continuous bit requirement
+                        return null;
+                    }
+
+                    if (count + (currentBitsInWord - 1) < num)
+                    {
+                        // impossible to satisfy the continuous bit requirement in this word
+                        CheckTrailingSequence();
+                        continue;
+                    }
+
+                    // we look at the beginning of the word
+                    int numberOfSetBits = current switch
+                    {
+                        int integer => BitOperations.TrailingZeroCount(~integer),
+                        long l => BitOperations.TrailingZeroCount(~l),
+                        _ => throw new NotSupportedException()
+                    };
+                    count += numberOfSetBits;
+                    if (count >= num)
+                        return start;
+
+                    // reset for the next sequence
+                    CheckTrailingSequence();
+                }
+
+                void CheckTrailingSequence()
+                {
+                    int numberOfSetBits = current switch
+                    {
+                        int integer => BitOperations.LeadingZeroCount(~(uint)integer),
+                        long l => BitOperations.LeadingZeroCount(~(ulong)l),
+                        _ => throw new NotSupportedException()
+                    };
+                    if (numberOfSetBits == 0)
+                    {
+                        start = -1;
+                        count = 0;
+                    }
+                    else
+                    {
+                        // Calculate the starting bit position in the array
+                        start = (i * currentBitsInWord) + (currentBitsInWord - numberOfSetBits);
+                        count = numberOfSetBits;
+                    }
+                }
+            }
+
+        }
+
+        return null;
+    }
+
     public int NextUnsetBits(int start)
     {
         return FirstSetBit<Inverse>(start);
@@ -102,7 +282,7 @@ public unsafe struct StreamBitArray
 
             vectorStart += Vector256<int>.Count;
         }
-        for (int i = vectorStart; i < CountOfItems; i += Vector256<int>.Count)
+        for (int i = vectorStart; i < CountOfWords; i += Vector256<int>.Count)
         {
             var a = default(TModify).Modify(Vector256.LoadUnsafe(ref _inner[i]));
             var gt = Vector256.GreaterThan(a, Vector256<uint>.Zero);
@@ -179,7 +359,7 @@ public unsafe struct StreamBitArray
     public int GetEndRangeCount()
     {
         int count = 0;
-        for (int i = CountOfItems - Vector256<uint>.Count; i >= 0; i -= Vector256<uint>.Count)
+        for (int i = CountOfWords - Vector256<uint>.Count; i >= 0; i -= Vector256<uint>.Count)
         {
             var a = Vector256.LoadUnsafe(ref _inner[i]);
             if (a == Vector256<uint>.AllBitsSet)
@@ -210,14 +390,42 @@ public unsafe struct StreamBitArray
     {
         Debug.Assert(max <= 2048, "max <= 2048 - maximum range inside the bit array");
 
-        var next = NextUnsetBits(0);
-        return next == -1 || next >= max;
+        int count = 0;
+        for (int i = 0; i < CountOfWords; i += Vector256<uint>.Count)
+        {
+            var a = Vector256.LoadUnsafe(ref _inner[i]);
+            if (a == Vector256<uint>.AllBitsSet)
+            {
+                count += 256;
+                if (count >= max)
+                    return true;
+                continue;
+            }
+
+            for (int j = i; j < i + Vector256<uint>.Count; j++)
+            {
+                if (_inner[j] == uint.MaxValue)
+                {
+                    count += 32;
+                    if (count >= max)
+                        return true;
+                    continue;
+                }
+
+                count += BitOperations.TrailingZeroCount(~_inner[j]);
+                return count >= max;
+            }
+
+            break;
+        }
+
+        return count >= max;
     }
 
     public DynamicJsonValue ToJson(long key, bool hex)
     {
-        object[] collection = new object[CountOfItems];
-        for (var i = 0; i < CountOfItems; i++)
+        object[] collection = new object[CountOfWords];
+        for (var i = 0; i < CountOfWords; i++)
             collection[i] = hex ? _inner[i].ToString("X") : _inner[i];
 
         return new DynamicJsonValue
@@ -226,5 +434,16 @@ public unsafe struct StreamBitArray
             [nameof(SetCount)] = SetCount,
             ["Data"] = new DynamicJsonArray(collection)
         };
+    }
+
+
+    public override string ToString()
+    {
+        uint[] array = new uint[CountOfWords];
+        for (int i = 0; i < CountOfWords; i++)
+        {
+            array[i] = _inner[i];
+        }
+        return string.Join(", ", array);
     }
 }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1213,6 +1213,8 @@ namespace Voron.Impl
 
             OnRollBack?.Invoke(this);
 
+            _freeSpaceHandling.OnRollback();
+
             ValidateReadOnlyPages();
 
             var rollbackPages = _env.WriteTransactionPool.ScratchPagesInUse;

--- a/test/FastTests/Voron/StreamBitArrayTests.cs
+++ b/test/FastTests/Voron/StreamBitArrayTests.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using FastTests.Voron.FixedSize;
+using Tests.Infrastructure;
+using Voron.Impl.FreeSpace;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class StreamBitArrayTests : NoDisposalNeeded
+    {
+        public StreamBitArrayTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void VerifySingleSmallResult()
+        {
+            int[] arr =
+            [
+                962919237, 1548146341, 887074999, -1149229772, 1614889381, 1195459377, 241536840, 1976691873, 974616527, -1975930694, -842246417, 1992663471, -441749934,
+                1493649717, -1200378937, 316033463, 1754441570, -1514685861, 2086876795, -2023483551, -850791867, 2122928129, -2028633376, -1888571066, -1887046545,
+                -674291990, 937660561, 1660582309, -1011073175, -460586860, 145201398, 545934217, -1348896473, 529588057, -2125877939, 748147114, 304154730, -553437939,
+                -1685030522, 65856665, -2095037481, 1700335264, 1057375282, 488608589, -968824882, -942978190, -14718, 1690458861, -1432094240, -68039965, -392179582,
+                -1532304670, 695723974, -1515228467, -63736809, -271307999, 311526503, -1606718741, 2089777125, -633659368, -1900351717, 1564141405, 1909671261, 5492821
+            ];
+
+            var sba = new StreamBitArray();
+
+            for (var wordIndex = 0; wordIndex < arr.Length; wordIndex++)
+            {
+                var word = arr[wordIndex];
+                for (int i = 0; i < 32; i++)
+                {
+                    if ((word & (1 << i)) == 0)
+                        continue;
+
+                    int globalIndex = wordIndex * 32 + i;
+                    sba.Set(globalIndex, true);
+                }
+            }
+
+            const int num = 19;
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void VerifySingleLargeResultSearching100()
+        {
+            int[] arr =
+            [
+                0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0, 0, 0, 0, 0, -16777216, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0,
+                0, 0, 0, 0, -16777216, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0
+            ];
+
+            var sba = new StreamBitArray();
+
+            for (var wordIndex = 0; wordIndex < arr.Length; wordIndex++)
+            {
+                var word = arr[wordIndex];
+                for (int i = 0; i < 32; i++)
+                {
+                    if ((word & (1 << i)) == 0)
+                        continue;
+
+                    int globalIndex = wordIndex * 32 + i;
+                    sba.Set(globalIndex, true);
+                }
+            }
+
+            const int num = 100;
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void VerifySingleLargeResultSearching451()
+        {
+            int[] arr =
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -8, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 8388607, 0, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+            ];
+
+            var sba = new StreamBitArray();
+
+            for (var wordIndex = 0; wordIndex < arr.Length; wordIndex++)
+            {
+                var word = arr[wordIndex];
+                for (int i = 0; i < 32; i++)
+                {
+                    if ((word & (1 << i)) == 0)
+                        continue;
+
+                    int globalIndex = wordIndex * 32 + i;
+                    sba.Set(globalIndex, true);
+                }
+            }
+
+            const int num = 451;
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed]
+        public void VerifyResultWithRandomInput(int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            for (int j = 0; j < 2048; j += 1)
+            {
+                sba.Set(j, random.Next(2) == 1);
+            }
+
+            for (int j = 1; j <= 2048; j += 1)
+            {
+                var result1 = GetContinuousRangeSlow(sba, j);
+                var result2 = sba.GetContinuousRangeStart(j);
+                Assert.Equal(result1, result2);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(1, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 300)]
+        [InlineDataWithRandomSeed(32, 2048)]
+        [InlineDataWithRandomSeed(1, 2048)]
+        public void VerifyResultWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 0;
+            while (i < 2048)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i < 2048; k++, i++)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            for (int j = 1; j <= 2048; j += 1)
+            {
+                var result1 = GetContinuousRangeSlow(sba, j);
+                var result2 = sba.GetContinuousRangeStart(j);
+                Assert.Equal(result1, result2);
+            }
+        }
+
+        private static int? GetContinuousRangeSlow(StreamBitArray current, int num)
+        {
+            var start = -1;
+            var count = 0;
+
+            for (int i = 0; i < 2048; i++)
+            {
+                if (current.Get(i))
+                {
+                    if (start == -1)
+                        start = i;
+                    count++;
+
+                    if (count == num)
+                        return start;
+                }
+                else
+                {
+                    start = -1;
+                    count = 0;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/FastTests/Voron/StreamBitArrayTests.cs
+++ b/test/FastTests/Voron/StreamBitArrayTests.cs
@@ -158,6 +158,94 @@ namespace FastTests.Voron
             }
         }
 
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(0, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 64)]
+        [InlineDataWithRandomSeed(64, 2048)]
+        [InlineDataWithRandomSeed(0, 2048)]
+        public void VerifyEndRangeCountWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 2047;
+
+            while (i >= 0)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i >= 0; k++, i--)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            var result1 = GetEndRangeCountSlow(sba);
+            var result2 = sba.GetEndRangeCount();
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(0, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 64)]
+        [InlineDataWithRandomSeed(64, 2048)]
+        [InlineDataWithRandomSeed(0, 2048)]
+        public void VerifyStartRangeCountWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 0;
+            while (i < 2048)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i < 2048; k++, i++)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            var result1 = GetStartRangeCount(sba);
+            var result2 = sba.GetStartRangeCount();
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(0, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 64)]
+        [InlineDataWithRandomSeed(64, 2048)]
+        [InlineDataWithRandomSeed(0, 2048)]
+        public void VerifyHasStartRangeCountWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 0;
+            while (i < 2048)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i < 2048; k++, i++)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            for (int j = 1; j <= 2048; j += 1)
+            {
+                var result1 = HasStartRangeCount(sba, j);
+                var result2 = sba.HasStartRangeCount(j);
+                Assert.Equal(result1, result2);
+            }
+        }
+
         private static int? GetContinuousRangeSlow(StreamBitArray current, int num)
         {
             var start = -1;
@@ -182,6 +270,48 @@ namespace FastTests.Voron
             }
 
             return null;
+        }
+
+        public int GetEndRangeCountSlow(StreamBitArray current)
+        {
+            int c = 0;
+
+            for (int i = 2048 - 1; i >= 0; i--)
+            {
+                if (current.Get(i) == false)
+                    break;
+                c++;
+            }
+
+            return c;
+        }
+
+        public int GetStartRangeCount(StreamBitArray current)
+        {
+            int c = 0;
+
+            for (int i = 0; i < 2048; i++)
+            {
+                if (current.Get(i) == false)
+                    break;
+                c++;
+            }
+
+            return c;
+        }
+
+        public bool HasStartRangeCount(StreamBitArray current, int max)
+        {
+            int c = 0;
+
+            for (int i = 0; i < 2048 && c < max; i++)
+            {
+                if (current.Get(i) == false)
+                    break;
+                c++;
+            }
+
+            return c == max;
         }
     }
 }

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -322,6 +322,162 @@ namespace FastTests.Voron.Trees
             }
         }
 
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanUpdateMaxConsecutiveRanges()
+        {
+            const int totalSections = 4;
+            const int totalPages = FreeSpaceHandling.NumberOfPagesInSection * totalSections;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Empty(max);
+
+                for (int i = 0; i < totalPages; i++)
+                {
+                    tx.LowLevelTransaction.AllocatePage(1);
+                }
+
+                tx.Commit();
+
+                max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Empty(max);
+            }
+
+            const int lastPageInAllSections = totalPages - 1;
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int i = 0; i < totalPages; i += FreeSpaceHandling.NumberOfPagesInSection)
+                {
+                    Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i);
+                }
+
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, lastPageInAllSections);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AllocatePage(3);
+
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Equal(5, max.Count);
+
+                Assert.Equal(1, max[0].Max);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[0].StartBits);
+                Assert.Equal(0, max[0].EndBits);
+
+                for (var i = 1; i < totalSections - 1; i++)
+                {
+                    Assert.Equal(1, max[i].Max);
+                    Assert.Equal(1, max[i].StartBits);
+                    Assert.Equal(0, max[i].EndBits);
+                }
+
+                Assert.Equal(2, max[3].Max);
+                Assert.Equal(1, max[3].StartBits);
+                Assert.Equal(1, max[3].EndBits);
+
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[4].Max);
+                Assert.Equal(0, max[4].StartBits);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[4].EndBits);
+
+                // releasing 2 pages in section 4 to make 3 consecutive pages between two sections
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages);
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages + 1);
+                tx.Commit();
+
+                max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Equal(4, max.Count);
+
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[0].StartBits);
+
+                for (var i = 0; i < totalSections - 1; i++)
+                {
+                    Assert.Equal(1, max[i].Max);
+                }
+
+                Assert.Equal(2, max[3].Max);
+                Assert.Equal(1, max[3].StartBits);
+                Assert.Equal(1, max[3].EndBits);
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int i = 0; i < totalPages; i += FreeSpaceHandling.NumberOfPagesInSection)
+                {
+                    Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i + 2);
+                    Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i + 4);
+                }
+
+                tx.LowLevelTransaction.AllocatePage(4);
+
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[0].StartBits);
+
+                for (var i = 0; i < totalSections - 1; i++)
+                {
+                    Assert.Equal(3, max[i].Max);
+                    Assert.Equal(0, max[i].EndBits);
+                }
+
+                Assert.Equal(4, max[3].Max);
+                Assert.Equal(1, max[3].StartBits);
+                Assert.Equal(1, max[3].EndBits);
+
+                Assert.Equal(2, max[4].Max);
+                Assert.Equal(2, max[4].StartBits);
+
+                Assert.Equal(0, max[5].StartBits);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[5].EndBits);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[5].Max);
+
+                var page = tx.LowLevelTransaction.AllocatePage(3);
+                Assert.Equal(lastPageInAllSections, page.PageNumber);
+                tx.Commit();
+
+                // shouldn't find anything and update the max consecutive
+                tx.LowLevelTransaction.AllocatePage(2);
+
+                max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                for (var i = 0; i < totalSections + 1; i++)
+                {
+                    Assert.Equal(2, max[i].Max);
+                }
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // releasing from sections 0 and 2 - this should clear the in memory state for those sections
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 3);
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, FreeSpaceHandling.NumberOfPagesInSection * 2 + 15);
+
+                tx.Commit();
+
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                Assert.Equal(2, max[1].Max);
+                Assert.Equal(2, max[3].Max);
+                Assert.Equal(2, max[4].Max);
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 4);
+
+                // not commiting on purpose, this should simulate a rollback and clear the in memory state
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Empty(max);
+            }
+        }
+
 
         [RavenFact(RavenTestCategory.Voron)]
         public void ReproduceError()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22986/Free-space-fragmentation

### Additional description

This is port from 6.0 of the following changes:
https://github.com/ravendb/ravendb/pull/19386 and https://github.com/ravendb/ravendb/pull/19429.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
