### PR TITLE
RavenDB-23859 - Introduce grace period for upgrade required modal

### DIFF
--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -479,7 +479,7 @@ namespace Raven.Server.Commercial
                 {
                     // Getting build number from the license storage, just in case the license is expired and we have ability to downgrade
                     var licenseStorage = new LicenseStorage();
-                    licenseStorage.Initialize(_storageEnvironment, _contextPool);
+                    licenseStorage.Initialize(serverStore: null, _storageEnvironment, _contextPool);
                     var buildInfo = licenseStorage.GetBuildInfo();
 
                     if (buildInfo != null)

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -125,7 +125,7 @@ namespace Raven.Server.Commercial
             {
                 OnBeforeInitialize?.Invoke();
 
-                _licenseStorage.Initialize(environment, contextPool);
+                _licenseStorage.Initialize(_serverStore, environment, contextPool);
 
                 var firstServerStartDate = _licenseStorage.GetFirstServerStartDate();
                 if (firstServerStartDate == null)
@@ -240,7 +240,16 @@ namespace Raven.Server.Commercial
                         Minor = licenseStatus.Version.Minor,
                         UpdatedAt = SystemTime.UtcNow
                     };
-                    _licenseStorage.SetLicenseVersionInformation(licenseVersionInformation);
+
+                    try
+                    {
+                        _licenseStorage.SetLicenseVersionInformation(licenseVersionInformation);
+                    }
+                    catch
+                    {
+                        // avoid throwing here in case of an error (out of memory or out of disk space for example).
+                        // we'll set it on next license change or on startup.
+                    }
                 }
 
                 LicenseStatus.LicenseVersionInformation = licenseVersionInformation;

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -230,7 +230,22 @@ namespace Raven.Server.Commercial
 
             try
             {
-                SetLicense(GetLicenseStatus(license));
+                var licenseStatus = GetLicenseStatus(license);
+                var licenseVersionInformation = _licenseStorage.GetLicenseVersionInformation();
+                if (licenseVersionInformation == null || licenseVersionInformation.Version != licenseStatus.Version)
+                {
+                    licenseVersionInformation = new LicenseVersionInformation
+                    {
+                        Major = licenseStatus.Version.Major,
+                        Minor = licenseStatus.Version.Minor,
+                        UpdatedAt = SystemTime.UtcNow
+                    };
+                    _licenseStorage.SetLicenseVersionInformation(licenseVersionInformation);
+                }
+
+                LicenseStatus.LicenseVersionInformation = licenseVersionInformation;
+
+                SetLicense(licenseStatus);
                 _serverStore.Configuration.UpdateLicenseType(LicenseStatus.Type);
             }
             catch (Exception e)
@@ -506,6 +521,7 @@ namespace Raven.Server.Commercial
             LicenseStatus = new LicenseStatus
             {
                 FirstServerStartDate = LicenseStatus.FirstServerStartDate,
+                LicenseVersionInformation = LicenseStatus.LicenseVersionInformation,
                 ErrorMessage = error,
             };
         }
@@ -519,6 +535,7 @@ namespace Raven.Server.Commercial
                 ErrorMessage = null,
                 Attributes = licenseStatus.Attributes,
                 FirstServerStartDate = LicenseStatus.FirstServerStartDate,
+                LicenseVersionInformation = LicenseStatus.LicenseVersionInformation,
             };
         }
 

--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Commercial
                 if (Version <= currentVersion)
                     return null;
 
-                var allowDismissUntil = LicenseVersionInformation.UpdatedAt.AddDays(7);
+                var allowDismissUntil = LicenseVersionInformation.UpdatedAt.AddDays(14);
                 return new UpgradeRequired
                 {
                     AllowDismiss = allowDismissUntil >= DateTime.UtcNow,

--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using NuGet.Protocol;
 using Raven.Client.Properties;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
@@ -301,7 +302,7 @@ namespace Raven.Server.Commercial
                 [nameof(LicensedTo)] = LicensedTo,
                 [nameof(Status)] = Status,
                 [nameof(Expired)] = Expired,
-                [nameof(UpgradeRequired)] = UpgradeRequired,
+                [nameof(UpgradeRequired)] = UpgradeRequired?.ToJson(),
                 [nameof(FirstServerStartDate)] = FirstServerStartDate,
                 [nameof(Ratio)] = Ratio.ToString(CultureInfo.InvariantCulture),
                 [nameof(Attributes)] = TypeConverter.ToBlittableSupportedType(Attributes),

--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -21,6 +21,8 @@ namespace Raven.Server.Commercial
 
         public DateTime FirstServerStartDate { get; set; }
 
+        internal LicenseVersionInformation LicenseVersionInformation { get; set; }
+
         private T GetValue<T>(LicenseAttribute attributeName, T agplValue = default)
         {
             if (Attributes == null)
@@ -109,23 +111,31 @@ namespace Raven.Server.Commercial
             }
         }
 
-        public bool UpgradeRequired
+        public UpgradeRequired UpgradeRequired
         {
             get
             {
                 if (Type != LicenseType.Community)
-                    return false;
+                    return null;
 
                 if (IsCloud)
-                    return false;
+                    return null;
 
-                if (Version == null)
-                    return false;
+                if (Version == null || LicenseVersionInformation == null)
+                    return null;
 
                 if (Version.TryParse(RavenVersionAttribute.Instance.Version, out var currentVersion) == false)
-                    return false;
+                    return null;
 
-                return Version > currentVersion;
+                if (Version <= currentVersion)
+                    return null;
+
+                var allowDismissUntil = LicenseVersionInformation.UpdatedAt.AddDays(7);
+                return new UpgradeRequired
+                {
+                    AllowDismiss = allowDismissUntil >= DateTime.UtcNow,
+                    AllowDismissUntil = allowDismissUntil
+                };
             }
         }
 

--- a/src/Raven.Server/Commercial/LicenseStorage.cs
+++ b/src/Raven.Server/Commercial/LicenseStorage.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Json;
+using Raven.Server.NotificationCenter;
+using Raven.Server.Rachis.Commands;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -12,31 +16,32 @@ namespace Raven.Server.Commercial
 {
     public sealed class LicenseStorage
     {
+        private ServerStore _serverStore;
         private StorageEnvironment _environment;
-
         private TransactionContextPool _contextPool;
 
-        private readonly TableSchema _licenseStorageSchema = new TableSchema();
+        private static readonly TableSchema LicenseStorageSchema = new TableSchema();
         private const string FirstServerStartDateKey = "FirstServerStartDate";
 
         public LicenseStorage()
         {
-            _licenseStorageSchema.DefineKey(new TableSchema.IndexDef
+            LicenseStorageSchema.DefineKey(new TableSchema.IndexDef
             {
                 StartIndex = 0,
                 Count = 1
             });
         }
 
-        public void Initialize(StorageEnvironment environment, TransactionContextPool contextPool)
+        public void Initialize(ServerStore serverStore, StorageEnvironment environment, TransactionContextPool contextPool)
         {
+            _serverStore = serverStore;
             _environment = environment;
             _contextPool = contextPool;
 
             using (contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = _environment.WriteTransaction(context.PersistentContext))
             {
-                _licenseStorageSchema.Create(tx, LicenseInfoSchema.LicenseTree, 16);
+                LicenseStorageSchema.Create(tx, LicenseInfoSchema.LicenseTree, 16);
 
                 tx.Commit();
             }
@@ -52,7 +57,7 @@ namespace Raven.Server.Commercial
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenWriteTransaction())
             {
-                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+                var table = tx.InnerTransaction.OpenTable(LicenseStorageSchema, LicenseInfoSchema.LicenseTree);
 
                 var id = context.GetLazyString(FirstServerStartDateKey);
                 using (var json = context.ReadObject(firstServerStartDate, "firstServerStartDate",
@@ -76,7 +81,7 @@ namespace Raven.Server.Commercial
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenReadTransaction())
             {
-                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+                var table = tx.InnerTransaction.OpenTable(LicenseStorageSchema, LicenseInfoSchema.LicenseTree);
 
                 TableValueReader infoTvr;
                 using (Slice.From(tx.InnerTransaction.Allocator, FirstServerStartDateKey, out Slice keyAsSlice))
@@ -101,7 +106,7 @@ namespace Raven.Server.Commercial
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenWriteTransaction())
             {
-                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+                var table = tx.InnerTransaction.OpenTable(LicenseStorageSchema, LicenseInfoSchema.LicenseTree);
 
                 var id = context.GetLazyString(nameof(BuildNumber));
                 using (var json = context.ReadObject(buildNumber.ToJson(), nameof(BuildNumber), BlittableJsonDocumentBuilder.UsageMode.ToDisk))
@@ -124,7 +129,7 @@ namespace Raven.Server.Commercial
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenReadTransaction())
             {
-                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+                var table = tx.InnerTransaction.OpenTable(LicenseStorageSchema, LicenseInfoSchema.LicenseTree);
 
                 TableValueReader infoTvr;
                 using (Slice.From(tx.InnerTransaction.Allocator, nameof(LicenseVersionInformation), out Slice keyAsSlice))
@@ -141,27 +146,10 @@ namespace Raven.Server.Commercial
             }
         }
 
-        public unsafe void SetLicenseVersionInformation(LicenseVersionInformation licenseVersionInformation)
+        public void SetLicenseVersionInformation(LicenseVersionInformation licenseVersionInformation)
         {
-            using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (var tx = context.OpenWriteTransaction())
-            {
-                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
-
-                var id = context.GetLazyString(nameof(LicenseVersionInformation));
-                using (var json = context.ReadObject(licenseVersionInformation.ToJson(), nameof(LicenseVersionInformation), BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                {
-                    using (table.Allocate(out TableValueBuilder tvb))
-                    {
-                        tvb.Add(id.Buffer, id.Size);
-                        tvb.Add(json.BasePointer, json.Size);
-
-                        table.Set(tvb);
-                    }
-                }
-
-                tx.Commit();
-            }
+            var command = new SetLicenseVersionInformationCommand(licenseVersionInformation);
+            _serverStore.Engine.TxMerger.EnqueueSync(command);
         }
 
         public LicenseVersionInformation GetLicenseVersionInformation()
@@ -169,7 +157,7 @@ namespace Raven.Server.Commercial
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenReadTransaction())
             {
-                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+                var table = tx.InnerTransaction.OpenTable(LicenseStorageSchema, LicenseInfoSchema.LicenseTree);
 
                 TableValueReader infoTvr;
                 using (Slice.From(tx.InnerTransaction.Allocator, nameof(LicenseVersionInformation), out Slice keyAsSlice))
@@ -203,6 +191,40 @@ namespace Raven.Server.Commercial
                 public const int IdIndex = 0;
                 public const int JsonIndex = 1;
 #pragma warning restore 169
+            }
+        }
+
+        private class SetLicenseVersionInformationCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+        {
+            private readonly LicenseVersionInformation _licenseVersionInformation;
+
+            public SetLicenseVersionInformationCommand(LicenseVersionInformation licenseVersionInformation)
+            {
+                _licenseVersionInformation = licenseVersionInformation;
+            }
+
+            protected override unsafe long ExecuteCmd(ClusterOperationContext context)
+            {
+                var table = context.Transaction.InnerTransaction.OpenTable(LicenseStorageSchema, LicenseInfoSchema.LicenseTree);
+
+                var id = context.GetLazyString(nameof(LicenseVersionInformation));
+                using (var json = context.ReadObject(_licenseVersionInformation.ToJson(), nameof(LicenseVersionInformation), BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                {
+                    using (table.Allocate(out TableValueBuilder tvb))
+                    {
+                        tvb.Add(id.Buffer, id.Size);
+                        tvb.Add(json.BasePointer, json.Size);
+
+                        table.Set(tvb);
+                    }
+                }
+
+                return 1;
+            }
+
+            public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/src/Raven.Server/Commercial/LicenseStorage.cs
+++ b/src/Raven.Server/Commercial/LicenseStorage.cs
@@ -127,7 +127,7 @@ namespace Raven.Server.Commercial
                 var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
 
                 TableValueReader infoTvr;
-                using (Slice.From(tx.InnerTransaction.Allocator, nameof(BuildNumber), out Slice keyAsSlice))
+                using (Slice.From(tx.InnerTransaction.Allocator, nameof(LicenseVersionInformation), out Slice keyAsSlice))
                 {
                     // it seems like the database was shutdown rudely and never wrote it stats onto the disk
                     if (table.ReadByKey(keyAsSlice, out infoTvr) == false)
@@ -137,6 +137,51 @@ namespace Raven.Server.Commercial
                 using (var blittable = Read(context, ref infoTvr))
                 {
                     return JsonDeserializationServer.BuildNumber(blittable);
+                }
+            }
+        }
+
+        public unsafe void SetLicenseVersionInformation(LicenseVersionInformation licenseVersionInformation)
+        {
+            using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (var tx = context.OpenWriteTransaction())
+            {
+                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+
+                var id = context.GetLazyString(nameof(LicenseVersionInformation));
+                using (var json = context.ReadObject(licenseVersionInformation.ToJson(), nameof(LicenseVersionInformation), BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+                {
+                    using (table.Allocate(out TableValueBuilder tvb))
+                    {
+                        tvb.Add(id.Buffer, id.Size);
+                        tvb.Add(json.BasePointer, json.Size);
+
+                        table.Set(tvb);
+                    }
+                }
+
+                tx.Commit();
+            }
+        }
+
+        public LicenseVersionInformation GetLicenseVersionInformation()
+        {
+            using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (var tx = context.OpenReadTransaction())
+            {
+                var table = tx.InnerTransaction.OpenTable(_licenseStorageSchema, LicenseInfoSchema.LicenseTree);
+
+                TableValueReader infoTvr;
+                using (Slice.From(tx.InnerTransaction.Allocator, nameof(LicenseVersionInformation), out Slice keyAsSlice))
+                {
+                    // it seems like the database was shutdown rudely and never wrote it stats onto the disk
+                    if (table.ReadByKey(keyAsSlice, out infoTvr) == false)
+                        return null;
+                }
+
+                using (var blittable = Read(context, ref infoTvr))
+                {
+                    return JsonDeserializationServer.LicenseVersionInformation(blittable);
                 }
             }
         }

--- a/src/Raven.Server/Commercial/LicenseVersionInformation.cs
+++ b/src/Raven.Server/Commercial/LicenseVersionInformation.cs
@@ -1,0 +1,23 @@
+using System;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Commercial;
+
+public class LicenseVersionInformation : IDynamicJson
+{
+    public int Major { get; set; }
+    public int Minor { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public Version Version => new Version(Major, Minor);
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(Major)] = Major,
+            [nameof(Minor)] = Minor,
+            [nameof(UpdatedAt)] = UpdatedAt
+        };
+    }
+}

--- a/src/Raven.Server/Commercial/UpgradeRequired.cs
+++ b/src/Raven.Server/Commercial/UpgradeRequired.cs
@@ -1,10 +1,20 @@
 using System;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Commercial;
 
-public class UpgradeRequired
+public class UpgradeRequired : IDynamicJson
 {
     public bool AllowDismiss { get; set; }
 
     public DateTime AllowDismissUntil { get; set; }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(AllowDismiss)] = AllowDismiss,
+            [nameof(AllowDismissUntil)] = AllowDismissUntil
+        };
+    }
 }

--- a/src/Raven.Server/Commercial/UpgradeRequired.cs
+++ b/src/Raven.Server/Commercial/UpgradeRequired.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Raven.Server.Commercial;
+
+public class UpgradeRequired
+{
+    public bool AllowDismiss { get; set; }
+
+    public DateTime AllowDismissUntil { get; set; }
+}

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -269,6 +269,8 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, BuildNumber> BuildNumber = GenerateJsonDeserializationRoutine<BuildNumber>();
 
+        public static readonly Func<BlittableJsonReaderObject, LicenseVersionInformation> LicenseVersionInformation = GenerateJsonDeserializationRoutine<LicenseVersionInformation>();
+
         public static readonly Func<BlittableJsonReaderObject, LegacySourceReplicationInformation> LegacySourceReplicationInformation = GenerateJsonDeserializationRoutine<LegacySourceReplicationInformation>();
 
         public static readonly Func<BlittableJsonReaderObject, BackupConfiguration> BackupConfiguration = GenerateJsonDeserializationRoutine<BackupConfiguration>();

--- a/src/Raven.Studio/typescript/components/common/Modal.tsx
+++ b/src/Raven.Studio/typescript/components/common/Modal.tsx
@@ -16,6 +16,7 @@ export function Modal({ children, container, isLoading, className, ...props }: M
             centered
             contentClassName={classNames("position-relative", className)}
             container={container || document.getElementById("bs5-modal")}
+            backdropClassName="bs5-modal-backdrop"
             {...props}
         >
             {isLoading && <LoadingView />}

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
@@ -1205,7 +1205,7 @@ interface FeatureAvailabilitySection {
     items: FeatureAvailabilityItem[];
 }
 
-type DisplayableLicenseField = keyof Omit<LicenseStatus, "Attributes">;
+type DisplayableLicenseField = keyof Omit<LicenseStatus, "Attributes" | "UpgradeRequired">;
 
 interface FeatureAvailabilityItem {
     name: string;

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseSummary.tsx
@@ -292,7 +292,7 @@ function LicenseActions(props: LicenseActionsProps) {
     );
 }
 
-function LicenseTooltip(props: {
+export function LicenseTooltip(props: {
     children: React.ReactNode;
     target: string;
     operationEnabledInConfiguration: boolean;
@@ -300,7 +300,7 @@ function LicenseTooltip(props: {
     operationAction: string;
     operationTitle: string;
 }) {
-    const { children, target, operationEnabledInConfiguration, operationTitle, operationAction, hasPrivileges } = props;
+    const { children, operationEnabledInConfiguration, operationTitle, operationAction, hasPrivileges } = props;
 
     let msg = operationEnabledInConfiguration && hasPrivileges ? `${operationAction}` : "";
 
@@ -317,9 +317,9 @@ function LicenseTooltip(props: {
     }
 
     return (
-        <OverlayTrigger overlay={<Tooltip id={target}>{msg}</Tooltip>}>
+        <PopoverWithHoverWrapper message={msg}>
             <span>{children}</span>
-        </OverlayTrigger>
+        </PopoverWithHoverWrapper>
     );
 }
 

--- a/src/Raven.Studio/typescript/durandalPlugins/bootstrapModal.ts
+++ b/src/Raven.Studio/typescript/durandalPlugins/bootstrapModal.ts
@@ -58,10 +58,10 @@ dialog.addContext('bootstrapModal', {
             
             $(".modal-content").addClass("neo-modal");
             
-            $(".modal-backdrop").addClass("bs3");
+            $(".modal-backdrop").not('.bs5-modal-backdrop').addClass("bs3");
             
             if ($("body").hasClass("fullscreen")) {
-                $('.modal-backdrop ').appendTo('.modal-root');   
+                $('.modal-backdrop ').not('.bs5-modal-backdrop').appendTo('.modal-root');   
             }
             
             $('#bootstrapModal').on('hidden.bs.modal', () => {
@@ -69,7 +69,7 @@ dialog.addContext('bootstrapModal', {
                     theDialog.close();
                 }
                 ko.removeNode(theDialog.host);
-                $('.modal-backdrop').remove();
+                $('.modal-backdrop').not('.bs5-modal-backdrop').remove();
             });
         }
     } as any);

--- a/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
@@ -17,7 +17,7 @@ export class LicenseStubs {
             LicensedTo: "Studio Stubs",
             Status: "Commercial",
             Expired: false,
-            UpgradeRequired: false,
+            UpgradeRequired: null,
             FirstServerStartDate: moment()
                 .add(-1 as const, "month")
                 .format(),

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -127,7 +127,7 @@ class shell extends viewModelBase {
 
     private onBootstrapFinishedTask = $.Deferred<void>();
 
-    upgradeModalView: ReactInKnockout<typeof UpgradeModal>;
+    upgradeModalView: ReactInKnockout<typeof UpgradeModal.default>;
     isUpgradeModalVisible = ko.observable<boolean>(false);
 
     studioSearchWithDatabaseSwitcherView: ReactInKnockout<typeof StudioSearchWithDatabaseSwitcher.default>;
@@ -216,7 +216,12 @@ class shell extends viewModelBase {
 
         this.bindToCurrentInstance("toggleMenu");
 
-        this.upgradeModalView = ko.pureComputed(() => ({ component: UpgradeModal }))
+        this.upgradeModalView = ko.pureComputed(() => ({
+            component: UpgradeModal.default,
+            props: {
+                close: () => this.isUpgradeModalVisible(false),
+            },
+        }))
         
         const menuItems = ko.pureComputed(() => {
             

--- a/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
@@ -3,12 +3,13 @@ import { clusterSelectors } from "components/common/shell/clusterSlice";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import { useAppSelector } from "components/store";
-import React from "react";
 import Modal from "components/common/Modal";
+import moment from "moment";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 
 const upgradeLicenseImg = require("Content/img/upgrade-license.svg");
 
-export default function UpgradeModal() {
+export default function UpgradeModal(props: { close: () => void }) {
     const downloadLink = useRavenLink({ hash: "44DYH5", isDocs: false });
 
     const upgradeRequired = useAppSelector(licenseSelectors.statusValue("UpgradeRequired"));
@@ -19,22 +20,40 @@ export default function UpgradeModal() {
         return null;
     }
 
+    const allowDismissUntilUtc = moment.utc(upgradeRequired.AllowDismissUntil);
+
     return (
-        <Modal
-            show
-            contentClassName="modal-border bulge-warning"
-            size="lg"
-        >
-            <Modal.Body className="vstack gap-3 position-relative justify-content-center">
-                <div className="d-flex justify-content-center mb-3">
+        <Modal show contentClassName="modal-border bulge-warning" size="lg">
+            <Modal.Header
+                className="vstack gap-4"
+                closeButton={upgradeRequired.AllowDismiss}
+                onCloseClick={props.close}
+            >
+                <div className="d-flex justify-content-center">
                     <img src={upgradeLicenseImg} alt="Upgrade license" width="120" />
                 </div>
                 <h3 className="text-warning text-center mb-0">It&apos;s time to upgrade!</h3>
+            </Modal.Header>
+            <Modal.Body>
                 <p className="text-center mb-0">
                     Your server is running version <strong>{productVersion}</strong> while the latest version is{" "}
                     <strong>{latestVersion}</strong>.
                     <br />
                     In order to continue using RavenDB please upgrade your server to the latest available version.
+                    {upgradeRequired.AllowDismiss && upgradeRequired.AllowDismissUntil && (
+                        <>
+                            <br />
+                            <br />
+                            <span className="text-muted">
+                                You can dismiss this message until {allowDismissUntilUtc.format(dateFormat)} UTC
+                                <PopoverWithHoverWrapper
+                                    message={`${allowDismissUntilUtc.local().format(dateFormat)} your local time`}
+                                >
+                                    <Icon icon="info" color="info" margin="ms-1" />
+                                </PopoverWithHoverWrapper>
+                            </span>
+                        </>
+                    )}
                 </p>
             </Modal.Body>
             <Modal.Footer className="justify-content-center">
@@ -46,3 +65,5 @@ export default function UpgradeModal() {
         </Modal>
     );
 }
+
+const dateFormat = "YYYY-MM-DD HH:mm";

--- a/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
@@ -6,6 +6,12 @@ import { useAppSelector } from "components/store";
 import Modal from "components/common/Modal";
 import moment from "moment";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { LicenseTooltip } from "components/pages/resources/about/partials/LicenseSummary";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import { useAsync } from "react-async-hook";
+import { useServices } from "components/hooks/useServices";
+import registration from "viewmodels/shell/registration";
+import Button from "react-bootstrap/Button";
 
 const upgradeLicenseImg = require("Content/img/upgrade-license.svg");
 
@@ -15,6 +21,24 @@ export default function UpgradeModal(props: { close: () => void }) {
     const upgradeRequired = useAppSelector(licenseSelectors.statusValue("UpgradeRequired"));
     const latestVersion = useAppSelector(licenseSelectors.statusValue("Version"));
     const productVersion = useAppSelector(clusterSelectors.serverVersion)?.ProductVersion;
+    const isClusterAdminOrClusterNode = useAppSelector(accessManagerSelectors.isClusterAdminOrClusterNode);
+
+    const { licenseService } = useServices();
+    const asyncGetConfigurationSettings = useAsync(licenseService.getConfigurationSettings, []);
+    const canActivate = asyncGetConfigurationSettings.result?.CanActivate;
+    const isReplaceLicenseEnabled = canActivate && isClusterAdminOrClusterNode;
+
+    const licenseStatus = useAppSelector(licenseSelectors.status);
+    
+    const registerLicense = () => {
+        registration.showRegistrationDialog(licenseStatus, false, true);
+
+        // Remove tabindex from bs5 modal for bs3 to work
+        const upgradeModalElement = document.querySelector("#bs5-modal [role='dialog']");
+        if (upgradeModalElement && upgradeModalElement.hasAttribute("tabindex")) {
+            upgradeModalElement.removeAttribute("tabindex");
+        }
+    };
 
     if (!upgradeRequired || !latestVersion || !productVersion) {
         return null;
@@ -56,7 +80,25 @@ export default function UpgradeModal(props: { close: () => void }) {
                     )}
                 </p>
             </Modal.Body>
-            <Modal.Footer className="justify-content-center">
+            <Modal.Footer className="hstack gap-2 justify-content-center">
+                <LicenseTooltip
+                    target="replace-license-btn"
+                    operationEnabledInConfiguration={canActivate}
+                    hasPrivileges={isClusterAdminOrClusterNode}
+                    operationAction="Replace the current license with another"
+                    operationTitle="Replacing license"
+                >
+                    <span>
+                        <Button
+                            variant="outline-secondary"
+                            className="rounded-pill"
+                            onClick={registerLicense}
+                            disabled={!isReplaceLicenseEnabled}
+                        >
+                            <Icon icon="replace" /> Replace
+                        </Button>
+                    </span>
+                </LicenseTooltip>
                 <a href={downloadLink} target="_blank" className="btn btn-warning rounded-pill">
                     <Icon icon="download" />
                     Download now

--- a/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
@@ -74,8 +74,11 @@ export default function UpgradeModal(props: { close: () => void }) {
                                     message={`${allowDismissUntilUtc.local().format(dateFormat)} your local time`}
                                 >
                                     <Icon icon="info" color="info" margin="ms-1" />
-                                </PopoverWithHoverWrapper>. 
-                                Afterwards the RavenDB studio will be blocked.
+                                </PopoverWithHoverWrapper> 
+                            </span>
+                            <br />
+                            <span className="text-muted">
+                                Afterwards the <strong>RavenDB Studio</strong> will be <strong className="text-danger">blocked</strong>.
                             </span>
                         </>
                     )}

--- a/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
@@ -69,7 +69,7 @@ export default function UpgradeModal(props: { close: () => void }) {
                             <br />
                             <br />
                             <span className="text-muted">
-                                You can dismiss this message until {allowDismissUntilUtc.format(dateFormat)} UTC
+                                You can dismiss this message until {allowDismissUntilUtc.format(dateFormat)} UTC afterwards the RavenDB studio will be blocked
                                 <PopoverWithHoverWrapper
                                     message={`${allowDismissUntilUtc.local().format(dateFormat)} your local time`}
                                 >

--- a/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/shell/UpgradeModal.tsx
@@ -69,12 +69,13 @@ export default function UpgradeModal(props: { close: () => void }) {
                             <br />
                             <br />
                             <span className="text-muted">
-                                You can dismiss this message until {allowDismissUntilUtc.format(dateFormat)} UTC afterwards the RavenDB studio will be blocked
+                                You can dismiss this message until {allowDismissUntilUtc.format(dateFormat)} UTC
                                 <PopoverWithHoverWrapper
                                     message={`${allowDismissUntilUtc.local().format(dateFormat)} your local time`}
                                 >
                                     <Icon icon="info" color="info" margin="ms-1" />
-                                </PopoverWithHoverWrapper>
+                                </PopoverWithHoverWrapper>. 
+                                Afterwards the RavenDB studio will be blocked.
                             </span>
                         </>
                     )}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23859/Review-all-license-related-flows-in-context-of-studio-block-and-introduce-a-grace-period

### Additional description

Introduce grace period for upgrade required modal - 14 days.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/c081cedd-de4e-472f-8bc6-1f4329491493" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
