### PR TITLE
RavenDB-23995 Disable react compiler due to react-table issue

### DIFF
--- a/src/Raven.Studio/webpack.config.js
+++ b/src/Raven.Studio/webpack.config.js
@@ -289,17 +289,18 @@ module.exports = (env, args) => {
                         loader: 'swc-loader',
                     },
                 },
-                {
-                    test: /\.tsx?$/,
-                    exclude: /node_modules/,
-                    include: [
-                        path.resolve(__dirname, 'typescript/components/')
-                    ],
-                    use: {
-                        loader: reactCompilerLoader,
-                        options: defineReactCompilerLoaderOption()
-                    }
-                },
+                // Disabled temporary due to react @tanstack/react-table issue https://github.com/TanStack/table/issues/5903
+                // {
+                //     test: /\.tsx?$/,
+                //     exclude: /node_modules/,
+                //     include: [
+                //         path.resolve(__dirname, 'typescript/components/')
+                //     ],
+                //     use: {
+                //         loader: reactCompilerLoader,
+                //         options: defineReactCompilerLoaderOption()
+                //     }
+                // },
                 {
                     test: /\.html$/,
                     use: {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23995/Disable-react-compiler-due-to-react-table-issue

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
