### PR TITLE
RavenDB-24015 Remove exhaustiveStringTuple form Icon story

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Icon.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/Icon.stories.tsx
@@ -1,10 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { withStorybookContexts, withBootstrap5 } from "test/storybookTestUtils";
 import { Icon } from "./Icon";
-import { exhaustiveStringTuple } from "components/utils/common";
-import IconName from "typings/server/icons";
 import copyToClipboard from "common/copyToClipboard";
 import Button from "react-bootstrap/Button";
+import IconName from "typings/server/icons";
 
 export default {
     title: "Bits/Icon",
@@ -28,7 +27,7 @@ export const IconStory: StoryObj = {
     ),
 };
 
-const allIconNames = exhaustiveStringTuple<IconName>()(
+const allIconNames: IconName[] = [
     "about",
     "accept",
     "access-admin",
@@ -506,5 +505,5 @@ const allIconNames = exhaustiveStringTuple<IconName>()(
     "web-socket",
     "windows",
     "x",
-    "zombie"
-);
+    "zombie",
+];


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24015/Remove-exhaustiveStringTuple-from-Icon-stories

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
