### PR TITLE
RavenDB-22767 Making sure that a transaction is removed from ActiveTransactions if an exception is thrown after already adding it there

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -664,6 +664,8 @@ namespace Voron
 
             bool txLockTaken = false;
             bool flushInProgressReadLockTaken = false;
+            LowLevelTransaction tx = null;
+
             try
             {
                 IncrementUsageOnNewTransaction();
@@ -710,8 +712,6 @@ namespace Voron
                         _idleFlushTimer = Task.Run(() => IdleFlushTimer(SelfReference.WeekReference, Token), Token); 
                     }
                 }
-
-                LowLevelTransaction tx;
 
                 _txCreation.EnterReadLock();
                 try
@@ -766,6 +766,9 @@ namespace Voron
                 finally
                 {
                     DecrementUsageOnTransactionCreationFailure();
+
+                    if (tx != null)
+                        ActiveTransactions.TryRemove(tx);
                 }
                 throw;
             }

--- a/test/SlowTests/Voron/Issues/RavenDB_22767.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22767.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_22767 : StorageTest
+{
+    public RavenDB_22767(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MustRemoveFailedTransactionFromActiveTransactions()
+    {
+        Env.NewTransactionCreated += (tx) =>
+        {
+            throw new InvalidDataException();
+        };
+
+        Assert.Throws<InvalidDataException>(() =>
+        {
+            using (Env.ReadTransaction())
+            {
+
+            }
+        });
+
+        var oldestTxId = Env.ActiveTransactions.OldestTransaction;
+            
+        Assert.Equal(0, oldestTxId);
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767/Scratch-buffers-arent-released

### Additional description


Fixed cleanup of in-memory state of ActiveTransactions after an exception

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
