### PR TITLE
RavenDB-23998 Fix modal wrapper

### DIFF
--- a/src/Raven.Studio/.storybook/storeDecorator.tsx
+++ b/src/Raven.Studio/.storybook/storeDecorator.tsx
@@ -20,6 +20,7 @@ export const StoreDecorator = (Story, context) => {
         <Provider store={store}>
             <div className="h-100">
                 <Story />
+                <div id="bs5-modal" className="bs5"></div>
             </div>
         </Provider>
     );

--- a/src/Raven.Studio/typescript/components/common/Modal.tsx
+++ b/src/Raven.Studio/typescript/components/common/Modal.tsx
@@ -15,7 +15,7 @@ export function Modal({ children, container, isLoading, className, ...props }: M
         <ReactBootstrapModal
             centered
             contentClassName={classNames("position-relative", className)}
-            container={container || document.getElementById("page-host")}
+            container={container || document.getElementById("bs5-modal")}
             {...props}
         >
             {isLoading && <LoadingView />}

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/abstractDatabaseAndNodeAwareTableWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/abstractDatabaseAndNodeAwareTableWidget.ts
@@ -22,8 +22,8 @@ abstract class abstractDatabaseAndNodeAwareTableWidget<TRaw, TStats extends stat
     noDatabases = ko.pureComputed(() => !this.databaseManager.databases().length);
 
     isCreateDatabaseViewOpen = ko.observable(false);
-    createDatabaseView: ReactInKnockout<typeof CreateDatabase> = ko.pureComputed(() => ({
-        component: CreateDatabase,
+    createDatabaseView: ReactInKnockout<typeof CreateDatabase.default> = ko.pureComputed(() => ({
+        component: CreateDatabase.default,
         props: {
             closeModal: () => this.isCreateDatabaseViewOpen(false),
         }

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/welcomeWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/welcomeWidget.ts
@@ -18,7 +18,7 @@ class welcomeWidget extends widget {
     bootstrapped: KnockoutComputed<boolean>;
 
     isCreateDatabaseViewOpen = ko.observable(false);
-    createDatabaseView: ReactInKnockout<typeof CreateDatabase>;
+    createDatabaseView: ReactInKnockout<typeof CreateDatabase.default>;
 
     private static createLink(hash: string) {
         return ko.pureComputed(() => {
@@ -33,7 +33,7 @@ class welcomeWidget extends widget {
         this.bootstrapped = ko.pureComputed(() => this.controller.currentServerNodeTag !== "?");
 
         this.createDatabaseView = ko.pureComputed(() => ({
-            component: CreateDatabase,
+            component: CreateDatabase.default,
             props: {
                 closeModal: () => this.isCreateDatabaseViewOpen(false),
             }

--- a/src/Raven.Studio/wwwroot/index.html
+++ b/src/Raven.Studio/wwwroot/index.html
@@ -224,6 +224,7 @@
         </div>
         
         <div id="applicationHost"></div>
+        <div id="bs5-modal" class="bs5"></div>
 
         <div class="processing-spinner"></div>
         <iframe id="downloadFrame" style="display: none" name="hidden-form"></iframe>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23998

https://issues.hibernatingrhinos.com/issue/RavenDB-23958/Studio-Cluster-Dashboard-Database-widgets-Create-database-button-does-not-forward-me-to-a-modal

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
