### PR TITLE
RavenDB-23720 Fixed conversion of auto indexes with vector search to static

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
@@ -135,6 +135,9 @@ public class AutoToStaticIndexConverter
         indexDefinition.Maps = ConstructMaps(autoIndex, context);
         indexDefinition.Reduce = ConstructReduce(autoIndex);
         indexDefinition.Fields = ConstructFields(autoIndex, context);
+        
+        if (indexDefinition.Fields.Any(x => x.Value.Vector != null))
+            indexDefinition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = SearchEngineType.Corax.ToString();
 
         return indexDefinition;
 
@@ -595,9 +598,9 @@ public class AutoToStaticIndexConverter
                 }
                 else if (kvp.Value.Vector != null)
                 {
-                    var newFieldName = vectorCounter == 0 ? "Vector" : $"Vector{vectorCounter}";
+                    var newFieldName = $"Vector{vectorCounter}";
                     context.FieldNameMapping.Add(f.FieldName, newFieldName);
-                    sb.AppendLine($"{newFieldName} = {nameof(AbstractIndexCreationTask.CreateVector)}(item.{kvp.Value.Vector.SourceFieldName})");
+                    sb.AppendLine($"{newFieldName} = {nameof(AbstractIndexCreationTask.CreateVector)}(item.{kvp.Value.Vector.SourceFieldName}),");
                     vectorCounter++;
                 }
             }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
@@ -598,7 +598,7 @@ public class AutoToStaticIndexConverter
                 }
                 else if (kvp.Value.Vector != null)
                 {
-                    var newFieldName = $"Vector{vectorCounter}";
+                    var newFieldName = vectorCounter == 0 ? "Vector" : $"Vector{vectorCounter}";
                     context.FieldNameMapping.Add(f.FieldName, newFieldName);
                     sb.AppendLine($"{newFieldName} = {nameof(AbstractIndexCreationTask.CreateVector)}(item.{kvp.Value.Vector.SourceFieldName}),");
                     vectorCounter++;

--- a/test/SlowTests/Issues/RavenDB-23446.cs
+++ b/test/SlowTests/Issues/RavenDB-23446.cs
@@ -36,7 +36,7 @@ public class RavenDB_23446(ITestOutputHelper output) : RavenTestBase(output)
         Map = items => from item in items
                        select new
                        {
-                           Vector = CreateVector(item.Vector)
+                           Vector = CreateVector(item.Vector),
                        };
 
         Vector(""Vector"", factory => factory.SourceEmbedding(VectorEmbeddingType.Single).DestinationEmbedding(VectorEmbeddingType.Single));
@@ -94,7 +94,7 @@ public class RavenDB_23446(ITestOutputHelper output) : RavenTestBase(output)
         Map = items => from item in items
                        select new
                        {
-                           Vector = CreateVector(item.Vector)
+                           Vector = CreateVector(item.Vector),
                        };
 
         Vector(""Vector"", factory => factory.SourceEmbedding(VectorEmbeddingType.Single).DestinationEmbedding(VectorEmbeddingType.Int8));
@@ -152,7 +152,7 @@ public class RavenDB_23446(ITestOutputHelper output) : RavenTestBase(output)
         Map = items => from item in items
                        select new
                        {
-                           Vector = CreateVector(item.Text)
+                           Vector = CreateVector(item.Text),
                        };
 
         Vector(""Vector"", factory => factory.SourceEmbedding(VectorEmbeddingType.Text).DestinationEmbedding(VectorEmbeddingType.Single));

--- a/test/SlowTests/Issues/RavenDB-23720.cs
+++ b/test/SlowTests/Issues/RavenDB-23720.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Handlers.Processors.Indexes;
+using SlowTests.Server.Documents.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23720 : EmbeddingsGenerationTestBase
+{
+    public RavenDB_23720(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    public void AutoIndexWithVectorSearchShouldBeConvertibleToStatic()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Dto() { Name = "computer", EmbeddingRaw = [0.1f, 0.2f] });
+                session.SaveChanges();
+                
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+
+                var (configuration, _) = AddEmbeddingsGenerationTask(store);
+                
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                var autoResults1 = session.Query<Dto>().VectorSearch(x => x.WithText(x => x.Name).UsingTask(configuration.Identifier),
+                    factory => factory.ByText("some text")).ToList();
+                
+                var autoResults2 = session.Query<Dto>().Statistics(out var stats).VectorSearch(x => x.WithEmbedding(x => x.EmbeddingRaw),
+                    factory => factory.ByEmbedding([0.1f, 0.2f])).ToList();
+                
+                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+
+                var autoIndex = record.AutoIndexes.Values.First(x => x.Name == stats.IndexName);
+
+                var staticDefinition = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
+
+                var putIndexOp = new PutIndexesOperation(staticDefinition);
+                
+                store.Maintenance.Send(putIndexOp);
+                
+                Indexes.WaitForIndexing(store);
+
+                var textFieldName = staticDefinition.Fields.Single(x => x.Value.Vector.SourceEmbeddingType == VectorEmbeddingType.Text).Key;
+                var floatFieldName = staticDefinition.Fields.Single(x => x.Value.Vector.SourceEmbeddingType == VectorEmbeddingType.Single).Key;
+                
+                var staticResults1 = session.Query<Dto>(staticDefinition.Name).VectorSearch(x => x.WithField(textFieldName),
+                    factory => factory.ByText("some text")).ToList();
+                
+                Assert.Equal(autoResults1, staticResults1);
+                
+                var staticResults2 = session.Query<Dto>(staticDefinition.Name).VectorSearch(x => x.WithField(floatFieldName),
+                    factory => factory.ByEmbedding([0.1f, 0.2f])).ToList();
+                
+                Assert.Equal(autoResults2, staticResults2);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public float[] EmbeddingRaw { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23720/Vector-definition-is-created-improperly-by-the-Studio

### Additional description

Auto indexes that use vector search should be convertible to static

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
