### PR TITLE
RavenDB-23984 added support for MemoryExtensions.Contains and MemoryExtensions.ContainsAny in LINQ provider

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -290,6 +290,9 @@ namespace Raven.Client.Documents.Linq
 
         private static Expression SimplifyExpression(Expression expression)
         {
+            if (TryUnwrapImplicitOperatorIfNeeded(expression, out var newExpression))
+                expression = newExpression;
+
             while (true)
             {
                 switch (expression.NodeType)
@@ -393,6 +396,9 @@ namespace Raven.Client.Documents.Linq
                 case ExpressionType.Call:
                     if (expression is MethodCallExpression mce)
                     {
+                        if (TryUnwrapImplicitOperatorIfNeeded(expression, out var newExpression))
+                            return GetValueFromExpressionWithoutConversion(newExpression, out value);
+
                         if (mce.Method.DeclaringType == typeof(RavenQuery) &&
                             mce.Method.Name == nameof(RavenQuery.CmpXchg))
                         {
@@ -635,6 +641,19 @@ namespace Raven.Client.Documents.Linq
         public static bool IsIncludeCall(MethodCallExpression mce)
         {
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.Include);
+        }
+
+        private static bool TryUnwrapImplicitOperatorIfNeeded(Expression expression, out Expression newExpression)
+        {
+            newExpression = expression;
+
+            if (expression is MethodCallExpression { Method.Name: "op_Implicit" } callExpression)
+            {
+                newExpression = callExpression.Arguments[0];
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1360,6 +1360,13 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 }
                 return;
             }
+
+            if (declaringType == typeof(MemoryExtensions))
+            {
+                VisitMemoryExtensionsMethodCall(expression);
+                return;
+            }
+
             if (declaringType == typeof(LinqExtensions) ||
                 declaringType == typeof(RavenQueryableExtensions))
             {
@@ -1434,6 +1441,23 @@ The recommended method is to use full text search (mark the field as Analyzed an
             DocumentQuery.WhereRegex(
                 memberInfo.Path,
                 GetValueFromExpression(expression.Arguments[1], GetMemberType(memberInfo)).ToString());
+        }
+
+        private void VisitMemoryExtensionsMethodCall(MethodCallExpression expression)
+        {
+            switch (expression.Method.Name)
+            {
+                case nameof(RavenQueryableExtensions.ContainsAny):
+                    var memberInfo = GetMember(expression.Arguments[0]);
+                    var objects = GetValueFromExpression(expression.Arguments[1], GetMemberType(memberInfo));
+                    DocumentQuery.ContainsAny(memberInfo.Path, ((IEnumerable)objects).Cast<object>());
+                    break;
+                case nameof(MemoryExtensions.Contains):
+                    VisitContains(expression);
+                    break;
+                default:
+                    throw new NotSupportedException("Method not supported: " + expression.Method.Name);
+            }
         }
 
         private void VisitLinqExtensionsMethodCall(MethodCallExpression expression)

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -671,12 +671,12 @@ namespace Raven.Client.Util
                     context.Visitor.Visit(methodCallExpression.Object);
                     javascriptWriter.Write($".{newName}");
                     javascriptWriter.Write("(");
-                    context.Visitor.Visit(methodCallExpression.Arguments[0]);
+                    context.Visitor.Visit(UnwrapImplicitOperatorIfNeeded(methodCallExpression.Arguments[0]));
                     javascriptWriter.Write(")");
                 }
                 else
                 {
-                    context.Visitor.Visit(methodCallExpression.Arguments[0]);
+                    context.Visitor.Visit(UnwrapImplicitOperatorIfNeeded(methodCallExpression.Arguments[0]));
 
                     // When having no other arguments, don't call the function, when it's a .map operation
                     // .Sum()/.Average()/.Select() for example can be called without arguments, which means,
@@ -687,7 +687,7 @@ namespace Raven.Client.Util
                         javascriptWriter.Write("(");
                         if (methodCallExpression.Arguments.Count > 1)
                         {
-                            context.Visitor.Visit(methodCallExpression.Arguments[1]);
+                            context.Visitor.Visit(UnwrapImplicitOperatorIfNeeded(methodCallExpression.Arguments[1]));
                         }
                         javascriptWriter.Write(")");
                     }
@@ -696,6 +696,16 @@ namespace Raven.Client.Util
                 if (methodName == "Sum")
                 {
                     javascriptWriter.Write(".reduce((a, b) => a + b, 0)");
+                }
+
+                return;
+
+                static Expression UnwrapImplicitOperatorIfNeeded(Expression expression)
+                {
+                    if (expression is MethodCallExpression { Method.Name: "op_Implicit" } callExpression)
+                        return callExpression.Arguments[0];
+
+                    return expression;
                 }
             }
 
@@ -798,9 +808,9 @@ namespace Raven.Client.Util
             {
                 if (type.IsArray)
                     return true;
-                
+
                 if (type.GetGenericArguments().Length == 0)
-                    return type == typeof(Enumerable);
+                    return type == typeof(Enumerable) || type == typeof(MemoryExtensions);
 
                 return typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition());
             }
@@ -1013,7 +1023,7 @@ namespace Raven.Client.Util
                     foreach (var innerType in methodCallExpression.Method.GetGenericArguments())
                         _loadedTypes.Add(innerType);
                 }
-                
+
                 var writer = context.GetWriter();
                 using (writer.Operation(methodCallExpression))
                 {
@@ -1527,7 +1537,7 @@ namespace Raven.Client.Util
         internal abstract class DateSupportBase<TDate> : JavascriptConversionExtension
         {
             public abstract void ObjectParameterTranslator(string name, JavascriptWriter writer);
-            
+
             public override void ConvertToJavascript(JavascriptConversionContext context)
             {
                 if (context.Node is NewExpression newExp && newExp.Type == typeof(TDate))
@@ -1669,16 +1679,16 @@ namespace Raven.Client.Util
                 }
             }
         }
-        
+
 #if FEATURE_DATEONLY_TIMEONLY_SUPPORT
         internal sealed class DateOnlySupport : DateSupportBase<DateOnly>
         {
             public static DateOnlySupport Instance = new DateOnlySupport();
-            
+
             private DateOnlySupport()
             {
             }
-            
+
             public override void ObjectParameterTranslator(string name, JavascriptWriter writer)
             {
                 // Default values from DateOnly struct.
@@ -1695,7 +1705,7 @@ namespace Raven.Client.Util
             }
         }
 #endif
-        
+
         internal sealed class DateTimeSupport : DateSupportBase<DateTime>
         {
             public static DateTimeSupport Instance = new DateTimeSupport();
@@ -1703,7 +1713,7 @@ namespace Raven.Client.Util
             private DateTimeSupport()
             {
             }
-            
+
             public override void ObjectParameterTranslator(string name, JavascriptWriter writer)
             {
                 switch (name)
@@ -1731,7 +1741,7 @@ namespace Raven.Client.Util
                 }
             }
         }
-        
+
         internal sealed class TimeSpanSupport : JavascriptConversionExtension
         {
             public static TimeSpanSupport Instance = new TimeSpanSupport();
@@ -2620,7 +2630,7 @@ namespace Raven.Client.Util
             {
                 innerExpression = null;
 
-                if (expression is MethodCallExpression { Method.Name: nameof(RavenQuery.Id) } mce && mce.Method.DeclaringType == typeof(RavenQuery) )
+                if (expression is MethodCallExpression { Method.Name: nameof(RavenQuery.Id) } mce && mce.Method.DeclaringType == typeof(RavenQuery))
                 {
                     if (mce.Arguments.Count != 1)
                         throw new InvalidOperationException($"{nameof(RavenQuery.Id)} can only get one argument");
@@ -2635,7 +2645,7 @@ namespace Raven.Client.Util
                 if (expression is MemberExpression propertyExpression)
                 {
                     var expressionSourceType = propertyExpression.Expression?.Type ?? null;
-                    
+
                     foreach (var loadedType in loadTypes ?? Enumerable.Empty<Type>())
                     {
                         if (expressionSourceType != null && loadedType.IsEquivalentTo(expressionSourceType))
@@ -2645,7 +2655,7 @@ namespace Raven.Client.Util
                         }
                     }
                 }
-                
+
                 if (member.Expression is ParameterExpression parameter && (originalQueryType == null || originalQueryType.IsEquivalentTo(parameter.Type) || hasTypeInLoadType))
                 {
                     innerExpression = parameter;
@@ -2659,7 +2669,7 @@ namespace Raven.Client.Util
 
                 if (originalQueryType != null && innerExpression?.Type.IsEquivalentTo(originalQueryType) == false && hasTypeInLoadType == false)
                     return false;
-                
+
                 var p = GetParameter(innerMember)?.Name;
                 return p != null && (p.StartsWith(TransparentIdentifier) || p == parameterName);
             }

--- a/test/SlowTests/Tests/Linq/Contains.cs
+++ b/test/SlowTests/Tests/Linq/Contains.cs
@@ -45,6 +45,29 @@ namespace SlowTests.Tests.Linq
 
         [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryArrayWithContains_MemoryExtensions(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var doc = new TestDoc { StringArray = new[] { "test", "doc", "foo" } };
+                    session.Store(doc);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var otherDoc = new TestDoc { SomeProperty = "foo" };
+                    var doc = session.Query<TestDoc>()
+                        .FirstOrDefault(ar => MemoryExtensions.Contains(ar.StringArray, otherDoc.SomeProperty));
+                    Assert.NotNull(doc);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryListWithContainsAny(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23984

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
