### PR TITLE
RavenDB-23050 Corax Jint Converter will not persist the dynamic field in the field dictionary

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -289,11 +289,26 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
     {
         if (_fields.TryGetValue(propertyAsString, out var field) == false)
         {
+            // Check if we have already processed this name as a dynamic field in the current indexing batch
+            if (indexingScope.DynamicFields != null && indexingScope.DynamicFields.TryGetValue(propertyAsString, out field))
+                return field;
+            
             int currentId = CoraxLib.Constants.IndexWriter.DynamicField;
+            // Check if the name is declared as a static field in the index definition
             if (KnownFieldsForWriter.TryGetByFieldName(Allocator, propertyAsString, out var binding))
                 currentId = binding.FieldId;
 
-            field = _fields[propertyAsString] = IndexField.Create(propertyAsString, new IndexFieldOptions(), _allFields, currentId);
+            field = IndexField.Create(propertyAsString, new IndexFieldOptions(), _allFields, currentId);
+            if (currentId != CoraxLib.Constants.IndexWriter.DynamicField)
+            {
+                // This field is declared in the index definition,
+                // so the field exists in the writer mapping, we can cache it between calls
+                _fields.Add(propertyAsString, field);
+                return field;
+            }
+            
+            // This is the first occurrence of the field in the current indexing batch.
+            // We have to create a batch-bounded mapping for it and update the IndexWriter.
             indexingScope.DynamicFields ??= new();
             indexingScope.DynamicFields[propertyAsString] = field;
             indexingScope.IncrementDynamicFields();

--- a/test/SlowTests/Corax/RavenDB_23050.cs
+++ b/test/SlowTests/Corax/RavenDB_23050.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_23050(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MustAnalyzeFieldsOnUpdateInIndexJsDynamicFields(Options options)
+        => MustAnalyzeFieldsOnUpdateInIndex<IndexJsDynamic>(options);
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MustAnalyzeFieldsOnUpdateInIndexJsStaticFields(Options options)
+        => MustAnalyzeFieldsOnUpdateInIndex<IndexJsStaticFields>(options);
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void MustAnalyzeFieldsOnUpdateInIndexCsharpStaticFields(Options options)
+        => MustAnalyzeFieldsOnUpdateInIndex<IndexCsharpDynamic>(options);
+
+    private void MustAnalyzeFieldsOnUpdateInIndex<T>(Options options) where T : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Listing { Seller = "Abc" }, "listings/1");
+
+            session.SaveChanges();
+        }
+
+        new T().Execute(store);
+        Indexes.WaitForIndexing(store);
+        
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Listing, T>()
+                .Where(x => x.Seller == "Abc")
+                .ToList();
+            Assert.Equal(1, results.Count);
+            
+            var listing = session.Load<Listing>("listings/1");
+            listing.Seller = "Def";
+            session.SaveChanges();
+
+            results = session.Query<Listing, T>()
+                .Customize(x => x.WaitForNonStaleResults())
+                .Where(x => x.Seller == "Def")
+                .ToList();
+            Assert.Equal(1, results.Count);
+        }
+    }
+
+    private class Listing
+    {
+        public string Seller { get; set; }
+    }
+
+    private class IndexJsDynamic : AbstractJavaScriptIndexCreationTask
+    {
+        public IndexJsDynamic()
+        {
+            Maps = new HashSet<string>
+            {
+                @"map('Listings', listing => {
+
+    const result = Object.assign({
+        Seller: listing.Seller
+    });
+
+    return result
+})",
+            };
+        }
+    }
+
+    private class IndexCsharpDynamic : AbstractIndexCreationTask<Listing>
+    {
+        public IndexCsharpDynamic()
+        {
+            Map = listings => from listing in listings select new { _ = CreateField("Seller", listing.Seller) };
+        }
+    }
+
+    private class IndexJsStaticFields : AbstractJavaScriptIndexCreationTask
+    {
+        public IndexJsStaticFields()
+        {
+            Maps = new HashSet<string>
+            {
+                @"map('Listings', listing => {
+    return {
+        Seller: listing.Seller
+    }
+})",
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23050

### Additional description

We cannot persist `IndexField` objects of dynamic fields in the Jint Corax Converter, since we have to update the dynamic mapping in the IndexWriter in each indexing batch.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
