### PR TITLE
RavenDB-23722 Throw relevant exception for embeddings length mismatch

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -261,13 +261,18 @@ public static partial class CoraxQueryBuilder
                 return indexField.Vector;
 
             builderParameters.Index.IndexFieldsPersistence.TryReadVectorSourceEmbeddingType(fieldName, out var vectorSourceEmbeddingType);
-            return vectorSourceEmbeddingType switch
+            
+            var defaultVectorOptions = vectorSourceEmbeddingType switch
             {
                 VectorEmbeddingType.Single => VectorOptions.Default,
                 VectorEmbeddingType.Text => VectorOptions.DefaultText,
                 _ => throw new InvalidDataException(
                     $"Unknown vector source embedding type: {vectorSourceEmbeddingType}. Implicit configuration support only single and text vector source embedding types.")
             };
+
+            indexField.Vector = defaultVectorOptions;
+            
+            return defaultVectorOptions;
         }
 
         internal static void ThrowDifferentNumberOfDimensions(in IndexField indexField, in string fieldName, in VectorValue transformedEmbedding,

--- a/test/SlowTests/Issues/RavenDB-23722.cs
+++ b/test/SlowTests/Issues/RavenDB-23722.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23722 : RavenTestBase
+{
+    public RavenDB_23722(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void RelevantExceptionOnEmbeddingsLengthMismatch(Options options)
+    {
+        var v1 = new[] { 0.1f, 0.2f, 0.3f };
+        var v2 = new[] { 0.1f, 0.2f, 0.3f, 0.4f };
+        
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var doc1 = new Dto();
+                session.Store(doc1);
+                session.SaveChanges();      
+
+                using var memStream = new MemoryStream(MemoryMarshal.Cast<float, byte>(v1).ToArray());
+                session.Advanced.Attachments.Store(doc1, "embedding", memStream);
+                session.SaveChanges();
+
+                var index = new CSharpIndexWithVector();
+                index.Execute(store);
+                Indexes.WaitForIndexing(store);
+                var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+                Assert.Null(errors);
+                
+                var ex = Assert.Throws<RavenException>(() => session.Query<CSharpIndexWithVector.IndexEntry, CSharpIndexWithVector>()
+                    .VectorSearch(f => f.WithField(s => s.Vector), v => v.ByEmbedding(v2))
+                    .ProjectInto<Dto>()
+                    .FirstOrDefault());
+
+                Assert.Contains("Vector field `Vector` has 3 dimensions, but the vector passed to vector.search() has 4 dimensions", ex.Message);
+            }
+        }
+    }
+    
+    private class CSharpIndexWithVector : AbstractIndexCreationTask<Dto>
+    {
+        public class IndexEntry
+        {
+            public object Vector { get; set; }
+        }
+
+        public CSharpIndexWithVector()
+        {
+            Map = documents => from document in documents
+                let embeddings = LoadAttachment(document, "embedding")
+                select new
+                {
+                    Vector = CreateVector(embeddings.GetContentAsStream())
+                };
+        }
+    }
+
+    private class Dto;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23722/NRE-when-querying-with-different-dimension-size

### Additional description

Throw relevant exception for embeddings length mismatch when querying by index field created using `CreateVector`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
