### PR TITLE
RavenDB-24053 Some details are hidden for sharded db

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
@@ -39,7 +39,7 @@ describe("ValidDatabasePropertiesPanel", () => {
 
     describe("getLocalGeneralInfo", () => {
         describe("non-sharded", () => {
-            it("can get hasLocalNodeAllData", () => {
+            it("can get hasLocalNodeAllData for non-sharded database", () => {
                 const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
                     getDatabaseLocalInfo({ status: "idle", location: { nodeTag: "A" } }),
                     getDatabaseLocalInfo({ status: "success", location: { nodeTag: "B" } }),
@@ -48,6 +48,25 @@ describe("ValidDatabasePropertiesPanel", () => {
 
                 expect(getLocalGeneralInfo(dbStates, "A").hasLocalNodeAllData).toBe(false);
                 expect(getLocalGeneralInfo(dbStates, "B").hasLocalNodeAllData).toBe(true);
+                expect(getLocalGeneralInfo(dbStates, "C").hasLocalNodeAllData).toBe(false);
+            });
+
+            it("can get hasLocalNodeAllData for sharded database", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo({ status: "success", location: { nodeTag: "A", shardNumber: 0 } }),
+                    getDatabaseLocalInfo({
+                        status: "success",
+                        loadError: "Some Error",
+                        location: { nodeTag: "B", shardNumber: 0 },
+                    }),
+                    getDatabaseLocalInfo({ status: "success", location: { nodeTag: "B", shardNumber: 1 } }),
+                    getDatabaseLocalInfo({ status: "idle", location: { nodeTag: "C", shardNumber: 1 } }),
+                    getDatabaseLocalInfo({ status: "success", location: { nodeTag: "A", shardNumber: 2 } }),
+                    getDatabaseLocalInfo({ status: "success", location: { nodeTag: "C", shardNumber: 2 } }),
+                ];
+
+                expect(getLocalGeneralInfo(dbStates, "A").hasLocalNodeAllData).toBe(true);
+                expect(getLocalGeneralInfo(dbStates, "B").hasLocalNodeAllData).toBe(false);
                 expect(getLocalGeneralInfo(dbStates, "C").hasLocalNodeAllData).toBe(false);
             });
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
@@ -336,7 +336,9 @@ function getLocalGeneralInfo(
     dbStates: locationAwareLoadableData<DatabaseLocalInfo>[],
     localNodeTag: string
 ): LocalGeneralInfo {
-    const allShards = new Set(dbStates.map((x) => x.location.shardNumber ?? -1));
+    const allShards = new Set(
+        dbStates.filter((x) => x.location.nodeTag === localNodeTag).map((x) => x.location.shardNumber ?? -1)
+    );
 
     const localDbStatesWithoutErrors = dbStates.filter(
         (x) => x.location.nodeTag === localNodeTag && x.status === "success" && !x.data?.loadError


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24053/Some-details-are-hidden-for-sharded-db

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
