### PR TITLE
RavenDB-23976 Do not use `outputCount` as an indicator of the capacity of `bigDeltaOffsets` as it will likely be smaller.

### DIFF
--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -2,11 +2,9 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using Microsoft.VisualBasic.CompilerServices;
 using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Server;
-using Voron.Data.PostingLists;
 
 namespace Voron.Util.PFor;
 
@@ -108,7 +106,7 @@ public unsafe struct FastPForDecoder : IDisposable
 
         var bigDeltaStart = 0;
         ref var bigDeltaOffsets = ref _bigDeltaOffsets;
-        bigDeltaOffsets.ResetAndEnsureCapacity(_allocator, outputCount);
+        bigDeltaOffsets.Clear();
         var buffer = stackalloc uint[256];
         int read = 0;
         Span<long> outputSpan = new Span<long>(output, outputCount);
@@ -121,7 +119,8 @@ public unsafe struct FastPForDecoder : IDisposable
             switch (numOfBits)
             {
                 case FastPForEncoder.BiggerThanMaxMarker:
-                    bigDeltaOffsets.AddByRefUnsafe() = (long)_metadata;
+                    if (bigDeltaOffsets.TryAdd((long)_metadata) == false)
+                        bigDeltaOffsets.Add(_allocator, (long)_metadata);
                     // we don't need to worry about block fit, because we are ensured that we have at least
                     // 256 items to read into the output here, and these marker are for the next blcok
                     


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23976
https://issues.hibernatingrhinos.com/issue/RavenDB-23977

### Additional description

We still prevent array reallocation on each `Read` call. However, now the buffer grows in a more 'natural' way, ensuring no overallocation (since the `NativeList` capacity grows in power of 2 - no to the exact size we want).


### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
