### PR TITLE
RavenDB-23960 Disabled embeddings generation task shouldn't impact creating new tasks

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -413,27 +413,21 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         _work.Enqueue(works);
         _hasWork.Set();
     }
-    private AiWorker CreateAiWorker(EmbeddingsGenerationTaskIdentifier id)
+
+    private AiWorker CreateAiWorker(EmbeddingsGenerationConfiguration configuration)
     {
         var record = _database.ReadDatabaseRecord();
-        foreach (var task in record.EmbeddingsGenerations)
-        {
-            if (task.Disabled)
-                throw new InvalidOperationException($"The task {id.Value} has been disabled and cannot be used");
-            
-            if (string.Equals(id.Value, task.Identifier, StringComparison.OrdinalIgnoreCase))
-            {
-                var connectionString = GetConnectionString(record, task);
-                int maxConcurrentBatches = connectionString.GetQueryEmbeddingsMaxConcurrentBatches(_database.Configuration.Ai.EmbeddingsMaxConcurrentBatches);
-                if (maxConcurrentBatches > 0) 
-                    return new AiWorker(this, _database.DocumentsStorage, task, connectionString, maxConcurrentBatches, CancellationToken);
-                
-                string message = $"{RavenConfiguration.GetKey(x => x.Ai.EmbeddingsMaxConcurrentBatches)} must be a positive value: {connectionString.Identifier}";
-                throw new InvalidConfigurationException(message);
-            }
-        }
-        
-        throw new InvalidOperationException($"Could not find an embedding task named: {id.Value}");
+
+        if (configuration.Disabled)
+            throw new InvalidOperationException($"The task {configuration.Name} has been disabled and cannot be used");
+
+        var connectionString = GetConnectionString(record, configuration);
+        int maxConcurrentBatches = connectionString.GetQueryEmbeddingsMaxConcurrentBatches(_database.Configuration.Ai.EmbeddingsMaxConcurrentBatches);
+        if (maxConcurrentBatches > 0)
+            return new AiWorker(this, _database.DocumentsStorage, configuration, connectionString, maxConcurrentBatches, CancellationToken);
+
+        string message = $"{RavenConfiguration.GetKey(x => x.Ai.EmbeddingsMaxConcurrentBatches)} must be a positive value: {connectionString.Identifier}";
+        throw new InvalidConfigurationException(message);
     }
 
     private static AiConnectionString GetConnectionString(DatabaseRecord record, EmbeddingsGenerationConfiguration task)
@@ -701,7 +695,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
             if (_workers.TryGetValue(identifier, out var existing) is false)
             {
-                _ = _workers.GetOrAdd(identifier, CreateAiWorker).RunAsync();
+                _ = _workers.GetOrAdd(identifier, _ => CreateAiWorker(configuration)).RunAsync();
                 continue;
             }
 
@@ -713,7 +707,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                 {
                     _ = toDispose.ShutdownAsync();
                 }
-                _ = _workers.GetOrAdd(identifier, CreateAiWorker).RunAsync();
+                _ = _workers.GetOrAdd(identifier, _ => CreateAiWorker(configuration)).RunAsync();
             }
         }
 

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -414,10 +414,8 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         _hasWork.Set();
     }
 
-    private AiWorker CreateAiWorker(EmbeddingsGenerationConfiguration configuration)
+    private AiWorker CreateAiWorker(DatabaseRecord record, EmbeddingsGenerationConfiguration configuration)
     {
-        var record = _database.ReadDatabaseRecord();
-
         if (configuration.Disabled)
             throw new InvalidOperationException($"The task {configuration.Name} has been disabled and cannot be used");
 
@@ -695,7 +693,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
             if (_workers.TryGetValue(identifier, out var existing) is false)
             {
-                _ = _workers.GetOrAdd(identifier, _ => CreateAiWorker(configuration)).RunAsync();
+                _ = _workers.GetOrAdd(identifier, _ => CreateAiWorker(record, configuration)).RunAsync();
                 continue;
             }
 
@@ -707,7 +705,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                 {
                     _ = toDispose.ShutdownAsync();
                 }
-                _ = _workers.GetOrAdd(identifier, _ => CreateAiWorker(configuration)).RunAsync();
+                _ = _workers.GetOrAdd(identifier, _ => CreateAiWorker(record, configuration)).RunAsync();
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-23960.cs
+++ b/test/SlowTests/Issues/RavenDB-23960.cs
@@ -1,0 +1,37 @@
+﻿using Raven.Client.Documents.Operations.OngoingTasks;
+using SlowTests.Server.Documents.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void DisabledTaskDoesntImpactCreationOfOtherTasks(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "Task1");
+            
+            var op = new GetOngoingTaskInfoOperation(configuration.Name, OngoingTaskType.EmbeddingsGeneration);
+            var taskInfo = (EmbeddingsGeneration)store.Maintenance.Send(op);
+            
+            store.Maintenance.Send(new ToggleOngoingTaskStateOperation(taskInfo.TaskId, OngoingTaskType.EmbeddingsGeneration, true));
+                
+            var (configuration2, _) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "Task2");
+
+            op = new GetOngoingTaskInfoOperation(configuration.Name, OngoingTaskType.EmbeddingsGeneration);
+            taskInfo = (EmbeddingsGeneration)store.Maintenance.Send(op);
+
+            Assert.Equal(OngoingTaskState.Disabled, taskInfo.TaskState);
+            
+            op = new GetOngoingTaskInfoOperation(configuration2.Name, OngoingTaskType.EmbeddingsGeneration);
+            taskInfo = (EmbeddingsGeneration)store.Maintenance.Send(op);
+
+            Assert.Equal(OngoingTaskState.Enabled, taskInfo.TaskState);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23960/Error-on-creating-Embeddings-Generation-task-when-some-other-is-disabled

### Additional description

Disabling embeddings generation task shouldn't prevent creating another task

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
