### PR TITLE
RavenDB-24061 Load custom analyzers and sorters before initializing indexes, since indexes may start before they are loaded.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -814,11 +814,11 @@ namespace Raven.Server.Documents.Indexes
 
             return Task.Run(() =>
             {
-                if (_documentDatabase.Configuration.Indexing.RunInMemory == false)
-                    OpenIndexesFromRecord(record, raftIndex, addToInitLog);
-
                 HandleSorters(record, raftIndex);
                 HandleAnalyzers(record, raftIndex);
+                
+                if (_documentDatabase.Configuration.Indexing.RunInMemory == false)
+                    OpenIndexesFromRecord(record, raftIndex, addToInitLog);
             });
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24061

### Additional description

Load custom analyzers and sorters before initializing indexes, since indexes may start before they are loaded.

Same as on DatabaseRecord change:
https://github.com/ravendb/ravendb/blob/72a536b7fc53ee855792b168ce72d6b576213609/src/Raven.Server/Documents/Indexes/IndexStore.cs#L92-L107

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
