### PR TITLE
RavenDB-24061 Custom: Load custom analyzers and sorters before initializing indexes, since indexes may start before they are loaded.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -814,11 +814,11 @@ namespace Raven.Server.Documents.Indexes
 
             return Task.Run(() =>
             {
-                if (_documentDatabase.Configuration.Indexing.RunInMemory == false)
-                    OpenIndexesFromRecord(record, raftIndex, addToInitLog);
-
                 HandleSorters(record, raftIndex);
                 HandleAnalyzers(record, raftIndex);
+                
+                if (_documentDatabase.Configuration.Indexing.RunInMemory == false)
+                    OpenIndexesFromRecord(record, raftIndex, addToInitLog);
             });
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24061 

### Additional description

Original PR with description: https://github.com/ravendb/ravendb/pull/20458
