### PR TITLE
RavenDB-23119 - SlowTests.Cluster.ClusterTransactionTests.ClusterTransactionRequestWithRevisions (Add debug info)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -122,7 +122,8 @@ namespace Raven.Server.Documents.Handlers
 
                 context.Write(writer, new DynamicJsonValue
                 {
-                    ["Results"] = new DynamicJsonArray(items.Select(x => x.ToDebugJson()))
+                    ["Results"] = new DynamicJsonArray(items.Select(x => x.ToDebugJson())),
+                    ["DatabaseChangeVector"] = DocumentsStorage.GetFullDatabaseChangeVector(context)
                 });
             }
         }

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Utils;
@@ -11,6 +13,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
@@ -31,6 +34,7 @@ using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Sparrow.Json;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
@@ -1122,8 +1126,16 @@ namespace SlowTests.Cluster
                     }
                 }.Initialize())
                 {
-                    // let the document with the revision to replicate
-                    Assert.True(WaitForDocument(revivedStore, "foo/bar"));
+                    try
+                    {
+                        // let the document with the revision to replicate
+                        Assert.True(WaitForDocument(revivedStore, "foo/bar"));
+                    }
+                    catch
+                    {
+                        Console.WriteLine(await CollectDebugInfo(leader, revived, leaderStore, revivedStore, options));
+                        throw;
+                    }
                     using (var session = revivedStore.OpenAsyncSession())
                     {
                         session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
@@ -1170,6 +1182,93 @@ namespace SlowTests.Cluster
                     }
                 }
             }
+        }
+
+        private async Task<string> CollectDebugInfo(RavenServer leader, RavenServer revived, IDocumentStore leaderStore, IDocumentStore revivedStore, Options options)
+        {
+            var sb = new StringBuilder();
+            sb.Append("*********************************************************ClusterTransactionRequestWithRevisions(").Append(options.DatabaseMode)
+                .AppendLine(") Failed - Debug info -START-**********************************************************");
+
+            var nodeA = leader; //Servers[0];
+            var nodeB = revived;
+
+            if (nodeA != Servers[0])
+                sb.Append("nodeA (leader) is not Servers[0] - leader is '").Append(leader.ServerStore.NodeTag).Append("' and Servers[0] is '")
+                    .Append(Servers[0].ServerStore.NodeTag).AppendLine("'");
+
+            if (nodeB != Servers[1])
+                sb.Append("nodeB (revived) is not Servers[1] - revived is '").Append(revived.ServerStore.NodeTag).Append("' and Servers[1] is '")
+                    .Append(Servers[1].ServerStore.NodeTag).AppendLine("'");
+
+            sb.AppendLine("*********************************nodeA debug view*********************************");
+            GetDebugView(nodeA, sb);
+            sb.AppendLine("*********************************nodeA All Replication Items**********************");
+            var resA = await leaderStore.Maintenance.ForNode(nodeA.ServerStore.NodeTag).ForDatabase(leaderStore.Database).SendAsync(new GetAllReplicationItemsOperation());
+            sb.AppendLine(resA).AppendLine();
+
+            sb.AppendLine("*********************************nodeB debug view*********************************");
+            GetDebugView(nodeB, sb);
+            sb.AppendLine("*********************************nodeB All Replication Items**********************");
+            var resB = await revivedStore.Maintenance.ForNode(nodeB.ServerStore.NodeTag).ForDatabase(revivedStore.Database).SendAsync(new GetAllReplicationItemsOperation());
+            sb.AppendLine(resB).AppendLine();
+            
+            sb.AppendLine();
+            sb.Append("*********************************nodeA GetClusterDebugLogs*****************************");
+            GetClusterDebugLogsFromSpecificServer(sb, nodeA);
+            sb.AppendLine();
+            sb.Append("*********************************nodeB GetClusterDebugLogs******************************");
+            GetClusterDebugLogsFromSpecificServer(sb, nodeB);
+            
+            sb.AppendLine().AppendLine();
+            sb.Append("*********************************************************ClusterTransactionRequestWithRevisions(").Append(options.DatabaseMode)
+                .AppendLine(") Failed - Debug info -END-**********************************************************");
+            return sb.ToString();
+            
+            void GetDebugView(RavenServer server, StringBuilder sb)
+            {
+                var debugViewA = server.ServerStore.Engine.DebugView();
+                using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    debugViewA.PopulateLogs(context, fromIndex: null, take: Int32.MaxValue, detailed: true);
+                    var b = context.ReadObject(debugViewA.ToJson(), "");
+                    sb.AppendLine(b.ToString());
+                }
+            }
+        }
+
+
+
+        private class GetAllReplicationItemsOperation : IMaintenanceOperation<string>
+        {
+
+            public RavenCommand<string> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetAllReplicationItemsCommand();
+            }
+
+            private class GetAllReplicationItemsCommand : RavenCommand<string>
+            {
+                public override bool IsReadRequest => true;
+
+                public GetAllReplicationItemsCommand()
+                {
+                }
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/debug/replication/all-items";
+
+                    return new HttpRequestMessage { Method = HttpMethod.Get };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    Result = response.ToString();
+                }
+            }
+
         }
 
         [RavenTheory(RavenTestCategory.ClusterTransactions)]

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -13,7 +12,6 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
@@ -1204,21 +1202,33 @@ namespace SlowTests.Cluster
             sb.AppendLine("*********************************nodeA debug view*********************************");
             GetDebugView(nodeA, sb);
             sb.AppendLine("*********************************nodeA All Replication Items**********************");
-            var resA = await leaderStore.Maintenance.ForNode(nodeA.ServerStore.NodeTag).ForDatabase(leaderStore.Database).SendAsync(new GetAllReplicationItemsOperation());
+
+            var resA = string.Empty;
+            var resB = string.Empty;
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                var rA = await leaderStore.Maintenance.ForNode(nodeA.ServerStore.NodeTag).ForDatabase(leaderStore.Database)
+                    .SendAsync(ctx, new GetAllReplicationItemsOperation());
+
+                var rB = await revivedStore.Maintenance.ForNode(nodeB.ServerStore.NodeTag).ForDatabase(revivedStore.Database)
+                    .SendAsync(ctx, new GetAllReplicationItemsOperation());
+
+                resA = $"DatabaseChangeVector: {rA.DatabaseChangeVector} \nResults: {rA.Results}";
+                resB = $"DatabaseChangeVector: {rB.DatabaseChangeVector} \nResults: {rB.Results}";
+            }
             sb.AppendLine(resA).AppendLine();
 
             sb.AppendLine("*********************************nodeB debug view*********************************");
             GetDebugView(nodeB, sb);
             sb.AppendLine("*********************************nodeB All Replication Items**********************");
-            var resB = await revivedStore.Maintenance.ForNode(nodeB.ServerStore.NodeTag).ForDatabase(revivedStore.Database).SendAsync(new GetAllReplicationItemsOperation());
             sb.AppendLine(resB).AppendLine();
             
             sb.AppendLine();
             sb.Append("*********************************nodeA GetClusterDebugLogs*****************************");
-            GetClusterDebugLogsFromSpecificServer(sb, nodeA);
+            GetDebugLogsForNode(nodeA, sb);
             sb.AppendLine();
             sb.Append("*********************************nodeB GetClusterDebugLogs******************************");
-            GetClusterDebugLogsFromSpecificServer(sb, nodeB);
+            GetDebugLogsForNode(nodeB, sb);
             
             sb.AppendLine().AppendLine();
             sb.Append("*********************************************************ClusterTransactionRequestWithRevisions(").Append(options.DatabaseMode)
@@ -1236,39 +1246,6 @@ namespace SlowTests.Cluster
                     sb.AppendLine(b.ToString());
                 }
             }
-        }
-
-
-
-        private class GetAllReplicationItemsOperation : IMaintenanceOperation<string>
-        {
-
-            public RavenCommand<string> GetCommand(DocumentConventions conventions, JsonOperationContext context)
-            {
-                return new GetAllReplicationItemsCommand();
-            }
-
-            private class GetAllReplicationItemsCommand : RavenCommand<string>
-            {
-                public override bool IsReadRequest => true;
-
-                public GetAllReplicationItemsCommand()
-                {
-                }
-
-                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-                {
-                    url = $"{node.Url}/databases/{node.Database}/debug/replication/all-items";
-
-                    return new HttpRequestMessage { Method = HttpMethod.Get };
-                }
-
-                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-                {
-                    Result = response.ToString();
-                }
-            }
-
         }
 
         [RavenTheory(RavenTestCategory.ClusterTransactions)]

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1131,7 +1131,7 @@ namespace SlowTests.Cluster
                     }
                     catch
                     {
-                        Console.WriteLine(await CollectDebugInfo(leader, revived, leaderStore, revivedStore, options));
+                        Output.WriteLine(await CollectDebugInfo(leader, revived, leaderStore, revivedStore, options));
                         throw;
                     }
                     using (var session = revivedStore.OpenAsyncSession())

--- a/test/SlowTests/Issues/RavenDB_22195.cs
+++ b/test/SlowTests/Issues/RavenDB_22195.cs
@@ -25,49 +25,14 @@ namespace SlowTests.Issues
 
                 using (var commands = store.Commands())
                 {
-                    var command = new GetAllReplicationItemsCommand(etag: 234, pageSize: 100);
+                    var command = new GetAllReplicationItemsOperation.GetAllReplicationItemsCommand(etag: 234, pageSize: 100);
                     await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
 
-                    var results = command.Result;
+                    var results = command.Result.Results;
                     Assert.NotNull(results);
                 }
             }
         }
 
-        private class GetAllReplicationItemsCommand : RavenCommand<BlittableJsonReaderArray>
-        {
-            private readonly long _etag;
-            private readonly int _pageSize;
-
-            public override bool IsReadRequest => true;
-
-            public GetAllReplicationItemsCommand(long etag, int pageSize)
-            {
-                _etag = etag;
-                _pageSize = pageSize;
-            }
-
-            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-            {
-                url = $"{node.Url}/databases/{node.Database}/debug/replication/all-items?etag={_etag}&pageSize={_pageSize}";
-
-                return new HttpRequestMessage
-                {
-                    Method = HttpMethod.Get
-                };
-            }
-
-            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-            {
-                if (response == null ||
-                    response.TryGet("Results", out BlittableJsonReaderArray results) == false)
-                {
-                    ThrowInvalidResponse();
-                    return; // never hit
-                }
-
-                Result = results;
-            }
-        }
     }
 }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
@@ -1222,15 +1223,6 @@ namespace Tests.Infrastructure
             AppendDebugInfo(sb, debugInfo);
         }
 
-        internal void GetClusterDebugLogsFromSpecificServer(StringBuilder sb, RavenServer server)
-        {
-            NodeDebugInfo debugInfo = null;
-
-            debugInfo = GetDebugInfoForNode(server);
-
-            AppendDebugInfo(sb, debugInfo);
-        }
-
         internal static void GetDebugLogsForNode(RavenServer node, StringBuilder sb) => AppendDebugInfo(sb, GetDebugInfoForNode(node));
 
         private static NodeDebugInfo GetDebugInfoForNode(RavenServer node)
@@ -1330,6 +1322,76 @@ namespace Tests.Infrastructure
             }
 
             base.Dispose();
+        }
+
+        public class GetAllReplicationItemsOperation : IMaintenanceOperation<GetAllReplicationItemsOperation.Result>
+        {
+            private readonly long _etag;
+            private readonly int _pageSize;
+
+            public GetAllReplicationItemsOperation()
+            {
+                _etag = 0;
+                _pageSize = Int32.MaxValue;
+            }
+
+            public GetAllReplicationItemsOperation(long etag, int pageSize)
+            {
+                _etag = etag;
+                _pageSize = pageSize;
+            }
+
+            public RavenCommand<Result> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetAllReplicationItemsCommand(_etag, _pageSize);
+            }
+
+            public class GetAllReplicationItemsCommand : RavenCommand<Result>
+            {
+                private readonly long _etag;
+                private readonly int _pageSize;
+
+                public override bool IsReadRequest => true;
+
+                public GetAllReplicationItemsCommand(long etag, int pageSize)
+                {
+                    _etag = etag;
+                    _pageSize = pageSize;
+                }
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/debug/replication/all-items?etag={_etag}&pageSize={_pageSize}";
+
+                    return new HttpRequestMessage { Method = HttpMethod.Get };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    if (response == null ||
+                        response.TryGet("Results", out BlittableJsonReaderArray results) == false)
+                    {
+                        ThrowInvalidResponse();
+                        return; // never hit
+                    }
+
+                    if (response.TryGet("DatabaseChangeVector", out string databaseChangeVector) == false)
+                    {
+                        ThrowInvalidResponse();
+                        return; // never hit
+                    }
+
+                    Result = new Result() { Results = results, DatabaseChangeVector = databaseChangeVector };
+                }
+            }
+
+            public class Result
+            {
+                public BlittableJsonReaderArray Results { get; set; }
+
+                public string DatabaseChangeVector { get; set; }
+            }
+
         }
     }
 }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -1222,6 +1222,15 @@ namespace Tests.Infrastructure
             AppendDebugInfo(sb, debugInfo);
         }
 
+        internal void GetClusterDebugLogsFromSpecificServer(StringBuilder sb, RavenServer server)
+        {
+            NodeDebugInfo debugInfo = null;
+
+            debugInfo = GetDebugInfoForNode(server);
+
+            AppendDebugInfo(sb, debugInfo);
+        }
+
         internal static void GetDebugLogsForNode(RavenServer node, StringBuilder sb) => AppendDebugInfo(sb, GetDebugInfoForNode(node));
 
         private static NodeDebugInfo GetDebugInfoForNode(RavenServer node)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23119/SlowTests.Cluster.ClusterTransactionTests.ClusterTransactionRequestWithRevisionsoptions-DatabaseMode-Single-SearchEngineMode

### Additional description

Add debug info

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
