### PR TITLE
RavenDB-22755 Allow to save a document in studio via cluster transaction  

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -29,6 +29,7 @@ using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.TimeSeries;
+using Raven.Server.Extensions;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
@@ -142,6 +143,9 @@ namespace Raven.Server.Documents.Handlers
         private void CheckBackwardCompatibility(ref bool disableAtomicDocumentWrites)
         {
             if (disableAtomicDocumentWrites)
+                return;
+
+            if (HttpContext.Request.IsFromStudio())
                 return;
 
             if (RequestRouter.TryGetClientVersion(HttpContext, out var clientVersion) == false)

--- a/src/Raven.Studio/typescript/commands/database/documents/deleteDocumentsCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/deleteDocumentsCommand.ts
@@ -3,9 +3,9 @@ import database = require("models/resources/database");
 
 class deleteDocumentsCommand extends executeBulkDocsCommand {
 
-    constructor(docIds: Array<string>, db: database) {
+    constructor(docIds: Array<string>, db: database, transactionMode: Raven.Client.Documents.Session.TransactionMode = "SingleNode") {
         const bulkDocs = docIds.map(id => deleteDocumentsCommand.createDeleteDocument(id));
-        super(bulkDocs, db);
+        super(bulkDocs, db, transactionMode);
     }
 
     private static createDeleteDocument(id: string): Partial<Raven.Server.Documents.Handlers.BatchRequestParser.CommandData> {

--- a/src/Raven.Studio/typescript/commands/database/documents/saveDocumentCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/saveDocumentCommand.ts
@@ -4,8 +4,13 @@ import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
 class saveDocumentCommand extends commandBase {
-
-    constructor(private id: string, private document: document, private db: database, private reportSaveProgress: boolean = true) {
+    constructor(
+        private id: string,
+        private document: document,
+        private db: database,
+        private reportSaveProgress: boolean = true,
+        private transactionMode: Raven.Client.Documents.Session.TransactionMode = "SingleNode"
+    ) {
         super();
     }
 
@@ -16,7 +21,10 @@ class saveDocumentCommand extends commandBase {
             this.document.toBulkDoc("PUT")
         ];
 
-        const args = ko.toJSON({ Commands: commands });
+        const args = JSON.stringify({
+            Commands: commands,
+            TransactionMode: this.transactionMode,
+        });
         const url = endpoints.databases.batch.bulk_docs;
         
         const saveTask = this.post<saveDocumentResponseDto>(url, args, this.db);

--- a/src/Raven.Studio/typescript/viewmodels/common/deleteDocuments.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/deleteDocuments.ts
@@ -12,7 +12,7 @@ class deleteDocuments extends dialogViewModelBase {
     private deletionStarted = false;
     deletionTask = $.Deferred<void>();
 
-    constructor(documentIds: Array<string>, private db: database) {
+    constructor(documentIds: Array<string>, private db: database, private transactionMode: Raven.Client.Documents.Session.TransactionMode = "SingleNode") {
         super(null);
 
         if (documentIds.length === 0) {
@@ -26,7 +26,7 @@ class deleteDocuments extends dialogViewModelBase {
         const docCount = this.documentIds().length;
         const docsDescription = docCount === 1 ? this.documentIds()[0] : docCount + " docs";
 
-        new deleteDocumentsCommand(this.documentIds(), this.db)
+        new deleteDocumentsCommand(this.documentIds(), this.db, this.transactionMode)
             .execute()
             .done(() => {
                 messagePublisher.reportSuccess("Deleted " + docsDescription);

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -881,6 +881,10 @@ class editDocument extends viewModelBase {
     }
 
     saveDocument() {
+        this.handleSaveDocument(false);
+    }
+
+    handleSaveDocument(isClusterWide = false) {
         if (!this.isSaveEnabled()) {
             return ;
         }
@@ -890,7 +894,7 @@ class editDocument extends viewModelBase {
                 .then((canSave: boolean) => {
                     if (canSave) {
                         eventsCollector.default.reportEvent("document", "save");
-                        this.saveInternal(this.userSpecifiedId());
+                        this.saveInternal(this.userSpecifiedId(), false, isClusterWide);
                     }
                 });
         }
@@ -914,7 +918,7 @@ class editDocument extends viewModelBase {
         return true;
     }
     
-    private saveInternal(documentId: string, forceRevisionCreation = false) {
+    private saveInternal(documentId: string, forceRevisionCreation = false, isClusterWide = false) {
         let message = "";
         let updatedDto: any;
 
@@ -969,9 +973,11 @@ class editDocument extends viewModelBase {
         // as result we don't know exact destination document id.
         const newDoc = new document(updatedDto);
         
+        const transactionMode: Raven.Client.Documents.Session.TransactionMode = isClusterWide ? "ClusterWide" : "SingleNode";
+
         const saveCommand = forceRevisionCreation ?
                             new forceRevisionCreationCommand(documentId, this.activeDatabase()) :
-                            new saveDocumentCommand(documentId, newDoc, this.activeDatabase());
+                            new saveDocumentCommand(documentId, newDoc, this.activeDatabase(), true, transactionMode);
         
         this.isSaving(true);
         saveCommand
@@ -1279,11 +1285,14 @@ class editDocument extends viewModelBase {
         this.displayDocumentDeleted(false);
     }
 
-    deleteDocument() {
+    deleteDocument(isClusterWide = false) {
         eventsCollector.default.reportEvent("document", "delete");
         const doc = this.document();
         if (doc) {
-            const viewModel = new deleteDocuments([doc.getId()], this.activeDatabase());
+            
+            const transactionMode: Raven.Client.Documents.Session.TransactionMode = isClusterWide ? "ClusterWide" : "SingleNode";
+
+            const viewModel = new deleteDocuments([doc.getId()], this.activeDatabase(), transactionMode);
             viewModel.deletionTask.done(() => {
                 this.dirtyFlag().reset();
                 this.connectedDocuments.onDocumentDeleted();

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -51,22 +51,52 @@
             </div>
             <div class="btn-bar toolbar">
                 <div class="pull-left-sm">
-                    <button type="submit" class="btn btn-primary save-btn" 
-                            data-bind="enable: isSaveEnabled, css: { 'btn-spinner': isSaving }, visible: !inReadOnlyMode() && !inDiffMode(), 
-                                       attr: { 'title': isSaveEnabled ? 'Save your changes' : ''}, requiredAccess: 'DatabaseReadWrite'">
-                        <i class="icon-save"></i>
-                        <span>Save</span>
-                    </button>
+                    <div class="btn-group">
+                        <button type="submit" class="btn btn-primary save-btn" 
+                                data-bind="enable: isSaveEnabled, css: { 'btn-spinner': isSaving }, visible: !inReadOnlyMode() && !inDiffMode(), 
+                                           attr: { 'title': isSaveEnabled ? 'Save your changes' : ''}, requiredAccess: 'DatabaseReadWrite'">
+                            <i class="icon-save"></i>
+                            <span>Save</span>
+                        </button>
+                        <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                                data-bind="visible: !inReadOnlyMode() && !inDiffMode(), enable: isSaveEnabled, requiredAccess: 'DatabaseReadWrite'">
+                            <span class="caret"></span>
+                            <span class="sr-only">Toggle Dropdown</span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li>
+                                <a href="#" data-bind="click: () => handleSaveDocument(true), enable: isSaveEnabled">
+                                    <i class="icon-cluster"></i>
+                                    <span>Save it via cluster wide transaction</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                     <button type="button" class="clone-btn btn btn-default"
                             data-bind="click: tryCreateClone, enable: !showHugeDocumentWarning() && !isCreatingNewDocument(), visible: !isDeleteRevision() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
                         <i class="icon-clone"></i>
                         <span>Clone</span>
                     </button>
-                    <button type="button" class="delete-btn btn btn-danger"
-                            data-bind="click: deleteDocument, enable: !isCreatingNewDocument(), visible: !inReadOnlyMode() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
-                        <i class="icon-trash"></i>
-                        <span>Delete</span>
-                    </button>
+                    <div class="btn-group">
+                        <button type="button" class="delete-btn btn btn-danger"
+                                data-bind="click: deleteDocument, enable: !isCreatingNewDocument(), visible: !inReadOnlyMode() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
+                            <i class="icon-trash"></i>
+                            <span>Delete</span>
+                        </button>
+                        <button type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                                data-bind="visible: !inReadOnlyMode() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), enable: !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
+                            <span class="caret"></span>
+                            <span class="sr-only">Toggle Dropdown</span>
+                        </button>
+                        <ul class="dropdown-menu">
+                            <li>
+                                <a href="#" data-bind="click: () => deleteDocument(true), enable: !isCreatingNewDocument()">
+                                    <i class="icon-cluster"></i>
+                                    <span>Delete it via cluster wide transaction</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                     <a data-bind="attr: { href: latestRevisionUrl }, visible: inReadOnlyMode() && !isDeleteRevision()" class="btn btn-default">
                         <i class="icon-latest"></i>
                         <span>See the current document</span>

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -67,7 +67,7 @@
                             <li>
                                 <a href="#" data-bind="click: () => handleSaveDocument(true), enable: isSaveEnabled">
                                     <i class="icon-cluster"></i>
-                                    <span>Save it via cluster wide transaction</span>
+                                    <span>Save document via cluster wide transaction</span>
                                 </a>
                             </li>
                         </ul>
@@ -92,7 +92,7 @@
                             <li>
                                 <a href="#" data-bind="click: () => deleteDocument(true), enable: !isCreatingNewDocument()">
                                     <i class="icon-cluster"></i>
-                                    <span>Delete it via cluster wide transaction</span>
+                                    <span>Delete document via cluster wide transaction</span>
                                 </a>
                             </li>
                         </ul>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22755/Allow-to-save-a-document-in-studio-via-cluster-transaction

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
