### PR TITLE
RavenDB-23980 & RavenDB-23981 - Fixing memory corruption & optimizing vector writes

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1534,7 +1534,7 @@ namespace Corax.Indexing
 
                 void UnlikelyGrowBuffer(ByteStringContext allocator, int count, ref Span<long> termsBuffer, ref Span<int> indexesBuffer, ref Span<byte> processingBuffer)
                 {
-                    var length = Bits.PowerOf2(count + 1);
+                    var length = Bits.NextAllocationSize(count + 1);
                     memoryHandler?.Dispose();
                     memoryHandler = allocator.Allocate(length * (sizeof(int) + sizeof(long) + ZigZagEncoding.MaxEncodedSize), out var memory);
                     termsBuffer = MemoryMarshal.Cast<byte, long>(memory.ToSpan().Slice(0, length * sizeof(long)));

--- a/src/Corax/Querying/Matches/PharseMatch.cs
+++ b/src/Corax/Querying/Matches/PharseMatch.cs
@@ -132,7 +132,7 @@ public struct PhraseMatch<TInner> : IQueryMatch
     
     private void UnlikelyGrowBuffer(ref Span<long> buffer, ref Span<int> indexes)
     {
-        var length = Bits.PowerOf2(buffer.Length + 1);
+        var length = Bits.NextAllocationSize(buffer.Length + 1);
         var newDisposable = _indexSearcher.Allocator.Allocate(length * (sizeof(long) + sizeof(int)), out ByteString memory);
         Span<long> newBuffer = MemoryMarshal.Cast<byte, long>(memory.ToSpan().Slice(0, sizeof(long) * length));
         Span<int> newIndexes = MemoryMarshal.Cast<byte, int>(memory.ToSpan().Slice(length * sizeof(long)));

--- a/src/Raven.Server/Documents/DocumentIdWorker.cs
+++ b/src/Raven.Server/Documents/DocumentIdWorker.cs
@@ -62,9 +62,7 @@ namespace Raven.Server.Documents
             where TTransaction : RavenTransaction
         {
             var charCount = Encodings.Utf8.GetCharCount(id.Buffer, id.Size);
-            var tempBuffer = ByteStringContext.ToLowerTempBuffer;
-            if (tempBuffer == null || tempBuffer.Length < charCount)
-                ByteStringContext.ToLowerTempBuffer = tempBuffer = new char[Bits.PowerOf2(charCount)];
+            var tempBuffer = ByteStringContext.GetThreadStaticBufferOf(charCount);
 
             fixed (char* pChars = tempBuffer)
             {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/ReduceKeyProcessor.cs
@@ -333,7 +333,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             if (_buffer == null || 
                 _bufferPos + size > _buffer.SizeInBytes)
             {
-                var newBuffer = _buffersPool.Allocate(Bits.PowerOf2(_bufferPos + size));
+                var newBuffer = _buffersPool.Allocate(Bits.NextAllocationSize(_bufferPos + size));
                 if (_buffer != null)
                 {
                     Memory.Copy(newBuffer.Address, _buffer.Address, _buffer.SizeInBytes);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -708,7 +708,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
         {
             if (additionalSize + index >= _compoundFieldsBuffer.Length)
             {
-                var newSize = Bits.PowerOf2(additionalSize + index + 1);
+                var newSize = Bits.NextAllocationSize(additionalSize + index + 1);
                 Array.Resize(ref _compoundFieldsBuffer, newSize);
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -749,7 +749,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
 
         private byte[] GetStoredValue(BlittableJsonReaderObject value, IWriteOperationBuffer writeBuffer)
         {
-            var necessarySize = Bits.PowerOf2(value.Size);
+            var necessarySize = Bits.NextAllocationSize(value.Size);
 
             var storeValueBuffer = writeBuffer.GetBuffer(necessarySize);
 

--- a/src/Raven.Server/Rachis/Remote/SnapshotReader.cs
+++ b/src/Raven.Server/Rachis/Remote/SnapshotReader.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Rachis.Remote
             if (Buffer.Length < size)
             {
                 ArrayPool<byte>.Shared.Return(Buffer);
-                Buffer = ArrayPool<byte>.Shared.Rent(Bits.PowerOf2(size));
+                Buffer = ArrayPool<byte>.Shared.Rent(Bits.NextAllocationSize(size));
             }
             var totalRead = 0;
             while (totalRead < size)

--- a/src/Raven.Server/Routing/Trie.cs
+++ b/src/Raven.Server/Routing/Trie.cs
@@ -189,7 +189,7 @@ namespace Raven.Server.Routing
                 return;// already run
 
             var children = FilteredChildren;
-            var size = Bits.PowerOf2(children.Length);
+            var size = Bits.NextAllocationSize(children.Length);
             OptimizeInternal(size, children);
         }
 

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -1002,7 +1002,7 @@ namespace Sparrow.Server
             // that even looking for memory to reuse can dominate the actual operation cost.
             // We will allocate from the current segment.
             int allocationSize = length + sizeof(ByteStringStorage);
-            int allocationUnit = Bits.PowerOf2(allocationSize);
+            int allocationUnit = Bits.NextAllocationSize(allocationSize);
             _currentlyAllocated += allocationUnit;
             
             if (allocationUnit <= _internalCurrent.SizeLeft)
@@ -1028,7 +1028,7 @@ namespace Sparrow.Server
             // that even looking for memory to reuse can dominate the actual operation cost.
             // We will allocate from the current segment.
             int allocationSize = length + sizeof(ByteStringStorage);
-            int allocationUnit = Bits.PowerOf2(allocationSize);
+            int allocationUnit = Bits.NextAllocationSize(allocationSize);
             _currentlyAllocated += allocationUnit;
             
             if (allocationUnit <= _internalCurrent.SizeLeft)
@@ -1111,7 +1111,7 @@ namespace Sparrow.Server
             type &= ~ByteStringType.External; // We are allocating internal, so we will force it (even if we are checking for it in debug).
 
             int allocationSize = length + sizeof(ByteStringStorage);
-            int allocationUnit = Bits.PowerOf2(allocationSize);
+            int allocationUnit = Bits.NextAllocationSize(allocationSize);
             if (allocationUnit < 0)
             {
                 if (((long)length + sizeof(ByteStringStorage)) < int.MaxValue)
@@ -1251,7 +1251,15 @@ namespace Sparrow.Server
         }
 
         [ThreadStatic]
-        public static char[] ToLowerTempBuffer;
+        private static char[] _toLowerTempBuffer;
+
+        public static char[] GetThreadStaticBufferOf(int charCount)
+        {
+            var tempBuffer = _toLowerTempBuffer;
+            if (tempBuffer == null || tempBuffer.Length < charCount)
+                _toLowerTempBuffer = tempBuffer = new char[Bits.NextAllocationSize(charCount)];
+            return tempBuffer;
+        }
 
         /// <summary>
         /// Mutate the string to lower case
@@ -1265,23 +1273,18 @@ namespace Sparrow.Server
                 throw new InvalidOperationException("Cannot mutate an immutable ByteString");
 
             var charCount = Encodings.Utf8.GetCharCount(str._pointer->Ptr, str.Length);
-            if (ToLowerTempBuffer == null || ToLowerTempBuffer.Length < charCount)
-            {
-                ToLowerTempBuffer = new char[Bits.PowerOf2(charCount)];
-            }
 
             // PERF: We are not removing the fixed here because GetChars will use fixed internally.
             // When the framework removes the fixed from GetChars, we can remove the fixed here and
             // use the span version instead.
             // https://issues.hibernatingrhinos.com/issue/RavenDB-20321
-            fixed (char* pChars = ToLowerTempBuffer)
+            char[] tempBuffer = GetThreadStaticBufferOf(charCount * 2);
+            fixed (char* pChars = tempBuffer)
             {
-                charCount = Encodings.Utf8.GetChars(str._pointer->Ptr, str.Length, pChars, ToLowerTempBuffer.Length);
-                for (int i = 0; i < charCount; i++)
-                {
-                    ToLowerTempBuffer[i] = char.ToLowerInvariant(ToLowerTempBuffer[i]);
-                }
-                var byteCount = Encodings.Utf8.GetByteCount(pChars, charCount);
+                charCount = Encodings.Utf8.GetChars(str._pointer->Ptr, str.Length, pChars, tempBuffer.Length);
+                Span<char> span = tempBuffer.AsSpan();
+                MemoryExtensions.ToLowerInvariant(span[..charCount], span[charCount..]);
+                var byteCount = Encodings.Utf8.GetByteCount(pChars + charCount, charCount);
                 if (// we can't mutate external memory!
                     str.IsExternal ||
                     // calling to lower has increased the size, and we can't fit in the space
@@ -1290,7 +1293,8 @@ namespace Sparrow.Server
                 {
                     Allocate(byteCount, out str);
                 }
-                str._pointer->Length = Encodings.Utf8.GetBytes(pChars, charCount, str._pointer->Ptr, str._pointer->Size);
+
+                str._pointer->Length = Encodings.Utf8.GetBytes(pChars + charCount, charCount, str._pointer->Ptr, str._pointer->Size);
             }
         }
 
@@ -1318,7 +1322,7 @@ namespace Sparrow.Server
 
         private ByteString AllocateWholeSegment(int length, ByteStringType type)
         {
-            var size = Bits.PowerOf2(length + sizeof(ByteStringStorage));
+            var size = Bits.NextAllocationSize(length + sizeof(ByteStringStorage));
             SegmentInformation segment = AllocateSegment(size);
 
             var byteString = Create(segment.Current, length, segment.Size, type);

--- a/src/Sparrow/Binary/Bits.cs
+++ b/src/Sparrow/Binary/Bits.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using Sparrow.Global;
 
 namespace Sparrow.Binary
 {
@@ -280,6 +281,20 @@ namespace Sparrow.Binary
             256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256
         };
 #endif
+        private const int _64M = 64 * Constants.Size.Megabyte;
+
+        public static int NextAllocationSize(int v)
+        {
+            if (v < 0)
+                throw new ArgumentOutOfRangeException(nameof(v), "Argument cannot be negative, but was: " + v);
+            if (v < _64M)
+                return PowerOf2(v);
+            
+            var plus64MbAlign  = ((v + _64M - 1) / _64M) * _64M;
+            if (plus64MbAlign < 0)
+                return int.MaxValue; //overflow handling
+            return plus64MbAlign;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int PowerOf2(int v)

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -943,6 +944,9 @@ namespace Sparrow.Json
             _pos += buffer.Length;
         }
 
+#if NET6_0_OR_GREATER
+        [SkipLocalsInit]
+#endif
         public void WriteDouble(double val)
         {
             if (double.IsNaN(val))
@@ -963,11 +967,13 @@ namespace Sparrow.Json
                 return;
             }
 
-            using (var lazyStr = _context.GetLazyString(val.ToString(CultureInfo.InvariantCulture)))
+            Span<byte> buffer = stackalloc byte[32];
+            if (Utf8Formatter.TryFormat(val, buffer, out int bytesWritten) is false)
             {
-                EnsureBuffer(lazyStr.Size);
-                WriteRawString(lazyStr.Buffer, lazyStr.Size);
+                throw new InvalidOperationException("Somehow we failed to write double (max 25 chars) to a 32 bytes buffer?! " + val);
             }
+            EnsureBuffer(bytesWritten);
+            WriteRawString(buffer.Slice(0, bytesWritten));
         }
 
         protected void DisposeInternal()

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -295,7 +295,7 @@ namespace Sparrow.Json
             // Write the property names and register their positions
             if (_propertyArrayOffset == null || _propertyArrayOffset.Length < propertiesDiscovered)
             {
-                _propertyArrayOffset = new int[Bits.PowerOf2(propertiesDiscovered)];
+                _propertyArrayOffset = new int[Bits.NextAllocationSize(propertiesDiscovered)];
             }
 
             unsafe

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -175,6 +175,25 @@ namespace Sparrow.Json
         [ThreadStatic]
         private static byte[] _lazyStringTempComparisonBuffer;
 
+        private static char[] GetlazyStringTempBuffer(int charCount)
+        {
+            if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < charCount)
+                _lazyStringTempBuffer = new char[Bits.NextAllocationSize(charCount)];
+            return _lazyStringTempBuffer;
+        }
+        
+        private static byte[] GetLazyStringTempComparisonBuffer(int charCount)
+        {
+            if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < charCount * 5)
+            {
+                var sizeInBytes = Encodings.Utf8.GetMaxByteCount(charCount);
+
+                if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < charCount)
+                    _lazyStringTempComparisonBuffer = new byte[Bits.NextAllocationSize(sizeInBytes)];
+            }
+            return _lazyStringTempComparisonBuffer;
+        }
+
         public int[] EscapePositions;
         public AllocatedMemoryData AllocatedMemoryData;
 
@@ -212,18 +231,11 @@ namespace Sparrow.Json
                 return string.Equals(_string, other, StringComparison.Ordinal);
 
 
-            if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < other.Length * 5)
-            {
-                var sizeInBytes = Encodings.Utf8.GetMaxByteCount(other.Length);
-
-                if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < other.Length)
-                    _lazyStringTempComparisonBuffer = new byte[Bits.PowerOf2(sizeInBytes)];
-            }
-
+            var buffer = GetLazyStringTempComparisonBuffer(other.Length);
             fixed (char* pOther = other)
-            fixed (byte* pBuffer = _lazyStringTempComparisonBuffer)
+            fixed (byte* pBuffer = buffer)
             {
-                var tmpSize = Encodings.Utf8.GetBytes(pOther, other.Length, pBuffer, _lazyStringTempComparisonBuffer.Length);
+                var tmpSize = Encodings.Utf8.GetBytes(pOther, other.Length, pBuffer, buffer.Length);
                 if (Size != tmpSize)
                     return false;
 
@@ -253,11 +265,9 @@ namespace Sparrow.Json
 
             var sizeInBytes = Encodings.Utf8.GetMaxByteCount(other.Length);
 
-            if (_lazyStringTempComparisonBuffer == null || _lazyStringTempComparisonBuffer.Length < other.Length)
-                _lazyStringTempComparisonBuffer = new byte[Bits.PowerOf2(sizeInBytes)];
-
+            var buffer = GetLazyStringTempComparisonBuffer(other.Length);
             fixed (char* pOther = other)
-            fixed (byte* pBuffer = _lazyStringTempComparisonBuffer)
+            fixed (byte* pBuffer = buffer)
             {
                 var tmpSize = Encodings.Utf8.GetBytes(pOther, other.Length, pBuffer, sizeInBytes);
                 return Compare(pBuffer, tmpSize);
@@ -644,15 +654,13 @@ namespace Sparrow.Json
 
             ValidateIndexes(startIndex, count);
 
-            if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < Length)
-                _lazyStringTempBuffer = new char[Bits.PowerOf2(Length)];
-
-            fixed (char* pChars = _lazyStringTempBuffer)
+            var buffer = GetlazyStringTempBuffer(Length);
+            fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
 
             for (int i = startIndex; i < startIndex + count; i++)
             {
-                if (_lazyStringTempBuffer[i] == value)
+                if (buffer[i] == value)
                     return i;
             }
 
@@ -709,15 +717,13 @@ namespace Sparrow.Json
 
             ValidateIndexes(startIndex, count);
 
-            if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < Length)
-                _lazyStringTempBuffer = new char[Bits.PowerOf2(Length)];
-
-            fixed (char* pChars = _lazyStringTempBuffer)
+            var buffer = GetlazyStringTempBuffer(Length);
+            fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
 
             for (int i = startIndex; i < startIndex + count; i++)
             {
-                if (anyOf.Contains(_lazyStringTempBuffer[i]))
+                if (anyOf.Contains(buffer[i]))
                     return i;
             }
 
@@ -749,15 +755,14 @@ namespace Sparrow.Json
 
             ValidateIndexes(Length - startIndex - 1, count);
 
-            if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < Length)
-                _lazyStringTempBuffer = new char[Bits.PowerOf2(Length)];
+            var buffer = GetlazyStringTempBuffer(Length);
 
-            fixed (char* pChars = _lazyStringTempBuffer)
+            fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
 
             for (int i = startIndex; i > startIndex - count; i--)
             {
-                if (_lazyStringTempBuffer[i] == value)
+                if (buffer[i] == value)
                     return i;
             }
 
@@ -817,15 +822,14 @@ namespace Sparrow.Json
 
             ValidateIndexes(Length - startIndex - 1, count);
 
-            if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < Length)
-                _lazyStringTempBuffer = new char[Bits.PowerOf2(Length)];
+            var buffer = GetlazyStringTempBuffer(Length);
 
-            fixed (char* pChars = _lazyStringTempBuffer)
+            fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
 
             for (int i = startIndex; i > startIndex - count; i--)
             {
-                if (anyOf.Contains(_lazyStringTempBuffer[i]))
+                if (anyOf.Contains(buffer[i]))
                     return i;
             }
 
@@ -1142,8 +1146,7 @@ namespace Sparrow.Json
                 ThrowAlreadyDisposed();
 
             var maxCharCount = Encodings.Utf8.GetMaxCharCount(Length);
-            if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < maxCharCount)
-                _lazyStringTempBuffer = new char[Bits.PowerOf2(maxCharCount)];
+            var charBuf = GetlazyStringTempBuffer(maxCharCount);
 
             var buffer = _buffer;
 
@@ -1153,20 +1156,20 @@ namespace Sparrow.Json
                 fixed (char* stringBuffer = _string)
                 {
                     buffer = (byte*)stringBuffer;
-                    return GetReversedStringFromBuffer(buffer);
+                    return GetReversedStringFromBuffer(buffer, charBuf);
                 }
             }
 
-            return GetReversedStringFromBuffer(buffer);
+            return GetReversedStringFromBuffer(buffer, charBuf);
         }
 
-        private string GetReversedStringFromBuffer(byte* buffer)
+        private string GetReversedStringFromBuffer(byte* buffer, char[] charBuf)
         {
-            fixed (char* pChars = _lazyStringTempBuffer)
+            fixed (char* pChars = charBuf)
             {
-                var chars = Encodings.Utf8.GetChars(buffer, Length, pChars, _lazyStringTempBuffer.Length);
-                Array.Reverse(_lazyStringTempBuffer, 0, chars);
-                return new string(_lazyStringTempBuffer, 0, chars);
+                var chars = Encodings.Utf8.GetChars(buffer, Length, pChars, charBuf.Length);
+                Array.Reverse(charBuf, 0, chars);
+                return new string(charBuf, 0, chars);
             }
         }
 

--- a/src/Sparrow/Json/UnmanagedWriteBuffer.cs
+++ b/src/Sparrow/Json/UnmanagedWriteBuffer.cs
@@ -344,7 +344,7 @@ namespace Sparrow.Json
             var head = _head;
 
             // Update Segment invariants
-            *(T*)(head.Address) = value;
+            *(T*)(head.Address + head.Used) = value;
             head.AccumulatedSizeInBytes += count;
             head.Used += count;
         }

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -214,7 +214,7 @@ namespace Voron.Impl.Scratch
         {
             if (tx == null)
                 throw new ArgumentNullException(nameof(tx));
-            var size = Bits.PowerOf2(numberOfPages);
+            var size = Bits.NextAllocationSize(numberOfPages);
 
             var current = _current;
 

--- a/src/Voron/Util/ImmutableAppendOnlyList.cs
+++ b/src/Voron/Util/ImmutableAppendOnlyList.cs
@@ -109,7 +109,7 @@ namespace Voron.Util
             var tail = _head + _count;
             if (tail == _values.Length)
             {
-                var newArray = GrowTo(Math.Max(8, Bits.PowerOf2(newCount)));
+                var newArray = GrowTo(Math.Max(8, Bits.NextAllocationSize(newCount)));
                 newArray[_count] = item;
                 return new ImmutableAppendOnlyList<T>(newArray, 0, newCount);
             }

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -126,14 +126,14 @@ public unsafe struct NativeList<T>
 
     public void Initialize(ByteStringContext ctx, int count = 1)
     {
-        var capacity = count == 1 ? 1 : Math.Max(1, Bits.PowerOf2(count));
+        var capacity = count == 1 ? 1 : Math.Max(1, Bits.NextAllocationSize(count));
         ctx.Allocate(capacity * sizeof(T), out _storage);
         Capacity = _storage.Length / sizeof(T);
     }
     
     public void Grow(ByteStringContext ctx, int addition)
     {
-        var capacity = Math.Max(1, Bits.PowerOf2(Capacity + addition));
+        var capacity = Math.Max(1, Bits.NextAllocationSize(Capacity + addition));
         ctx.Allocate(capacity * sizeof(T), out var mem);
 
         if (_storage.HasValue)

--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -95,7 +95,7 @@ public unsafe struct FastPForDecoder : IDisposable
 
     private void GrowAllocation(int sizeInElements)
     {
-        int sizeInBytes = Bits.PowerOf2(sizeInElements * sizeof(uint));
+        int sizeInBytes = Bits.NextAllocationSize(sizeInElements * sizeof(uint));
         _allocator.GrowAllocation(ref _buffer, ref _exceptionsScope, sizeInBytes);
         _exceptions = (uint*)_buffer.Ptr;
     }

--- a/src/Voron/ValueReader.cs
+++ b/src/Voron/ValueReader.cs
@@ -136,7 +136,7 @@ namespace Voron
             if (_tmpBuf != null && _tmpBuf.Length >= size)
                 return _tmpBuf;
 
-            return _tmpBuf = new byte[Bits.PowerOf2(size)];
+            return _tmpBuf = new byte[Bits.NextAllocationSize(size)];
         }
 
         public string ReadString(int length)

--- a/test/FastTests/Blittable/RavenDB-23980.cs
+++ b/test/FastTests/Blittable/RavenDB-23980.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading.Tasks;
+using NetTopologySuite.Utilities;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Json;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Assert = Xunit.Assert;
+
+namespace FastTests.Blittable;
+
+public class RavenDB_23980(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.Core)]
+    public void CanProperlyHandleCreationOfVectorOnSegmentBoundary()
+    {
+        using var ctx = JsonOperationContext.ShortTermSingleUse();
+        var conventions = new DocumentConventions();
+        var item = new
+        {
+            Name = new string('a', 4095),
+            Vector = new RavenVector<float>([1,2,3])
+        };
+
+        using (var json = conventions.Serialization.DefaultConverter.ToBlittable(item, new MetadataAsDictionary(),
+                   ctx, conventions.Serialization.CreateSerializer()))
+        {
+            Assert.NotNull(json.ToString()); // check it does not throws
+        }
+        using (var json = conventions.Serialization.DefaultConverter.ToBlittable(item, new MetadataAsDictionary(),
+                   ctx, conventions.Serialization.CreateSerializer()))
+        {
+            Assert.NotNull(json.ToString()); // check it does not throws
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23980
https://issues.hibernatingrhinos.com/issue/RavenDB-23981

### Additional description

Found & fixed a corruption issue were writing a vector using `WriteValue` on the end of a segment _and_ the memory was able to be reallocated would cause a corruption of the start of the segment.

In addition, optimized writing of vectors by avoiding string allocations in favor of using `Utf8Formatter`

### Type of change

- [x] Bug fix
- [x] Optimization

### How risky is the change?

- [x] Low 

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
