### PR TITLE
RavenDB-24041 switched to tx merger when incrementing engine boots in snmp

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -19,6 +19,7 @@ using Raven.Client;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Config.Categories;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Monitoring.Snmp.Objects.Cluster;
 using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.Monitoring.Snmp.Objects.Server;
@@ -226,15 +227,9 @@ namespace Raven.Server.Monitoring.Snmp
                 }
             }
 
-            int engineBoots;
-            using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (var tx = context.OpenWriteTransaction())
-            {
-                var tree = tx.InnerTransaction.CreateTree(nameof(SnmpWatcher));
-                engineBoots = (int)tree.Increment("EngineBoots", 1);
-
-                tx.Commit();
-            }
+            var command = new IncrementEngineBootsCommand();
+            server.ServerStore.Engine.TxMerger.EnqueueSync(command);
+            var engineBoots = command.EngineBoots;
 
             var engineGroup = new EngineGroup(engineBoots, GetIsInTime(server.Configuration.Monitoring))
             {
@@ -243,7 +238,7 @@ namespace Raven.Server.Monitoring.Snmp
 
             var engine = new SnmpEngine(factory, listener, engineGroup);
             engine.Listener.AddBinding(new IPEndPoint(IPAddress.Any, server.Configuration.Monitoring.Snmp.Port));
-            engine.Listener.ExceptionRaised += (sender, e) =>
+            engine.Listener.ExceptionRaised += (_, e) =>
             {
                 // MessageFactoryException hides inner exception
                 if (Logger.IsOperationsEnabled)
@@ -305,8 +300,8 @@ namespace Raven.Server.Monitoring.Snmp
         private static Func<int[], int, int, bool> GetIsInTime(MonitoringConfiguration monitoringConfiguration)
         {
             return monitoringConfiguration.Snmp.DisableTimeWindowChecks
-                ? (currentTimeData, pastReboots, pastTime) => true
-                : (Func<int[], int, int, bool>)null;
+                ? (_, _, _) => true
+                : null;
         }
 
         private static (HashSet<SnmpVersion> Versions, string HandlerVersion) GetVersions(RavenServer server)
@@ -694,6 +689,24 @@ namespace Raven.Server.Monitoring.Snmp
 
                 _logger.Info(builder.ToString());
 #endif
+            }
+        }
+
+        private class IncrementEngineBootsCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+        {
+            public int EngineBoots;
+
+            protected override long ExecuteCmd(ClusterOperationContext context)
+            {
+                var tree = context.Transaction.InnerTransaction.CreateTree(nameof(SnmpWatcher));
+                EngineBoots = (int)tree.Increment(nameof(EngineBoots), 1);
+
+                return 1;
+            }
+
+            public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+            {
+                throw new NotImplementedException();
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24041

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
