### PR TITLE
RavenDB-22767 Adding more debug info to narrow down the issue

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
+  <BuildWithNetFrameworkHostedCompiler>True</BuildWithNetFrameworkHostedCompiler>
     <Version></Version>
     <LangVersion>preview</LangVersion>
     <DebugType>embedded</DebugType>

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -86,6 +86,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.TotalAllocatedSize)] = new Size(lowLevelTransaction.TotalAllocatedInBytes, SizeUnit.Bytes).ToString(),
                 [nameof(TxInfoResult.DecompressedBufferSize)] = new Size(lowLevelTransaction.DecompressedBufferBytes, SizeUnit.Bytes).ToString(),
                 [nameof(TxInfoResult.TotalEncryptionBufferSize)] = lowLevelTransaction.TotalEncryptionBufferInBytes.ToString(),
+                [nameof(TxInfoResult.IsDisposed)] = lowLevelTransaction.IsDisposed,
             };
         }
     }
@@ -106,5 +107,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public string TotalAllocatedSize;
         public string DecompressedBufferSize;
         public string TotalEncryptionBufferSize;
+        public bool IsDisposed;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -25,10 +25,12 @@ using Raven.Server.Documents.Queries.Revisions;
 using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Json;
+using Voron.Impl;
 
 namespace Raven.Server.Documents.Handlers.Processors.Documents;
 
@@ -57,9 +59,34 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
     public override async ValueTask ExecuteAsync()
     {
-        using (ContextPool.AllocateOperationContext(out TOperationContext context))
+        try
         {
-            await ExecuteInternalAsync(context);
+            TOperationContext context;
+            using (ContextPool.AllocateOperationContext(out context))
+            {
+                await ExecuteInternalAsync(context);
+            }
+
+            if (context is DocumentsOperationContext documentsOperationContext)
+            {
+                if (documentsOperationContext.Transaction != null)
+                {
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Not disposed docs transaction - Document");
+                }
+            }
+            
+            if (ReadTransaction != null && ReadTransaction.IsDisposed == false)
+            {
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Not disposed LowLevel read transaction - Document");
+            }
+        }
+        catch (Exception e)
+        {
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations("Failed to handle GET request - Document", e);
+            throw;
         }
     }
 
@@ -191,6 +218,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         }
     }
 
+    public LowLevelTransaction ReadTransaction { get; set; }
+    
     protected async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> GetDocumentsByIdAsync(TOperationContext context,
         QueryStringParameters parameters, RevisionIncludeField revisions, HashSet<AbstractTimeSeriesRange> timeSeries, string etag)
     {
@@ -198,6 +227,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag)
                                 .ConfigureAwait(false);
 
+        ReadTransaction = result.ReadTx?.InnerTransaction?.LowLevelTransaction;
+        
         if (result.StatusCode == HttpStatusCode.NotFound)
         {
             if (etag == HttpCache.NotFoundResponse)
@@ -481,6 +512,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
     protected sealed class DocumentsByIdResult<T>
     {
+        public DocumentsTransaction ReadTx { get; set; }
         public List<T> Documents { get; set; }
 
         public List<T> Includes { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -73,7 +73,18 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         }
 
         long lastModifiedIndex = RequestHandler.Database.ClusterWideTransactionIndexWaiter.LastIndex;
-        context.OpenReadTransaction();
+        DocumentsTransaction readTx;
+        try
+        {
+            readTx = context.OpenReadTransaction();
+        }
+        catch (Exception e)
+        {
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations("Failed to open read transaction in GetDocumentsByIdImplAsync", e);
+                
+            throw;
+        }
 
         foreach (var id in ids)
         {
@@ -155,7 +166,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             RevisionIncludes = includeRevisions,
             CounterIncludes = includeCounters,
             TimeSeriesIncludes = includeTimeSeries,
-            CompareExchangeIncludes = includeCompareExchangeValues?.Results
+            CompareExchangeIncludes = includeCompareExchangeValues?.Results,
+            ReadTx = readTx,
         });
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -19,6 +19,7 @@ using Raven.Server.Extensions;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Web;
 using Sparrow.Json;
@@ -96,7 +97,10 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
     public override async ValueTask ExecuteAsync()
     {
-        using (AllocateContextForQueryOperation(out var queryContext, out var context))
+        TQueryContext queryContext;
+        TOperationContext context;
+        
+        using (AllocateContextForQueryOperation(out queryContext, out context))
         using (var tracker = CreateRequestTimeTracker())
         {
             try
@@ -199,6 +203,9 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
             }
             catch (Exception e)
             {
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Failed to handle GET request - Query", e);
+                
                 if (tracker.Query == null)
                 {
                     string errorMessage;
@@ -218,6 +225,15 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
                 }
 
                 throw;
+            }
+        }
+
+        if (context is DocumentsOperationContext docsContext)
+        {
+            if (docsContext.Transaction != null)
+            {
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations("Not disposed docs transaction - Query");
             }
         }
     }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3359,7 +3359,19 @@ namespace Raven.Server.Documents.Indexes
                     using (var indexTx = indexContext.OpenReadTransaction())
                     {
                         if (queryContext.AreTransactionsOpened() == false)
-                            queryContext.OpenReadTransaction();
+                        {
+                            try
+                            {
+                                queryContext.OpenReadTransaction();
+                            }
+                            catch (Exception e)
+                            {
+                                if (_logger.IsOperationsEnabled)
+                                    _logger.Operations("Failed to open read transaction in QueryInternal", e);
+                                
+                                throw;
+                            }
+                        }
 
                         // we have to open read tx for mapResults _after_ we open index tx
 
@@ -3372,7 +3384,16 @@ namespace Raven.Server.Documents.Indexes
                             isStale = IsStale(queryContext, indexContext, cutoffEtag?.DocEtag, cutoffEtag?.ReferenceEtag, cutoffEtag?.CompareExchangeReferenceEtag);
                             if (WillResultBeAcceptable(isStale, query, wait) == false)
                             {
-                                queryContext.CloseTransaction();
+                                try
+                                {
+                                    queryContext.CloseTransaction();
+                                }
+                                catch (Exception e)
+                                {
+                                    if (_logger.IsOperationsEnabled)
+                                        _logger.Operations("Failed to close read transaction in QueryInternal", e);
+                                    throw;
+                                }
 
                                 Debug.Assert(query.WaitForNonStaleResultsTimeout != null);
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -768,17 +768,19 @@ namespace Voron
                     DecrementUsageOnTransactionCreationFailure();
 
                     if (tx != null)
+                    {
                         ActiveTransactions.TryRemove(tx);
-                }
-
-                try
-                {
-                    if (_log.IsOperationsEnabled)
-                        _log.Operations("Failed to create transaction", e);
-                }
-                catch
-                {
-                   // ignored
+                        
+                        try
+                        {
+                            if (_log.IsOperationsEnabled)
+                                _log.Operations("Failed to create transaction so we removed it from ActiveTransactions", e);
+                        }
+                        catch
+                        {
+                            // ignored
+                        }
+                    }
                 }
 
                 throw;

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+  <BuildWithNetFrameworkHostedCompiler>True</BuildWithNetFrameworkHostedCompiler>
     <Version></Version>
 
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767/Scratch-buffers-arent-released

### Additional description

More debugging logs

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
