### PR TITLE
RavenDB-23642 Support for unbounded time queries in Corax between operation.

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -453,8 +453,12 @@ namespace Raven.Client
                     internal const string ShardContextDocumentIds = "DocumentIds";
 
                     internal const string ShardContextPrefixes = "Prefixes";
-
-
+                }
+                
+                public sealed class Terms
+                {
+                    internal const string LeftNullValueOfBetweenQuery = "*";
+                    internal const string RightNullValueOfBetweenQuery = "NULL";
                 }
             }
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -818,8 +818,13 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             AppendOperatorIfNeeded(tokens);
             NegateIfNeeded(tokens, fieldName);
 
-            var fromParameterName = AddQueryParameter(start == null ? "*" : TransformValue(new WhereParams { Value = start, FieldName = fieldName }, forRange: true));
-            var toParameterName = AddQueryParameter(end == null ? "NULL" : TransformValue(new WhereParams { Value = end, FieldName = fieldName }, forRange: true));
+            var fromParameterName = AddQueryParameter(start == null ? 
+                Constants.Documents.Querying.Terms.LeftNullValueOfBetweenQuery 
+                : TransformValue(new WhereParams { Value = start, FieldName = fieldName }, forRange: true));
+            
+            var toParameterName = AddQueryParameter(end == null 
+                ? Constants.Documents.Querying.Terms.RightNullValueOfBetweenQuery 
+                : TransformValue(new WhereParams { Value = end, FieldName = fieldName }, forRange: true));
 
             var whereToken = WhereToken.Create(WhereOperator.Between, fieldName, null, new WhereToken.WhereOptions(exact, fromParameterName, toParameterName));
             tokens.AddLast(whereToken);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -838,8 +838,7 @@ public static class CoraxQueryBuilder
         return (valueFirstType, valueSecondType) switch
         {
             (ValueTokenType.String, ValueTokenType.String) => HandleStringBetween(),
-            _ => CoraxBooleanItem.Build(builderParameters.IndexSearcher, index, fieldMetadata, valueFirst, valueSecond, UnaryMatchOperation.Between, leftSideOperation,
-                rightSideOperation, ref builderParameters.StreamingDisabled)
+            _ => CoraxBooleanItem.BuildBetween(builderParameters.IndexSearcher, index, fieldMetadata, valueFirst, valueSecond, leftSideOperation, rightSideOperation, ref builderParameters.StreamingDisabled)
         };
 
         IQueryMatch HandleStringBetween()
@@ -854,8 +853,7 @@ public static class CoraxQueryBuilder
                 builderParameters.HighlightingTerms[fieldName] = highlightingTerm;
             }
 
-            return CoraxBooleanItem.Build(builderParameters.IndexSearcher, index, fieldMetadata, valueFirstAsString, valueSecondAsString, UnaryMatchOperation.Between,
-                leftSideOperation, rightSideOperation, ref builderParameters.StreamingDisabled);
+            return CoraxBooleanItem.BuildBetween(builderParameters.IndexSearcher, index, fieldMetadata, valueFirstAsString, valueSecondAsString, leftSideOperation, rightSideOperation, ref builderParameters.StreamingDisabled);
         }
     }
 
@@ -871,7 +869,6 @@ public static class CoraxQueryBuilder
         return streamingOptimization.TrySetMultiTermMatchAsStreamingField(builderParameters.IndexSearcher, fieldMetadata, MethodType.Exists) 
             ? builderParameters.IndexSearcher.ExistsQuery(fieldMetadata, forward: streamingOptimization.Forward, streamingEnabled: true) 
             : builderParameters.IndexSearcher.ExistsQuery(fieldMetadata);
-        
     }
 
     private static IQueryMatch HandleStartsWith(Parameters builderParameters, MethodExpression expression, bool exact, ref StreamingOptimization streamingOptimization,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Corax;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Raven.Server.Documents.Queries;
 using Sparrow.Binary;
 using Sparrow.Extensions;
 using Voron;
+using Constants = Raven.Client.Constants;
 using IndexSearcher = Corax.Querying.IndexSearcher;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
@@ -20,26 +23,22 @@ public struct CoraxBooleanItem : IQueryMatch
     public readonly UnaryMatchOperation BetweenLeft;
     public readonly UnaryMatchOperation BetweenRight;
     private readonly IndexSearcher _indexSearcher;
-    private readonly bool _isTime;
     public bool IsBoosting => Boosting.HasValue;
     public float? Boosting;
     public long Count { get; }
 
-    private CoraxBooleanItem(IndexSearcher searcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation)
+    private CoraxBooleanItem(IndexSearcher indexSearcher, FieldMetadata field, object term, UnaryMatchOperation operation)
     {
         Field = field;
-        var ticks = default(long);
-        
-        _isTime = term is not null && index.IndexFieldsPersistence.HasTimeValues(Field.FieldName.ToString()) && QueryBuilderHelper.TryGetTime(index, term, out ticks);
-        Term = _isTime ? ticks : term;
+        Term = term;
 
         // in case of query "Field != null" or `Field != ""`
         if (Term is null || Term is string s)
             Term = QueryBuilderHelper.CoraxGetValueAsString(Term);
-        
-        
+
+
         Operation = operation;
-        _indexSearcher = searcher;
+        _indexSearcher = indexSearcher;
 
         Unsafe.SkipInit(out Term2);
         Unsafe.SkipInit(out BetweenLeft);
@@ -49,63 +48,121 @@ public struct CoraxBooleanItem : IQueryMatch
         {
             if (term is not (long or double))
                 TermAsString = QueryBuilderHelper.CoraxGetValueAsString(term);
-            
+
             Count = Term switch
             {
-                long l => searcher.NumberOfDocumentsUnderSpecificTerm(Field, l),
-                double d => searcher.NumberOfDocumentsUnderSpecificTerm(Field, d),
-                _ => searcher.NumberOfDocumentsUnderSpecificTerm(Field, TermAsString)
+                long l => indexSearcher.NumberOfDocumentsUnderSpecificTerm(Field, l),
+                double d => indexSearcher.NumberOfDocumentsUnderSpecificTerm(Field, d),
+                _ => indexSearcher.NumberOfDocumentsUnderSpecificTerm(Field, TermAsString)
             };
         }
         else
         {
             Unsafe.SkipInit(out TermAsString);
-            Count = searcher.GetTermAmountInField(Field);
+            Count = indexSearcher.GetTermAmountInField(Field);
         }
     }
 
-    public static IQueryMatch Build(IndexSearcher searcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization)
+
+    private CoraxBooleanItem(IndexSearcher indexSearcher, FieldMetadata field, object leftTerm, object rightTerm,
+        UnaryMatchOperation leftOperation, UnaryMatchOperation rightOperation)
     {
-        var cbi = new CoraxBooleanItem(searcher, index, field, term, operation);
-        if (field.HasBoost)
-            return cbi.Materialize(ref streamingOptimization);
-        return cbi;
+        Operation = UnaryMatchOperation.Between;
+        BetweenLeft = leftOperation;
+        BetweenRight = rightOperation;
+        Field = field;
+        Count = indexSearcher.GetTermAmountInField(Field);
+        _indexSearcher = indexSearcher;
+        Term = leftTerm is not string ? leftTerm : QueryBuilderHelper.CoraxGetValueAsString(leftTerm);
+        Term2 = rightTerm is not string ? rightTerm : QueryBuilderHelper.CoraxGetValueAsString(rightTerm);
     }
+
+    public static IQueryMatch Build(IndexSearcher indexSearcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization) => Build(indexSearcher, index, field, term, operation, ref streamingOptimization, out _);
     
-    public static IQueryMatch Build(IndexSearcher searcher, Index index, FieldMetadata field, object term1, object term2, UnaryMatchOperation operation, UnaryMatchOperation left, UnaryMatchOperation right, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization)
+    private static IQueryMatch Build(IndexSearcher indexSearcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization, out bool isTimeOrNumerical)
     {
-        var cbi = new CoraxBooleanItem(searcher, index, field, term1, term2, operation, left, right);
-        if (field.HasBoost)
-            return cbi.Materialize(ref streamingOptimization);
-        return cbi;
-    }
-    
-    private CoraxBooleanItem(IndexSearcher searcher, Index index, FieldMetadata field, object term1, object term2, UnaryMatchOperation operation, UnaryMatchOperation left, UnaryMatchOperation right) : this(searcher, index, field, term1, operation)
-    {
-        //Between handler
+        long timeTicks = 0L;
+        var fieldHasTime = index.IndexFieldsPersistence.HasTimeValues(field.FieldName.ToString());
+        var isTimeValue = fieldHasTime 
+                          && term is not null 
+                          && QueryBuilderHelper.TryGetTime(index, term, out timeTicks);
+        term = isTimeValue ? timeTicks : term;
         
-        if (_isTime) //found time at `Term1`, lets check if second item also contains time
-        {
-            if (term2 != null && index.IndexFieldsPersistence.HasTimeValues(field.FieldName.ToString()) && QueryBuilderHelper.TryGetTime(index, term2, out var ticks))
-            {
-                Term2 = ticks;
-            }
-            else  //not found, lets revert Term1 
-            {
-                Term = term1;
-                Term2 = term2;
-                _isTime = false;
-            }
-        }
-        else
-        {
-            Term2 = term2;
-        }
-
-        BetweenRight = right;
-        BetweenLeft = left;
+        if (fieldHasTime)
+            field = field.ChangeAnalyzer(FieldIndexingMode.Exact);
+        
+        var cbi = new CoraxBooleanItem(indexSearcher, field, term, operation);
+        
+        isTimeOrNumerical = term is long or double;
+        return field.HasBoost 
+            ? cbi.Materialize(ref streamingOptimization) 
+            : cbi;
     }
-    
+
+    public static IQueryMatch BuildBetween(IndexSearcher indexSearcher, Index index, FieldMetadata field, object leftValue, object rightValue,
+        UnaryMatchOperation leftOperator, UnaryMatchOperation rightOperator, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization)
+    {
+        var leftIsUnbounded = leftValue is null or Constants.Documents.Querying.Terms.LeftNullValueOfBetweenQuery;
+        var rightIsUnbounded = rightValue is null or Constants.Documents.Querying.Terms.RightNullValueOfBetweenQuery;
+
+        switch (IsLeftUnbounded: leftIsUnbounded, IsRightUnbounded: rightIsUnbounded)
+        {
+            case (IsLeftUnbounded: true, IsRightUnbounded: true):
+            {
+                Debug.Assert(streamingOptimization.OptimizationIsPossible == false);
+                var existsQuery = indexSearcher.ExistsQuery(field, streamingEnabled: false, forward: true);
+                
+                // matching lucene results, nulls included
+                return indexSearcher.IncludeNullMatch(field, existsQuery, forward: false);
+            }
+            
+            case (IsLeftUnbounded: true, IsRightUnbounded: false):
+            {
+                Debug.Assert(streamingOptimization.OptimizationIsPossible == false);
+                // between null and Value => (oo, x)
+                return Build(indexSearcher, index, field, rightValue, rightOperator, ref streamingOptimization);
+            }
+
+            case (IsLeftUnbounded: false, IsRightUnbounded: true):
+            {
+                Debug.Assert(streamingOptimization.OptimizationIsPossible == false);
+                // between Value and null => (x, oo)
+                var query = Build(indexSearcher, index, field, leftValue, leftOperator, ref streamingOptimization, out bool isNumerical);
+
+                // For numerical queries we will include the null values for backward compatibility.
+                if (isNumerical == false)
+                    return query;
+                
+                var materializedQuery = query switch
+                {
+                    CoraxBooleanItem bq => bq.Materialize(ref streamingOptimization),
+                    _ => query
+                };
+                
+                //matching lucene results, nulls included to right side (only for numerical & time queries)
+                return indexSearcher.IncludeNullMatch(field, materializedQuery, false);
+            }
+
+            case (IsLeftUnbounded: false, IsRightUnbounded: false):
+            {
+                var fieldHasTime = index.IndexFieldsPersistence.HasTimeValues(field.FieldName.ToString());
+                long ticksFromTerm1 = 0L, ticksFromTerm2 = 0L;
+                var term1HasTime = fieldHasTime && QueryBuilderHelper.TryGetTime(index, leftValue, out ticksFromTerm1);
+                var term2HasTime = fieldHasTime && QueryBuilderHelper.TryGetTime(index, rightValue, out ticksFromTerm2);
+
+                if (term1HasTime && term2HasTime)
+                    return new CoraxBooleanItem(indexSearcher, field, ticksFromTerm1, ticksFromTerm2, leftOperator, rightOperator);
+        
+                // since the field has time values, and time values are indexed in the exact manner,
+                // we disable analyzer (matching Lucene behavior) 
+                if (fieldHasTime)
+                    field = field.ChangeAnalyzer(FieldIndexingMode.Exact);
+        
+                return new CoraxBooleanItem(indexSearcher, field, leftValue, rightValue, leftOperator, rightOperator);
+            }
+        }
+    }
+
     public IQueryMatch OptimizeCompoundField(ref CoraxQueryBuilder.StreamingOptimization streamingOptimization)
     {
         switch (Operation)
@@ -114,7 +171,8 @@ public struct CoraxBooleanItem : IQueryMatch
             {
                 Slice startWith = GetStartWithTerm();
                 streamingOptimization.SkipOrderByClause = true;
-                return _indexSearcher.StartWithQuery(streamingOptimization.CompoundField, startWith, isNegated: false, forward: streamingOptimization.Forward, streamingEnabled: true, validatePostfixLen: true);
+                return _indexSearcher.StartWithQuery(streamingOptimization.CompoundField, startWith, isNegated: false, forward: streamingOptimization.Forward,
+                    streamingEnabled: true, validatePostfixLen: true);
             }
             default:
                 // TODO: RavenDB-21188

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -76,10 +76,8 @@ public struct CoraxBooleanItem : IQueryMatch
         Term = leftTerm is not string ? leftTerm : QueryBuilderHelper.CoraxGetValueAsString(leftTerm);
         Term2 = rightTerm is not string ? rightTerm : QueryBuilderHelper.CoraxGetValueAsString(rightTerm);
     }
-
-    public static IQueryMatch Build(IndexSearcher indexSearcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization) => Build(indexSearcher, index, field, term, operation, ref streamingOptimization, out _);
     
-    private static IQueryMatch Build(IndexSearcher indexSearcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization, out bool isTimeOrNumerical)
+    public static IQueryMatch Build(IndexSearcher indexSearcher, Index index, FieldMetadata field, object term, UnaryMatchOperation operation, ref CoraxQueryBuilder.StreamingOptimization streamingOptimization)
     {
         long timeTicks = 0L;
         var fieldHasTime = index.IndexFieldsPersistence.HasTimeValues(field.FieldName.ToString());
@@ -88,12 +86,8 @@ public struct CoraxBooleanItem : IQueryMatch
                           && QueryBuilderHelper.TryGetTime(index, term, out timeTicks);
         term = isTimeValue ? timeTicks : term;
         
-        if (fieldHasTime)
-            field = field.ChangeAnalyzer(FieldIndexingMode.Exact);
-        
         var cbi = new CoraxBooleanItem(indexSearcher, field, term, operation);
         
-        isTimeOrNumerical = term is long or double;
         return field.HasBoost 
             ? cbi.Materialize(ref streamingOptimization) 
             : cbi;
@@ -127,11 +121,7 @@ public struct CoraxBooleanItem : IQueryMatch
             {
                 Debug.Assert(streamingOptimization.OptimizationIsPossible == false);
                 // between Value and null => (x, oo)
-                var query = Build(indexSearcher, index, field, leftValue, leftOperator, ref streamingOptimization, out bool isNumerical);
-
-                // For numerical queries we will include the null values for backward compatibility.
-                if (isNumerical == false)
-                    return query;
+                var query = Build(indexSearcher, index, field, leftValue, leftOperator, ref streamingOptimization);
                 
                 var materializedQuery = query switch
                 {
@@ -139,7 +129,6 @@ public struct CoraxBooleanItem : IQueryMatch
                     _ => query
                 };
                 
-                //matching lucene results, nulls included to right side (only for numerical & time queries)
                 return indexSearcher.IncludeNullMatch(field, materializedQuery, false);
             }
 
@@ -155,7 +144,7 @@ public struct CoraxBooleanItem : IQueryMatch
         
                 // since the field has time values, and time values are indexed in the exact manner,
                 // we disable analyzer (matching Lucene behavior) 
-                if (fieldHasTime)
+                if (term1HasTime || term2HasTime)
                     field = field.ChangeAnalyzer(FieldIndexingMode.Exact);
         
                 return new CoraxBooleanItem(indexSearcher, field, leftValue, rightValue, leftOperator, rightOperator);

--- a/test/SlowTests/Issues/RavenDB-23642.cs
+++ b/test/SlowTests/Issues/RavenDB-23642.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using FastTests;
+using Raven.Client;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void UnboundedBetweenTimeQueries(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        var user2021 =
+            new User { StartDate = new DateTime(2021, 1, 1), EndDate = new DateTime(2021, 1, 31) };
+        var user2022 =
+            new User { StartDate = new DateTime(2022, 1, 1), EndDate = new DateTime(2022, 1, 31) };
+        var emptyUser = new User();
+
+        session.Store(user2021);
+        session.Store(user2022);
+        session.Store(emptyUser);
+        session.SaveChanges();
+
+        var results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereBetween(x => x.StartDate, new DateTime(2022, 1, 1), null)
+            .ToList();
+        Assert.Equal(2, results.Count);
+        Assert.Equal(user2022.Id, results[0].Id);
+        Assert.Equal(emptyUser.Id, results[1].Id);
+
+        results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereBetween(x => x.StartDate, null, new DateTime(2021, 12, 31))
+            .ToList();
+        Assert.Equal(1, results.Count);
+        Assert.Equal(user2021.Id, results[0].Id);
+
+
+        results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereBetween(x => x.StartDate, null, null)
+            .ToList();
+        Assert.Equal(3, results.Count);
+        Assert.Equal(user2021.Id, results[0].Id);
+        Assert.Equal(user2022.Id, results[1].Id);
+        Assert.Equal(emptyUser.Id, results[2].Id);
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CoraxUnboundedTextualBetweenQueries(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        
+        var u0 = new User() { Textual = "&" };
+        var u1 = new User() { Textual = "&a" };
+        var u2 = new User() { Textual = "aa" };
+        var u3 = new User() { Textual = "o" };
+        var u4 = new User() { Textual = null };
+        session.Store(u0);
+        session.Store(u1);
+        session.Store(u2);
+        session.Store(u3);
+        session.Store(u4);
+        session.SaveChanges();
+
+
+        var results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereBetween(x => x.Textual, null, "aa")
+            .ToList();
+
+        WaitForUserToContinueTheTest(store);
+        Assert.Equal(3, results.Count);
+        Assert.Equal(u0.Id, results[0].Id);
+        Assert.Equal(u1.Id, results[1].Id);
+        Assert.Equal(u2.Id, results[2].Id);
+        
+        
+        results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereBetween(x => x.Textual, "&a", null)
+            .ToList();
+        
+        Assert.Equal(3, results.Count);
+        Assert.Equal(u1.Id, results[0].Id);
+        Assert.Equal(u2.Id, results[1].Id);
+        Assert.Equal(u3.Id, results[2].Id);
+        
+        results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereBetween(x => x.Textual, null, null)
+            .ToList();
+        
+        Assert.Equal(5, results.Count);
+        Assert.Equal(u0.Id, results[0].Id);
+        Assert.Equal(u1.Id, results[1].Id);
+        Assert.Equal(u2.Id, results[2].Id);
+        Assert.Equal(u3.Id, results[3].Id);
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Textual { get; set; }
+
+        public float? Number { get; set; }
+
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23642.cs
+++ b/test/SlowTests/Issues/RavenDB-23642.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FastTests;
 using Raven.Client;
+using Sparrow.Server.Extensions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,10 +17,15 @@ public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
         using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        var upTo = new DateTime(2021, 1, 1).ToString("O");
+
         var user2021 =
-            new User { StartDate = new DateTime(2021, 1, 1), EndDate = new DateTime(2021, 1, 31) };
+            new User { StartDate = new DateTime(2021, 1, 1), 
+                EndDate = new DateTime(2021, 1, 31),
+                Textual = upTo
+            };
         var user2022 =
-            new User { StartDate = new DateTime(2022, 1, 1), EndDate = new DateTime(2022, 1, 31) };
+            new User { StartDate = new DateTime(2022, 1, 1), EndDate = new DateTime(2022, 1, 31), Textual = "Maciej"};
         var emptyUser = new User();
 
         session.Store(user2021);
@@ -54,6 +60,23 @@ public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal(user2021.Id, results[0].Id);
         Assert.Equal(user2022.Id, results[1].Id);
         Assert.Equal(emptyUser.Id, results[2].Id);
+
+
+        results = session.Advanced
+            .RawQuery<User>($"from Users where Textual between '1' and '{upTo}'")
+            .WaitForNonStaleResults()
+            .ToList();
+        Assert.Equal(1, results.Count);
+        Assert.Equal(user2021.Id, results[0].Id);
+
+        results = session.Advanced
+            .RawQuery<User>($"from Users where Textual between 'm' and 'Maciej'")
+            .WaitForNonStaleResults()
+            .ToList();
+        
+        Assert.Equal(1, results.Count);
+        Assert.Equal(user2022.Id, results[0].Id);
+
     }
     
     [RavenTheory(RavenTestCategory.Querying)]
@@ -96,10 +119,11 @@ public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
             .WhereBetween(x => x.Textual, "&a", null)
             .ToList();
         
-        Assert.Equal(3, results.Count);
+        Assert.Equal(4, results.Count);
         Assert.Equal(u1.Id, results[0].Id);
         Assert.Equal(u2.Id, results[1].Id);
         Assert.Equal(u3.Id, results[2].Id);
+        Assert.Equal(u4.Id, results[3].Id);
         
         results = session.Advanced
             .DocumentQuery<User>()
@@ -112,6 +136,7 @@ public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal(u1.Id, results[1].Id);
         Assert.Equal(u2.Id, results[2].Id);
         Assert.Equal(u3.Id, results[3].Id);
+        Assert.Equal(u4.Id, results[4].Id);
     }
 
     private class User


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23642

### Additional description
This PR allows querying unbounded time queries via `between` method (exactly the same way as Lucene does). However, the Corax string unbounded queries do not match null values, since Lucene's `between` matches null only because it has indexed `NULL_VALUE`, so it matches them as a string


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
