### PR TITLE
RavenDB-23700 Fixing Should_stop_unloading_database_after_consecutive_corruptions_in_given_time test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_10744.cs
+++ b/test/SlowTests/Issues/RavenDB_10744.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void Shold_stop_unloading_database_after_consecutive_corruptions_in_given_time()
+        public void Should_stop_unloading_database_after_consecutive_corruptions_in_given_time()
         {
             UseNewLocalServer();
 
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
                         Assert.True(unloadTask.Wait(TimeSpan.FromSeconds(30)));
                 }
 
-                handler.Execute(db.Name, new Exception("Catastrophic"), Guid.Empty, null, Environment.StackTrace);
+                handler.Execute(db.Name, new Exception("Catastrophic"), environmentId, null, Environment.StackTrace);
 
                 handler.TryGetStats(environmentId, out failureStats);
 
@@ -64,7 +64,10 @@ namespace SlowTests.Issues
                 handler.TryGetStats(environmentId, out failureStats);
 
                 Assert.True(failureStats.WillUnloadDatabase);
-                Assert.True(failureStats.DatabaseUnloadTask.Wait(TimeSpan.FromSeconds(30)));
+                var unloadTask2 = failureStats.DatabaseUnloadTask;
+
+                if (unloadTask2 != null) // could already unload it and null DatabaseUnloadTask 
+                    Assert.True(unloadTask2.Wait(TimeSpan.FromSeconds(30)));
             }
         }
 


### PR DESCRIPTION

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23700/SlowTests.Issues.RavenDB10744.Sholdstopunloadingdatabaseafterconsecutivecorruptionsingiventime

### Additional description

The test started to fail on v6.2 and v7.0 branches although the problem was already in v5.4

### Type of change

- [x] Testfix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
