### PR TITLE
RavenDB-23443 Throw exception for query with vector search and filter

### DIFF
--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -96,7 +96,7 @@ namespace Raven.Server.Documents.Queries
             if (query.Filter != null)
             {
                 if (HasVectorSearch)
-                    throw new NotSupportedException("Vector search is not supported in combination with filter.");
+                    throw new InvalidQueryException("Cannot use 'filter' when 'vector.search' is used in where statement.");
                 
                 BuildFilterScript(query);
             }

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -75,11 +75,6 @@ namespace Raven.Server.Documents.Queries
             IsDistinct = Query.IsDistinct;
             IsGroupBy = Query.GroupBy != null;
 
-            if (query.Filter != null)
-            {
-                BuildFilterScript(query);
-            }
-
             IsDynamic = Query.From.Index == false;
             var fromToken = Query.From.From;
 
@@ -97,6 +92,14 @@ namespace Raven.Server.Documents.Queries
             DeclaredFunctions = Query.DeclaredFunctions;
 
             Build(parameters);
+            
+            if (query.Filter != null)
+            {
+                if (HasVectorSearch)
+                    throw new NotSupportedException("Vector search is not supported in combination with filter.");
+                
+                BuildFilterScript(query);
+            }
 
             CanCache = cacheKey != 0 && AddSpatialProperties == false;
 

--- a/test/SlowTests/Issues/RavenDB-23443.cs
+++ b/test/SlowTests/Issues/RavenDB-23443.cs
@@ -17,32 +17,32 @@ public class RavenDB_23443 : RavenTestBase
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
     public void VectorSearchAndFilterShouldThrow()
     {
-        const string expectedMessage = "Vector search is not supported in combination with filter.";
+        const string expectedMessage = "Cannot use 'filter' when 'vector.search' is used in where statement.";
         
         using (var store = GetDocumentStore())
         {
             using (var session = store.OpenSession())
             {
-                var ex = Assert.Throws<RavenException>(() => session.Query<Dto>()
+                var ex = Assert.Throws<InvalidQueryException>(() => session.Query<Dto>()
                     .VectorSearch(x => x.WithText(p => p.Name), v => v.ByText("test"))
                     .Filter(x => x.Name == "test")
                     .ToList());
 
-                Assert.Contains(expectedMessage, ex.InnerException?.Message);
+                Assert.Contains(expectedMessage, ex.Message);
 
-                ex = Assert.Throws<RavenException>(() => session.Query<Dto>()
+                ex = Assert.Throws<InvalidQueryException>(() => session.Query<Dto>()
                     .Filter(x => x.Name == "test")
                     .VectorSearch(x => x.WithText(p => p.Name), v => v.ByText("test"))
                     .ToList());
 
-                Assert.Contains(expectedMessage, ex.InnerException?.Message);
+                Assert.Contains(expectedMessage, ex.Message);
                 
-                ex = Assert.Throws<RavenException>(() => _ = session.Advanced.RawQuery<Dto>("from Dtos where vector.search(embedding.text(Name), $p0) filter (Name = $p1)")
+                ex = Assert.Throws<InvalidQueryException>(() => _ = session.Advanced.RawQuery<Dto>("from Dtos where vector.search(embedding.text(Name), $p0) filter (Name = $p1)")
                     .AddParameter("$p0", "test")
                     .AddParameter("$p1", "test")
                     .ToList());
                 
-                Assert.Contains(expectedMessage, ex.InnerException?.Message);
+                Assert.Contains(expectedMessage, ex.Message);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-23443.cs
+++ b/test/SlowTests/Issues/RavenDB-23443.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23443 : RavenTestBase
+{
+    public RavenDB_23443(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void VectorSearchAndFilterShouldThrow()
+    {
+        const string expectedMessage = "Vector search is not supported in combination with filter.";
+        
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var ex = Assert.Throws<RavenException>(() => session.Query<Dto>()
+                    .VectorSearch(x => x.WithText(p => p.Name), v => v.ByText("test"))
+                    .Filter(x => x.Name == "test")
+                    .ToList());
+
+                Assert.Contains(expectedMessage, ex.InnerException?.Message);
+
+                ex = Assert.Throws<RavenException>(() => session.Query<Dto>()
+                    .Filter(x => x.Name == "test")
+                    .VectorSearch(x => x.WithText(p => p.Name), v => v.ByText("test"))
+                    .ToList());
+
+                Assert.Contains(expectedMessage, ex.InnerException?.Message);
+                
+                ex = Assert.Throws<RavenException>(() => _ = session.Advanced.RawQuery<Dto>("from Dtos where vector.search(embedding.text(Name), $p0) filter (Name = $p1)")
+                    .AddParameter("$p0", "test")
+                    .AddParameter("$p1", "test")
+                    .ToList());
+                
+                Assert.Contains(expectedMessage, ex.InnerException?.Message);
+            }
+        }
+    }
+    
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23443/Vector-Search-Support-or-throw-when-using-the-filter-keyword

### Additional description

Combining vector search and filter is not supported, we want to throw relevant exception for queries that use both

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
