### PR TITLE
RavenDB-23848 detect TrueToken properly when adding default operator

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1690,6 +1690,12 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
 
             var lastToken = tokens.Last.Value;
 
+            if (lastToken is TrueToken)
+            {
+                tokens.AddLast(GetDefaultOperatorToken());
+                return;
+            }
+
             if (lastToken is WhereToken == false && lastToken is CloseSubclauseToken == false)
                 return;
 
@@ -1706,12 +1712,18 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 current = current.Previous;
             }
 
-            var token = DefaultOperator == QueryOperator.And ? QueryOperatorToken.And : QueryOperatorToken.Or;
+            var token = GetDefaultOperatorToken();
 
             if (lastWhere.Options?.SearchOperator != null)
                 token = QueryOperatorToken.Or; // default to OR operator after search if AND was not specified explicitly
 
             tokens.AddLast(token);
+            return;
+
+            QueryOperatorToken GetDefaultOperatorToken()
+            {
+                return DefaultOperator == QueryOperator.And ? QueryOperatorToken.And : QueryOperatorToken.Or;
+            }
         }
 
         private IEnumerable<object> TransformEnumerable(string fieldName, IEnumerable<object> values)

--- a/test/FastTests/Issues/RavenDB_23848.cs
+++ b/test/FastTests/Issues/RavenDB_23848.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_23848 : RavenTestBase
+{
+    public RavenDB_23848(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public void should_generate_correct_rql_for_contains_all_with_empty_list()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var rql = session
+                    .Advanced.DocumentQuery<Course>()
+                    .WhereEquals(x => x.OwnerId, "test")
+                    .ContainsAll(x => x.Tags, new List<string>())
+                    .OpenSubclause()
+                    .WhereEquals(x => x.Status, CourseStatus.Published)
+                    .OrElse()
+                    .WhereEquals(x => x.Status, CourseStatus.Draft)
+                    .CloseSubclause()
+                    .ToString();
+                
+                Assert.Equal("from 'Courses' where OwnerId = $p0 and true and (Status = $p1 or Status = $p2)", rql);
+            }
+        }
+    }
+
+    private class Course
+    {
+        public string OwnerId { get; set; }
+        
+        public string[] Tags { get; set; }
+        
+        public CourseStatus Status { get; set; }
+    }
+    
+    private enum CourseStatus
+    {
+        Draft,
+        Published
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23848

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
