### PR TITLE
RavenDB-23962 Handle staleness for referenced collections in auto map indexes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     internal sealed class AutoMapIndex : MapIndexBase<AutoMapIndexDefinition, AutoIndexField>
     {
-        private readonly HashSet<string> _referencedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, HashSet<CollectionName>> _referencedCollections = new (StringComparer.OrdinalIgnoreCase);
 
         private AutoMapIndex(AutoMapIndexDefinition definition)
             : base(IndexType.AutoMap, IndexSourceType.Documents, definition, compiled: null)
@@ -48,7 +48,9 @@ namespace Raven.Server.Documents.Indexes.Auto
 
         protected override void HandleDocumentChange(DocumentChange change)
         {
-            if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false && _referencedCollections.Contains(change.CollectionName) == false)
+            var collectionName = new CollectionName(change.CollectionName);
+            
+            if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false && _referencedCollections.First().Value.Contains(collectionName) == false)
                 return;
             
             _mre.Set();
@@ -69,17 +71,30 @@ namespace Raven.Server.Documents.Indexes.Auto
                 // We only have a single collection for auto map index
                 string collection = Collections.First();
                 var referencedEmbeddingsCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collection);
-
-                _referencedCollections.Add(referencedEmbeddingsCollection);
-
-                var referencedCollections = new Dictionary<string, HashSet<CollectionName>>();
                 
-                referencedCollections.Add(collection, new HashSet<CollectionName>() { new CollectionName(referencedEmbeddingsCollection) });
+                _referencedCollections.Add(collection, new HashSet<CollectionName>() { new CollectionName(referencedEmbeddingsCollection) });
                 
-                workers.Add(new HandleDocumentReferences(this, referencedCollections, DocumentDatabase.DocumentsStorage, _indexStorage, Configuration));
+                workers.Add(new HandleDocumentReferences(this, _referencedCollections, DocumentDatabase.DocumentsStorage, _indexStorage, Configuration));
             }
             
             return workers.ToArray();
+        }
+        
+        internal override bool IsStale(QueryOperationContext queryContext, TransactionOperationContext indexContext, long? cutoff = null, long? referenceCutoff = null, long? compareExchangeReferenceCutoff = null, List<string> stalenessReasons = null)
+        {
+            var isStale = base.IsStale(queryContext, indexContext, cutoff, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons);
+            if (isStale && stalenessReasons == null)
+                return isStale;
+            
+            if (_referencedCollections.Count == 0)
+                return isStale;
+
+            return StaticIndexHelper.IsStaleDueToReferences(this, queryContext, indexContext, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons) || isStale;
+        }
+        
+        public override Dictionary<string, HashSet<CollectionName>> GetReferencedCollections()
+        {
+            return _referencedCollections;
         }
 
         public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -7,8 +7,10 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
+using Raven.Server.Documents.Queries;
 using Raven.Server.ServerWide.Context;
 using Voron;
 
@@ -16,7 +18,12 @@ namespace Raven.Server.Documents.Indexes.Auto
 {
     internal sealed class AutoMapIndex : MapIndexBase<AutoMapIndexDefinition, AutoIndexField>
     {
-        private readonly Dictionary<string, HashSet<CollectionName>> _referencedCollections = new (StringComparer.OrdinalIgnoreCase);
+        // Auto map index references at most one collection (embeddings), this means single hash set is sufficient
+        // We only want to use dictionary to pass data to relevant methods
+        private readonly HashSet<string> _referencedCollections = new (StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, HashSet<CollectionName>> _referencedCollectionsDict = new (StringComparer.OrdinalIgnoreCase);
+        
+        private HandleDocumentReferences _handleReferences;
 
         private AutoMapIndex(AutoMapIndexDefinition definition)
             : base(IndexType.AutoMap, IndexSourceType.Documents, definition, compiled: null)
@@ -48,9 +55,7 @@ namespace Raven.Server.Documents.Indexes.Auto
 
         protected override void HandleDocumentChange(DocumentChange change)
         {
-            var collectionName = new CollectionName(change.CollectionName);
-            
-            if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false && _referencedCollections.First().Value.Contains(collectionName) == false)
+            if (HandleAllDocs == false && Collections.Contains(change.CollectionName) == false && _referencedCollections.Contains(change.CollectionName) == false)
                 return;
             
             _mre.Set();
@@ -71,10 +76,14 @@ namespace Raven.Server.Documents.Indexes.Auto
                 // We only have a single collection for auto map index
                 string collection = Collections.First();
                 var referencedEmbeddingsCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collection);
+
+                var referencedEmbeddingsCollectionName = new CollectionName(referencedEmbeddingsCollection);
+                _referencedCollections.Add(referencedEmbeddingsCollection);
+                _referencedCollectionsDict.Add(collection, new HashSet<CollectionName>() { referencedEmbeddingsCollectionName });
                 
-                _referencedCollections.Add(collection, new HashSet<CollectionName>() { new CollectionName(referencedEmbeddingsCollection) });
-                
-                workers.Add(new HandleDocumentReferences(this, _referencedCollections, DocumentDatabase.DocumentsStorage, _indexStorage, Configuration));
+                _handleReferences = new HandleDocumentReferences(this, _referencedCollectionsDict, DocumentDatabase.DocumentsStorage, _indexStorage, Configuration);
+
+                workers.Add(_handleReferences);
             }
             
             return workers.ToArray();
@@ -83,10 +92,7 @@ namespace Raven.Server.Documents.Indexes.Auto
         internal override bool IsStale(QueryOperationContext queryContext, TransactionOperationContext indexContext, long? cutoff = null, long? referenceCutoff = null, long? compareExchangeReferenceCutoff = null, List<string> stalenessReasons = null)
         {
             var isStale = base.IsStale(queryContext, indexContext, cutoff, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons);
-            if (isStale && stalenessReasons == null)
-                return isStale;
-            
-            if (_referencedCollections.Count == 0)
+            if (isStale && (stalenessReasons == null || _handleReferences == null))
                 return isStale;
 
             return StaticIndexHelper.IsStaleDueToReferences(this, queryContext, indexContext, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons) || isStale;
@@ -94,7 +100,42 @@ namespace Raven.Server.Documents.Indexes.Auto
         
         public override Dictionary<string, HashSet<CollectionName>> GetReferencedCollections()
         {
-            return _referencedCollections;
+            return _referencedCollectionsDict;
+        }
+        
+        public override HandleReferencesBase.InMemoryReferencesInfo GetInMemoryReferencesState(string collection, bool isCompareExchange)
+        {
+            var references = isCompareExchange ? (HandleReferencesBase)null : _handleReferences;
+            return references == null ? HandleReferencesBase.InMemoryReferencesInfo.Default : references.GetReferencesInfo(collection);
+        }
+        
+        protected override long CalculateIndexEtag(QueryOperationContext queryContext, TransactionOperationContext indexContext, QueryMetadata query, bool isStale)
+        {
+            if (_handleReferences == null)
+                return base.CalculateIndexEtag(queryContext, indexContext, query, isStale);
+
+            return CalculateIndexEtagWithReferences(
+                _handleReferences, null, queryContext,
+                indexContext, query, isStale, _referencedCollections, _referencedCollectionsDict, null);
+        }
+        
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
+        {
+            if (tombstoneType != ITombstoneAware.TombstoneType.Documents)
+                return null;
+
+            using (CurrentlyInUse())
+            {
+                return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
+                    this, _referencedCollections, Collections, _referencedCollectionsDict, _indexStorage, lastProcessedTombstonesInfo);
+            }
+        }
+        
+        public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
+        {
+            StaticIndexHelper.HandleReferencesDelete(_handleReferences, null, tombstone, collection, writer, indexContext, stats);
+
+            base.HandleDelete(tombstone, collection, writer, indexContext, stats);
         }
 
         public override void Update(IndexDefinitionBaseServerSide definition, IndexingConfiguration configuration)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2638,7 +2638,7 @@ namespace Raven.Server.Documents.Indexes
         public virtual void DeleteArchived(IndexItem indexItem, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats, LazyStringValue lowerId)
         {
             if (MustDeleteArchivedDocument(indexItem))
-                HandleDelete(new Tombstone { LowerId = lowerId}, collection, writer, indexContext, stats);
+                HandleDelete(new Tombstone { LowerId = lowerId }, collection, writer, indexContext, stats);
         }
         
         private void HandleIndexChange(IndexChange change)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4184,10 +4184,15 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public unsafe long CalculateIndexEtagWithReferences(
+        protected long CalculateIndexEtagWithReferences(
             HandleReferences handleReferences, HandleReferences handleCompareExchangeReferences,
             QueryOperationContext queryContext, TransactionOperationContext indexContext, QueryMetadata query, bool isStale,
-            HashSet<string> referencedCollections, AbstractStaticIndexBase compiled)
+            HashSet<string> referencedCollections, AbstractStaticIndexBase compiled) => CalculateIndexEtagWithReferences(handleReferences, handleCompareExchangeReferences, queryContext, indexContext, query, isStale, referencedCollections, compiled.ReferencedCollections, compiled.CollectionsWithCompareExchangeReferences);
+
+        protected unsafe long CalculateIndexEtagWithReferences(
+            HandleReferences handleReferences, HandleReferences handleCompareExchangeReferences,
+            QueryOperationContext queryContext, TransactionOperationContext indexContext, QueryMetadata query, bool isStale,
+            HashSet<string> referencedCollections, Dictionary<string,HashSet<CollectionName>> referencedCollectionsDict, HashSet<string> collectionsWithCompareExchangeReferences)
         {
             var minLength = MinimumSizeForCalculateIndexEtagLength(query);
             var length = minLength;
@@ -4205,7 +4210,7 @@ namespace Raven.Server.Documents.Indexes
                 // last referenced collection etags (document + tombstone)
                 // last processed reference collection etags (document + tombstone)
                 // last processed in memory (early exit batch) etags (document + tombstone)
-                length += sizeof(long) * 6 * compiled.CollectionsWithCompareExchangeReferences.Count;
+                length += sizeof(long) * 6 * collectionsWithCompareExchangeReferences.Count;
             }
 
             var indexEtagBytes = stackalloc byte[length];
@@ -4215,7 +4220,7 @@ namespace Raven.Server.Documents.Indexes
 
             var writePos = indexEtagBytes + minLength;
 
-            return StaticIndexHelper.CalculateIndexEtag(this, compiled, length, indexEtagBytes, writePos, queryContext, indexContext);
+            return StaticIndexHelper.CalculateIndexEtag(this, length, indexEtagBytes, writePos, queryContext, indexContext, referencedCollectionsDict, collectionsWithCompareExchangeReferences);
         }
 
         private static unsafe void UseAllDocumentsCounterCmpXchgAndTimeSeriesEtags(QueryOperationContext queryContext, QueryMetadata q, int length, byte* indexEtagBytes)

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Raven.Client;
+using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Static;
@@ -42,15 +43,22 @@ namespace Raven.Server.Documents.Indexes
         {
             return IsStaleDueToReferences(index, index._compiled, queryContext, indexContext, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons);
         }
+        
+        internal static bool IsStaleDueToReferences(AutoMapIndex index, QueryOperationContext queryContext,
+            TransactionOperationContext indexContext, long? referenceCutoff, long? compareExchangeReferenceCutoff, List<string> stalenessReasons) => IsStaleDueToReferences(index, index.GetReferencedCollections(), null, queryContext, indexContext, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsStaleDueToReferences(Index index, AbstractStaticIndexBase compiled, QueryOperationContext queryContext, TransactionOperationContext indexContext, long? referenceCutoff, long? compareExchangeReferenceCutoff, List<string> stalenessReasons)
+        private static bool IsStaleDueToReferences(Index index, AbstractStaticIndexBase compiled, QueryOperationContext queryContext,
+            TransactionOperationContext indexContext, long? referenceCutoff, long? compareExchangeReferenceCutoff, List<string> stalenessReasons) =>
+            IsStaleDueToReferences(index, compiled.ReferencedCollections, compiled.CollectionsWithCompareExchangeReferences, queryContext, indexContext, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons);
+
+        private static bool IsStaleDueToReferences(Index index, Dictionary<string, HashSet<CollectionName>> referencedCollectionsDictionary, HashSet<string> collectionsWithCompareExchangeReferences, QueryOperationContext queryContext, TransactionOperationContext indexContext, long? referenceCutoff, long? compareExchangeReferenceCutoff, List<string> stalenessReasons)
         {
             foreach (var collection in index.Collections)
             {
                 long lastIndexedEtag = -1;
-
-                if (compiled.ReferencedCollections.TryGetValue(collection, out HashSet<CollectionName> referencedCollections))
+                
+                if (referencedCollectionsDictionary.TryGetValue(collection, out HashSet<CollectionName> referencedCollections))
                 {
                     lastIndexedEtag = index._indexStorage.ReadLastIndexedEtag(indexContext.Transaction, collection);
 
@@ -136,7 +144,7 @@ namespace Raven.Server.Documents.Indexes
                     }
                 }
 
-                if (compiled.CollectionsWithCompareExchangeReferences.Contains(collection))
+                if (collectionsWithCompareExchangeReferences != null && collectionsWithCompareExchangeReferences.Contains(collection))
                 {
                     if (lastIndexedEtag == -1)
                         lastIndexedEtag = index._indexStorage.ReadLastIndexedEtag(indexContext.Transaction, collection);

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -210,11 +210,11 @@ namespace Raven.Server.Documents.Indexes
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe long CalculateIndexEtag(Index index, AbstractStaticIndexBase compiled, int length, byte* indexEtagBytes, byte* writePos, QueryOperationContext queryContext, TransactionOperationContext indexContext)
+        public static unsafe long CalculateIndexEtag(Index index, int length, byte* indexEtagBytes, byte* writePos, QueryOperationContext queryContext, TransactionOperationContext indexContext, Dictionary<string,HashSet<CollectionName>> referencedCollectionsDict, HashSet<string> collectionsWithCompareExchangeReferences)
         {
             foreach (var collection in index.Collections)
             {
-                if (compiled.ReferencedCollections.TryGetValue(collection, out HashSet<CollectionName> referencedCollections))
+                if (referencedCollectionsDict.TryGetValue(collection, out HashSet<CollectionName> referencedCollections))
                 {
                     foreach (var referencedCollection in referencedCollections)
                     {
@@ -240,7 +240,7 @@ namespace Raven.Server.Documents.Indexes
                     }
                 }
 
-                if (compiled.CollectionsWithCompareExchangeReferences.Contains(collection))
+                if (collectionsWithCompareExchangeReferences != null && collectionsWithCompareExchangeReferences.Contains(collection))
                 {
                     var lastCompareExchangeEtag = queryContext.Documents.DocumentDatabase.CompareExchangeStorage.GetLastCompareExchangeIndex(queryContext.Server);
                     var lastProcessedReferenceEtag = index._indexStorage.ReferencesForCompareExchange.ReadLastProcessedReferenceEtag(indexContext.Transaction.InnerTransaction, collection, referencedCollection: IndexStorage.CompareExchangeReferences.CompareExchange);

--- a/test/SlowTests/Issues/RavenDB-23962.cs
+++ b/test/SlowTests/Issues/RavenDB-23962.cs
@@ -188,6 +188,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
                 
                 var result = session.Query<Dto>()
+                    .Statistics(out var stats)
                     .Customize(c => c.WaitForNonStaleResults())
                     .VectorSearch(x => x
                             .WithText(d => d.Name)
@@ -196,10 +197,28 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 
                 Assert.Single(result);
                 
+                var stopIndexOp = new StopIndexOperation(stats.IndexName);
+                
+                store.Maintenance.Send(stopIndexOp);
+                
                 var embeddingDocId = EmbeddingsHelper.GetEmbeddingDocumentId(dto.Id);
                 
                 session.Delete(embeddingDocId);
                 session.SaveChanges();
+                
+                _ = session.Query<Dto>()
+                    .VectorSearch(x => x
+                            .WithText(d => d.Name)
+                            .UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("fruit"), 0.75f).ToList();
+
+                var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(stats.IndexName));
+
+                Assert.True(staleness.IsStale);
+                Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still some tombstone references to process from collection '@embeddings/Dtos'")));
+                
+                var startIndexOp = new StartIndexOperation(stats.IndexName);
+                store.Maintenance.Send(startIndexOp);
                 
                 Indexes.WaitForIndexing(store);
                 

--- a/test/SlowTests/Issues/RavenDB-23962.cs
+++ b/test/SlowTests/Issues/RavenDB-23962.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using SlowTests.Server.Documents.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void ReferencedCollectionsShouldWorkWithStalenessHandling()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { Name = "computer" };
+                session.Store(dto);
+                session.SaveChanges();
+                
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+                var (configuration, _) = AddEmbeddingsGenerationTask(store);
+            
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                var result = session.Query<Dto>()
+                    .Statistics(out var stats)
+                    .VectorSearch(x => x
+                        .WithText(d => d.Name)
+                        .UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("fruit"), 0.75f).ToList();
+                
+                Assert.Empty(result);
+                
+                var stopIndexOp = new StopIndexOperation(stats.IndexName);
+                
+                store.Maintenance.Send(stopIndexOp);
+                
+                dto.Name = "strawberry";
+                session.SaveChanges();
+
+                result = session.Query<Dto>().Statistics(out stats).VectorSearch(x => x
+                        .WithText(d => d.Name)
+                        .UsingTask(configuration.Identifier),
+                    factory => factory.ByText("fruit"), 0.75f).ToList();
+                
+                Assert.True(stats.IsStale);
+                Assert.Empty(result);
+                
+                var startIndexOp = new StartIndexOperation(stats.IndexName);
+                
+                store.Maintenance.Send(startIndexOp);
+                
+                Indexes.WaitForIndexing(store);
+
+                result = session.Query<Dto>().Statistics(out stats).VectorSearch(x => x
+                        .WithText(d => d.Name)
+                        .UsingTask(configuration.Identifier),
+                    factory => factory.ByText("fruit"), 0.75f).ToList();
+                
+                Assert.False(stats.IsStale);
+                Assert.Single(result);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23962.cs
+++ b/test/SlowTests/Issues/RavenDB-23962.cs
@@ -1,6 +1,9 @@
 using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.ServerWide.Context;
 using SlowTests.Server.Documents.AI.Embeddings;
 using Tests.Infrastructure;
 using Xunit;
@@ -13,6 +16,9 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
     [RavenFact(RavenTestCategory.Indexes)]
     public void ReferencedCollectionsShouldWorkWithStalenessHandling()
     {
+        const string collectionName = "Dtos";
+        var referencedCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collectionName);
+
         using (var store = GetDocumentStore())
         {
             using (var session = store.OpenSession())
@@ -28,13 +34,26 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
                 
                 var result = session.Query<Dto>()
+                    .Customize(c => c.WaitForNonStaleResults())
                     .Statistics(out var stats)
                     .VectorSearch(x => x
                         .WithText(d => d.Name)
                         .UsingTask(configuration.Identifier), 
                         factory => factory.ByText("fruit"), 0.75f).ToList();
                 
+                var resultEtag1 = stats.ResultEtag;
+                
                 Assert.Empty(result);
+                
+                var database = GetDatabase(store.Database).GetAwaiter().GetResult();
+                var index = database.IndexStore.GetIndex(stats.IndexName);
+
+                long lastProcessedReferenceEtag;
+                using (index._indexStorage._contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (var tx = context.OpenReadTransaction())
+                {
+                    lastProcessedReferenceEtag = index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceEtag(tx.InnerTransaction, collectionName, new CollectionName(referencedCollection));
+                }
                 
                 var stopIndexOp = new StopIndexOperation(stats.IndexName);
                 
@@ -43,13 +62,26 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 dto.Name = "strawberry";
                 session.SaveChanges();
 
-                result = session.Query<Dto>().Statistics(out stats).VectorSearch(x => x
+                result = session.Query<Dto>()
+                    .Statistics(out stats)
+                    .VectorSearch(x => x
                         .WithText(d => d.Name)
                         .UsingTask(configuration.Identifier),
                     factory => factory.ByText("fruit"), 0.75f).ToList();
                 
+                var resultEtag2 = stats.ResultEtag;
+                
                 Assert.True(stats.IsStale);
                 Assert.Empty(result);
+                Assert.NotEqual(resultEtag1, resultEtag2);
+                
+                using (index._indexStorage._contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (var tx = context.OpenReadTransaction())
+                {
+                    var lastProcessedReferenceEtag2 = index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceEtag(tx.InnerTransaction, collectionName, new CollectionName(referencedCollection));
+                    
+                    Assert.Equal(lastProcessedReferenceEtag, lastProcessedReferenceEtag2);
+                }
                 
                 var startIndexOp = new StartIndexOperation(stats.IndexName);
                 
@@ -57,13 +89,26 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 
                 Indexes.WaitForIndexing(store);
 
-                result = session.Query<Dto>().Statistics(out stats).VectorSearch(x => x
+                result = session.Query<Dto>()
+                    .Statistics(out stats)
+                    .VectorSearch(x => x
                         .WithText(d => d.Name)
                         .UsingTask(configuration.Identifier),
                     factory => factory.ByText("fruit"), 0.75f).ToList();
                 
+                var resultEtag3 = stats.ResultEtag;
+                
                 Assert.False(stats.IsStale);
                 Assert.Single(result);
+                Assert.NotEqual(resultEtag2, resultEtag3);
+                
+                using (index._indexStorage._contextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (var tx = context.OpenReadTransaction())
+                {
+                    var lastProcessedReferenceEtag3 = index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceEtag(tx.InnerTransaction, collectionName, new CollectionName(referencedCollection));
+                    
+                    Assert.NotEqual(lastProcessedReferenceEtag, lastProcessedReferenceEtag3);
+                }
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-23962.cs
+++ b/test/SlowTests/Issues/RavenDB-23962.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.AI.Embeddings;
 using Raven.Server.ServerWide.Context;
 using SlowTests.Server.Documents.AI.Embeddings;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Operations;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -28,9 +29,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
                 
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-            
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
                 
                 var result = session.Query<Dto>()
@@ -78,13 +77,21 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 using (index._indexStorage._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
                 {
-                    var lastProcessedReferenceEtag2 = index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceEtag(tx.InnerTransaction, collectionName, new CollectionName(referencedCollection));
-                    
+                    var lastProcessedReferenceEtag2 =
+                        index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceEtag(tx.InnerTransaction, collectionName,
+                            new CollectionName(referencedCollection));
+
                     Assert.Equal(lastProcessedReferenceEtag, lastProcessedReferenceEtag2);
                 }
                 
+                WaitForValue(() =>
+                {
+                    var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(stats.IndexName));
+
+                    return staleness.StalenessReasons.Any(x => x.Contains("There are still some document references to process from collection '@embeddings/Dtos'"));
+                }, true);
+
                 var startIndexOp = new StartIndexOperation(stats.IndexName);
-                
                 store.Maintenance.Send(startIndexOp);
                 
                 Indexes.WaitForIndexing(store);
@@ -113,8 +120,104 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TombstonesAreProcessed()
+    {
+        const string collectionName = "Dtos";
+        var referencedCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collectionName);
+        
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { Id = "dtos/1", Name = "computer" };
+                session.Store(dto);
+                session.SaveChanges();
+                
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+                var (configuration, _) = AddEmbeddingsGenerationTask(store);
+            
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                _ = session.Query<Dto>()
+                    .Customize(c => c.WaitForNonStaleResults())
+                    .Statistics(out var stats)
+                    .VectorSearch(x => x
+                            .WithText(d => d.Name)
+                            .UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("fruit"), 0.75f).ToList();
+                
+                var index = GetDatabase(store.Database).GetAwaiter().GetResult().IndexStore.GetIndex(stats.IndexName);
+                
+                var tombstones = index.GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType.Documents);
+
+                Assert.Equal(0, tombstones[collectionName]);
+                Assert.Equal(0, tombstones[referencedCollection]);
+                
+                var embeddingDocId = EmbeddingsHelper.GetEmbeddingDocumentId(dto.Id);
+                
+                session.Delete(embeddingDocId);
+                session.SaveChanges();
+                
+                Indexes.WaitForIndexing(store);
+                
+                tombstones = index.GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType.Documents);
+
+                Assert.Equal(0, tombstones[collectionName]);
+                Assert.NotEqual(0, tombstones[referencedCollection]);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void DeletesAreHandled()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { Id = "dtos/1", Name = "strawberry" };
+                session.Store(dto);
+                session.SaveChanges();
+                
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+                var (configuration, _) = AddEmbeddingsGenerationTask(store);
+            
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                var result = session.Query<Dto>()
+                    .Customize(c => c.WaitForNonStaleResults())
+                    .VectorSearch(x => x
+                            .WithText(d => d.Name)
+                            .UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("fruit"), 0.75f).ToList();
+                
+                Assert.Single(result);
+                
+                var embeddingDocId = EmbeddingsHelper.GetEmbeddingDocumentId(dto.Id);
+                
+                session.Delete(embeddingDocId);
+                session.SaveChanges();
+                
+                Indexes.WaitForIndexing(store);
+                
+                result = session.Query<Dto>()
+                    .Customize(c => c.WaitForNonStaleResults())
+                    .VectorSearch(x => x
+                            .WithText(d => d.Name)
+                            .UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("fruit"), 0.75f).ToList();
+                
+                Assert.Empty(result);
+            }
+        }
+    }
+
     private class Dto
     {
+        public string Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -362,17 +361,11 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
         using (var session = store.OpenSession())
         {
-            WaitForUserToContinueTheTest(store);
-
             session.Store(new Dto() { TextualValue = "pizza" }, "dto/1");
             session.SaveChanges();
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
-            WaitForUserToContinueTheTest(store);
-
-            Thread.Sleep(2000); // TODO - auto index staleness need to take into account referenced embeddings collections
-
+            
             var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
                 .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f).ToList();
             Assert.Equal(1, multiVectorTextualQuery.Count);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23962/Staleness-detection-in-auto-map-index-needs-to-take-into-account-referenced-embedding-collections

### Additional description

Referenced collections should work properly with staleness for auto map indexes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
