### PR TITLE
RavenDB-23649 Create a func to support the creation of exact or search analyzers and allow changing analyzers for static fields as well.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
@@ -99,14 +99,11 @@ public static class CoraxIndexingHelpers
         using var mappingBuilder = forQuerying 
             ? IndexFieldsMappingBuilder.CreateForReader() 
             : IndexFieldsMappingBuilder.CreateForWriter(false);
-        mappingBuilder.AddDefaultAnalyzer(defaultAnalyzer ?? defaultAnalyzerToUse);
+        mappingBuilder
+            .AddDefaultAnalyzer(defaultAnalyzer ?? defaultAnalyzerToUse)
+            .AddExactAnalyzer(fieldName => GetOrCreateAnalyzer(fieldName, index.Configuration.DefaultExactAnalyzerType.Value.Type, forQuerying, CreateKeywordAnalyzer))
+            .AddSearchAnalyzer(fieldName => GetOrCreateAnalyzer(fieldName, index.Configuration.DefaultSearchAnalyzerType.Value.Type,forQuerying, CreateStandardAnalyzer));
         
-        if (indexDefinition.HasDynamicFields)
-        {
-            mappingBuilder
-                .AddExactAnalyzer(fieldName => GetOrCreateAnalyzer(fieldName, index.Configuration.DefaultExactAnalyzerType.Value.Type, forQuerying, CreateKeywordAnalyzer))
-                .AddSearchAnalyzer(fieldName => GetOrCreateAnalyzer(fieldName, index.Configuration.DefaultSearchAnalyzerType.Value.Type,forQuerying, CreateStandardAnalyzer));
-        }
         
         //Adding id of document        
         mappingBuilder.AddBinding(global::Corax.Constants.IndexWriter.PrimaryKeyFieldId, keyFieldName, defaultAnalyzer);

--- a/test/SlowTests/Corax/RavenDB-23649.cs
+++ b/test/SlowTests/Corax/RavenDB-23649.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_23649(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanDynamicallyCreateExactAnalyzerForSearchWildcardQuery(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenSession())
+        {
+            foreach (var dto in new List<Dto> { new() { Surname = "O'Cfirst" }, new() { Surname = "O'Second" }, new() { Surname = "Third" }, })
+                session.Store(dto);
+            
+            session.SaveChanges();
+        }
+
+        var index = new Index();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.RawQuery<Dto>(
+                    """
+                    from index 'Index'
+                              where boost(search(Surname, $term), 10) or search(SurnameAnalyzed, $term)
+                              order by score()
+                    """)
+                .AddParameter("term", "O'C*")
+                .ToList();
+            
+            Assert.Equal(2, results.Count);
+            Assert.Equal("O'Cfirst", results[0].Surname);
+            Assert.Equal("O'Second", results[1].Surname);
+        }
+    }
+    
+    private class Dto
+    {
+        public string Surname { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask
+    {
+        public override string IndexName => "Index";
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition
+            {
+                Maps =
+                {
+                    """
+                    docs.Dtos.Select(dto => new {
+                        Surname = dto.Surname,
+                        SurnameAnalyzed = dto.Surname,
+                    })
+                    """
+                },
+                Fields =
+                {
+                    { "SurnameAnalyzed", new IndexFieldOptions { Indexing = FieldIndexing.Search, Analyzer = "SimpleAnalyzer" } },
+                    { "Surname", new IndexFieldOptions { Indexing = FieldIndexing.Search, Analyzer = "KeywordAnalyzer" } }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23649

### Additional description

Since v6.0, the analyzer of a static field can be changed in the `search` query method, and we need to support that in the mapping object.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
