### PR TITLE
RavenDB-23097 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -13,6 +14,7 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -256,14 +258,15 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 session.SaveChanges();
             }
 
-            await WaitForValueAsync(async () =>
+            Assert.True(await WaitForValueAsync(async () =>
             {
                 ongoingTask = await src.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(name, OngoingTaskType.RavenEtl));
                 return ongoingTask.ResponsibleNode.NodeTag != responsibleNodeNodeTag;
-            }, true);
+            }, expectedVal: true, timeout: 30_000), 
+                userMessage: $"new responsible node was not selected in time {Environment.NewLine}{await AddEtlDebugInfo(src.Database, responsibleNode: null, originalResponsibleNode: responsibleNodeNodeTag, srcRaft.Nodes)}");
 
             Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", timeout: 30_000), 
-                userMessage: await Etl.GetEtlDebugInfo(src.Database, server: srcRaft.Nodes.Single(s => s.ServerStore.NodeTag == ongoingTask.ResponsibleNode.NodeTag)));
+                userMessage: $"document 'users/2' did not reach destination in time {Environment.NewLine}{await AddEtlDebugInfo(src.Database, ongoingTask.ResponsibleNode.NodeTag, responsibleNodeNodeTag, srcRaft.Nodes)}");
         }
     }
 
@@ -522,5 +525,29 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
             Assert.Equal(1, await WaitForValueAsync(async () => await GetMembersCount(hubStore, hubStore.Database), 1));
             Assert.Equal(3, await WaitForValueAsync(async () => await GetMembersCount(sinkStore, sinkStore.Database), 3));
         }
+    }
+
+    private async Task<string> AddEtlDebugInfo(string database, string responsibleNode, string originalResponsibleNode, List<RavenServer> servers)
+    {
+        var sb = new StringBuilder();
+
+        var original = servers.SingleOrDefault(s => s.ServerStore.NodeTag == originalResponsibleNode);
+        var etlStatsFromOriginalResponsibleNode = await Etl.GetEtlDebugInfo(database, server: original);
+        sb.AppendLine($"ETL stats from original responsible node '{originalResponsibleNode}':")
+            .AppendLine(etlStatsFromOriginalResponsibleNode);
+
+        if (responsibleNode != null)
+        {
+            var newResponsibleNode = servers.SingleOrDefault(s => s.ServerStore.NodeTag == responsibleNode);
+            var etlStatsFromNewResponsibleNode = await Etl.GetEtlDebugInfo(database, server: newResponsibleNode);
+
+            sb.AppendLine($"ETL stats from new responsible node '{responsibleNode}':")
+                .AppendLine(etlStatsFromNewResponsibleNode);
+        }
+
+        sb.AppendLine("clusterDebugInfo:");
+        await GetClusterDebugLogsAsync(sb);
+
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23097/SlowTests.Server.Documents.OngoingTasks.PinOnGoingTaskToMentorNode.CanFailOverWhenRemovingMentorNodeEtl

### Additional description

Adjustments to test `Can_Fail_Over_When_Removing_Mentor_Node_Etl`:

- avoid running into "Sequence contains no matching element" error when trying to find the new responsible node via `System.Linq.Enumerable.Single`
- if there's no new responsible node - add ETL debug info from the original responsible node to the failure message
- add cluster debug logs to failure message

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [X] Tests stabilization

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [X] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [X] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [X] No UI work is needed
