### PR TITLE
RavenDB-24010 Fixing ocassionally failing MustRemoveFailedTransactionFromActiveTransactions test

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_22767.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22767.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using FastTests.Voron;
 using Tests.Infrastructure;
+using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,6 +11,11 @@ public class RavenDB_22767 : StorageTest
 {
     public RavenDB_22767(ITestOutputHelper output) : base(output)
     {
+    }
+    
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.ManualFlushing = true;
     }
     
     [RavenFact(RavenTestCategory.Voron)]


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24010/SlowTests.Voron.Issues.RavenDB22767.MustRemoveFailedTransactionFromActiveTransactions

### Additional description

The test was occasionally failing because the background flusher was doing its job

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
