### PR TITLE
RavenDB-22767 Adjusting the assertion in `MustRemoveFailedTransactionFromActiveTransactions` test since the calculation of oldest transaction is different in 7.1

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_22767.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22767.cs
@@ -34,8 +34,6 @@ public class RavenDB_22767 : StorageTest
             }
         });
 
-        var oldestTxId = Env.ActiveTransactions.OldestTransaction;
-            
-        Assert.Equal(0, oldestTxId);
+        Assert.Empty(Env.ActiveTransactions.AllTransactionsInstances);
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767

### Additional description

In 7.1 there is the perf optimization so check against `EnvironmentStateRecord.TransactionId` and not doing full scan:

https://github.com/ravendb/ravendb/blob/c709dc09099100febdece2f1ac4779f178abaf70/src/Voron/Util/ActiveTransactions.cs#L57-L61

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
