### PR TITLE
RavenDB-23907 Can't test SQL Connection String conectivity

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -20,7 +20,7 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
-using DbProviderFactories = System.Data.Common.DbProviderFactories;
+using DbProviderFactories = Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL.RelationalWriters.DbProviderFactories;
 
 namespace Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.RelationalWriters;
 

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -25,6 +25,7 @@ using Raven.Server.Config;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.Test;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL;
+using Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL.RelationalWriters;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.SqlMigration;
 using Raven.Tests.Core.Utils.Entities;
@@ -1175,6 +1176,54 @@ loadToOrders(orderData);
                             Assert.Equal(3, dbCommand.ExecuteScalar());
                         }
                     }
+                }
+            }
+        }
+
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
+        public void CanTestMsSqlConnection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    SqlDatabaseWriter.TestConnection("Microsoft.Data.SqlClient", connectionString);
+                }
+            }
+        }
+        
+        [RequiresNpgSqlFact]
+        public void CanTestNpgsqlConnection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    SqlDatabaseWriter.TestConnection("Npgsql", connectionString);
+                }
+            }
+        }
+                
+        [RequiresOracleSqlFact]
+        public void CanTestOracleConnection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.Oracle, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    SqlDatabaseWriter.TestConnection("Oracle.ManagedDataAccess.Client", connectionString);
+                }
+            }
+        }
+                
+        [RequiresMySqlFact]
+        public void CanTestMySqlConnection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.MySQL_MySqlConnector, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    SqlDatabaseWriter.TestConnection("MySqlConnector.MySqlConnectorFactory", connectionString);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

Previous PR: https://github.com/ravendb/ravendb/pull/20327
GitHub Issue: https://github.com/ravendb/ravendb/issues/20325
https://issues.hibernatingrhinos.com/issue/RavenDB-23907/Cant-test-SQL-Connection-String-conectivity

### Additional description

I found the root issue: incorrect import of an ambiguously named component. This fixes the weird 'Unregistered Factory' error.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
