### PR TITLE
RavenDB-23260 Lookup optimizations

### DIFF
--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -129,10 +129,7 @@ namespace Voron.Data.Lookups
                     if (state.LastSearchPosition < state.Header->NumberOfEntries)
                     {
                         var read = Math.Min(results.Length, state.Header->NumberOfEntries - state.LastSearchPosition);
-                        for (int i = 0; i < read; i++)
-                        {
-                            results[i] = GetKeyData(ref state, state.LastSearchPosition++);
-                        }
+                        GetKeyDataInBulk(ref state, state.LastSearchPosition, results.Slice(0, read));
                         return read;
                     }
                     if (_tree.GoToNextPage(ref _cursor) == false)

--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -144,6 +144,7 @@ namespace Voron.Data.Lookups
             {
                 if (_cursor._pos < 0 || _isFinished)
                     return 0;
+                
                 ref var state = ref _cursor._stk[_cursor._pos];
                 while (true)
                 {
@@ -151,17 +152,7 @@ namespace Voron.Data.Lookups
                     if (state.LastSearchPosition < state.Header->NumberOfEntries)
                     {
                         var read = Math.Min(results.Length, state.Header->NumberOfEntries - state.LastSearchPosition);
-                        for (int i = 0; i < read; i++)
-                        {
-                            results[i] = GetValue(ref state, state.LastSearchPosition++);
-                            
-                            if (results[i] == lastId)
-                            {
-                                _isFinished = true;
-                                return includeMax ? i + 1 : i;
-                            }
-                        }
-                        return read;
+                        return GetValueDataInBulkUpTo(ref state, state.LastSearchPosition, lastId, includeMax, results.Slice(0, read), out _isFinished);
                     }
                     if (_tree.GoToNextPage(ref _cursor) == false)
                     {

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -128,9 +128,9 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     /// <param name="keyDataDest">The destination buffer for the keys.</param>
     private static void GetKeyDataInBulk(ref CursorState state, int fromIdx, Span<long> keyDataDest)
     {
-        Debug.Assert(fromIdx + keyDataDest.Length < state.Header->NumberOfEntries);
+        Debug.Assert(fromIdx + keyDataDest.Length <= state.Header->NumberOfEntries);
         Debug.Assert(fromIdx >= 0 && fromIdx < state.Header->NumberOfEntries);
-        Debug.Assert(fromIdx >= 0 && fromIdx + keyDataDest.Length < state.Header->NumberOfEntries);
+        Debug.Assert(fromIdx >= 0 && fromIdx + keyDataDest.Length <= state.Header->NumberOfEntries);
         var pagePtr = state.Page.Pointer;
         var entriesOffsetsPtr = state.EntriesOffsetsPtr;
         var stateHeader = state.Header;
@@ -142,6 +142,35 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         }
         
         state.LastSearchPosition += keyDataDest.Length;
+    }
+    
+    private static int GetValueDataInBulkUpTo(ref CursorState state, int fromIdx, long maxId, bool includeMax, Span<long> keyDataDest, out bool isFinished)
+    {
+        Debug.Assert(fromIdx + keyDataDest.Length <= state.Header->NumberOfEntries);
+        Debug.Assert(fromIdx >= 0 && fromIdx < state.Header->NumberOfEntries);
+        Debug.Assert(fromIdx >= 0 && fromIdx + keyDataDest.Length <= state.Header->NumberOfEntries);
+        var pagePtr = state.Page.Pointer;
+        var entriesOffsetsPtr = state.EntriesOffsetsPtr;
+        var stateHeader = state.Header;
+
+        var idX = 0;
+        for (; idX < keyDataDest.Length; idX++)
+        {
+            var buffer = pagePtr + entriesOffsetsPtr[fromIdx + idX];
+            var keyLen = buffer[0] >> 4;
+            var valLen = buffer[0] & 0xF;
+            long v = ReadBackward(buffer + 1 + keyLen, valLen);
+            keyDataDest[idX] = Unzag(v, stateHeader->ValuesBase);
+
+            if (keyDataDest[idX] == maxId)
+                break;
+        }
+        
+        var maxFound = idX != keyDataDest.Length;
+        isFinished = maxFound;
+        var read = idX + (maxFound && includeMax).ToInt32();
+        state.LastSearchPosition += read;
+        return read;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -120,6 +119,31 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         return keyLen + valLen + 1;
     }
 
+    /// <summary>
+    /// Reads keys from a single cursor state into the provided buffer.
+    /// This method is bounded by the length of the specified destination buffer.
+    /// </summary>
+    /// <param name="state">Reference of the current state.</param>
+    /// <param name="fromIdx">Index from which to start reading.</param>
+    /// <param name="keyDataDest">The destination buffer for the keys.</param>
+    private static void GetKeyDataInBulk(ref CursorState state, int fromIdx, Span<long> keyDataDest)
+    {
+        Debug.Assert(fromIdx + keyDataDest.Length < state.Header->NumberOfEntries);
+        Debug.Assert(fromIdx >= 0 && fromIdx < state.Header->NumberOfEntries);
+        Debug.Assert(fromIdx >= 0 && fromIdx + keyDataDest.Length < state.Header->NumberOfEntries);
+        var pagePtr = state.Page.Pointer;
+        var entriesOffsetsPtr = state.EntriesOffsetsPtr;
+        var stateHeader = state.Header;
+        
+        for (int i = 0; i < keyDataDest.Length; i++)
+        {
+            var buffer = pagePtr + entriesOffsetsPtr[fromIdx + i];
+            keyDataDest[i] = GetKeyData(stateHeader, buffer);
+        }
+        
+        state.LastSearchPosition += keyDataDest.Length;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static long GetKeyData(ref CursorState state, int pos)
     {
@@ -189,7 +213,18 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
 
     public struct CursorState
     {
-        public Page Page;
+        private Page _page;
+
+        public Page Page
+        {
+            get => _page;
+            set
+            {
+                _page = value;
+                Header = (LookupPageHeader*)Page.Pointer;
+                EntriesOffsetsPtr = (ushort*)(Page.Pointer + PageHeader.SizeOf);
+            }
+        }
         
         /// <summary>
         /// Values:
@@ -201,10 +236,10 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         
         public int LastSearchPosition;
 
-        public LookupPageHeader* Header => (LookupPageHeader*)Page.Pointer;
+        public LookupPageHeader* Header;
 
-        public Span<ushort> EntriesOffsets => new Span<ushort>(Page.Pointer + PageHeader.SizeOf, Header->NumberOfEntries);
-        public ushort* EntriesOffsetsPtr => (ushort*)(Page.Pointer + PageHeader.SizeOf);
+        public Span<ushort> EntriesOffsets => new Span<ushort>(EntriesOffsetsPtr, Header->NumberOfEntries);
+        public ushort* EntriesOffsetsPtr;
 
         public int ComputeFreeSpace()
         {
@@ -630,8 +665,10 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         long pageNum = destinationState.Page.PageNumber;
         Debug.Assert(_llt.IsDirty(destinationState.Page.PageNumber));
         Memory.Copy(destinationState.Page.Pointer, sourceState.Page.Pointer, Constants.Storage.PageSize);
-        destinationState.Page.PageNumber = pageNum;
-
+        var overridenPage = destinationState.Page;
+        overridenPage.PageNumber = pageNum;
+        destinationState.Page = overridenPage;
+        
         // now ask that we'll remove the _sibling_ page, not us, since we copied it
         parent.LastSearchPosition++;
         FreePageFor(ref destinationState, ref sourceState, ref parent);
@@ -649,8 +686,12 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             var parentPageNumber = parent.Page.PageNumber;
             Debug.Assert(_llt.IsDirty(parent.Page.PageNumber));
             Memory.Copy(parent.Page.Pointer, stateToKeep.Page.Pointer, Constants.Storage.PageSize);
-            parent.Page.PageNumber = parentPageNumber; // we overwrote it...
 
+            var overridenPage = parent.Page;
+            overridenPage.PageNumber = parentPageNumber; // we overwrote it...
+            parent.Page = overridenPage;
+            
+            
             _llt.FreePage(stateToDelete.Page.PageNumber);
             _llt.FreePage(stateToKeep.Page.PageNumber);
             var copy = stateToKeep; // we are about to clear this value, but we need to set the search location here

--- a/test/FastTests/Corax/CoraxProjections.cs
+++ b/test/FastTests/Corax/CoraxProjections.cs
@@ -125,7 +125,7 @@ WaitForUserToContinueTheTest(store);
         }
 
         await new DynamicIndexProjection().ExecuteAsync(store);
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenAsyncSession())
         {
@@ -135,7 +135,6 @@ WaitForUserToContinueTheTest(store);
                 .Select(i => i.Name)
                 .SingleAsync();
                 
-            WaitForUserToContinueTheTest(store);
             var expected = (options.SearchEngineMode, projectionBehavior) switch
             {
                 (_, ProjectionBehavior.FromDocument) => "Jan",


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23260

### Additional description

- Read keys in Lookup in a bulk manner to avoid overhead from method calls.
- Set properties in CursorState on Page change instead of calculating them each time.

400M docs, 3 queries:
![image](https://github.com/user-attachments/assets/377519e3-4c77-4c90-b477-c99934c1e33f)


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
