### PR TITLE
RavenDB-24063 AVE due to wrong free space handling

### DIFF
--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -27,6 +27,8 @@ namespace Voron.Global
         {
             public const int PageSize = 8 * Size.Kilobyte;
 
+            public const int JournalPageSize = 4 * Size.Kilobyte;
+
             static Storage()
             {
                 GC.KeepAlive(new int[

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -493,10 +493,6 @@ namespace Voron.Impl.FreeSpace
                 }
 
                 var index = (int)(pageNumber % NumberOfPagesInSection);
-
-                if (sba.Get(index))
-                    throw new InvalidOperationException($"trying to double free page {pageNumber}");
-
                 sba.Set(index, true);
                 
                 if (_disableSparseRegions == false && sba.SetCount > NumberOfFreePagesForSparseConsideration)

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -284,18 +284,20 @@ namespace Voron.Impl.FreeSpace
             var currentEndRange = current.GetEndRangeCount();
 
             var nextSectionId = currentSectionId + 1;
-            StreamBitArray? next = null;
+            StreamBitArray next = default;
+            var streamBitArrayHasValue = false;
             int nextRangeStart = 0;
             using (freeSpaceTree.Read(nextSectionId, out Slice read))
             {
                 if (read.HasValue)
                 {
                     next = new StreamBitArray(read.CreateReader().Base);
-                    nextRangeStart = next.Value.GetStartRangeCount();
+                    nextRangeStart = next.GetStartRangeCount();
+                    streamBitArrayHasValue = true;
                 }
             }
 
-            if (currentEndRange == 0 || next == null || currentEndRange + nextRangeStart < num)
+            if (currentEndRange == 0 || streamBitArrayHasValue == false || currentEndRange + nextRangeStart < num)
             {
                 // we update the cache in any of the following cases:
                 // - the current section has no more available space at its end
@@ -322,7 +324,7 @@ namespace Voron.Impl.FreeSpace
             }
 
             var nextRange = num - currentEndRange;
-            if (next.Value.SetCount == nextRange)
+            if (next.SetCount == nextRange)
             {
                 freeSpaceTree.Delete(nextSectionId);
             }
@@ -330,10 +332,10 @@ namespace Voron.Impl.FreeSpace
             {
                 for (int i = 0; i < nextRange; i++)
                 {
-                    next.Value.Set(i, false);
+                    next.Set(i, false);
                 }
 
-                next.Value.Write(freeSpaceTree, nextSectionId);
+                next.Write(freeSpaceTree, nextSectionId);
             }
 
             if (current.SetCount == currentEndRange)
@@ -489,7 +491,13 @@ namespace Voron.Impl.FreeSpace
                 {
                     sba = !result.HasValue ? new StreamBitArray() : new StreamBitArray(result.CreateReader().Base);
                 }
-                sba.Set((int)(pageNumber % NumberOfPagesInSection), true);
+
+                var index = (int)(pageNumber % NumberOfPagesInSection);
+
+                if (sba.Get(index))
+                    throw new InvalidOperationException($"trying to double free page {pageNumber}");
+
+                sba.Set(index, true);
                 
                 if (_disableSparseRegions == false && sba.SetCount > NumberOfFreePagesForSparseConsideration)
                 {

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -345,6 +346,10 @@ public unsafe struct StreamBitArray
 
     public void Set(int index, bool value)
     {
+        var current = Get(index);
+        if (current == value)
+            ThrowValueAlreadyExists(index, value);
+
         if (value)
         {
             _inner[index >> 5] |= (uint)(1 << (index & 31));
@@ -355,6 +360,12 @@ public unsafe struct StreamBitArray
             _inner[index >> 5] &= (uint)~(1 << (index & 31));
             SetCount--;
         }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowValueAlreadyExists(int index, bool value)
+    {
+        throw new InvalidOperationException($"the index {index} is already has the requested value: {value}");
     }
 
     public int GetEndRangeCount()

--- a/src/Voron/Impl/Journal/JournalWriter.cs
+++ b/src/Voron/Impl/Journal/JournalWriter.cs
@@ -46,7 +46,7 @@ namespace Voron.Impl.Journal
             FileName = new VoronPathSetting(filename);
             _journalNumber = journalNumber;
             _writeHandle = new SafeJournalHandle();
-            NumberOfAllocated4Kb = (int)(sourceFile.JournalSize.GetValue(SizeUnit.Bytes) / (4 * Constants.Size.Kilobyte));
+            NumberOfAllocated4Kb = (int)(sourceFile.JournalSize.GetValue(SizeUnit.Bytes) / Constants.Storage.JournalPageSize);
         }
         
         public JournalWriter(StorageEnvironmentOptions options, VoronPathSetting filename, long journalNumber, long size, PalFlags.JournalMode mode = PalFlags.JournalMode.Safe)
@@ -60,7 +60,7 @@ namespace Voron.Impl.Journal
             if (result != PalFlags.FailCodes.Success)
                 PalHelper.ThrowLastError(result, error, $"Attempted to open journal file - Path: {filename.FullPath} Size :{size}");
 
-            NumberOfAllocated4Kb = (int)(actualSize / (4 * Constants.Size.Kilobyte));
+            NumberOfAllocated4Kb = (int)(actualSize / Constants.Storage.JournalPageSize);
         }
 
         public void Write(long posBy4Kb, Span<Pal.journal_entry> entries, long totalNumberOf4Kbs)
@@ -70,11 +70,11 @@ namespace Voron.Impl.Journal
             fixed (Pal.journal_entry* pEntries = entries)
             {
                 using var metrics = _options.IoMetrics.MeterIoRate(FileName.FullPath, IoMetrics.MeterType.JournalWrite,
-                    totalNumberOf4Kbs * 4L * Constants.Size.Kilobyte);
-                var result = Pal.rvn_write_journal(_writeHandle, pEntries, entries.Length, posBy4Kb * 4L * Constants.Size.Kilobyte, out var error);
+                    totalNumberOf4Kbs * Constants.Storage.JournalPageSize);
+                var result = Pal.rvn_write_journal(_writeHandle, pEntries, entries.Length, posBy4Kb * Constants.Storage.JournalPageSize, out var error);
                 if (result != PalFlags.FailCodes.Success)
                     PalHelper.ThrowLastError(result, error,
-                        $"Attempted to write to journal file - Path: {FileName.FullPath} Size: {totalNumberOf4Kbs * 4L * Constants.Size.Kilobyte}, numberOf4Kb={totalNumberOf4Kbs}");
+                        $"Attempted to write to journal file - Path: {FileName.FullPath} Size: {totalNumberOf4Kbs * Constants.Storage.JournalPageSize}, numberOf4Kb={totalNumberOf4Kbs}");
 
                 if (error == ERROR_WORKING_SET_QUOTA && _log.IsDebugEnabled && _workingSetQuotaLogged == false)
                 {
@@ -84,7 +84,7 @@ namespace Voron.Impl.Journal
                     _workingSetQuotaLogged = true;
                 }
 
-                metrics.SetFileSize(NumberOfAllocated4Kb * (4L * Constants.Size.Kilobyte));
+                metrics.SetFileSize(NumberOfAllocated4Kb * Constants.Storage.JournalPageSize);
             }
         }
 
@@ -93,7 +93,7 @@ namespace Voron.Impl.Journal
             var flags = Pal.OpenFileFlags.None;
             if(_options.ForceUsing32BitsPager || PlatformDetails.Is32Bits)
                 flags |= Pal.OpenFileFlags.DoNotMap;
-            return Pager.Create(_options, FileName.FullPath, 0, flags);
+            return Pager.Create(_options, FileName.FullPath, 0, flags, pageSize: Constants.Storage.JournalPageSize);
         }
 
         public void Read(byte* buffer, long numOfBytes, long offsetInFile)
@@ -131,7 +131,7 @@ namespace Voron.Impl.Journal
             var result = Pal.rvn_truncate_journal(_writeHandle, size, out var error);
             if (result != PalFlags.FailCodes.Success)
                 PalHelper.ThrowLastError(result, error, $"Attempted to truncate journal file - Path: {FileName.FullPath} Size: {size}");
-            NumberOfAllocated4Kb = checked((int)(size / (4 * Constants.Size.Kilobyte)));
+            NumberOfAllocated4Kb = checked((int)(size / Constants.Storage.JournalPageSize));
         }
 
         public void AddRef()

--- a/src/Voron/Impl/Journal/SharedJournalState.cs
+++ b/src/Voron/Impl/Journal/SharedJournalState.cs
@@ -62,7 +62,7 @@ public class SharedJournalState()
 
         foreach (var record in _mergedJournalJournalRecordsBuffer)
         {
-            record.Tcs.SetCanceled();
+            record.Tcs.TrySetCanceled();
         }
     }
 }

--- a/src/Voron/Impl/Paging/Pager.32.cs
+++ b/src/Voron/Impl/Paging/Pager.32.cs
@@ -124,7 +124,7 @@ public unsafe partial class Pager
         {
             var pagerTxState = GetTxState(pager, state, ref txState);
             
-            if (pageNumber > state.NumberOfAllocatedPages || pageNumber < 0)
+            if (pageNumber >= state.NumberOfAllocatedPages || pageNumber < 0)
                 goto InvalidPage;
             if (state.Disposed)
                 goto AlreadyDisposed;

--- a/src/Voron/Impl/Paging/Pager.64.cs
+++ b/src/Voron/Impl/Paging/Pager.64.cs
@@ -43,7 +43,7 @@ public unsafe partial class Pager
         public static byte* AcquirePagePointer(Pager pager, State state, ref PagerTransactionState txState, long pageNumber)
         {
             _ = txState;
-            if (pageNumber > state.NumberOfAllocatedPages || pageNumber < 0)
+            if (pageNumber >= state.NumberOfAllocatedPages || pageNumber < 0)
                 goto InvalidPage;
             if (state.Disposed)
                 goto AlreadyDisposed;

--- a/src/Voron/Impl/Paging/Pager.State.cs
+++ b/src/Voron/Impl/Paging/Pager.State.cs
@@ -21,12 +21,12 @@ public unsafe partial class Pager
 
         public readonly WeakReference<State> WeakSelf;
 
-        public State(Pager pager, byte* readAddress, byte* writeMemory, long totalAllocatedSize, void* handle)
+        public State(Pager pager, byte* readAddress, byte* writeMemory, long totalAllocatedSize, void* handle, int pageSize)
         {
             ReadAddress = readAddress;
             WriteAddress = writeMemory;
             TotalAllocatedSize = totalAllocatedSize;
-            NumberOfAllocatedPages = totalAllocatedSize / Constants.Storage.PageSize;
+            NumberOfAllocatedPages = totalAllocatedSize / pageSize;
             Handle = handle;
 
             Pager = pager;

--- a/src/Voron/Impl/Paging/Pager.cs
+++ b/src/Voron/Impl/Paging/Pager.cs
@@ -47,7 +47,7 @@ public unsafe partial class Pager : IDisposable
     private const int MinIncreaseSize = 16 * Constants.Size.Kilobyte;
     private const int MaxIncreaseSize = Constants.Size.Gigabyte;
 
-    public static (Pager Pager, State State) Create(StorageEnvironmentOptions options, string filename, long initialFileSize, Pal.OpenFileFlags flags)
+    public static (Pager Pager, State State) Create(StorageEnvironmentOptions options, string filename, long initialFileSize, Pal.OpenFileFlags flags, int? pageSize = null)
     {
         if (Pal.PalVoronPageSize != Constants.Storage.PageSize)// JIT should eliminate this
             throw new InvalidOperationException($"Expected the PAL to have page size matching Voron but was: {Pal.PalVoronPageSize}");
@@ -57,8 +57,9 @@ public unsafe partial class Pager : IDisposable
             out var handle, out var readOnlyMemory, out var writeMemory, out var memorySize, out var error);
         if (result != PalFlags.FailCodes.Success)
             RaiseError(filename, error, result, initialFileSize);
+
         pager.Write = Pal.rvn_get_writer(handle);
-        var state = new State(pager, readOnlyMemory, writeMemory, memorySize, handle);
+        var state = new State(pager, readOnlyMemory, writeMemory, memorySize, handle, pageSize ?? options.PageSize);
         (state.TotalFileSize, state.TotalDiskSpace) = pager.GetFileSize(state);
         pager.InstallState(state);
         pager.Initialize(memorySize);
@@ -353,12 +354,13 @@ public unsafe partial class Pager : IDisposable
         var rc = Pal.rvn_increase_pager_size(state.Handle, 
             allocationSize, out var handle, out var readAddress, out var writeAddress, 
             out var totalAllocatedSize, out var errorCode);
+
         if (rc != PalFlags.FailCodes.Success)
         {
             PalHelper.ThrowLastError(rc, errorCode, $"Failed to increase file '{state.Pager.FileName}' to {new Size(allocationSize, SizeUnit.Bytes)}");
         }
         Debug.Assert(totalAllocatedSize >= state.TotalAllocatedSize, "totalAllocatedSize >= state.TotalAllocatedSize");
-        state = new State(this, readAddress, writeAddress, totalAllocatedSize, handle);
+        state = new State(this, readAddress, writeAddress, totalAllocatedSize, handle, pageSize: Options.PageSize);
         InstallState(state);
     }
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -768,7 +768,7 @@ namespace Voron
                 var flags = Pal.OpenFileFlags.ReadOnly;
                 if (ForceUsing32BitsPager || PlatformDetails.Is32Bits)
                     flags |= Pal.OpenFileFlags.DoNotMap;
-                return Pager.Create(this, filename, 0, flags);
+                return Pager.Create(this, filename, 0, flags, pageSize: Constants.Storage.JournalPageSize);
                     }
 
             private FileInfo GetJournalFileInfo(long journalNumber, JournalInfo journalInfo)

--- a/test/FastTests/Voron/StreamBitArrayTests.cs
+++ b/test/FastTests/Voron/StreamBitArrayTests.cs
@@ -115,7 +115,11 @@ namespace FastTests.Voron
 
             for (int j = 0; j < 2048; j += 1)
             {
-                sba.Set(j, random.Next(2) == 1);
+                var value = random.Next(2) == 1;
+                if (sba.Get(j) == value)
+                    continue;
+
+                sba.Set(j, value);
             }
 
             for (int j = 1; j <= 2048; j += 1)
@@ -146,6 +150,9 @@ namespace FastTests.Voron
 
                 for (int k = 0; k < blockSize && i < 2048; k++, i++)
                 {
+                    if (sba.Get(i) == value)
+                        continue;
+
                     sba.Set(i, value);
                 }
             }
@@ -178,6 +185,9 @@ namespace FastTests.Voron
 
                 for (int k = 0; k < blockSize && i >= 0; k++, i--)
                 {
+                    if (sba.Get(i) == value)
+                        continue;
+
                     sba.Set(i, value);
                 }
             }
@@ -206,6 +216,9 @@ namespace FastTests.Voron
 
                 for (int k = 0; k < blockSize && i < 2048; k++, i++)
                 {
+                    if (sba.Get(i) == value)
+                        continue;
+
                     sba.Set(i, value);
                 }
             }
@@ -234,6 +247,9 @@ namespace FastTests.Voron
 
                 for (int k = 0; k < blockSize && i < 2048; k++, i++)
                 {
+                    if (sba.Get(i) == value)
+                        continue;
+
                     sba.Set(i, value);
                 }
             }

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -466,8 +466,7 @@ namespace FastTests.Voron.Trees
 
             using (var tx = Env.WriteTransaction())
             {
-                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 4);
-
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 5);
                 // not commiting on purpose, this should simulate a rollback and clear the in memory state
             }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24063 

### Additional description

The issue was that we used nullable struct so calling upon `Value` will create a copy by value for the struct.

This change is relevant only for the 7.1 branch, since in prior versions the `StreamBitArray` is class, while here it was changed to struct.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
