### PR TITLE
RavenDB-24004 Select creatable - get custom options from value

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, ReactNode, useRef, useState } from "react";
 import genUtils from "common/generalUtils";
 import { Checkbox, CheckboxProps, Radio, Switch } from "components/common/Checkbox";
-import { Control, ControllerProps, FieldPath, FieldValues, useController } from "react-hook-form";
+import { Control, ControllerProps, FieldPath, FieldValues, PathValue, useController } from "react-hook-form";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
@@ -231,7 +231,10 @@ export function FormSelectCreatable<
     const valueAccessor = rest.getOptionValue ?? ((option: any) => option.value);
     const optionCreator = rest.optionCreator ?? ((value: string) => ({ value, label: value }));
 
-    const getOptionsFromValue = (formValues: any, creator: (value: string) => any) => {
+    const getOptionsFromValue = (
+        formValues: PathValue<TFieldValues, TName>,
+        creator: (value: string) => Option
+    ): Option[] => {
         if (!formValues) {
             return [];
         }

--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -228,10 +228,19 @@ export function FormSelectCreatable<
         shouldUnregister,
     });
 
-    const [customOptions, setCustomOptions] = useState<OptionsOrGroups<Option, Group>>(rest.customOptions ?? []);
-
     const valueAccessor = rest.getOptionValue ?? ((option: any) => option.value);
     const optionCreator = rest.optionCreator ?? ((value: string) => ({ value, label: value }));
+
+    const getOptionsFromValue = (formValues: any, creator: (value: string) => any) => {
+        if (!formValues) {
+            return [];
+        }
+        return Array.isArray(formValues) ? formValues.map(creator) : [creator(formValues)];
+    };
+
+    const [customOptions, setCustomOptions] = useState<OptionsOrGroups<Option, Group>>(
+        rest.customOptions ?? getOptionsFromValue(formValues, optionCreator)
+    );
 
     const selectedOptions = getFormSelectedOptions<Option>(
         formValues,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24004/AI-connection-strings-Custom-model-endpoint-not-shown-when-editing

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
