### PR TITLE
RavenDB-23975 Fixed CollisionOfTwoEmbeddingsInTwoTasks test

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -162,7 +162,6 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
              );
          }
 
-
         public ValueTask<ReadOnlyMemory<ReadOnlyMemory<byte>>> GetEmbeddingsForQueryAsync(
             DocumentsOperationContext documentsContext, 
             string value)
@@ -364,8 +363,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                         $"('{RavenConfiguration.GetKey(x => x.Ai.EmbeddingsGenerationMaxBatchSize)}') or increasing the " +
                         $"limits on your model deployment.", httpOperationException);
                 }
-
-
+                
                 PortableExceptions.ThrowIf<IOException>(allEmbeddings.Count != batch.Count, "Model returned a different count of embeddings than expected");
 
                 for (int i = 0; i < allEmbeddings.Count; i++)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationTask.cs
@@ -35,8 +35,7 @@ public sealed class EmbeddingsGenerationTask : EtlProcess<EmbeddingsGenerationIt
     private const string EmbeddingsTaskTag = "AI/Embeddings Generation";
 
     private int _fallbackCounter = 0;
-
-
+    
     public EmbeddingsGenerationTask(Transformation transformation, EmbeddingsGenerationConfiguration configuration, DocumentDatabase database, ServerStore serverStore)
         : base(transformation, configuration, database, serverStore, EmbeddingsTaskTag)
     {
@@ -132,9 +131,11 @@ public sealed class EmbeddingsGenerationTask : EtlProcess<EmbeddingsGenerationIt
         {
             foreach (var embeddingItem in embeddingsScriptRun.Additions)
             {
-                batch.StartGenerateEmbeddingFor(context,embeddingItem.DocumentId, embeddingItem.DocumentCollectionName,
+                batch.StartGenerateEmbeddingFor(context, embeddingItem.DocumentId, embeddingItem.DocumentCollectionName,
                     embeddingItem.Fields);
             }
+            // We only wait for embeddings generation here, documents creation (and update) is done in the background
+            // https://issues.hibernatingrhinos.com/issue/RavenDB-24062
             batch.WaitForGenerationAsync().GetAwaiter().GetResult();
             storageScope.NumberOfEmbeddingsInCache = batch.CachedEmbeddings;
             storageScope.NumberOfGeneratedEmbeddings = embeddingsScriptRun.Additions.Count;

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -101,7 +101,8 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         string docId,
         VectorEmbeddingType targetQuantization = VectorEmbeddingType.Single)
     {
-        AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: false);
+        WaitForValue(() => 
+            AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: false), true);
     }
     protected void AssertMissingEmbeddingsForPath(
         IDocumentStore store,
@@ -112,9 +113,11 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         string docId,
         VectorEmbeddingType targetQuantization = VectorEmbeddingType.Single)
     {
-        AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: true);
+        WaitForValue(() =>
+            AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: true), true);
     }
-    protected void AssertEmbeddingsForPath(
+    
+    private bool AssertEmbeddingsForPath(
         IDocumentStore store,
         EmbeddingsGenerationTaskIdentifier integrationIdentifier,
         AiConnectionStringIdentifier connectionStringIdentifier,
@@ -136,38 +139,51 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
             var hashOfInput = EmbeddingsHelper.CalculateInputValueHash(inputValue);
             var embeddingsDocumentId = EmbeddingsHelper.GetEmbeddingCacheDocumentId(connectionStringIdentifier, hashOfInput, targetQuantization);
             var embeddingCacheDocument = session.Load<object>(embeddingsDocumentId) as JObject;
-            Assert.NotNull(embeddingCacheDocument);
+
+            if (embeddingCacheDocument == null)
+                return false;
 
             var attachmentsInEmbeddingCache = session.Advanced.Attachments.Get(embeddingsDocumentId, hashOfInput);
-            Assert.NotNull(attachmentsInEmbeddingCache);
+            
+            if (attachmentsInEmbeddingCache == null)
+                return false;
+            
             var hashContentHash = AttachmentsStorageHelper.CalculateHash(attachmentsInEmbeddingCache.Stream.ReadData());
 
             //Assert if embeddings document exists
             var documentEmbeddingsId = EmbeddingsHelper.GetEmbeddingDocumentId(docId);
             var documentEmbeddings = session.Load<object>(documentEmbeddingsId) as JObject;
-            Assert.NotNull(documentEmbeddings);
+
+            if (documentEmbeddings == null)
+                return false;
 
             // Assert if contains current ETL result
             var currentEtlObject = documentEmbeddings[integrationIdentifier.Value];
-            Assert.NotNull(currentEtlObject);
+            
+            if (currentEtlObject is null)
+                return false;
 
             // Assert if ETL result contains current path
             var currentPathObject = currentEtlObject[path] as JArray;
-            Assert.NotNull(currentPathObject);
+
+            if (currentPathObject == null)
+                return false;
 
             var attachmentExistsInEmbeddingsDocument = session.Advanced.Attachments.Exists(documentEmbeddingsId, hashContentHash);
             if (assertMissing is false)
             {
                 // Assert if current path contain embedding of current input value
-                Assert.Contains(hashContentHash, currentPathObject.Select(x=>x.ToString()));
-                Assert.True(attachmentExistsInEmbeddingsDocument);
+                if (currentPathObject.Select(x => x.ToString()).Contains(hashContentHash) == false || attachmentExistsInEmbeddingsDocument == false)
+                    return false;
             }
             else
             {
-                Assert.DoesNotContain(hashContentHash, currentPathObject.Select(x=>x.ToString()));
-                Assert.False(attachmentExistsInEmbeddingsDocument);
+                if (currentPathObject.Select(x => x.ToString()).Contains(hashContentHash) || attachmentExistsInEmbeddingsDocument)
+                    return false;
             }
         }
+        
+        return true;
     }
 
     public override void Dispose()

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -101,9 +101,14 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         string docId,
         VectorEmbeddingType targetQuantization = VectorEmbeddingType.Single)
     {
-        WaitForValue(() => 
-            AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: false), true);
+        Exception innerException = null;
+        var result = WaitForValue(() => 
+            RunAssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: false, out innerException), true);
+        
+        if (result is false)
+            throw innerException;
     }
+    
     protected void AssertMissingEmbeddingsForPath(
         IDocumentStore store,
         EmbeddingsGenerationTaskIdentifier integrationIdentifier,
@@ -113,11 +118,43 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         string docId,
         VectorEmbeddingType targetQuantization = VectorEmbeddingType.Single)
     {
-        WaitForValue(() =>
-            AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: true), true);
+        Exception innerException = null;
+        var result = WaitForValue(() =>
+            RunAssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing: true, out innerException), true, timeout: (int)DefaultEtlTimeout.TotalMilliseconds);
+
+        if (result is false)
+            throw innerException;
     }
     
-    private bool AssertEmbeddingsForPath(
+    /// <summary>
+    /// Since embeddings are added to the database via TxMerger, there is no easy way to ensure the embeddings are
+    /// processed and stored.
+    /// This way we will loop the assertion in a specific time period (DefaultEtlTimeout) and wait until they appear.
+    /// If not, we will throw the inner exception to get information about which assertion failed.
+    /// </summary>
+    private bool RunAssertEmbeddingsForPath(IDocumentStore store,
+        EmbeddingsGenerationTaskIdentifier integrationIdentifier,
+        AiConnectionStringIdentifier connectionStringIdentifier,
+        string path,
+        string[] inputValues,
+        string docId,
+        VectorEmbeddingType targetQuantization,
+        bool assertMissing, out Exception exception)
+    {
+        try
+        {
+            AssertEmbeddingsForPath(store, integrationIdentifier, connectionStringIdentifier, path, inputValues, docId, targetQuantization, assertMissing);
+            exception = null;
+            return true;
+        }
+        catch (Exception e)
+        {
+            exception = e;
+            return false;
+        }
+    }
+    
+    private void AssertEmbeddingsForPath(
         IDocumentStore store,
         EmbeddingsGenerationTaskIdentifier integrationIdentifier,
         AiConnectionStringIdentifier connectionStringIdentifier,
@@ -139,51 +176,38 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
             var hashOfInput = EmbeddingsHelper.CalculateInputValueHash(inputValue);
             var embeddingsDocumentId = EmbeddingsHelper.GetEmbeddingCacheDocumentId(connectionStringIdentifier, hashOfInput, targetQuantization);
             var embeddingCacheDocument = session.Load<object>(embeddingsDocumentId) as JObject;
-
-            if (embeddingCacheDocument == null)
-                return false;
+            Assert.NotNull(embeddingCacheDocument);
 
             var attachmentsInEmbeddingCache = session.Advanced.Attachments.Get(embeddingsDocumentId, hashOfInput);
-            
-            if (attachmentsInEmbeddingCache == null)
-                return false;
-            
+            Assert.NotNull(attachmentsInEmbeddingCache);
             var hashContentHash = AttachmentsStorageHelper.CalculateHash(attachmentsInEmbeddingCache.Stream.ReadData());
 
             //Assert if embeddings document exists
             var documentEmbeddingsId = EmbeddingsHelper.GetEmbeddingDocumentId(docId);
             var documentEmbeddings = session.Load<object>(documentEmbeddingsId) as JObject;
-
-            if (documentEmbeddings == null)
-                return false;
+            Assert.NotNull(documentEmbeddings);
 
             // Assert if contains current ETL result
             var currentEtlObject = documentEmbeddings[integrationIdentifier.Value];
-            
-            if (currentEtlObject is null)
-                return false;
+            Assert.NotNull(currentEtlObject);
 
             // Assert if ETL result contains current path
             var currentPathObject = currentEtlObject[path] as JArray;
-
-            if (currentPathObject == null)
-                return false;
+            Assert.NotNull(currentPathObject);
 
             var attachmentExistsInEmbeddingsDocument = session.Advanced.Attachments.Exists(documentEmbeddingsId, hashContentHash);
             if (assertMissing is false)
             {
                 // Assert if current path contain embedding of current input value
-                if (currentPathObject.Select(x => x.ToString()).Contains(hashContentHash) == false || attachmentExistsInEmbeddingsDocument == false)
-                    return false;
+                Assert.Contains(hashContentHash, currentPathObject.Select(x=>x.ToString()));
+                Assert.True(attachmentExistsInEmbeddingsDocument);
             }
             else
             {
-                if (currentPathObject.Select(x => x.ToString()).Contains(hashContentHash) || attachmentExistsInEmbeddingsDocument)
-                    return false;
+                Assert.DoesNotContain(hashContentHash, currentPathObject.Select(x=>x.ToString()));
+                Assert.False(attachmentExistsInEmbeddingsDocument);
             }
         }
-        
-        return true;
     }
 
     public override void Dispose()

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -152,7 +152,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "SubDtos.Name" , ChunkingOptions = DefaultChunkingOptions}]);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "SubDtos.Name", ["Subname1", "Subname2"], dto.Id);
+            AssertEmbeddingsForPath(store, config, connectionString, "SubDtos.Name", ["Subname1", "Subname2"], dto.Id);
         }
     }
 
@@ -501,9 +501,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             }
             
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            AddEmbeddingsGenerationTask(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["Name1"], dto.Id);
+            
             using (var session = store.OpenSession())
             {
                 var allDocs = session.Advanced.RawQuery<Test>("from '@all_docs' as t select { Id: id(t), Expires: t[\"@metadata\"][\"@expires\"] }").ToList();
@@ -531,8 +532,9 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             }
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            var (config, _) = AddEmbeddingsGenerationTask(store);
+            var (config, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Name1"], dto.Id);
 
             Test embeddingCache;
 
@@ -562,6 +564,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             }
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Name1"], dto.Id);
 
             using (var session = store.OpenSession())
             {
@@ -981,22 +984,23 @@ Console.WriteLine(""Hello, World!"");";
                 
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
 
+                var nameConfig = new EmbeddingPathConfiguration()
+                {
+                    Path = "Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 100 }
+                };
+
+                var subdtoNameConfig = new EmbeddingPathConfiguration()
+                {
+                    Path = "SubDto.Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 5 }
+                };
+                
                 var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                     targetQuantization: quantization,
-                    embeddingsPaths: [
-                        new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = new ChunkingOptions()
-                        {
-                            ChunkingMethod = ChunkingMethod.PlainTextSplitLines,
-                            MaxTokensPerChunk = 2137
-                        }},
-                        new EmbeddingPathConfiguration() { Path = "SubDto.Name", ChunkingOptions = new ChunkingOptions()
-                        {
-                            ChunkingMethod = ChunkingMethod.PlainTextSplitLines,
-                            MaxTokensPerChunk = 5
-                        }}
-                    ]);
+                    embeddingsPaths: [nameConfig, subdtoNameConfig]);
                 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                AssertEmbeddingsForPath(store, configuration, connectionString, nameConfig.Path, Raven.Server.Documents.AI.TextChunker.Chunk(dto.Name, nameConfig.ChunkingOptions).ToArray(), dto.Id, quantization);
+                AssertEmbeddingsForPath(store, configuration, connectionString, subdtoNameConfig.Path, Raven.Server.Documents.AI.TextChunker.Chunk(dto.SubDto.Name, subdtoNameConfig.ChunkingOptions).ToArray(), dto.Id, quantization);
 
                 var result = session.Query<Dto>().VectorSearch(x =>
                         x.WithText("SubDto.Name").UsingTask(configuration.Identifier).TargetQuantization(quantization),

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -1127,7 +1127,9 @@ Console.WriteLine(""Hello, World!"");";
             session.Load<Dto>(id).Name = "Updated";
             session.SaveChanges();
         }        
+
         Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
         AssertEmbeddingsForPath(store, config, connection, "Name", ["Updated"], id);
         AssertEmbeddingsForPath(store, config2, connection2, "Names", ["Name1"], id);
     }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
@@ -18,18 +18,28 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     public void CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int8()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        string id;
         using (var session = store.OpenSession())
         {
-            session.Store(new Dto { Name = "car" });
+            var dto = new Dto { Name = "car" };
+            session.Store(dto);
             session.SaveChanges();
+            id = dto.Id;
         }
 
         var etl = Etl.WaitForEtlToComplete(store);
-        AddEmbeddingsGenerationTask(store, embeddingsPaths: new List<EmbeddingPathConfiguration>()
+        var nameConfig = new EmbeddingPathConfiguration()
         {
-            new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }}
+            Path = "Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }
+        };
+        var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: new List<EmbeddingPathConfiguration>()
+        {
+            nameConfig
         }, targetQuantization: VectorEmbeddingType.Int8);
+        
         etl.Wait(DefaultEtlTimeout);
+        AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Int8);
+        
         
         new Index().Execute(store);
         Indexes.WaitForIndexing(store);
@@ -53,18 +63,20 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     public void CanPerformQuantizationInIndexFromEtl()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        var id = "dtos/1";
         using (var session = store.OpenSession())
         {
-            session.Store(new Dto { Name = "car" });
+            session.Store(new Dto { Name = "car" }, id);
             session.SaveChanges();
         }
 
         var etl = Etl.WaitForEtlToComplete(store);
-        AddEmbeddingsGenerationTask(store, embeddingsPaths: new List<EmbeddingPathConfiguration>()
+        var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: new List<EmbeddingPathConfiguration>()
         {
             new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }}
         }, targetQuantization: VectorEmbeddingType.Single);
         Assert.True(etl.Wait(DefaultEtlTimeout));
+        AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id);
         
         new QuantizationInIndex().Execute(store);
         Indexes.WaitForIndexing(store);
@@ -88,16 +100,18 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     public void CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int1()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        var id = "dtos/1";
         using (var session = store.OpenSession())
         {
-            session.Store(new Dto { Name = "car" });
+            session.Store(new Dto { Name = "car" }, id);
             session.SaveChanges();
         }
 
         var etl = Etl.WaitForEtlToComplete(store);
-        AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Binary);
+        var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Binary);
         Assert.True(etl.Wait(DefaultEtlTimeout));
-        
+        AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Binary);
+
         new Index().Execute(store);
         Indexes.WaitForIndexing(store);
 
@@ -120,20 +134,24 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     public void QuantizedValuesInCacheAreSeparated()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        string id = "Dtos/1";
         using (var session = store.OpenSession())
         {
-            session.Store(new Dto { Name = "car" });
+            session.Store(new Dto { Name = "car" }, id);
             session.SaveChanges();
         }
 
         var etl = Etl.WaitForEtlToComplete(store);
-        AddEmbeddingsGenerationTask(embeddingsGenerationTaskName: "secondEtl", store: store, targetQuantization: VectorEmbeddingType.Single);
+        var (configurationSingle, connectionStringSingle) = AddEmbeddingsGenerationTask(embeddingsGenerationTaskName: "secondEtl", store: store, targetQuantization: VectorEmbeddingType.Single);
         Assert.True(etl.Wait(DefaultEtlTimeout));
-        
+        AssertEmbeddingsForPath(store, configurationSingle, connectionStringSingle, "Name", ["car"], id, VectorEmbeddingType.Single);
         etl.Reset();
         
-        AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Int8);
+        var (configurationInt8, connectionStringInt8) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Int8);
         Assert.True(etl.Wait(DefaultEtlTimeout));
+        AssertEmbeddingsForPath(store, configurationInt8, connectionStringInt8, "Name", ["car"], id, VectorEmbeddingType.Int8);
+
+        
         
         new Index().Execute(store);
         Indexes.WaitForIndexing(store);
@@ -180,6 +198,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
 
     private class Dto
     {
+        public string Id { get; set; }
         public object Vector { get; set; }
         public string Name { get; set; }
     }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
@@ -54,6 +54,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store);
         Assert.True(etlStatus.Wait(DefaultEtlTimeout));
+        AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Joe"], id);
 
         store.Maintenance.Send(new StartIndexOperation(index.IndexName));
         Indexes.WaitForIndexing(store);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -1,6 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Diagnostics.Tracing.Parsers;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
@@ -148,12 +148,19 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
 
-            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, 
+                embeddingsPaths: new List<EmbeddingPathConfiguration>()
+                {
+                    new EmbeddingPathConfiguration()
+                    {
+                        ChunkingOptions = DefaultChunkingOptions,
+                        Path = "TextualValue"
+                    }
+                });
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
-            
             
             using (var session = store.OpenSession())
             {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing.Parsers;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
@@ -60,7 +61,10 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["apple"], dto1.Id);
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
+            
+            
             var connectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
 
             using (var session = store.OpenSession())
@@ -108,7 +112,11 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
 
+            
+            
             using (var session = store.OpenSession())
             {
                 var result = session.Query<Dto>().VectorSearch(x => x.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), factory => factory.ByText(queriedText), minimumSimilarity: 0.75f).ToList();
@@ -140,10 +148,13 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
 
-            AddEmbeddingsGenerationTask(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
+            
+            
             using (var session = store.OpenSession())
             {
                 var ex = Assert.Throws<InvalidQueryException>(() => session.Query<Dto>().VectorSearch(x => x.WithText(d => d.TextualValue).UsingTask("NotExistingTask"), factory => factory.ByText(queriedText)).ToList());
@@ -178,12 +189,14 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
 
-            var (_, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
+            
+            
             var connectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
-
             var index = new SomeIndex();
             index.Execute(store);
             Indexes.WaitForIndexing(store);
@@ -232,7 +245,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             ], chunkingOptionsForQuerying: new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 5 });
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
+            
             var index = new SomeIndex();
             index.Execute(store);
             Indexes.WaitForIndexing(store);
@@ -253,17 +267,27 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         using var store = GetDocumentStore(options);
 
         var aiTaskDone = Etl.WaitForEtlToComplete(store);
-        AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
+        var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
 
+
+        
         using (var session = store.OpenSession())
         {
-            session.Store(new Dto() { TextualValue = "pizza" });
-            session.Store(new Dto() { TextualValue = "car" });
-            session.Store(new Dto() { TextualValue = "beach" });
+            var dto1 = new Dto() { TextualValue = "pizza" };
+            var dto2 = new Dto() { TextualValue = "car" };
+            var dto3 = new Dto() { TextualValue = "beach" };
+            
+            session.Store(dto1);
+            session.Store(dto2);
+            session.Store(dto3);
             session.SaveChanges();
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
+            AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto3.TextualValue], dto3.Id);
+            
+            
             var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
                 .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f).ToList();
             Assert.Equal(2, multiVectorTextualQuery.Count);
@@ -303,18 +327,25 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         using (var store = GetDocumentStore(options))
         {
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
 
             using (var session1 = store.OpenAsyncSession())
             using (var session2 = store.OpenAsyncSession())
             using (var session3 = store.OpenAsyncSession())
             {
-                await session1.StoreAsync(new Dto() { TextualValue = "pizza" });
-                await session1.StoreAsync(new Dto() { TextualValue = "car" });
-                await session1.StoreAsync(new Dto() { TextualValue = "beach" });
+                var dto1 = new Dto() { TextualValue = "pizza" };
+                var dto2 = new Dto() { TextualValue = "car" };
+                var dto3 = new Dto() { TextualValue = "beach" };
+                
+                await session1.StoreAsync(dto1);
+                await session1.StoreAsync(dto2);
+                await session1.StoreAsync(dto3);
                 await session1.SaveChangesAsync();
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
+                AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
+                AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto3.TextualValue], dto3.Id);
 
                 var q1 = session1.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
                     .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f)
@@ -343,7 +374,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         using var store = GetDocumentStore(options);
 
         var aiTaskDone = Etl.WaitForEtlToComplete(store);
-        AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
+        var (config, connection) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
 
         using (var session = store.OpenSession())
         {
@@ -351,7 +382,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.SaveChanges();
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            AssertEmbeddingsForPath(store, config, connection, "TextualValue", ["asdsdfsdf"], "dto/1");
+            
             var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
                 .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f).ToList();
             Assert.Equal(0, multiVectorTextualQuery.Count);
@@ -365,7 +397,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.SaveChanges();
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            
+            AssertEmbeddingsForPath(store, config, connection, "TextualValue", ["pizza"], "dto/1");
+
             var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
                 .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask("localaitask"), v => v.ByTexts(["italian food", "vehicle"]), minimumSimilarity: 0.75f).ToList();
             Assert.Equal(1, multiVectorTextualQuery.Count);
@@ -380,15 +413,20 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         using (var store = GetDocumentStore(options))
         {
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration(){ ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration(){ ChunkingOptions = DefaultChunkingOptions, Path = "TextualValue" }]);
 
             using (var session = store.OpenSession())
             {
-                session.Store(new Dto() { TextualValue = "pizza" });
-                session.Store(new Dto() { TextualValue = "fruit" });
+                var dto1 = new Dto() { TextualValue = "pizza" };
+                var dto2 = new Dto() { TextualValue = "fruit" };
+                
+                session.Store(dto1);
+                session.Store(dto2);
                 session.SaveChanges();
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
+                AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
 
                 var multiVectorTextualQueryResult = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
                     .VectorSearch(f => f.WithText(s => s.TextualValue).UsingTask(configuration.Identifier), v => v.ByTexts(["pizza", "pineapple", "cherry", "strawberry", "blueberry"]))
@@ -428,6 +466,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     private class Dto
     {
+        public string Id { get; set; }
         public string TextualValue { get; set; }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -167,8 +167,7 @@ namespace FastTests
                     if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
                         mre.Set();
                 };
-
-
+                
                 return mre;
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23975/SlowTests.Server.Documents.AI.Embeddings.GenerateEmbeddingsTests.CollisionOfTwoEmbeddingsInTwoTasks

### Additional description

The test failed sometimes because the embeddings generation task doesn't wait for embeddings storage (which is done in background) before notifying it finished its work. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
