### PR TITLE
RavenDB-23922:  add support filtering inheritance tests by adding cust…

### DIFF
--- a/.github/workflows/test-conventions.yml
+++ b/.github/workflows/test-conventions.yml
@@ -15,11 +15,7 @@ on:
 
 jobs:
   release:
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-          os: [ ubuntu-latest, windows-latest, macos-13 ]
-        fail-fast: false
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test-conventions.yml
+++ b/.github/workflows/test-conventions.yml
@@ -1,0 +1,65 @@
+name: test/conventions
+
+on:
+  push:
+    branches:
+        - feature/*
+        - release/**
+        - 'v[4-9]+.[0-9]+'
+
+  pull_request:
+    branches:
+        - feature/*
+        - release/**
+        - 'v[4-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+          os: [ ubuntu-latest, windows-latest, macos-13 ]
+        fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Install dependencies
+      run: dotnet restore SlowTests.csproj
+      working-directory: ./test/SlowTests
+
+    - name: Test - Release
+      run: dotnet test SlowTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~InheritanceTests"
+      env: # Or as an environment variable
+        RAVEN_LICENSE: ${{ secrets.RAVEN_LICENSE }}
+        RAVEN_MAX_RUNNING_TESTS: 1
+      working-directory: ./test/SlowTests
+
+  debug:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+          os: [ ubuntu-latest, windows-latest, macos-13 ]
+        fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Install dependencies
+      run: dotnet restore SlowTests.csproj
+      working-directory: ./test/SlowTests
+
+    - name: Test - Debug
+      run: dotnet test SlowTests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~InheritanceTests"
+      env: # Or as an environment variable
+        RAVEN_LICENSE: ${{ secrets.RAVEN_LICENSE }}
+        RAVEN_MAX_RUNNING_TESTS: 1
+      working-directory: ./test/SlowTests

--- a/.github/workflows/test-conventions.yml
+++ b/.github/workflows/test-conventions.yml
@@ -1,4 +1,4 @@
-name: test/conventions
+name: tests/conventions
 
 on:
   push:

--- a/.github/workflows/test-conventions.yml
+++ b/.github/workflows/test-conventions.yml
@@ -12,6 +12,7 @@ on:
         - feature/*
         - release/**
         - 'v[4-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/test-conventions.yml
+++ b/.github/workflows/test-conventions.yml
@@ -12,7 +12,6 @@ on:
         - feature/*
         - release/**
         - 'v[4-9]+.[0-9]+'
-  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/test-conventions.yml
+++ b/.github/workflows/test-conventions.yml
@@ -33,33 +33,9 @@ jobs:
       working-directory: ./test/SlowTests
 
     - name: Test - Release
-      run: dotnet test SlowTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~InheritanceTests"
+      run: dotnet test SlowTests.csproj --configuration Release --no-restore --filter Category=Conventions
       env: # Or as an environment variable
         RAVEN_LICENSE: ${{ secrets.RAVEN_LICENSE }}
         RAVEN_MAX_RUNNING_TESTS: 1
       working-directory: ./test/SlowTests
 
-  debug:
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-          os: [ ubuntu-latest, windows-latest, macos-13 ]
-        fail-fast: false
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: global.json
-
-    - name: Install dependencies
-      run: dotnet restore SlowTests.csproj
-      working-directory: ./test/SlowTests
-
-    - name: Test - Debug
-      run: dotnet test SlowTests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~InheritanceTests"
-      env: # Or as an environment variable
-        RAVEN_LICENSE: ${{ secrets.RAVEN_LICENSE }}
-        RAVEN_MAX_RUNNING_TESTS: 1
-      working-directory: ./test/SlowTests

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Tests
         private readonly HashSet<Assembly> _assemblies = new HashSet<Assembly>();
 
         // In linux we might encounter Microsoft's VisualStudio assembly types, so we skip this test in linux, and rely on the windows tests result as good for linux too
-        [NonLinuxFact]
+        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void NonDisposableTestShouldNotExist()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -44,7 +44,7 @@ namespace SlowTests.Tests
             throw new Exception(userMessage);
         }
 
-        [NonLinuxFact]
+        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void TestsShouldInheritFromRightBaseClasses()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -61,7 +61,7 @@ namespace SlowTests.Tests
             throw new Exception(userMessage);
         }
 
-        [NonLinuxFact]
+        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void HandlersShouldNotInheritStraightFromRequestHandler()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -78,7 +78,7 @@ namespace SlowTests.Tests
             throw new Exception(userMessage);
         }
 
-        [Fact]
+        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.All)]
         public void AllTestsShouldUseRavenFactOrRavenTheoryAttributes()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Tests
         private readonly HashSet<Assembly> _assemblies = new HashSet<Assembly>();
 
         // In linux we might encounter Microsoft's VisualStudio assembly types, so we skip this test in linux, and rely on the windows tests result as good for linux too
-        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.Windows | RavenPlatform.OsX)]
+        [RavenMultiplatformFact(RavenTestCategory.Conventions, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void NonDisposableTestShouldNotExist()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -44,7 +44,7 @@ namespace SlowTests.Tests
             throw new Exception(userMessage);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.Windows | RavenPlatform.OsX)]
+        [RavenMultiplatformFact(RavenTestCategory.Conventions, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void TestsShouldInheritFromRightBaseClasses()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -61,7 +61,7 @@ namespace SlowTests.Tests
             throw new Exception(userMessage);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.Windows | RavenPlatform.OsX)]
+        [RavenMultiplatformFact(RavenTestCategory.Conventions, RavenPlatform.Windows | RavenPlatform.OsX)]
         public void HandlersShouldNotInheritStraightFromRequestHandler()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -78,7 +78,7 @@ namespace SlowTests.Tests
             throw new Exception(userMessage);
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Inheritance, RavenPlatform.All)]
+        [RavenFact(RavenTestCategory.Conventions)]
         public void AllTestsShouldUseRavenFactOrRavenTheoryAttributes()
         {
             var types = from assembly in GetAssemblies(typeof(TestsInheritanceTests).Assembly)
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6392;
+            const int numberToTolerate = 6391;
             if (array.Length == numberToTolerate)
                 return;
 

--- a/test/Tests.Infrastructure/RavenTestCategory.cs
+++ b/test/Tests.Infrastructure/RavenTestCategory.cs
@@ -59,5 +59,5 @@ public enum RavenTestCategory : long
     Monitoring = 1L << 44,
     Core = 1L << 45,
     Interversion = 1L << 46,
-    Inheritance = 1L << 47
+    Conventions = 1L << 47
 }

--- a/test/Tests.Infrastructure/RavenTestCategory.cs
+++ b/test/Tests.Infrastructure/RavenTestCategory.cs
@@ -59,4 +59,5 @@ public enum RavenTestCategory : long
     Monitoring = 1L << 44,
     Core = 1L << 45,
     Interversion = 1L << 46,
+    Inheritance = 1L << 47
 }


### PR DESCRIPTION
…om category, add gh wf to test inheritance tests

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23922/Adjust-GH-actions-to-run-inheritance-tests

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
