### PR TITLE
RavenDB-23887 added 1.19.1 OID which will return oldest tx duration

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.19/ServerLongestTransaction.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.19/ServerLongestTransaction.cs
@@ -38,6 +38,9 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
                     oldestTransaction = databaseOldestTransaction;
             }
 
+            if (oldestTransaction == DateTime.MinValue)
+                return SnmpValuesHelper.TimeTicksZero;
+
             var transactionAge = now - oldestTransaction;
             return SnmpValuesHelper.TimeSpanToTimeTicks(transactionAge.TotalMilliseconds > 0 ? transactionAge : TimeSpan.Zero);
         }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.19/ServerLongestTransaction.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.19/ServerLongestTransaction.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Lextm.SharpSnmpLib;
+using Raven.Client.Util;
+using Raven.Server.ServerWide;
+using Voron;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server
+{
+    public class ServerLongestTransaction : ScalarObjectBase<TimeTicks>
+    {
+        private readonly ServerStore _store;
+
+        public ServerLongestTransaction(ServerStore store)
+            : base(SnmpOids.Server.ServerLongestTransaction)
+        {
+            _store = store;
+        }
+
+        protected override TimeTicks GetData()
+        {
+            var now = SystemTime.UtcNow;
+            TryGetOldestTransaction(_store._env, out var oldestTransaction);
+
+            foreach (var storageEnvironment in GetAllStorageEnvironmentsForLoadedDatabases())
+            {
+                if (TryGetOldestTransaction(storageEnvironment, out var databaseOldestTransaction) == false)
+                    continue;
+
+                if (oldestTransaction == DateTime.MinValue)
+                {
+                    oldestTransaction = databaseOldestTransaction;
+                    continue;
+                }
+
+                if (databaseOldestTransaction < oldestTransaction)
+                    oldestTransaction = databaseOldestTransaction;
+            }
+
+            var transactionAge = now - oldestTransaction;
+            return SnmpValuesHelper.TimeSpanToTimeTicks(transactionAge.TotalMilliseconds > 0 ? transactionAge : TimeSpan.Zero);
+        }
+
+        private IEnumerable<StorageEnvironment> GetAllStorageEnvironmentsForLoadedDatabases()
+        {
+            foreach (var kvp in _store.DatabasesLandlord.DatabasesCache)
+            {
+                var databaseTask = kvp.Value;
+
+                if (databaseTask == null || databaseTask.IsCompletedSuccessfully == false)
+                    continue;
+
+                var database = databaseTask.Result;
+
+                foreach (var storageEnvironmentWithType in database.GetAllStoragesEnvironment())
+                    yield return storageEnvironmentWithType.Environment;
+            }
+        }
+
+        private static bool TryGetOldestTransaction(StorageEnvironment env, out DateTime oldestTransaction)
+        {
+            oldestTransaction = DateTime.MinValue;
+
+            try
+            {
+                var allTransactionsInstances = env.ActiveTransactions.AllTransactionsInstances;
+                if (allTransactionsInstances.Count == 0)
+                    return false;
+
+                oldestTransaction = allTransactionsInstances.Min(x => x.TxStartTime);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -286,6 +286,9 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("Monitor lock contention count")]
             public const string MonitorLockContentionCount = "1.18.1";
 
+            [Description("Time since creation of oldest transaction")]
+            public const string ServerLongestTransaction = "1.19.1";
+
             public static DynamicJsonArray ToJson()
             {
                 var array = new DynamicJsonArray();

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -511,6 +511,8 @@ namespace Raven.Server.Monitoring.Snmp
 
             store.Add(new MonitorLockContentionCount());
 
+            store.Add(new ServerLongestTransaction(server.ServerStore));
+
             return store;
 
             void AddGc(GCKind gcKind)

--- a/src/Voron/Util/ActiveTransactions.cs
+++ b/src/Voron/Util/ActiveTransactions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 using System.Threading;
 using Sparrow.Threading;
 using Voron.Debugging;
@@ -12,7 +11,7 @@ namespace Voron.Util
 {
     public class ActiveTransactions
     {
-        private RacyConcurrentBag _activeTxs = new RacyConcurrentBag(growthFactor: 64);
+        private readonly RacyConcurrentBag _activeTxs = new RacyConcurrentBag(growthFactor: 64);
 
         private long _oldestTransaction;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23887

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
