### PR TITLE
RavenDB-21079: Ports reservation for server

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -96,7 +96,7 @@ public class LetsEncryptSimulationHelper
                     .UseShutdownTimeout(TimeSpan.FromMilliseconds(150));
 
                 webHost = webHostBuilder.Build();
-                serverStore.Server.ForTestingPurposesOnly().UnbindSocketForPort(port);
+                serverStore.Server._forTestingPurposes?.UnbindSocketForPort(port);
                 await webHost.StartAsync(token);
             }
             catch (Exception e)
@@ -174,6 +174,7 @@ public class LetsEncryptSimulationHelper
         {
             if (webHost != null)
                 await webHost.StopAsync(TimeSpan.Zero);
+            serverStore.Server._forTestingPurposes?.OnSimulateRunningServerFinally?.Invoke(port);
         }
     }
 }

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -96,7 +96,7 @@ public class LetsEncryptSimulationHelper
                     .UseShutdownTimeout(TimeSpan.FromMilliseconds(150));
 
                 webHost = webHostBuilder.Build();
-
+                serverStore.Server.ForTestingPurposesOnly().UnbindSocketForPort(port);
                 await webHost.StartAsync(token);
             }
             catch (Exception e)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -247,8 +247,7 @@ namespace Raven.Server
 
                         _refreshClusterCertificate = new Timer(RefreshClusterCertificateTimerCallback);
                     }
-                    if (_forTestingPurposes != null && _forTestingPurposes.SocketsToFree != null)
-                        _forTestingPurposes.UnbindSocketForPort(ListenEndpoints.Port);
+                    _forTestingPurposes?.UnbindSocketForPort(ListenEndpoints.Port);
                 }
 
                 var webHostBuilder = new WebHostBuilder()
@@ -1929,9 +1928,7 @@ namespace Raven.Server
             {
                 foreach (var serverUrl in Configuration.Core.ServerUrls)
                 {
-                    var uri = new Uri(serverUrl);
-                    port = uri.Port;
-                    var host = uri.DnsSafeHost;
+                    var host = new Uri(serverUrl).DnsSafeHost;
                     StartListeners(host, customPort ?? port, status, listenToNewTcpConnection);
                 }
             }
@@ -1973,8 +1970,8 @@ namespace Raven.Server
                         Logger.Info($"RavenDB TCP is configured to use {string.Join(", ", Configuration.Core.TcpServerUrls)} and bind to {ipAddress} at {port}");
 
                     var listener = new TcpListener(ipAddress, status.Port != 0 ? status.Port : port);
-                    if (_forTestingPurposes != null && _forTestingPurposes.SocketsToFree != null)
-                        _forTestingPurposes.UnbindSocketForPort(port);
+ 
+                    _forTestingPurposes?.UnbindSocketForPort(port);
                     try
                     {
                         listener.Start();
@@ -2951,26 +2948,27 @@ namespace Raven.Server
             {
                 internal string[] RoutesToSkip = new string[] { };
             }
-            internal List<Socket> SocketsToFree = new List<Socket> { };
-            public void UnbindSocketForPort(int listenEndpointsPort)
+            internal Action<int> OnSimulateRunningServerFinally;
+            internal List<Socket> ReservedSockets;
+            internal void UnbindSocketForPort(int port)
             {
-                var socketList = SocketsToFree
-                    .Where(x =>
+                if (ReservedSockets == null)
+                    return;
+
+                var socket = ReservedSockets.FirstOrDefault(x =>
+                {
+                    try
                     {
-                        try
-                        {
-                            return x.LocalEndPoint is IPEndPoint ep && ep.Port == listenEndpointsPort;
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            return false;
-                        }
-                    })
-                    .ToList();
-                foreach (var socket in socketList)
-               {
+                        return x.LocalEndPoint is IPEndPoint ep && ep.Port == port;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        return false;
+                    }
+                });
+
+                if (socket != null)
                     socket.Close();
-               }
             }
         }
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -247,6 +247,8 @@ namespace Raven.Server
 
                         _refreshClusterCertificate = new Timer(RefreshClusterCertificateTimerCallback);
                     }
+                    if (_forTestingPurposes != null && _forTestingPurposes.SocketsToFree != null)
+                        _forTestingPurposes.UnbindSocketForPort(ListenEndpoints.Port);
                 }
 
                 var webHostBuilder = new WebHostBuilder()
@@ -1927,8 +1929,9 @@ namespace Raven.Server
             {
                 foreach (var serverUrl in Configuration.Core.ServerUrls)
                 {
-                    var host = new Uri(serverUrl).DnsSafeHost;
-
+                    var uri = new Uri(serverUrl);
+                    port = uri.Port;
+                    var host = uri.DnsSafeHost;
                     StartListeners(host, customPort ?? port, status, listenToNewTcpConnection);
                 }
             }
@@ -1970,7 +1973,8 @@ namespace Raven.Server
                         Logger.Info($"RavenDB TCP is configured to use {string.Join(", ", Configuration.Core.TcpServerUrls)} and bind to {ipAddress} at {port}");
 
                     var listener = new TcpListener(ipAddress, status.Port != 0 ? status.Port : port);
-
+                    if (_forTestingPurposes != null && _forTestingPurposes.SocketsToFree != null)
+                        _forTestingPurposes.UnbindSocketForPort(port);
                     try
                     {
                         listener.Start();
@@ -2946,6 +2950,27 @@ namespace Raven.Server
             internal class DebugPackageTestingStuff
             {
                 internal string[] RoutesToSkip = new string[] { };
+            }
+            internal List<Socket> SocketsToFree = new List<Socket> { };
+            public void UnbindSocketForPort(int listenEndpointsPort)
+            {
+                var socketList = SocketsToFree
+                    .Where(x =>
+                    {
+                        try
+                        {
+                            return x.LocalEndPoint is IPEndPoint ep && ep.Port == listenEndpointsPort;
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            return false;
+                        }
+                    })
+                    .ToList();
+                foreach (var socket in socketList)
+               {
+                    socket.Close();
+               }
             }
         }
 

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -51,8 +51,7 @@ namespace SlowTests.Authentication
 
             SetupLocalServer();
             TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
+            Server.ForTestingPurposesOnly().ReservedSockets = new List<Socket> { setupInfo.Sockets[0], setupInfo.Sockets[1] };
             await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
 
             Server.Dispose();
@@ -65,14 +64,17 @@ namespace SlowTests.Authentication
             
             SetupLocalServer();
             TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
-
+            // this is needed because we simulate running server inside GetCertificateFromLetsEncrypt
+            Server.ForTestingPurposesOnly().OnSimulateRunningServerFinally = port =>
+            {
+                setupInfo.Sockets[0] = ReservePort(port).Socket;
+            };
+            Server._forTestingPurposes.ReservedSockets = new List<Socket> { setupInfo.Sockets[0], setupInfo.Sockets[1] };
             var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
             var firstServerCertThumbprint = serverCert.Thumbprint;
             Server.Dispose();
 
-            UseNewLocalServer(null, null, null, null, setupInfo.Sockets);
+            UseNewLocalServer(sockets: setupInfo.Sockets);
             await RenewCertificate(serverCert, firstServerCertThumbprint);
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
@@ -108,11 +110,14 @@ namespace SlowTests.Authentication
             
             SetupLocalServer();
             TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
+            Server.ForTestingPurposesOnly().OnSimulateRunningServerFinally = port =>
+            {
+                setupInfo.Sockets[0] = ReservePort(port).Socket;
+            };
+            Server._forTestingPurposes.ReservedSockets = new List<Socket> { setupInfo.Sockets[0], setupInfo.Sockets[1] };
             var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
             Server.Dispose();
-            UseNewLocalServer(null, null, null, null, setupInfo.Sockets);
+            UseNewLocalServer(sockets: setupInfo.Sockets);
 
             var mre = new AsyncManualResetEvent();
             Server.ServerCertificateChanged += (sender, args) => mre.Set();
@@ -179,13 +184,16 @@ namespace SlowTests.Authentication
 
             SetupLocalServer();
             TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
-            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
+            Server.ForTestingPurposesOnly().OnSimulateRunningServerFinally = port =>
+            {
+                setupInfo.Sockets[0] = ReservePort(port).Socket;
+            };
+            Server._forTestingPurposes.ReservedSockets = new List<Socket> { setupInfo.Sockets[0], setupInfo.Sockets[1] };
             var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
             var firstServerCertThumbprint = serverCert.Thumbprint;
             Server.Dispose();
 
-            UseNewLocalServer(null, null, null, null, setupInfo.Sockets);
+            UseNewLocalServer(sockets: setupInfo.Sockets);
             Server.ForTestingPurposesOnly().ThrowExceptionAfterLetsEncryptRefresh = true;
             await RenewCertificate(serverCert, firstServerCertThumbprint);
 
@@ -215,14 +223,14 @@ namespace SlowTests.Authentication
             UseNewLocalServer(customConfigPath: settingPath);
         }
 
-        private async Task<X509Certificate2> GetCertificateFromLetsEncrypt(TestingSetupInfo setupInfo, string acmeUrl)
+        private async Task<X509Certificate2> GetCertificateFromLetsEncrypt(TestingSetupInfo info, string acmeUrl)
         {
             X509Certificate2 serverCert;
             using (var store = GetDocumentStoreForServerOnly())
             using (var commands = store.Commands())
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                var command = new SetupLetsEncryptCommand(store.Conventions, context, setupInfo.setupInfo)
+                var command = new SetupLetsEncryptCommand(store.Conventions, context, info.SetupInfo)
                 {
                     Timeout = TimeSpan.FromMinutes(10)
                 };
@@ -327,11 +335,12 @@ namespace SlowTests.Authentication
             }
         }
 
-        public class TestingSetupInfo
+        internal class TestingSetupInfo
         {
-            public SetupInfo setupInfo;
+            public SetupInfo SetupInfo;
             public List<Socket> Sockets;
         }
+
         private async Task<TestingSetupInfo> SetupClusterInfo(string acmeUrl)
         {
             Server.Configuration.Core.AcmeUrl = acmeUrl;
@@ -375,7 +384,7 @@ namespace SlowTests.Authentication
                     ["A"] = new NodeInfo { Port = port, TcpPort = tcpPort, Addresses = new List<string> { "127.0.0.1" } }
                 }
             };
-            var testingSetupInfo = new TestingSetupInfo { setupInfo = setupInfo, Sockets = new List<Socket> { socketPort, socketTcpPort } };
+            var testingSetupInfo = new TestingSetupInfo { SetupInfo = setupInfo, Sockets = new List<Socket> { socketPort, socketTcpPort } };
             return testingSetupInfo;
         }
 

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Sparrow.Server;
 using System.Linq;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using Raven.Client;
 using Raven.Client.Documents;
@@ -49,8 +50,9 @@ namespace SlowTests.Authentication
             RemoveAcmeCache(acmeUrl);
 
             SetupLocalServer();
-            SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-
+            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
             await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
 
             Server.Dispose();
@@ -62,13 +64,15 @@ namespace SlowTests.Authentication
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
             
             SetupLocalServer();
-            SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
 
             var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
             var firstServerCertThumbprint = serverCert.Thumbprint;
             Server.Dispose();
 
-            UseNewLocalServer();
+            UseNewLocalServer(null, null, null, null, setupInfo.Sockets);
             await RenewCertificate(serverCert, firstServerCertThumbprint);
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
@@ -103,11 +107,12 @@ namespace SlowTests.Authentication
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
             
             SetupLocalServer();
-            SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-
+            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
             var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
             Server.Dispose();
-            UseNewLocalServer();
+            UseNewLocalServer(null, null, null, null, setupInfo.Sockets);
 
             var mre = new AsyncManualResetEvent();
             Server.ServerCertificateChanged += (sender, args) => mre.Set();
@@ -173,13 +178,14 @@ namespace SlowTests.Authentication
             RemoveAcmeCache(acmeUrl);
 
             SetupLocalServer();
-            SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
-
+            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[0]);
+            Server.ForTestingPurposesOnly().SocketsToFree.Add(setupInfo.Sockets[1]);
             var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
             var firstServerCertThumbprint = serverCert.Thumbprint;
             Server.Dispose();
 
-            UseNewLocalServer();
+            UseNewLocalServer(null, null, null, null, setupInfo.Sockets);
             Server.ForTestingPurposesOnly().ThrowExceptionAfterLetsEncryptRefresh = true;
             await RenewCertificate(serverCert, firstServerCertThumbprint);
 
@@ -209,14 +215,14 @@ namespace SlowTests.Authentication
             UseNewLocalServer(customConfigPath: settingPath);
         }
 
-        private async Task<X509Certificate2> GetCertificateFromLetsEncrypt(SetupInfo setupInfo, string acmeUrl)
+        private async Task<X509Certificate2> GetCertificateFromLetsEncrypt(TestingSetupInfo setupInfo, string acmeUrl)
         {
             X509Certificate2 serverCert;
             using (var store = GetDocumentStoreForServerOnly())
             using (var commands = store.Commands())
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                var command = new SetupLetsEncryptCommand(store.Conventions, context, setupInfo)
+                var command = new SetupLetsEncryptCommand(store.Conventions, context, setupInfo.setupInfo)
                 {
                     Timeout = TimeSpan.FromMinutes(10)
                 };
@@ -245,6 +251,7 @@ namespace SlowTests.Authentication
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Security.CertificatePassword), out string certPassword);
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Security.CertificateLetsEncryptEmail), out string letsEncryptEmail);
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), out string publicServerUrl);
+                settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.TcpServerUrls), out string tcpServerUrl);
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ServerUrls), out string serverUrl);
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.SetupMode), out SetupMode setupMode);
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ExternalIp), out string externalIp);
@@ -258,6 +265,7 @@ namespace SlowTests.Authentication
                     [RavenConfiguration.GetKey(x => x.Security.CertificateLetsEncryptEmail)] = letsEncryptEmail,
                     [RavenConfiguration.GetKey(x => x.Security.CertificatePassword)] = certPassword,
                     [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = publicServerUrl,
+                    [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = tcpServerUrl,
                     [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl,
                     [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
                     [RavenConfiguration.GetKey(x => x.Core.ExternalIp)] = externalIp,
@@ -319,7 +327,12 @@ namespace SlowTests.Authentication
             }
         }
 
-        private async Task<SetupInfo> SetupClusterInfo(string acmeUrl)
+        public class TestingSetupInfo
+        {
+            public SetupInfo setupInfo;
+            public List<Socket> Sockets;
+        }
+        private async Task<TestingSetupInfo> SetupClusterInfo(string acmeUrl)
         {
             Server.Configuration.Core.AcmeUrl = acmeUrl;
             Server.ServerStore.Configuration.Core.SetupMode = SetupMode.Initial;
@@ -343,6 +356,8 @@ namespace SlowTests.Authentication
                 rootDomain = command.Result.RootDomains[0];
                 email = command.Result.Email;
             }
+            var (port, socketPort) = ReservePort();
+            var (tcpPort, socketTcpPort) = ReservePort();
 
             var setupInfo = new SetupInfo
             {
@@ -357,10 +372,11 @@ namespace SlowTests.Authentication
                 Email = email,
                 NodeSetupInfos = new Dictionary<string, NodeInfo>()
                 {
-                    ["A"] = new NodeInfo { Port = GetAvailablePort(), TcpPort = GetAvailablePort(), Addresses = new List<string> { "127.0.0.1" } }
+                    ["A"] = new NodeInfo { Port = port, TcpPort = tcpPort, Addresses = new List<string> { "127.0.0.1" } }
                 }
             };
-            return setupInfo;
+            var testingSetupInfo = new TestingSetupInfo { setupInfo = setupInfo, Sockets = new List<Socket> { socketPort, socketTcpPort } };
+            return testingSetupInfo;
         }
 
         public DocumentStore GetDocumentStoreForServerOnly(X509Certificate2 certificate = null, [CallerMemberName] string caller = null)

--- a/test/SlowTests/Tools/SetupUnsecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupUnsecuredClusterUsingRvn.cs
@@ -29,6 +29,8 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
     public async Task Should_Create_Unsecured_Cluster_And_Setup_Zip_File_From_Rvn_One_Node()
     {
         DoNotReuseServer();
+        var (port, socketPort) = ReservePort();
+        var (tcpPort, socketTcpPort) = ReservePort();
 
         var unsecuredSetupInfo = new UnsecuredSetupInfo
         {
@@ -36,7 +38,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             ZipOnly = false,
             NodeSetupInfos = new Dictionary<string,NodeInfo>()
             {
-                ["A"] = new() { Port = GetAvailablePort(), TcpPort = GetAvailablePort(), Addresses = new List<string> { "127.0.0.1" } },
+                ["A"] = new() { Port = port, TcpPort = tcpPort, Addresses = new List<string> { "127.0.0.1" } },
             }
         };
       
@@ -66,6 +68,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             false);
 
         settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ServerUrls), out string serverUrl);
+        settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.TcpServerUrls), out string tcpServerUrl);
         settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.SetupMode), out SetupMode setupMode);
 
         using var server = GetNewServer(new ServerCreationOptions
@@ -74,8 +77,11 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             {
                 [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = serverUrl,
                 [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl,
+                [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = tcpServerUrl,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
-            }
+            },
+            ReservedSocket = socketPort,
+            ReservedTcpSocket = socketTcpPort
         });
 
 
@@ -103,6 +109,13 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
     public async Task Should_Create_Unsecured_Cluster_And_Setup_Zip_File_From_Rvn_Three_Nodes()
     {
         DoNotReuseServer();
+        var (portA, socketPortA) = ReservePort();
+        var (portB, socketPortB) = ReservePort();
+        var (portC, socketPortC) = ReservePort();
+
+        var (tcpPortA, socketTcpPortA) = ReservePort();
+        var (tcpPortB, socketTcpPortB) = ReservePort();
+        var (tcpPortC, socketTcpPortC) = ReservePort();
 
         var unsecuredSetupInfo = new UnsecuredSetupInfo
         {
@@ -110,9 +123,9 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             ZipOnly = false,
             NodeSetupInfos = new Dictionary<string,NodeInfo>()
             {
-                ["A"] = new() { Port = GetAvailablePort(), TcpPort = GetAvailablePort(), Addresses = new List<string> { "127.0.0.1" } },
-                ["B"] = new() { Port = GetAvailablePort(), TcpPort = GetAvailablePort(), Addresses = new List<string> { "127.0.0.1" } },
-                ["C"] = new() { Port = GetAvailablePort(), TcpPort = GetAvailablePort(), Addresses = new List<string> { "127.0.0.1" } }
+                ["A"] = new() { Port = portA, TcpPort = tcpPortA, Addresses = new List<string> { "127.0.0.1" } },
+                ["B"] = new() { Port = portB, TcpPort = tcpPortB, Addresses = new List<string> { "127.0.0.1" } },
+                ["C"] = new() { Port = portC, TcpPort = tcpPortC, Addresses = new List<string> { "127.0.0.1" } }
             }
         };
         Assert.True(unsecuredSetupInfo.ZipOnly == false, nameof(unsecuredSetupInfo.ZipOnly) + " != false");
@@ -140,6 +153,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             false);
 
         settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ServerUrls), out string serverUrl);
+        settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.TcpServerUrls), out string tcpServerUrl);
         settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.SetupMode), out SetupMode setupMode);
 
 
@@ -153,8 +167,11 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             {
                 [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = serverUrl,
                 [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl,
+                [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = tcpServerUrl,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
-            }
+            },
+            ReservedSocket = socketPortA,
+            ReservedTcpSocket = socketTcpPortA
         });
 
         using var __ = GetNewServer(new ServerCreationOptions
@@ -162,8 +179,11 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             CustomSettings = new ConcurrentDictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = url2,
+                [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = "tcp://" + unsecuredSetupInfo.NodeSetupInfos["B"].Addresses[0] + ":" + unsecuredSetupInfo.NodeSetupInfos["B"].TcpPort,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
-            }
+            },
+            ReservedSocket = socketPortB,
+            ReservedTcpSocket = socketTcpPortB
         });
 
         using var ___ = GetNewServer(new ServerCreationOptions
@@ -171,8 +191,11 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
             CustomSettings = new ConcurrentDictionary<string, string>
             {
                 [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = url3,
+                [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = "tcp://" + unsecuredSetupInfo.NodeSetupInfos["C"].Addresses[0] + ":" + unsecuredSetupInfo.NodeSetupInfos["C"].TcpPort,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
-            }
+            },
+            ReservedSocket = socketPortC,
+            ReservedTcpSocket = socketTcpPortC
         });
 
         var dbName = GetDatabaseName();

--- a/test/SlowTests/Tools/SetupUnsecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupUnsecuredClusterUsingRvn.cs
@@ -80,8 +80,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
                 [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = tcpServerUrl,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
             },
-            ReservedSocket = socketPort,
-            ReservedTcpSocket = socketTcpPort
+            ReservedSockets = new ServerCreationOptions.ReservedSocketsToFree{ ReservedSocket = socketPort, ReservedTcpSocket = socketTcpPort }
         });
 
 
@@ -170,8 +169,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
                 [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = tcpServerUrl,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
             },
-            ReservedSocket = socketPortA,
-            ReservedTcpSocket = socketTcpPortA
+            ReservedSockets = new ServerCreationOptions.ReservedSocketsToFree { ReservedSocket = socketPortA, ReservedTcpSocket = socketTcpPortA }
         });
 
         using var __ = GetNewServer(new ServerCreationOptions
@@ -182,8 +180,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
                 [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = "tcp://" + unsecuredSetupInfo.NodeSetupInfos["B"].Addresses[0] + ":" + unsecuredSetupInfo.NodeSetupInfos["B"].TcpPort,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
             },
-            ReservedSocket = socketPortB,
-            ReservedTcpSocket = socketTcpPortB
+            ReservedSockets = new ServerCreationOptions.ReservedSocketsToFree { ReservedSocket = socketPortB, ReservedTcpSocket = socketTcpPortB }
         });
 
         using var ___ = GetNewServer(new ServerCreationOptions
@@ -194,8 +191,7 @@ public class SetupUnsecuredClusterUsingRvn : ClusterTestBase
                 [RavenConfiguration.GetKey(x => x.Core.TcpServerUrls)] = "tcp://" + unsecuredSetupInfo.NodeSetupInfos["C"].Addresses[0] + ":" + unsecuredSetupInfo.NodeSetupInfos["C"].TcpPort,
                 [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
             },
-            ReservedSocket = socketPortC,
-            ReservedTcpSocket = socketTcpPortC
+            ReservedSockets = new ServerCreationOptions.ReservedSocketsToFree { ReservedSocket = socketPortC, ReservedTcpSocket = socketTcpPortC }
         });
 
         var dbName = GetDatabaseName();

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -924,15 +924,13 @@ namespace FastTests
                 };
             }
         }
-
-        public int GetAvailablePort()
+        public (int port, Socket socket) ReservePort()
         {
-            var tcpListener = new TcpListener(IPAddress.Loopback, 0);
-            tcpListener.Start();
-            var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
-            tcpListener.Stop();
-
-            return port;
+            Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            int port = ((IPEndPoint)socket.LocalEndPoint).Port;
+            return (port, socket);
         }
 
         public static string GenRandomString(int size)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -924,12 +924,12 @@ namespace FastTests
                 };
             }
         }
-        public (int port, Socket socket) ReservePort()
+        public (int Port, Socket Socket) ReservePort(int port = 0)
         {
             Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-            int port = ((IPEndPoint)socket.LocalEndPoint).Port;
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+            port = ((IPEndPoint)socket.LocalEndPoint).Port;
             return (port, socket);
         }
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using System.Text;
@@ -359,7 +360,7 @@ namespace FastTests
             }
         }
 
-        public void UseNewLocalServer(IDictionary<string, string> customSettings = null, bool? runInMemory = null, string customConfigPath = null, [CallerMemberName] string caller = null)
+        public void UseNewLocalServer(IDictionary<string, string> customSettings = null, bool? runInMemory = null, string customConfigPath = null, [CallerMemberName] string caller = null, List<Socket> sockets = null)
         {
             if (_localServer != _globalServer && _globalServer != null)
             {
@@ -374,6 +375,13 @@ namespace FastTests
                 CustomConfigPath = customConfigPath,
                 RegisterForDisposal = false
             };
+
+            if (sockets != null && sockets.Count > 0)
+            {
+                co.ReservedSocket = sockets[0];
+                co.ReservedTcpSocket = sockets[1];
+            }
+
             _localServer = GetNewServer(co, caller);
         }
 
@@ -383,6 +391,28 @@ namespace FastTests
         public class ServerCreationOptions
         {
             private IDictionary<string, string> _customSettings;
+            private Socket _reservedSocket;
+            private Socket _reservedTcpSocket;
+
+            public Socket ReservedSocket
+            {
+                get => _reservedSocket;
+                set
+                {
+                    AssertNotFrozen();
+                    _reservedSocket = value;
+                }
+            }
+
+            public Socket ReservedTcpSocket
+            {
+                get => _reservedTcpSocket;
+                set
+                {
+                    AssertNotFrozen();
+                    _reservedTcpSocket = value;
+                }
+            }
 
             public IDictionary<string, string> CustomSettings
             {
@@ -565,6 +595,11 @@ namespace FastTests
                     if (options.BeforeDatabasesStartup != null)
                         server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().BeforeHandleClusterDatabaseChanged = options.BeforeDatabasesStartup;
 
+                    if (options.ReservedSocket != null && options.ReservedTcpSocket != null)
+                    {
+                        server.ForTestingPurposesOnly().SocketsToFree.Add(options.ReservedSocket);
+                        server.ForTestingPurposesOnly().SocketsToFree.Add(options.ReservedTcpSocket);
+                    }
                     server.Initialize();
                     server.ServerStore.ValidateFixedPort = false;
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -378,8 +378,7 @@ namespace FastTests
 
             if (sockets != null && sockets.Count > 0)
             {
-                co.ReservedSocket = sockets[0];
-                co.ReservedTcpSocket = sockets[1];
+                co.ReservedSockets = new ServerCreationOptions.ReservedSocketsToFree { ReservedSocket = sockets[0], ReservedTcpSocket = sockets[1] };
             }
 
             _localServer = GetNewServer(co, caller);
@@ -390,27 +389,22 @@ namespace FastTests
 
         public class ServerCreationOptions
         {
-            private IDictionary<string, string> _customSettings;
-            private Socket _reservedSocket;
-            private Socket _reservedTcpSocket;
-
-            public Socket ReservedSocket
+            internal class ReservedSocketsToFree
             {
-                get => _reservedSocket;
-                set
-                {
-                    AssertNotFrozen();
-                    _reservedSocket = value;
-                }
+                public Socket ReservedSocket { get; set; }
+                public Socket ReservedTcpSocket { get; set; }
             }
 
-            public Socket ReservedTcpSocket
+            private IDictionary<string, string> _customSettings;
+
+            private ReservedSocketsToFree _reservedSockets;
+
+            internal ReservedSocketsToFree ReservedSockets
             {
-                get => _reservedTcpSocket;
+                get => _reservedSockets;
                 set
                 {
-                    AssertNotFrozen();
-                    _reservedTcpSocket = value;
+                    _reservedSockets = value;
                 }
             }
 
@@ -595,10 +589,10 @@ namespace FastTests
                     if (options.BeforeDatabasesStartup != null)
                         server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().BeforeHandleClusterDatabaseChanged = options.BeforeDatabasesStartup;
 
-                    if (options.ReservedSocket != null && options.ReservedTcpSocket != null)
+                    if (options.ReservedSockets != null)
                     {
-                        server.ForTestingPurposesOnly().SocketsToFree.Add(options.ReservedSocket);
-                        server.ForTestingPurposesOnly().SocketsToFree.Add(options.ReservedTcpSocket);
+                        var forTesting = server.ForTestingPurposesOnly();
+                        forTesting.ReservedSockets = new List<Socket> { options.ReservedSockets.ReservedSocket, options.ReservedSockets.ReservedTcpSocket };
                     }
                     server.Initialize();
                     server.ServerStore.ValidateFixedPort = false;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21079/SlowTests.Tools.SetupUnsecuredClusterUsingRvn.ShouldCreateUnsecuredClusterAndSetupZipFileFromRvnThreeNodes

### Additional description

Reserving ports before server initialization in order to avoid `address already in use` exception 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
