### PR TITLE
RavenDB-24020 Allow to parallelize HNSW work 

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -76,6 +76,8 @@ namespace Corax.Indexing
         private Lookup<Int64LookupKey> _entryIdToLocation;
         private IndexFieldsMapping _dynamicFieldsMapping;
         private PostingList _largePostingListSet;
+        public int? MaximumConcurrentBatchesForHnswAcceleration;
+        
         private long _compactTreeDictionaryId = Constants.IndexSearcher.InvalidId;
 
         /// <summary>

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -993,6 +993,8 @@ namespace Corax.Indexing
                 {
                     using var __ = staticFieldScope.For(CommitOperation.VectorValues);
                     RegisterVectorRootPage(indexedField.FieldRootPage);
+                    if (MaximumConcurrentBatchesForHnswAcceleration != null)
+                        indexedField.VectorIndexer.MaxConcurrentBatches = MaximumConcurrentBatchesForHnswAcceleration.Value;
                     indexedField.VectorIndexer.Commit();
                 }
                 

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -260,7 +260,7 @@ namespace Corax.Querying.Matches
                 if (_smallPostListIds.Count == 0)
                     return;
                 
-                Container.GetAll(_searcher._transaction.LowLevelTransaction, _smallPostListIds.ToSpan(), _containerItems, long.MinValue, _pageLocator);
+                Container.GetAll(_searcher._transaction.LowLevelTransaction, _smallPostListIds.ToSpan(), new Span<UnmanagedSpan>(_containerItems, _smallPostListIds.Count), long.MinValue, _pageLocator);
             }
 
             private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -187,7 +187,7 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending);
             var indexes = SortByTerms(ref match, batchTermIds, batchTerms, descending, indirectComparer);
             for (int i = 0; i < indexes.Length; i++)
@@ -446,7 +446,7 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var heapCapacity = _take == -1 ? batchResults.Length : Math.Min(_take, batchResults.Length);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(heapCapacity)];
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -372,7 +372,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             if (_smallPostListIds.Count == 0)
                 return;
 
-            Container.GetAll(_llt, _smallPostListIds.ToSpan(), _containerItems, long.MinValue, _pageLocator);
+            Container.GetAll(_llt, _smallPostListIds.ToSpan(), new Span<UnmanagedSpan>(_containerItems, _smallPostListIds.Count), long.MinValue, _pageLocator);
         }
 
         private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -227,7 +227,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             match._token.ThrowIfCancellationRequested();
             bool isDescending = orderMetadata[0].Ascending == false;
 
@@ -558,7 +558,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             for (int i = 0; i < batchTermIds.Length; i++)
                 documents[i] = i;

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
@@ -203,7 +203,7 @@ namespace Corax.Querying.Matches.TermProviders
             }
             
             
-            Voron.Data.Containers.Container.GetAll(_searcher._transaction.LowLevelTransaction, containersIds, containersPtr, -1, _searcher.Transaction.LowLevelTransaction.PageLocator);
+            Voron.Data.Containers.Container.GetAll(_searcher._transaction.LowLevelTransaction, containersIds, new Span<UnmanagedSpan>(containersPtr, containersIds.Length), -1, _searcher.Transaction.LowLevelTransaction.PageLocator);
             
             for (int i = _nullExists ? 1 : 0; i < NumberOfTerms; ++i)
             {

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
@@ -268,7 +268,7 @@ namespace Corax.Querying.Matches.TermProviders
             using var _ = allocator.Allocate((sizeof(UnmanagedSpan)) * postingLists.Count, out ByteString containers);
             var containersPtr = (UnmanagedSpan*)containers.Ptr;
       
-            Container.GetAll(_searcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersPtr, singleMarker, _searcher._transaction.LowLevelTransaction.PageLocator);
+            Container.GetAll(_searcher._transaction.LowLevelTransaction, postingLists.ToSpan(), new Span<UnmanagedSpan>(containersPtr, postingLists.Count), singleMarker, _searcher._transaction.LowLevelTransaction.PageLocator);
 
             long totalCount = 0;
             for (int i = 0; i < postingLists.Count; ++i)

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
@@ -269,7 +269,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, I
         using var _ = allocator.Allocate((sizeof(UnmanagedSpan)) * postingLists.Count, out ByteString containers);
         var containersPtr = (UnmanagedSpan*)containers.Ptr;
 
-        Container.GetAll(_indexSearcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersPtr, singleMarker,
+        Container.GetAll(_indexSearcher._transaction.LowLevelTransaction, postingLists.ToSpan(), new Span<UnmanagedSpan>(containersPtr, postingLists.Count), singleMarker,
             _indexSearcher._transaction.LowLevelTransaction.PageLocator);
 
         long totalCount = 0;

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -644,7 +644,13 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.Corax.VectorSearch.MaxNumberOfThreadsForLocalEmbeddingsGeneration", ConfigurationEntryScope.ServerWideOnly)]
         public int MaxNumberOfThreadsForLocalEmbeddingsGeneration { get; set; }
-        
+
+        [Description("Expert: The maximum number of concurrent batches for HNSW distance computation acceleration.")]
+        [DefaultValue(512)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.MaximumConcurrentBatchesForHnswAcceleration", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public int MaximumConcurrentBatchesForHnswAcceleration { get; set; }
+
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForDebug.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForDebug.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -85,6 +86,13 @@ internal sealed class IndexHandlerProcessorForDebug : AbstractIndexHandlerProces
 
                 writer.WriteEndObject();
 
+                return;
+            }
+            
+            if (string.Equals(operation, "hnsw", StringComparison.OrdinalIgnoreCase))
+            {
+                var field = RequestHandler.GetStringQueryString("field");
+                index.HnswOutput(field, writer);
                 return;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -1,13 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
+using Corax.Querying;
+using Microsoft.AspNetCore.Connections.Features;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
+using Raven.Server.Documents.Indexes.Persistence;
+using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Results;
+using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -21,6 +28,7 @@ using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Compression;
 using Voron.Data.Fixed;
+using Voron.Data.Graphs;
 using Voron.Data.Tables;
 using Constants = Raven.Client.Constants;
 
@@ -190,6 +198,54 @@ namespace Raven.Server.Documents.Indexes.Debugging
                 return scope.Delay();
             }
         }
+        
+        public static void HnswOutput(this Index self, string field, AsyncBlittableJsonTextWriter writer)
+        {
+            using var _ = self._contextPool.AllocateOperationContext(out TransactionOperationContext indexContext);
+            using var tx = indexContext.OpenReadTransaction();
+            writer.WriteStartArray();
+            bool first = true;
+            var indexReader = (CoraxIndexReadOperation)self.IndexPersistence.OpenIndexReader(tx.InnerTransaction);
+            foreach (var node in Hnsw.IterateNodes(tx.InnerTransaction.LowLevelTransaction, field))
+            {
+                if (first is false)
+                {
+                    writer.WriteComma();
+                    writer.WriteRawString("\n"u8);
+                }
+                first = false;
+                var edges = new DynamicJsonArray();
+                for (int i = 0; i < node.EdgesByLevel.Length; i++)
+                {
+                    var lists = new DynamicJsonArray();
+                    for (int j = 0; j < node.EdgesByLevel[i].Length; j++)
+                    {
+                        (long NodeId, float Distance) = node.EdgesByLevel[i][j];
+                        lists.Add(new DynamicJsonValue
+                        {
+                            [nameof(NodeId)] = NodeId,
+                            [nameof(Distance)] = Distance
+                        });
+                    }
+                    edges.Add(new DynamicJsonValue
+                    {
+                        ["Level"] = i,
+                        ["Links"] = lists
+                    });
+                }
+
+                var djv = new DynamicJsonValue
+                {
+                    [nameof(node.NodeId)] = node.NodeId,
+                    [nameof(node.Entries)] = node.Entries.Select(indexReader.GetDocumentIdFor),
+                    [nameof(node.EdgesByLevel)] = edges
+                };
+                
+                indexContext.Write(writer, djv);
+            }
+            writer.WriteEndArray();
+        }
+
 
         private static IEnumerable<ReduceTree> IterateTrees(Index self, List<FixedSizeTree> mapEntries,
             Tree reducePhaseTree, FixedSizeTree typePerHash, TransactionOperationContext indexContext, DisposableScope scope)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1323,6 +1323,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             QueryPool.Return(ids);
         }
 
+        public string GetDocumentIdFor(long entryId)
+        {
+            return _documentIdReader.GetTermFor(entryId);
+        }
+        
         public override IEnumerable<BlittableJsonReaderObject> IndexEntries(IndexQueryServerSide query, Reference<long> totalResults,
             DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField, bool ignoreLimit, CancellationToken token)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -46,9 +46,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             _allocator = writeTransaction.Allocator;
             try
             {
-                _indexWriter =  new IndexWriter(writeTransaction, knownFields, new SupportedFeatures(
+                _indexWriter = new IndexWriter(writeTransaction, knownFields, new SupportedFeatures(
                     isPhraseQuerySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes,
-                    isStoreOnlySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.StoreOnlySupportInCoraxIndexes));
+                    isStoreOnlySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.StoreOnlySupportInCoraxIndexes))
+                {
+                    MaximumConcurrentBatchesForHnswAcceleration = index.Configuration.MaximumConcurrentBatchesForHnswAcceleration
+                };
             }
             catch (Exception e) when (e.IsOutOfMemory())
             {

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -31,6 +31,7 @@ using Sparrow.Server.Logging;
 using Sparrow.Server.Platform;
 using Sparrow.Utils;
 using Voron;
+using Voron.Data.Graphs;
 using Voron.Exceptions;
 using Voron.Impl;
 using NativeMemory = Sparrow.Utils.NativeMemory;

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -46,13 +46,12 @@ class configurationItem {
         "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
         "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
         "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
-
-
         "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
         "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying",
-        "Indexing.Corax.VectorSearch.OrderByScoreAutomatically"
+        "Indexing.Corax.VectorSearch.OrderByScoreAutomatically",
+        "Indexing.Corax.VectorSearch.MaximumConcurrentBatchesForHnswAcceleration",
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -584,7 +584,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteRawString(ReadOnlySpan<byte> buffer)
+        public void WriteRawString(ReadOnlySpan<byte> buffer)
         {
             if (buffer.Length < JsonOperationContext.MemoryBuffer.DefaultSize)
             {

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -1417,7 +1417,7 @@ namespace Voron.Data.Containers
         /// <summary>
         /// Assumes that ids is sorted 
         /// </summary>
-        public static void GetAll(LowLevelTransaction llt, Span<long> ids, UnmanagedSpan* spans, long missingValue, PageLocator pageCache)
+        public static void GetAll(LowLevelTransaction llt, Span<long> ids, Span<UnmanagedSpan> spans, long missingValue, PageLocator pageCache)
         {
             for (int i = 0; i < ids.Length; i++)
             {
@@ -1434,14 +1434,14 @@ namespace Voron.Data.Containers
                     pageCache.SetReadable(page);
                 }
 
-                var container = new Container(page);
-                
-                if (container._page.IsOverflow)
+                if (page.IsOverflow)
                 {
                     spans[i] = new(page.DataPointer, page.OverflowSize);
                     continue;
                 }
-
+                
+                var container = new Container(page);
+                
                 var metadata = container.MetadataFor(OffsetToIndex(offset));
                 Debug.Assert(metadata.IsFree == false);
                 var p = page.Pointer;

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -13,29 +13,70 @@ using Voron.Debugging;
 using Voron.Global;
 using Voron.Impl;
 using Voron.Util;
+using Voron.Util.PFor;
 using Constants = Voron.Global.Constants;
 
 namespace Voron.Data.Graphs;
 
 public unsafe partial class Hnsw
 {
-    private static long GetPostingListCount(LowLevelTransaction llt,long postingListId)
+    public record NodeForDebug(
+        long NodeId,
+        long[] Entries,
+        (long NodeId, float Distance)[][] EdgesByLevel
+    );
+    
+    public static IEnumerable<NodeForDebug> IterateNodes(LowLevelTransaction llt, string name)
     {
+        var searchState = new SearchState(llt, name);
+        for (long nodeId = 1; nodeId <= searchState.Options.CountOfVectors; nodeId++)
+        {
+            var node = searchState.GetNodeById(nodeId);
+            int nodeIndex = searchState.GetNodeIndexById(nodeId);
+            long[] entries = GetEntries(llt, node.PostingListId);
+            var edgesByLevel = new (long NodeId, float Distance)[node.EdgesPerLevel.Count][];
+            for (int i = 0; i < node.EdgesPerLevel.Count; i++)
+            {
+                edgesByLevel[i] = new (long NodeId, float Distance)[node.EdgesPerLevel[i].Count];
+                for (int j = 0; j <  node.EdgesPerLevel[i].Count; j++)
+                {
+                    long id = node.EdgesPerLevel[i][j];
+                    int index = searchState.GetNodeIndexById(id);
+                    edgesByLevel[i][j] = (id, searchState.Distance(ReadOnlySpan<byte>.Empty, nodeIndex, index));
+                }
+            }
+            yield return new NodeForDebug(nodeId, entries, edgesByLevel);
+        }
+    }
+
+    public static long[] GetEntries(LowLevelTransaction llt,long postingListId)
+    {
+        long rawPostingListId = postingListId & Constants.Graphs.VectorId.ContainerType;
         switch (postingListId & Constants.Graphs.VectorId.EnsureIsSingleMask)
         {
             case Constants.Graphs.VectorId.Tombstone:
-                return 0;
+                return [];
             case Constants.Graphs.VectorId.Single:
-                return 1;
+                return [rawPostingListId];
             case Constants.Graphs.VectorId.SmallPostingList:
             {
-                var item = Container.Get(llt, postingListId & Constants.Graphs.VectorId.ContainerType);
-                return VariableSizeEncoding.Read<int>(item.Address, out _);
+                var list = new ContextBoundNativeList<long>(llt.Allocator);
+                FastPForDecoder decoder = new();
+                SearchState.ReadPostingList(llt, rawPostingListId, ref list, ref decoder, out var size);
+                list.Count = size;
+                long[] array = list.ToSpan().ToArray();
+                list.Dispose();
+                return array;
             }
             case Constants.Graphs.VectorId.PostingList:
             {
-                var item = Container.Get(llt, postingListId & Constants.Graphs.VectorId.ContainerType);
-                return ((PostingListState*)item.Address)->NumberOfEntries;
+                var setStateSpan = Container.GetReadOnly(llt, rawPostingListId);
+                ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
+                var postingList = new PostingList(llt, Slices.Empty, setState);
+                var result = new long[(int)Math.Min(postingList.State.NumberOfEntries, 16)];
+                var it = postingList.Iterate();
+                it.Fill(result, out var count);
+                return result;
             }
         }
 
@@ -123,19 +164,20 @@ table, th, td {
                 int cols = 0;
                 for (int j = 1; j <= searchState.Options.CountOfVectors; j++)
                 {
-                    ref var n = ref searchState.GetNodeById(j);
+                    var nodeIdx = searchState.GetNodeIndexById(j);
+                    ref var n = ref searchState.Nodes[nodeIdx];
                     if (level >= n.EdgesPerLevel.Count)
                         continue;
 
-                    var dist = searchState.Distance(vector, -1, j);
-                    var isPath = path[level] == j ? "path" : "";
-                    var isResult =  level == 0 && edges.Items.Contains(j) ? "result": "";
-                    var nextId = level == 0 ? (edges.Items.Contains(j) ?"***": "") : $"N_{path[level - 1]}_{level - 1}";
+                    var dist = searchState.Distance(vector, -1, nodeIdx);
+                    var isPath = path[level] == nodeIdx ? "path" : "";
+                    var isResult =  level == 0 && edges.Items.Contains(nodeIdx) ? "result": "";
+                    var nextId = level == 0 ? (edges.Items.Contains(nodeIdx) ?"***": "") : $"N_{path[level - 1]}_{level - 1}";
                     f.WriteLine($"<td> <table id='N_{j}_{level}'><tr><th class='{isPath} {isResult}'>N_{j}_{level} - {GetEntryId(llt,n.PostingListId)}</th>" +
                                 $"<th>{n.EdgesPerLevel[level].Count}</th><th>{dist} (<a href='#{nextId}'>{nextId}</a>)</th></tr><tr>");
                     foreach (var to in n.EdgesPerLevel[level])
                     {
-                        dist = searchState.Distance(Span<byte>.Empty, j, searchState.GetNodeIndexById(to));
+                        dist = searchState.Distance(Span<byte>.Empty, nodeIdx, searchState.GetNodeIndexById(to));
                         var srcDist = searchState.Distance(vector, -1, searchState.GetNodeIndexById(to));
                         var id = $"N_{to}_{Math.Max(0, level-1)}";
                      

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -143,7 +143,8 @@ public partial class Hnsw
             private ulong[] _visitedBitmap = [];
             private int[] _visitedBitmapVersion = [];
             private int _visitedVersion;
-
+            private readonly LinkedListNode<int> _listNode = new(-1);
+            
             private void ClearVisited()
             {
                 // this needs to be _cheap_, since it is called per node per level
@@ -199,10 +200,13 @@ public partial class Hnsw
                         // to keep whatever is "in-flight" in a linked list that we can 
                         // cheaply add & remove to
                         var currentNodeIndex = _searchState.GetCreatedNodeIndex(createdNodeIndex); 
+                        _listNode.Value = currentNodeIndex;
+                        runner.AddInFlight(_listNode);
                         foreach (var item in FindGraphPlacementForNode(createdNodeIndex, currentNodeIndex))
                         {
                             yield return item;
                         }
+                        runner.RemoveInFlight(_listNode);
                     }
                 }
                 finally
@@ -285,22 +289,19 @@ public partial class Hnsw
                 }
             }
 
-            private void AddEdgesFromInFlightNodes(ref Node n, int currentNodeIndex)
+            private void AddEdgesFromInFlightNodes(ref Node n, int createdNodeIndex)
             {
-                CollectionsMarshal.SetCount(_indexes, _searchState.Options.NumberOfEdges);
-
                 // Here we add "number of edges" previously added items to as the edges in all their levels
                 // so the next stage will add the edges that were already added to the graph and then find 
                 // only the most suitable ones. It has the impact of increasing the likelihood that 
                 // items that are added at the same time (and thus temporally linked, at least) will
                 // be joined. Quite important when you consider that a single document may have multiple
                 // vectors associated with it (for example, because of chunking).
-                var limit = Math.Max(0, currentNodeIndex - _searchState.Options.NumberOfEdges);
-                for (int i = currentNodeIndex -1; i >= limit; i--)
+                CollectionsMarshal.SetCount(_indexes, _searchState.Options.NumberOfEdges);
+                var used = runner.GetInFlightIndexes(_listNode, CollectionsMarshal.AsSpan(_indexes));
+                for (int i = 0; i < used; i++)
                 {
-                    ref var edge = ref _searchState.GetNodeByIndex(
-                        _searchState.GetCreatedNodeIndex(i)
-                    );
+                    ref var edge = ref _searchState.GetNodeByIndex(_indexes[i]);
                     int sharedLevels = Math.Min(edge.EdgesPerLevel.Count, n.EdgesPerLevel.Count);
                     for (int level = 0; level < sharedLevels; level++)
                     {
@@ -599,8 +600,20 @@ public partial class Hnsw
             private readonly SearchState _searchState;
             private readonly CancellationTokenSource _cts = new();
             private readonly List<Exception> _errors = [];
+            private readonly LinkedList<int> _inFlightIndexes = [];
 
             public bool IsCancelled => _cts.IsCancellationRequested;
+            
+
+            public void AddInFlight(LinkedListNode<int> node)
+            {
+                _inFlightIndexes.AddLast(node);
+            }
+
+            public void RemoveInFlight(LinkedListNode<int> node)
+            {
+                _inFlightIndexes.Remove(node);
+            }
 
             public NodePlacementRunner(Registration parent, int activeTasksCount)
             {
@@ -740,6 +753,19 @@ public partial class Hnsw
             public void Done()
             {
                 _completed++;
+            }
+            
+            public int GetInFlightIndexes(LinkedListNode<int> n, Span<int> buffer)
+            {
+                var index = 0;
+                var cur = n.Previous;
+                while(cur != null && index < buffer.Length)
+                {
+                    buffer[index++] = cur.Value;
+                    cur = cur.Previous;
+                }
+
+                return index;
             }
         }
         

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -1,0 +1,809 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow;
+using Sparrow.Binary;
+using Sparrow.Server.Utils;
+using Sparrow.Server.Utils.VxSort;
+using Voron.Data.Containers;
+using Voron.Util;
+using Array = System.Array;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    /*
+     * The problem with HNSW is that it is a graph algorithm, which requires
+     * that we'll touch significantly more nodes than we would usually do in a B+Tree, 
+     * for example. 
+     * 
+     * If we need to index 1M items, using a B+Tree, I can sort them and be sure that I 
+     * can get pretty good disk access patterns. For HNSW - the problem is that we need to
+     * do effectively random I/O for each lookup. Sequential HNSW is running this one node 
+     * at a time, which link each node to its nearest neighbors. It has horrible performance
+     * once you exceed the size of memory on the machine.
+     * 
+     * Adding 1M nodes to a HNSW graph with 15M nodes is _expensive_. Assume that they use 768 dimensions
+     * and no quantization. That 15M * 768 * 4 = 42GB of data just for the vectors. And adding a new node
+     * means that we need to compare (and thus read, randomly) about 600 vectors (with peaks of 2,000 vectors). 
+     * 
+     * Typically, the solution for that is to get a bigger machine, but that is something that we can
+     * try to address. This is the purpose of the code in this file. We go through many gymnastics to
+     * try to optimize the disk access pattern and parallelize what we can.
+     * 
+     * Parallelization is complicated by the fact that we are running under a write transaction scope.
+     * A write transaction in Voron is a _single threaded operation_. Another problem is that HNSW is
+     * inherently a single-threaded algorithm. If I add two nodes to the graph, the second node will 
+     * consider the first node as a candidate for its neighbors.
+     * 
+     * Moving to parallel mode make things more complex. If I add two nodes to the graph at the same time,
+     * they will _not_ consider each other for neighbors. Given that HNSW is *approximate* nearest neighbor
+     * algorithm, this is not too big an issue. We can assume that they will reside "nearby" and that the
+     * greedy nature of the algorithm will find the right nodes.
+     * 
+     * But it does show that paralleling HNSW *will* impact the resulting graph. To address that, we added
+     * a step in the process where we'll add all the existing inflight nodes (being added in parallel) to each
+     * other. This means that we create artificial edges to vectors added at the same time. Those edges may be
+     * removed if during the insert process we'll find better (closer) edges. 
+     * 
+     * Having said all of that, the performance difference for large graph is significant. Therefor, we 
+     * use a parallel algorithm to build the graph. However, just adding threads isn't simple, because we
+     * operate under a single threaded write transaction.
+     * 
+     * There are two expensive parts in the graph building operations:
+     * * Computing distance between vectors
+     * * Loading the vectors from disk
+     * 
+     * This code is designed to allow to parallelize the distance computation and to allow for
+     * batch load optimization for reading the vectors. 
+     * 
+     * To start with, we aren't actually using parallel here to say threads. Instead, we re-wrote
+     * the algorithm using yield an enumerators. And we run it using a dedicated runner that consumes and
+     * execute all the interleaved (vs. concurrent) operations.
+     * 
+     * Whenever we need to do an expensive operation (such as loading vectors, or computing distances),
+     * we yield to the caller, giving a chance for the rest of the system to make forward progress while
+     * the task is completed in the background. 
+     * 
+     * That async operation is _not_ scheduled on a different thread. Instead, it is queued until all
+     * current operations are completed, then we check what pending work we have and start a batch 
+     * loads of all the vectors we need. The next step is to run the distance computation using the 
+     * thread pool. When that is completed, we can continue with the next step.
+     * 
+     * The idea is that we run N interleaved tasks, where N between 1..MaxConcurrentBatches, and in 
+     * each one of them, we pick an item to be inserted to the graph. We then run the HNSW until we
+     * need to do an expensive operation (which we'll offload to the thread pool if it is computation, or
+     * do a batch preload to amortise the costs of going to disk). At that point, we yield to *another*
+     * interleaved operation. By the time we hit the MaxConcurrentBatches, we gathered enough vectors to load and
+     * distances to compute that we can really start pumping through all the items. 
+     * 
+     * The key here is to batching of I/O for loading the vectors. See the runner for handling that 
+     * part of the process. Both NodePlacement and NodePlacementRunner are working very closely 
+     * together to achieve this work.
+     * 
+     * # Distance computation using the thread pool
+     * 
+     * Distance computation is expensive, and we want to run it in parallel. Each work item that we 
+     * send to the thread pool already had its vectors loaded by the batch process, so we can assume 
+     * that they are ready in memory. The work item compares a vector to a set of vectors (typically all 
+     * the edges of a particular node) and returns the shortest distance or the filtered set of edges.
+     * 
+     * We use the thread pool because:
+     * * There is a known limit to the amount of work we have (up to MaxConcurrentBatches), and it
+     *   cannot grow without bound. We won't cause thread pool starvation.
+     * * The amount of work for each item is well scoped and _short_. Under 0.5ms for each work item, 
+     *   so we won't cause a bottleneck in the thread pool.
+     * * We tested using a dedicated thread pool, but those performed significantly worse than the 
+     *   default .NET one. 
+     */
+    public partial class Registration
+    {
+        private int _nextNodeIndex;
+
+        public int MaxConcurrentBatches = 512;
+        void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer)
+        {
+            if (_searchState.TryGetLocationForNode(EntryPointId, out var entryPointNode) is false)
+            {
+                if (_searchState.CreatedNodes is 0)
+                    return;
+                
+                _nextNodeIndex++; // do not attempt to insert the first node, since it is the graph root
+                ref Node startingNode = ref _searchState.Nodes[0];
+                Span<byte> span = startingNode.Encode(ref byteBuffer);
+                entryPointNode = Container.Allocate(_searchState.Llt, _searchState.Options.Container, span.Length, out Span<byte> allocated);
+                span.CopyTo(allocated);
+                _searchState.RegisterNodeLocation(EntryPointId, entryPointNode);
+            }
+
+            // Run 1..MaxConcurrentBatches batches here, depending on how much work we have to run
+            int numberOfBatches = Math.Max(1, _searchState.CreatedNodes / MaxConcurrentBatches);
+            // but not too much...
+            int maxTasks = Math.Min(numberOfBatches, MaxConcurrentBatches);
+            NodePlacementRunner runner = new(this, maxTasks);
+            runner.Run();
+        }
+
+        private class NodePlacement(Registration parent, NodePlacementRunner runner)
+        {
+            private readonly SearchState _searchState = parent._searchState;
+            private readonly List<int> _candidates = [];
+            private readonly List<int> _nearestIndexes = [];
+            private readonly List<int> _indexes = [];
+            private readonly List<int> _requiresEdgeFiltering = [];
+            private readonly List<UnmanagedSpan> _vectors = [];
+            private readonly PriorityQueue<int, float> _candidatesQ = new();
+            private readonly PriorityQueue<int, float> _nearestEdgesQ = new();
+            private ulong[] _visitedBitmap = [];
+            private int[] _visitedBitmapVersion = [];
+            private int _visitedVersion;
+
+            private void ClearVisited()
+            {
+                // this needs to be _cheap_, since it is called per node per level
+                _visitedVersion++;
+            }
+            private bool MarkVisited(int pos)
+            {
+                int index = pos >> 6; // / 64
+                int bit = pos & 63; // % 64
+                
+                if (index >= _visitedBitmap.Length)
+                {
+                    Grow();
+                }
+
+                if (_visitedBitmapVersion[index] != _visitedVersion)
+                {
+                    // we reset the value if detected the version changed
+                    _visitedBitmapVersion[index] = _visitedVersion;
+                    _visitedBitmap[index] = 0;
+                }
+                
+                ulong old = _visitedBitmap[index];
+                ulong mask = (1ul << bit);
+                _visitedBitmap[index] = old | mask;
+                bool isNew = (mask & old) == 0;
+                return isNew;
+
+                void Grow()
+                {
+                    int max = Math.Max(_searchState.Nodes.Length, index);
+                    int newSize = Bits.NextAllocationSize(max);
+                    Array.Resize(ref _visitedBitmap, newSize);
+                    Array.Resize(ref _visitedBitmapVersion, newSize);
+                }
+            }
+
+            public IEnumerable<WorkItem> Process()
+            {
+                try
+                {
+                    int createdNodesLength = _searchState.CreatedNodes;
+                    while (runner.IsCancelled is false)
+                    {
+                        // shared across all tasks, we are processing 
+                        // multiple nodes in an interleaved (but not concurrently) via
+                        // multiple running placement processing at the same time
+                        var createdNodeIndex  = parent._nextNodeIndex++;  
+                        if (createdNodeIndex  >= createdNodesLength)
+                            break;
+
+                        // we do not process these in linear order, so we need
+                        // to keep whatever is "in-flight" in a linked list that we can 
+                        // cheaply add & remove to
+                        var currentNodeIndex = _searchState.GetCreatedNodeIndex(createdNodeIndex); 
+                        foreach (var item in FindGraphPlacementForNode(createdNodeIndex, currentNodeIndex))
+                        {
+                            yield return item;
+                        }
+                    }
+                }
+                finally
+                {
+                    runner.Done();
+                }
+            }
+
+            private IEnumerable<WorkItem> FindGraphPlacementForNode(int createdNodeIndex, int currentNodeIndex)
+            {
+                var currentMaxLevel = _searchState.Options.CurrentMaxLevel(_searchState.CreatedNodes - createdNodeIndex);
+                int nodeRandomLevel = GetLevelForNewNode(currentMaxLevel);
+                UnmanagedSpan insertedVector;
+                {
+                    //  scoping n here, to avoid "leaking" the reference and async issues
+                    ref var n = ref _searchState.GetNodeByIndex(currentNodeIndex);
+                    n.EdgesPerLevel.SetCapacity(_searchState.Llt.Allocator, nodeRandomLevel + 1);
+                    insertedVector = n.GetVectorUnmanagedSpan(_searchState);
+                    AddEdgesFromInFlightNodes(ref n, createdNodeIndex);
+                }
+                foreach(var item in SearchNearestAcrossLevels(insertedVector, currentMaxLevel))
+                {
+                    yield return item;
+                }
+                for (int level = nodeRandomLevel; level >= 0; level--)
+                {
+                    int startingPointIndex = _nearestIndexes[level];
+                    foreach (var item in NearestEdges(startingPointIndex, currentNodeIndex, insertedVector, level))
+                    {
+                        yield return item;
+                    }
+                    PortableExceptions.ThrowIf<InvalidOperationException>(_candidates.Count == 0, "Cannot add a node to the graph without any edges");
+                    ref var node = ref _searchState.GetNodeByIndex(currentNodeIndex);
+                    ref var list = ref node.EdgesPerLevel[level];
+                    // important - we cannot reset here, since we have added edges from the in flight nodes in AddEdgesFromInFlightNodes()
+                    list.EnsureCapacityFor(_searchState.Llt.Allocator, _candidates.Count);
+                    _requiresEdgeFiltering.Clear();
+                    foreach (var edgeIdx in _candidates)
+                    {
+                        Debug.Assert(edgeIdx != currentNodeIndex);
+                        ref Node edge = ref _searchState.GetNodeByIndex(edgeIdx);
+                        list.AddUnsafe(edge.NodeId);
+
+                        ref var edgeList = ref edge.EdgesPerLevel[level];
+                        edgeList.Add(_searchState.Llt.Allocator, node.NodeId);
+
+                        if (edgeList.Count <= _searchState.Options.NumberOfEdges)
+                            continue;
+
+                        _requiresEdgeFiltering.Add(edgeIdx);
+                    }
+
+                    foreach (var edgeIdx in _requiresEdgeFiltering)
+                    {
+                        UnmanagedSpan vector;
+                        {
+                            ref Node edge = ref _searchState.GetNodeByIndex(edgeIdx);
+                            vector = edge.GetVectorUnmanagedSpan(_searchState);
+                            ClearVisited();
+                            MarkVisited(edgeIdx);
+                        }
+
+                        yield return new FilterEdgesHeuristicWorker(this, vector)
+                        {
+                            CurrentNodeIndex = edgeIdx, 
+                            Level = level
+                        };
+                        
+                        PortableExceptions.ThrowIf<InvalidOperationException>(_candidates.Count == 0 , "Cannot add a node to the graph without any edges after heuristic");
+                        {
+                            ref Node edge = ref _searchState.GetNodeByIndex(edgeIdx);
+                            ref var edgeList = ref edge.EdgesPerLevel[level];
+                            edgeList.ResetAndEnsureCapacity(_searchState.Llt.Allocator, _candidates.Count);
+                            foreach (var idx in _candidates)
+                            {
+                                edgeList.AddUnsafe(_searchState.GetNodeByIndex(idx).NodeId);
+                            }
+                        }
+                    }
+                }
+            }
+
+            private void AddEdgesFromInFlightNodes(ref Node n, int currentNodeIndex)
+            {
+                CollectionsMarshal.SetCount(_indexes, _searchState.Options.NumberOfEdges);
+
+                // Here we add "number of edges" previously added items to as the edges in all their levels
+                // so the next stage will add the edges that were already added to the graph and then find 
+                // only the most suitable ones. It has the impact of increasing the likelihood that 
+                // items that are added at the same time (and thus temporally linked, at least) will
+                // be joined. Quite important when you consider that a single document may have multiple
+                // vectors associated with it (for example, because of chunking).
+                var limit = Math.Max(0, currentNodeIndex - _searchState.Options.NumberOfEdges);
+                for (int i = currentNodeIndex -1; i >= limit; i--)
+                {
+                    ref var edge = ref _searchState.GetNodeByIndex(
+                        _searchState.GetCreatedNodeIndex(i)
+                    );
+                    int sharedLevels = Math.Min(edge.EdgesPerLevel.Count, n.EdgesPerLevel.Count);
+                    for (int level = 0; level < sharedLevels; level++)
+                    {
+                        n.EdgesPerLevel[level].Add(_searchState.Llt.Allocator, edge.NodeId);
+                    }
+                }
+                _indexes.Clear();
+            }
+
+            private IEnumerable<WorkItem> NearestEdges(int startingPointIndex, int currentNodeIndex, UnmanagedSpan vector, int level)
+            {
+                Debug.Assert(_candidatesQ.Count == 0, "_candidatesQ.Count == 0");
+                Debug.Assert(_nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
+
+                float lowerBound = float.MaxValue;
+                ClearVisited();
+                MarkVisited(currentNodeIndex); // we can't have an edge to itself
+ 
+                // candidates queue is sorted using the distance, so the lowest distance
+                // will always pop first.
+                // nearest edges is sorted using _reversed_ distance, so when we add a 
+                // new item to the queue, we'll pop the one with the largest distance
+                _candidatesQ.Enqueue(startingPointIndex, -lowerBound);
+
+                while (_candidatesQ.TryDequeue(out var cur, out var curDistance))
+                {
+                    if (-curDistance < lowerBound &&
+                        _nearestEdgesQ.Count == _searchState.Options.NumberOfCandidates)
+                        break;
+
+                    var worker = new ProcessEdgesWorker(this, vector, lowerBound)
+                    {
+                        CurrentNodeIndex = cur,
+                        Level = level,
+                    };
+                    yield return worker;
+                    lowerBound = worker.LowerBound;
+                }
+
+                _candidatesQ.Clear();
+                _candidates.Clear();
+                while (_nearestEdgesQ.TryDequeue(out var edgeId, out var d))
+                {
+                    _candidates.Add(edgeId);
+                }
+                _candidates.Reverse();
+
+                if (_candidates.Count <= _searchState.Options.NumberOfEdges) 
+                    yield break;
+                
+                _indexes.Clear();
+                _vectors.Clear();
+                foreach (var candidate in _candidates)
+                {
+                    ref var n = ref _searchState.GetNodeByIndex(candidate);
+                    _indexes.Add(candidate);
+                    _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
+                }
+
+                yield return new FilterEdgesHeuristicWorker(this, vector)
+                {
+                    // disable preloading - we already got everything from the 
+                    // previous preloading step and are operating purely in memory 
+                    CurrentNodeIndex = -1,
+                    Level = level
+                };
+            }
+
+            private record FilterEdgesHeuristicWorker(
+                NodePlacement Owner,
+                UnmanagedSpan Src) : WorkItem(Owner)
+            {
+                public override void Execute()
+                {
+                    // See: https://icode.best/i/45208840268843 - Chinese, but auto-translate works, and a good explanation with 
+                    // conjunction of: https://img-bc.icode.best/20210425010212938.png
+                    // See also the paper here: https://arxiv.org/pdf/1603.09320
+                    // This implements the Fig. 2 / Algorithm 4
+
+                    var searchState = Owner._searchState;
+                    var candidates = Owner._candidates;
+                    var vectors = Owner._vectors;
+                    var indexes = Owner._indexes;
+                    var queue = Owner._candidatesQ;
+                    
+                    Debug.Assert(queue.Count is 0);
+                    for (int i = 0; i < indexes.Count; i++)
+                    {
+                        var distance = searchState.Distance(Src, vectors[i]);
+                        // note that we use local indexes here!
+                        queue.Enqueue(i, distance);
+                    }
+
+                    candidates.Clear();
+
+                    while (candidates.Count <= searchState.Options.NumberOfEdges &&
+                           queue.TryDequeue(out var cur, out var distance))
+                    {
+                        bool match = true;
+                        foreach (var alternativeIndex in candidates)
+                        {
+                            var curDist = searchState.Distance(vectors[cur], vectors[alternativeIndex]);
+                            // there is already an item in the result that is *closer* to the current
+                            // node than the target node, so no need to add it
+                            if (curDist < distance)
+                            {
+                                match = false;
+                                break;
+                            }
+                        }
+
+                        if (match)
+                        {
+                            candidates.Add(cur);
+                        }
+                    }
+
+                    for (int i = 0; i < candidates.Count; i++)
+                    {
+                        // turn the local indexing into a global one
+                        candidates[i] = indexes[candidates[i]];
+                    }
+
+                    queue.Clear();
+                }
+            }
+            private record ProcessEdgesWorker(NodePlacement Owner, UnmanagedSpan Vector, float LowerBound) : WorkItem(Owner)
+            {
+                public float LowerBound { get; private set; } = LowerBound;
+
+                public override void Execute()
+                {
+                    var searchState = Owner._searchState;
+                    var indexes = Owner._indexes;
+                    var vectors = Owner._vectors;
+                    var nearestEdgesQ = Owner._nearestEdgesQ;
+                    var candidatesQ = Owner._candidatesQ;
+                    var lowerBound  = LowerBound;
+                    
+                    int numberOfCandidates = searchState.Options.NumberOfCandidates;
+                    for (int i = 0; i < indexes.Count; i++)
+                    {
+                        var nextIndex = indexes[i];
+                        Debug.Assert(searchState.Nodes[nextIndex].EdgesPerLevel.Count > Level); 
+                   
+                        float nextDist = -searchState.Distance(Vector, vectors[i]);
+                        if (nearestEdgesQ.Count < numberOfCandidates)
+                        {
+                            candidatesQ.Enqueue(nextIndex, -nextDist);
+                            nearestEdgesQ.Enqueue(nextIndex, nextDist);
+                        }
+                        else if (lowerBound < nextDist)
+                        {
+                            candidatesQ.Enqueue(nextIndex, -nextDist);
+                            nearestEdgesQ.EnqueueDequeue(nextIndex, nextDist);
+                        }
+                        else
+                        {
+                            continue;
+                        }
+
+                        Debug.Assert(candidatesQ.Count > 0);
+                        nearestEdgesQ.TryPeek(out _, out lowerBound);
+                    }
+                    LowerBound = lowerBound;
+                }
+                
+            }
+
+            private IEnumerable<WorkItem> SearchNearestAcrossLevels(UnmanagedSpan from, int maxLevel)
+            {
+                _nearestIndexes.Clear();
+                ClearVisited();
+                var currentNodeIndex = _searchState.GetNodeIndexById(EntryPointId);
+                var level = maxLevel;
+                var distance = float.MaxValue;
+                while (level >= 0)
+                {
+                    do
+                    {
+                        var worker = new FindNearestWorker(this, from)
+                        {
+                            CurrentNodeIndex = currentNodeIndex,
+                            Level = level
+                        };
+                        yield return worker;
+                        if (worker.Distance >= distance)
+                            break;
+                        currentNodeIndex = worker.CurrentNodeIndex;
+                        distance = worker.Distance;
+                    } while (true);
+
+                    _nearestIndexes.Add(currentNodeIndex);
+                    level--;
+                }
+
+                _nearestIndexes.Reverse();
+            }
+
+            private record FindNearestWorker(NodePlacement Owner,UnmanagedSpan From) : WorkItem(Owner)
+            {
+                public float Distance = float.MaxValue;
+
+                public override void Execute()
+                {
+                    var indexes = Owner._indexes;
+                    var vectors = Owner._vectors;
+                    var searchState = Owner._searchState;
+                    
+                    for (var i = 0; i < indexes.Count; i++)
+                    {
+                        var edgeIdx = indexes[i];
+                        var curDist = searchState.Distance(From, vectors[i]);
+                        if (curDist >= Distance || double.IsNaN(curDist))
+                            continue;
+                        Distance = curDist;
+                        CurrentNodeIndex = edgeIdx;
+                    }
+                }
+            }
+            
+            private int GetLevelForNewNode(int maxLevel)
+            {
+                int level = 0;
+                while ((parent.Random.Next() & 1) == 0 && // 50% chance 
+                       level < maxLevel)
+                {
+                    level++;
+                }
+
+                return level;
+            }
+
+            /// <summary>
+            /// This is called after the Preload() call and we can assume that
+            /// all the vectors are now in memory.
+            ///
+            /// It setups the _indexes/_vectors with the new values, so the call to
+            /// WorkItem.Execute() can run without any waiting / hassles.
+            ///
+            /// This also checks if we have already visited these edges and avoid
+            /// running the distance computation if we already did that. 
+            /// </summary>
+            public bool AfterPreloading(int currentNodeIndex, int level)
+            {
+                if (currentNodeIndex is -1)
+                    return _indexes.Count > 0; // has work
+                
+                ref var n = ref _searchState.GetNodeByIndex(currentNodeIndex);
+                _indexes.Clear();
+                _vectors.Clear();
+                if (MarkVisited(currentNodeIndex))
+                {
+                    _indexes.Add(currentNodeIndex);
+                    _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
+                }
+                
+                ref var edgesList = ref n.EdgesPerLevel[level];
+                ref var edgesIndexes = ref n.EdgesIndexesPerLevel[level];
+                if (edgesIndexes.Count != edgesList.Count)
+                {
+                    edgesIndexes.ResetAndEnsureCapacity(_searchState.Llt.Allocator, edgesList.Count);
+                    foreach (var nodeId in edgesList)
+                    {
+                        edgesIndexes.AddUnsafe(_searchState.GetNodeIndexById(nodeId));
+                    }
+                }
+                foreach (var idx in edgesIndexes)
+                {
+                    if (MarkVisited(idx) is false)
+                        continue; // already checked
+                    _indexes.Add(idx);
+                    ref var edge = ref _searchState.GetNodeByIndex(idx);
+                    _vectors.Add(edge.GetVectorUnmanagedSpan(_searchState));
+                }
+
+                return _indexes.Count > 0; // has work
+            }
+        }
+
+        /// <summary>
+        /// This works opposite to how you'll usually think about such runners.
+        /// It is running everything in a _single_ threaded (because it uses the single threaded transaction)
+        /// and offload computational work to the thread pool, this is done using the NodePlacement yielding
+        /// whenever it wants to offload a computation, and the runner is then taking care of running the code,
+        /// 
+        /// </summary>
+        private class NodePlacementRunner
+        {
+            private readonly int _activeTasksCount;
+            private int _completed;
+            private readonly ManualResetEventSlim _ready = new();
+            private readonly ConcurrentQueue<IEnumerator<WorkItem>> _placementTasks = [];
+            private readonly ConcurrentQueue<(Exception Error, IEnumerator<WorkItem> It)> _placementErrors = [];
+            private readonly List<WorkItem> _items = [];
+            private readonly SearchState _searchState;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly List<Exception> _errors = [];
+
+            public bool IsCancelled => _cts.IsCancellationRequested;
+
+            public NodePlacementRunner(Registration parent, int activeTasksCount)
+            {
+                _activeTasksCount = activeTasksCount;
+                _searchState = parent._searchState;
+                for (int i = 0; i < activeTasksCount; i++)
+                {
+                    Enqueue(new NodePlacement(parent, this).Process().GetEnumerator());
+                }
+            }
+
+            private void RunWorkItem(object state)
+            {
+                WorkItem workItem = (WorkItem)state;
+                try
+                {
+                    workItem.Execute();
+                    Enqueue(workItem.Iterator);
+                }
+                catch (Exception e)
+                {
+                    Error(workItem.Iterator, e);
+                }
+            }
+            
+            public void Run()
+            {
+                List<long> batch = [];
+                WaitCallback callback = RunWorkItem;
+                while (true)
+                {
+                    _ready.Wait();
+                    _ready.Reset();
+                    
+                    while(_placementTasks.TryDequeue(out var it))
+                    {
+                        if (it.MoveNext())
+                        {
+                            WorkItem current = it.Current!;
+                            current.Iterator = it;
+                            _items.Add(current);
+                        }
+                        else
+                        {
+                            it.Dispose();
+                        }
+                    }
+
+                    while (_placementErrors.TryDequeue(out var cur))
+                    {
+                        HandleError(cur.Error, cur.It);
+                    }
+
+                    if (_completed == _activeTasksCount)
+                    {
+                        if(_errors.Count > 0)
+                            throw new AggregateException(_errors);
+                        return; // done
+                    }
+                    
+                    // we executed all that we could, now let's check if we have
+                    // any edges to load that we can do in bulk
+                    batch.Clear();
+                    for (int index = 0; index < _items.Count; index++)
+                    {
+                        WorkItem item = _items[index];
+                        if (item.RegisterForPreloading(_searchState, batch)) 
+                            continue;
+                        
+                        // we can run this directly, since there is nothing to preload
+                        
+                        _items[index] = null; // skip it in the rest of the process
+                        if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level) is false)
+                        {
+                            Enqueue(item.Iterator);
+                            continue; // no work to do, everything was already visited
+                        }
+
+                        ThreadPool.UnsafeQueueUserWorkItem(callback, item);
+                    }
+
+                    var batchSpan = CollectionsMarshal.AsSpan(batch);
+                    var used = Sorting.SortAndRemoveDuplicates(batchSpan);
+                    if (used > 0)
+                    {
+                        _searchState.PreloadNodesVectors(batchSpan[..used]);
+                    }
+
+                    foreach (var item in _items)
+                    {
+                        if (item is null) continue;
+
+                        if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level))
+                        {
+                            ThreadPool.UnsafeQueueUserWorkItem(callback, item);
+                        }
+                        else
+                        {
+                            // this means that there is no work to do (all the nodes were already visited)
+                            // so we can re-schedule this immediately
+                            Enqueue(item.Iterator);
+                        }
+                    }
+
+                    _items.Clear();
+                }
+            }
+            
+            
+            private void HandleError(Exception error, IEnumerator<WorkItem> it)
+            {
+                // force all pending work to stop now, instead of when it is all done
+                _cts.Cancel();
+                _errors.Add(error);
+                try
+                {
+                    it.Dispose();
+                }
+                catch (Exception e)
+                {
+                    _errors.Add(e);
+                }
+            }
+
+            private void Enqueue(IEnumerator<WorkItem> it)
+            { 
+                _placementTasks.Enqueue(it);
+                _ready.Set();
+            }
+
+            private void Error(IEnumerator<WorkItem> it, Exception exception)
+            {
+                _placementErrors.Enqueue((exception, it));
+                _ready.Set();
+            }
+
+            public void Done()
+            {
+                _completed++;
+            }
+        }
+        
+        private abstract record WorkItem(NodePlacement Owner)
+        {
+            public IEnumerator<WorkItem> Iterator;
+
+            public abstract void Execute();
+
+            public int CurrentNodeIndex;
+            public int Level;
+
+            /// <summary>
+            /// This scans over all the items that we _want_ to load and check if
+            /// their vectors were already loaded. If not, it registers them to be loaded
+            /// in a batch manner.
+            ///
+            /// It may find out that there is no actual work to be done here, in which case
+            /// the work item can start immediately.
+            /// </summary>
+            public bool RegisterForPreloading(SearchState searchState, List<long> batch)
+            {
+                if (CurrentNodeIndex is -1)
+                    return false;
+                
+                int old = batch.Count;
+                ref var n = ref searchState.GetNodeByIndex(CurrentNodeIndex);
+                if (n.VectorLoaded is false)
+                    batch.Add(n.NodeId);
+                
+                n.EdgesPerLevel.SetCapacity(searchState.Llt.Allocator, Level + 1);
+                n.EdgesIndexesPerLevel.SetCapacity(searchState.Llt.Allocator, Level + 1);
+
+                ref var edgesList = ref n.EdgesPerLevel[Level];
+                ref var edgesIndexes = ref n.EdgesIndexesPerLevel[Level];
+                // turns out that the checks for the node id -> index are really expensive
+                // so we try to cache them
+                if (edgesIndexes.Count != edgesList.Count)
+                {
+                    edgesIndexes.ResetAndEnsureCapacity(searchState.Llt.Allocator, edgesList.Count);
+                    for (int i = 0; i < edgesList.Count; i++)
+                    {
+                        var nodeId = edgesList[i];
+                        if (searchState.TryGetNodeById(nodeId, out var nodeIndex))
+                        {
+                            edgesIndexes.AddUnsafe(nodeIndex);
+                            continue;
+                        }
+                        // we add it to be pre-loaded
+                        batch.Add(nodeId);
+                        // not that we did NOT add to the edges, so the _next_ time
+                        // we run, we'll re-do the whole check and find the node index
+                    }
+                }
+                
+                for (int i = 0; i < edgesIndexes.Count; i++)
+                {
+                    int index = edgesIndexes[i];
+                    if (searchState.Nodes[index].VectorLoaded)
+                        continue;
+                    batch.Add(edgesList[i]);
+                }
+                return old != batch.Count;
+            }
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -185,6 +185,7 @@ public unsafe partial class Hnsw
             if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
             {
                 _vectorSpan = span;
+                return;
             }
 
             var count = (byte)(VectorId >> 1);

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using Sparrow;
+using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Platform;
 using Sparrow.Server;
@@ -73,7 +74,7 @@ public unsafe partial class Hnsw
 
         public static UnmanagedSpan ReadVector(long vectorId, in SearchState state)
         {
-            if ((vectorId & 1) == 0)
+            if ((vectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
             {
                 var item = Container.Get(state.Llt, vectorId);
                 var vectorSpan = new UnmanagedSpan(item.Address, item.Length);
@@ -96,8 +97,19 @@ public unsafe partial class Hnsw
         public long VectorId;
         public long NodeId;
         public NativeList<NativeList<long>> EdgesPerLevel;
+        public NativeList<NativeList<int>> EdgesIndexesPerLevel;
         private UnmanagedSpan _vectorSpan;
         public int Visited;
+
+        public bool VectorLoaded => _vectorSpan.Length > 0;
+
+        public long GetVectorContainerId()
+        {
+            if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
+                return VectorId;
+
+            return VectorId & ~0xFFF;
+        }
 
         public static NodeReader Decode(LowLevelTransaction llt, long id)
         {
@@ -114,12 +126,7 @@ public unsafe partial class Hnsw
             var countOfLevels = VariableSizeEncoding.Read<int>(span, out pos, offset);
             offset += pos;
 
-            return new NodeReader(llt.Allocator, span[offset..])
-            {
-                PostingListId = postingListId,
-                VectorId = vectorId,
-                CountOfLevels = countOfLevels
-            };
+            return new NodeReader(llt.Allocator, span[offset..]) { PostingListId = postingListId, VectorId = vectorId, CountOfLevels = countOfLevels };
         }
 
         public Span<byte> Encode(ref ContextBoundNativeList<byte> buffer)
@@ -132,14 +139,15 @@ public unsafe partial class Hnsw
             {
                 maxSize += EdgesPerLevel[i].Count * VariableSizeEncoding.MaximumSizeOf<long>();
             }
+
             buffer.EnsureCapacityFor(maxSize);
 
             var bufferSpan = buffer.ToFullCapacitySpan();
-            
+
             var pos = VariableSizeEncoding.Write(bufferSpan, PostingListId);
             pos += VariableSizeEncoding.Write(bufferSpan, VectorId, pos);
             pos += VariableSizeEncoding.Write(bufferSpan, countOfLevels, pos);
-            
+
             for (int i = 0; i < countOfLevels; i++)
             {
                 Span<long> span = EdgesPerLevel[i].ToSpan();
@@ -158,13 +166,30 @@ public unsafe partial class Hnsw
             return bufferSpan[..pos];
         }
 
-        public Span<byte> GetVector(SearchState state)
+        public UnmanagedSpan GetVectorUnmanagedSpan(SearchState state)
         {
-            if (_vectorSpan.Length > 0) 
-                return _vectorSpan.ToSpan();
+            if (_vectorSpan.Length > 0)
+                return _vectorSpan;
 
             _vectorSpan = NodeReader.ReadVector(VectorId, in state);
             return _vectorSpan;
+        }
+
+        public Span<byte> GetVector(SearchState state)
+        {
+            return GetVectorUnmanagedSpan(state).ToSpan();
+        }
+
+        internal void SetVector(SearchState searchState, UnmanagedSpan span)
+        {
+            if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
+            {
+                _vectorSpan = span;
+            }
+
+            var count = (byte)(VectorId >> 1);
+            var offset = count * searchState.Options.VectorSizeBytes;
+            _vectorSpan = new UnmanagedSpan(span.Address + offset, searchState.Options.VectorSizeBytes);
         }
     }
 
@@ -247,7 +272,9 @@ public unsafe partial class Hnsw
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
 
-        public Span<int> CreatedNodes => _newNodes.ToSpan();
+        public int CreatedNodes => _newNodes.Count;
+        
+        public int GetCreatedNodeIndex(int index) => _newNodes[index];
 
         public Options Options;
 
@@ -376,7 +403,7 @@ public unsafe partial class Hnsw
         }
 
         /// <summary>
-        /// This accepts a list of node ids (mutable, we do destructive to it) and translate
+        /// This accepts a list of node ids (mutable, we do destructive updates to it) and translate
         /// that to a list of the indexes in the nodes array. If needed, it will load the nodes
         /// from the disk in a batch oriented manner. 
         /// </summary>
@@ -408,8 +435,7 @@ public unsafe partial class Hnsw
             }
             _nodeIdToLocations.GetFor(keys, keys, -1);
             
-            using var _ = Llt.Allocator.AllocateDirect(sizeof(UnmanagedSpan) * keys.Length, out var buffer);
-            var spans = (UnmanagedSpan*)buffer.Ptr;
+            var spans = Buffers.GetSpans(keys.Length);
             Container.GetAll(Llt, keys, spans, -1, Llt.PageLocator);
             for (int i = 0; i < keys.Length; i++)
             {
@@ -441,6 +467,11 @@ public unsafe partial class Hnsw
             return ref GetNodeByIndex(idx);
         }
 
+        public float Distance(UnmanagedSpan src, UnmanagedSpan dst)
+        {
+            return SimilarityCalc(src.ToSpan(), dst.ToSpan());
+        }
+
         public float Distance(ReadOnlySpan<byte> vector, int fromIdx, int toIdx)
         {
             if (vector.IsEmpty)
@@ -454,10 +485,15 @@ public unsafe partial class Hnsw
             var distance = SimilarityCalc(vector, v2);
             return distance;
         }
-        
+
         public void ReadPostingList(long rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
         {
-            var smallPostingList = Container.Get(Llt, rawPostingListId);
+            ReadPostingList(Llt, rawPostingListId, ref listBuffer, ref pforDecoder, out postingListSize);
+        }
+
+        public static void ReadPostingList(LowLevelTransaction llt, long rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
+        {
+            var smallPostingList = Container.Get(llt, rawPostingListId);
             var count = VariableSizeEncoding.Read<int>(smallPostingList.Address, out var offset);
             
             var requiredSize = Math.Max(256, 256 * (int)Math.Ceiling((count + listBuffer.Count) / 256f));
@@ -467,50 +503,6 @@ public unsafe partial class Hnsw
             pforDecoder.Init(smallPostingList.Address + offset, smallPostingList.Length - offset);
             listBuffer.Count += pforDecoder.Read(listBuffer.RawItems + listBuffer.Count, listBuffer.Capacity - listBuffer.Count);
             postingListSize = smallPostingList.Length;
-        }
-
-        public void FilterEdgesHeuristic(int srcIdx, ref NativeList<int> candidates)
-        {
-            // See: https://icode.best/i/45208840268843 - Chinese, but auto-translate works, and a good explanation with 
-            // conjunction of: https://img-bc.icode.best/20210425010212938.png
-            // See also the paper here: https://arxiv.org/pdf/1603.09320
-            // This implements the Fig. 2 / Algorithm 4
-            
-            Debug.Assert(_candidatesQ.Count is 0);
-            for (int i = 0; i < candidates.Count; i++)
-            {
-                var dstIndex = candidates[i];
-                var distance = Distance(Span<byte>.Empty, srcIdx, dstIndex);
-                _candidatesQ.Enqueue(dstIndex, distance);
-            }
-
-            candidates.Clear();
-            
-            while (candidates.Count <= Options.NumberOfEdges &&
-                   _candidatesQ.TryDequeue(out var cur, out var distance))
-            {
-                bool match = true;
-                for (int i = 0; i < candidates.Count; i++)
-                {
-                    int alternativeIndex = candidates[i];
-                    var curDist = Distance(Span<byte>.Empty, cur, alternativeIndex);
-                    // there is already an item in the result that is *closer* to the current
-                    // node than the target node, so no need to add it
-                    if (curDist < distance)
-                    {
-                        match = false;
-                        break;
-                    }
-                }
-
-                if (match)
-                {
-                    Debug.Assert(candidates.HasCapacityFor(1), "candidates.HasCapacityFor(1)");
-                    candidates.AddUnsafe(cur);
-                }
-            }
-
-            _candidatesQ.Clear();
         }
 
         [Flags]
@@ -664,9 +656,132 @@ public unsafe partial class Hnsw
             nodeIds.Dispose(Llt.Allocator);
             nearestIndexes.Reverse();
         }
+        
+        
+       private static class Buffers
+       {
+           [ThreadStatic]
+           private static long[] IdsToLoad;
+           [ThreadStatic]
+           private static int[] IndexesOfIds;
+           [ThreadStatic]
+           private static long[] VectorIdsToLoad;
+           [ThreadStatic]
+           private static UnmanagedSpan[] SpansToLoad;
+           [ThreadStatic]
+           private static int[] NodeIndexes;
+
+           public static Span<UnmanagedSpan> GetSpans(int count)
+           {
+               if (IdsToLoad is null || count > IdsToLoad.Length)
+               {
+                   Allocate(count);
+               }
+
+               return SpansToLoad;
+           }
+
+           public static void Get(int count, out Span<long> idsToLoad, out Span<long> vectorIdsToLoad, out Span<UnmanagedSpan> spansToLoad, out Span<int> nodeIndexes, out Span<int> indexesOfIds)
+           {
+               if (IdsToLoad is null || count > IdsToLoad.Length)
+               {
+                   Allocate(count);
+               }
+
+               idsToLoad = IdsToLoad;
+               vectorIdsToLoad = VectorIdsToLoad;
+               spansToLoad = SpansToLoad;
+               nodeIndexes = NodeIndexes;
+               indexesOfIds = IndexesOfIds;
+           }
+
+           private static void Allocate(int count)
+           {
+               count = Bits.NextAllocationSize(count);
+
+               IndexesOfIds = new int[count];
+               IdsToLoad = new long[count];
+               VectorIdsToLoad = new long[count];
+               SpansToLoad = new UnmanagedSpan[count];
+               NodeIndexes = new int[count];
+           }
+       }
+
+       /// <summary>
+       /// Load all the _vectors_ associated with the provided node ids.
+       /// Note that this actually requires us to first look up the nodes by id (loading them via batch)
+       /// then load any yet unloaded vector (again using a batch) 
+       /// </summary>
+       public void PreloadNodesVectors(Span<long> nodeIds)
+       {
+           Buffers.Get(nodeIds.Length, 
+               out var idsToLoad, 
+               out var vectorIdsToLoad, 
+               out var spans, 
+               out var nodeIndexes,
+               out var indexesOfIds);
+           int idsToLoadIdx = 0;
+           var vectorsToLoadIdx = 0;
+           foreach (var nodeId in nodeIds)
+           {
+               if (_nodeIdToIdx.TryGetValue(nodeId, out var existingIdx))
+               {
+                   ref var n = ref _nodes[existingIdx];
+                   if (n.VectorLoaded)
+                       continue;
+                   nodeIndexes[vectorsToLoadIdx] = existingIdx;
+                   vectorIdsToLoad[vectorsToLoadIdx++] = n.GetVectorContainerId();
+                   continue;
+               }
+
+               var nodeIdx = AllocateNodeIndex(nodeId);
+               _nodes[nodeIdx].NodeId = nodeId;
+               _nodeIdToIdx[nodeId] = nodeIdx;
+               indexesOfIds[idsToLoadIdx] = nodeIdx;
+               idsToLoad[idsToLoadIdx++] = nodeId;
+           }
+
+           if (idsToLoadIdx is not 0)
+           {
+               idsToLoad = idsToLoad[..idsToLoadIdx];
+               indexesOfIds = indexesOfIds[..idsToLoadIdx];
+           
+               _nodeIdToLocations.GetFor(idsToLoad, idsToLoad, -1);
+               idsToLoad.Sort(indexesOfIds);
+               Container.GetAll(Llt, idsToLoad, spans, -1, Llt.PageLocator);
+               for (int i = 0; i < indexesOfIds.Length; i++)
+               {
+                   var buf = spans[i].ToSpan();
+                   var reader = Node.Decode(Llt, buf);
+                   var nodeIndex = indexesOfIds[i];
+                   ref var n = ref _nodes[nodeIndex];
+                   reader.LoadInto(ref n);
+                   nodeIndexes[vectorsToLoadIdx] = nodeIndex;
+                   vectorIdsToLoad[vectorsToLoadIdx++] = n.GetVectorContainerId();
+               }
+           }
+           if (vectorsToLoadIdx is 0)
+               return;
+
+           vectorIdsToLoad = vectorIdsToLoad[..vectorsToLoadIdx];
+           nodeIndexes = nodeIndexes[..vectorsToLoadIdx];
+           vectorIdsToLoad.Sort(nodeIndexes);
+           Container.GetAll(Llt, vectorIdsToLoad, spans, -1, Llt.PageLocator);
+           for (int i = 0; i < vectorIdsToLoad.Length; i++)
+           {
+               // note, small vectors (where multiple can fit in a single page), will be 
+               // partition inside the SetVector if needed
+               _nodes[nodeIndexes[i]].SetVector(this, spans[i]);
+           }
+       }
+
+       public bool TryGetNodeById(long nodeId, out int nodeIndex)
+       {
+           return _nodeIdToIdx.TryGetValue(nodeId, out nodeIndex);
+       }
     }
     
-    public class Registration : IDisposable
+    public partial class Registration : IDisposable
     {
         public bool IsCommited { get; private set; }
         private readonly Dictionary<ByteString, (ByteString Key, int NodeIndex, NativeList<long> PostingList)> _vectorHashCache = new(ByteStringContentComparer.Instance);
@@ -886,17 +1001,6 @@ public unsafe partial class Hnsw
             Sodium.GenericHash(vector, hashBuffer.ToSpan());
             return hashBuffer;
         }
-        
-        private int GetLevelForNewNode(int maxLevel)
-        {
-            int level = 0;
-            while ((Random.Next() & 1) == 0 && // 50% chance 
-                   level < maxLevel)
-            {
-                level++;
-            }
-            return level;
-        }
 
         public void Commit()
         {
@@ -1104,94 +1208,6 @@ public unsafe partial class Hnsw
             locationId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, encoded.Length, out var storage);
             _searchState.RegisterNodeLocation(node.NodeId, locationId);
             encoded.CopyTo(storage);
-        }
-        
-        void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer)
-        {
-            var createdNodesIndexes = _searchState.CreatedNodes;
-            
-            if (_searchState.TryGetLocationForNode(EntryPointId, out var entryPointNode) is false)
-            {
-                if (createdNodesIndexes.IsEmpty)
-                    return;
-
-                ref Node startingNode = ref _searchState.Nodes[0];
-                Span<byte> span = startingNode.Encode(ref byteBuffer);
-                entryPointNode = Container.Allocate(_searchState.Llt, _searchState.Options.Container, span.Length, out Span<byte> allocated);
-                span.CopyTo(allocated);
-                _searchState.RegisterNodeLocation(EntryPointId, entryPointNode);
-            }
-
-            var nearestNodesByLevel = new NativeList<int>();
-            var edges = new NativeList<int>();
-            var tmp = new NativeList<int>();
-
-            nearestNodesByLevel.EnsureCapacityFor(_searchState.Llt.Allocator, _searchState.Options.MaxLevel + 1);
-
-            for (int createdNodeIndex = 0; createdNodeIndex < createdNodesIndexes.Length; createdNodeIndex++)
-            {
-                nearestNodesByLevel.Clear();
-                
-                var currentNodeIndex = createdNodesIndexes[createdNodeIndex];
-                var currentMaxLevel = _searchState.Options.CurrentMaxLevel(createdNodesIndexes.Length - createdNodeIndex);
-                int nodeRandomLevel = GetLevelForNewNode(currentMaxLevel);
-                Span<byte> vector;
-                {
-                    // intentionally scoping Node here, to avoid "leaking" the reference
-                    // it isn't _stable_ one and may move if the _nodes list is realloced
-                    ref var node = ref _searchState.GetNodeByIndex(currentNodeIndex);
-                    node.EdgesPerLevel.SetCapacity(_searchState.Llt.Allocator, nodeRandomLevel + 1);
-                    vector = node.GetVector(_searchState);
-                    _searchState.SearchNearestAcrossLevels(vector, currentNodeIndex, currentMaxLevel, ref nearestNodesByLevel);
-                }
-                for (int level = nodeRandomLevel; level >= 0; level--)
-                {
-                    int startingPointIndex = nearestNodesByLevel[level];
-                    edges.Clear();
-                    var flags = currentNodeIndex != startingPointIndex ? 
-                        SearchState.NearestEdgesFlags.StartingPointAsEdge : 
-                        SearchState.NearestEdgesFlags.None;
-                    
-                    _searchState.NearestEdges(startingPointIndex, currentNodeIndex,
-                        vector,
-                        level, _searchState.Options.NumberOfCandidates, ref edges, flags);
-
-                    if (edges.Count > _searchState.Options.NumberOfEdges)
-                        _searchState.FilterEdgesHeuristic(currentNodeIndex, ref edges);
-
-                    ref var node = ref _searchState.GetNodeByIndex(currentNodeIndex);
-                    ref var list = ref node.EdgesPerLevel[level];
-                    list.EnsureCapacityFor(_searchState.Llt.Allocator, edges.Count);
-                    list.Clear();
-                    for (int i = 0; i < edges.Count; i++)
-                    {
-                        int edgeIdx = edges[i];
-                        ref Node edge = ref _searchState.GetNodeByIndex(edgeIdx);
-                        list.AddUnsafe(edge.NodeId);
-                        Debug.Assert(edge.NodeId != node.NodeId, "edge.NodeId != node.NodeId");
-                        
-                        ref var edgeList = ref edge.EdgesPerLevel[level];
-                        edgeList.Add(_searchState.Llt.Allocator, node.NodeId);
-
-                        if (edgeList.Count <= _searchState.Options.NumberOfEdges)
-                            continue;
-
-                        // FilterEdgesHeuristic works on node indexes, while edges list is node ids
-                        // so we need to convert them back & forth in this manner
-                        tmp.ResetAndEnsureCapacity(_searchState.Llt.Allocator, edgeList.Count);
-                        for (int k = 0; k < edgeList.Count; k++)
-                        {
-                            tmp.AddUnsafe(_searchState.GetNodeIndexById(edgeList[k]));
-                        }
-                        _searchState.FilterEdgesHeuristic(edgeIdx, ref tmp);
-                        edgeList.Clear();
-                        for (int k = 0; k < tmp.Count; k++)
-                        {
-                            edgeList.AddUnsafe(_searchState.GetNodeByIndex(tmp[k]).NodeId);
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/src/Voron/Debugging/DebugStuff.cs
+++ b/src/Voron/Debugging/DebugStuff.cs
@@ -221,13 +221,15 @@ namespace Voron.Debugging
             {
                 string pathToChromeX86 = @"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe";
                 string pathToChromeX64 = @"C:\Program Files\Google\Chrome\Application\chrome.exe";
-
+                string pathToEdge = @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe";
                 string pathToChrome;
 
                 if (File.Exists(pathToChromeX64))
                     pathToChrome = pathToChromeX64;
                 else if (File.Exists(pathToChromeX86))
                     pathToChrome = pathToChromeX86;
+                else if (File.Exists(pathToEdge))
+                    pathToChrome = pathToEdge;
                 else
                     throw new InvalidOperationException("Make sure path to chrome.exe is valid");
 

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -40,7 +40,11 @@ public unsafe struct NativeList<T>
 
     public ref T this[int index]
     {
-        get => ref Unsafe.AsRef<T>((T*)_storage.Ptr + index);
+        get
+        {
+            Debug.Assert(index >= 0 && index < Count);
+            return ref Unsafe.AsRef<T>((T*) _storage.Ptr +index);
+        }
     }
 
     public bool TryAdd(in T l)
@@ -139,9 +143,13 @@ public unsafe struct NativeList<T>
     public void Grow(ByteStringContext ctx, int addition)
     {
         var capacity = Math.Max(1, Bits.NextAllocationSize(Capacity + addition));
-        
+
         if (capacity > MaxCapacity)
-            ThrowMaxCapacityExceeded(capacity);
+        {
+            if(Capacity + addition > MaxCapacity)
+                ThrowMaxCapacityExceeded(capacity);
+            capacity = MaxCapacity;
+        }
         
         ctx.Allocate(capacity * sizeof(T), out var mem);
 

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -95,6 +95,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying",
                 "Indexing.Corax.VectorSearch.OrderByScoreAutomatically",
+                "Indexing.Corax.VectorSearch.MaximumConcurrentBatchesForHnswAcceleration",
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
                 "Indexing.Analyzers.NGram.MaxGram",

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -81,14 +81,14 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         // nearest to v2, then v1
         float[] v3 = v2.Select(x => x + 0.05f).ToArray();
 
-        
-        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v1,v1)));
-        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v1,v2)));
-        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v1,v3)));
-        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v2,v2)));
-        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v2,v3)));
-        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v3,v3)));
-        
+
+        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v1, v1)));
+        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v1, v2)));
+        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v1, v3)));
+        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v2, v2)));
+        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v2, v3)));
+        Assert.False(float.IsNaN(TensorPrimitives.CosineSimilarity(v3, v3)));
+
         using (var txw = Env.WriteTransaction())
         {
             Hnsw.Create(txw.LowLevelTransaction, "test", 1536 * sizeof(float), 3, 12, VectorEmbeddingType.Single);
@@ -99,7 +99,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
                 registration.Register(2, MemoryMarshal.Cast<float, byte>(v2));
                 registration.Commit();
             }
-            
+
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Register(3, MemoryMarshal.Cast<float, byte>(v1));
@@ -124,14 +124,14 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             Span<float> distances = new float[8];
             using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test", numberOfCandidates: 32, MemoryMarshal.Cast<float, byte>(v3), 0f);
             int read = nearest.Fill(matches, distances);
-             Assert.Equal(3, read);
+            Assert.Equal(3, read);
             Assert.False(distances.Slice(0, read).ToArray().Any(float.IsNaN));
             Assert.Equal(2, matches[0]);
             Assert.Equal(1, matches[1]);
             Assert.Equal(3, matches[2]);
         }
     }
-    
+
     [RavenTheory(RavenTestCategory.Voron)]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -26,6 +26,7 @@ using SlowTests.Server;
 using SlowTests.SlowTests.MailingList;
 using SlowTests.Server.Documents.AI;
 using SlowTests.Server.Documents.AI.Embeddings;
+using FastTests.Corax.Vectors;
 
 namespace Tryouts;
 
@@ -42,18 +43,18 @@ public static class Program
         var sources = EventSource.GetSources();
         var runtime = sources.FirstOrDefault(x => x.Name == "System.Runtime");
         runtime?.Dispose();
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < 200; i++)
         {
             Console.WriteLine($"Starting to run {i}");
 
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new GenerateEmbeddingsTests(testOutputHelper))
+                using (var test = new MultiVectorSearchClientAPI(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
 
-                    //test.Test();
+                    test.CanSearchByMultipleVectorsByRavenVector();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24020 

### Additional description

This PR allows us to build HNSW graph in parallel, as well as restructure how we load the data for the graph to allow us to handle batching / pre-fetching in a better manner.

Indexing of 224,000 vectors dropped from 6 minutes to just over 2. 
Indexing of millions of vectors dropped to < 3 hours.

### Type of change
- [x] Optimization

### How risky is the change?

- [x] Moderate 

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] No documentation update is needed 

### Testing by Contributor

- [x] It has been verified by manual testing

Benchmarks

- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] No UI work is needed
