### PR TITLE
RavenDB-23893 Open index errors by default

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanel.tsx
@@ -188,7 +188,7 @@ function IndexErrorsPanelDetailsStatus({
     hasErrors,
     table,
 }: IndexErrorsPanelDetailsStatusProps) {
-    const { value: panelCollapsed, toggle: togglePanelCollapsed } = useBoolean(true);
+    const { value: panelCollapsed, toggle: togglePanelCollapsed } = useBoolean(false);
     const ref = useRef<HTMLDivElement>(null);
     const { width } = useResizeObserver({ ref });
     const mostRecentDateId = useUniqueId("most-recent-date");

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/errors/IndexErrorsPanel.tsx
@@ -243,22 +243,24 @@ function IndexErrorsPanelDetailsStatus({
                         </PopoverWithHoverWrapper>
                     </LazyLoad>
                 </RichPanelDetails>
-                <div ref={ref}>
-                    <Collapse in={!panelCollapsed} mountOnEnter unmountOnExit>
-                        <RichPanelDetails>
-                            <div className="w-100">
-                                <IndexErrorsPanelTable
-                                    status={asyncFetchErrorDetails.status}
-                                    refresh={asyncFetchErrorDetails.execute}
-                                    indexErrors={mappedIndexErrors}
-                                    isLoading={asyncFetchErrorDetails.loading}
-                                    width={width}
-                                    table={table}
-                                />
-                            </div>
-                        </RichPanelDetails>
-                    </Collapse>
-                </div>
+                {!isLoading && (
+                    <div ref={ref}>
+                        <Collapse in={!panelCollapsed} mountOnEnter unmountOnExit>
+                            <RichPanelDetails>
+                                <div className="w-100">
+                                    <IndexErrorsPanelTable
+                                        status={asyncFetchErrorDetails.status}
+                                        refresh={asyncFetchErrorDetails.execute}
+                                        indexErrors={mappedIndexErrors}
+                                        isLoading={asyncFetchErrorDetails.loading}
+                                        width={width}
+                                        table={table}
+                                    />
+                                </div>
+                            </RichPanelDetails>
+                        </Collapse>
+                    </div>
+                )}
             </>
         );
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23893

### Additional description

Index errors details will now be opened by default

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
