### PR TITLE
RavenDB-24052 - fix OperationCanceledException on waiting subscriptions

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -269,8 +269,7 @@ namespace Raven.Server.Documents.TcpHandlers
                             $"{_subscriptionConnectionsState.GetConnectionsAsString()} is released");
                     }
 
-                    var timeout = TimeSpan.FromMilliseconds(Math.Max(250, (long)_options.TimeToWaitBeforeConnectionRetry.TotalMilliseconds / 2) + random.Next(15, 50));
-                    await Task.Delay(timeout);
+                    await Task.Delay(random.Next(2400, 2600), CancellationTokenSource.Token);
                     await SendHeartBeatIfNeededAsync(sp,
                         $"A connection from IP {TcpConnection.TcpClient.Client.RemoteEndPoint} is waiting for Subscription Task that is serving a connection from IP " +
                         $"{_subscriptionConnectionsState.GetConnectionsAsString()} to be released");

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -30,8 +30,10 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.System;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using DisposableAction = Voron.Util.DisposableAction;
@@ -782,7 +784,7 @@ namespace SlowTests.Client.Subscriptions
                 await Assert.ThrowsAsync<SubscriptionClosedException>(() => subscription.Run(x => { }).WaitAsync(_reasonableWaitTime));
             }
         }
-
+        
         [Fact]
         public async Task ShouldThrow()
         {
@@ -1508,6 +1510,71 @@ namespace SlowTests.Client.Subscriptions
 
             var db = await Databases.GetDocumentDatabaseInstanceFor(server, store);
             await AssertWaitForExceptionAsync<KeyNotFoundException>(async () => await Task.Run(() => db.SubscriptionStorage.GetSubscriptionStateById(state.SubscriptionId)), interval: 1000);
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscriptions_WithWaitForFree_ShouldNotDisconnectOnStreamTimeout()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var sub = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>
+                {
+                    Filter = user => user.Count > 0
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        await session.StoreAsync(new User { Count = 1 });
+                    }
+                    await session.SaveChangesAsync();
+                }
+
+                async Task ProcessDocuments(SubscriptionBatch<User> x)
+                {
+                    using var session = x.OpenAsyncSession();
+
+                    foreach (var item in x.Items)
+                    {
+                        item.Result.Count--;
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var ops = new SubscriptionWorkerOptions(sub)
+                {
+                    TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(40),
+                    MaxErroneousPeriod = TimeSpan.FromHours(1),
+                    Strategy = SubscriptionOpeningStrategy.WaitForFree,
+                    ConnectionStreamTimeout = TimeSpan.FromSeconds(15),
+                };
+
+                var mre = new AsyncManualResetEvent();
+                await using var subscription = store.Subscriptions.GetSubscriptionWorker<User>(ops);
+                subscription.OnEstablishedSubscriptionConnection += () => mre.Set();
+
+                var processingSubs = subscription.Run(ProcessDocuments);
+                await using var subscription2 = store.Subscriptions.GetSubscriptionWorker<User>(ops);
+                await using var subscription3 = store.Subscriptions.GetSubscriptionWorker<User>(ops);
+
+                var exceptions = new ConcurrentSet<Exception>();
+                subscription2.OnSubscriptionConnectionRetry += exception => exceptions.Add(exception);
+                subscription2.OnUnexpectedSubscriptionError += exception => exceptions.Add(exception);
+                subscription3.OnSubscriptionConnectionRetry += exception => exceptions.Add(exception);
+                subscription3.OnUnexpectedSubscriptionError += exception => exceptions.Add(exception);
+
+                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+
+                var waitingSubs1 = subscription2.Run(ProcessDocuments);
+                var waitingSubs2 = subscription3.Run(ProcessDocuments);
+
+                var delay = Task.Delay((ops.TimeToWaitBeforeConnectionRetry / 2) + TimeSpan.FromSeconds(5));
+                await delay;
+
+                Assert.True(exceptions.Count == 0, $"Exceptions: {string.Join(", ", exceptions.Select(x => x))}");
+            }
         }
 
         private class IdleDatabaseStatistics


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24052

### Additional description

In certain values of TimeToWaitBeforeConnectionRetry  configuration we might get OperationCanceledException on waiting subscriptions

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
