### PR TITLE
RavenDB-24054 Fix creating test index

### DIFF
--- a/src/Raven.Studio/typescript/models/database/index/testIndex.ts
+++ b/src/Raven.Studio/typescript/models/database/index/testIndex.ts
@@ -25,7 +25,6 @@ class testIndex {
         testing: ko.observable<boolean>(false)
     };
 
-    private readonly indexDefinitionProvider: () => indexDefinition;
     private readonly dbProvider: () => database;
 
     testTimeLimit = ko.observable<number>();
@@ -54,14 +53,8 @@ class testIndex {
 
     languageService: rqlLanguageService;
 
-    constructor(dbProvider: () => database, indexDefinitionProvider: () => indexDefinition) {
+    constructor(dbProvider: () => database) {
         this.dbProvider = dbProvider;
-        this.indexDefinitionProvider = indexDefinitionProvider;
-
-        if (indexDefinitionProvider().name()) {
-            this.query(`from index "${indexDefinitionProvider().name()}"`)
-        }
-
         aceEditorBindingHandler.install();
 
         this.languageService = new rqlLanguageService(dbProvider(), ko.observableArray([]), "Select"); // we intentionally pass empty indexes here as subscriptions works only on collections
@@ -75,9 +68,9 @@ class testIndex {
         });
     }
 
-    toDto(): Raven.Server.Documents.Indexes.Test.TestIndexParameters {
+    toDto(indexDef: indexDefinition): Raven.Server.Documents.Indexes.Test.TestIndexParameters {
         return {
-            IndexDefinition: this.indexDefinitionProvider().toDto(),
+            IndexDefinition: indexDef.toDto(),
             WaitForNonStaleResultsTimeoutInSec: this.testTimeLimit() ?? 15,
             Query: this.query(),
             QueryParameters: null,
@@ -130,14 +123,14 @@ class testIndex {
         }
     }
 
-    runTest(location: databaseLocationSpecifier) {
+    runTest(location: databaseLocationSpecifier, indexDef: indexDefinition) {
         const db = this.dbProvider();
 
         eventsCollector.default.reportEvent("index", "test");
 
         this.columnsSelector.reset();
 
-        this.fetchTask = this.fetchTestDocuments(db, location);
+        this.fetchTask = this.fetchTestDocuments(db, location, indexDef);
 
         this.goToTab("queryResults");
 
@@ -183,10 +176,10 @@ class testIndex {
         this.languageService.dispose();
     }
 
-    private fetchTestDocuments(db: database, location: databaseLocationSpecifier): JQueryPromise<TestIndexResult> {
+    private fetchTestDocuments(db: database, location: databaseLocationSpecifier, indexDef: indexDefinition): JQueryPromise<TestIndexResult> {
         this.spinners.testing(true);
 
-        const dto = this.toDto();
+        const dto = this.toDto(indexDef);
 
         return new testIndexCommand(dto, db, location).execute()
             .done(result => {

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -76,7 +76,7 @@ class editIndex extends shardViewModelBase {
     editedIndex = ko.observable<indexDefinition>();
     isAutoIndex = ko.observable<boolean>(false);
     
-    testIndex: KnockoutComputed<testIndex>;
+    testIndex: testIndex;
     originalIndexName: string;
     isSaveEnabled: KnockoutComputed<boolean>;
     saveInProgress = ko.observable<boolean>(false);
@@ -175,6 +175,8 @@ class editIndex extends shardViewModelBase {
         aceEditorBindingHandler.install();
         autoCompleteBindingHandler.install();
 
+        this.testIndex = new testIndex(() => this.db);
+
         this.initializeObservables();
 
         this.shardSelector = db.isSharded() ? new inlineShardSelector(db, { dropup: true }) : null;
@@ -187,7 +189,7 @@ class editIndex extends shardViewModelBase {
     detached() {
         super.detached();
         
-        this.testIndex().dispose();
+        this.testIndex.dispose();
     }
 
     textForArchivedDataProcessingBehavior(mode: Raven.Client.Documents.DataArchival.ArchivedDataProcessingBehavior) {
@@ -233,6 +235,10 @@ class editIndex extends shardViewModelBase {
         }
     }
 
+    private updateTestIndexName(name: string) {
+        this.testIndex.query(`from index "${name || '<TestIndexName>'}"`);
+    }
+
     private initializeObservables() {
         this.editedIndex.subscribe(indexDef => {
             const firstMap = indexDef.maps()[0].map;
@@ -241,8 +247,14 @@ class editIndex extends shardViewModelBase {
                 this.updateIndexFields();
             });
         });
+        
+        this.editedIndex.subscribe((indexDef) => {
+            this.updateTestIndexName(indexDef.name());
 
-        this.testIndex = ko.pureComputed(() => new testIndex(() => this.db, this.editedIndex));
+            indexDef.name.subscribe((name) => {
+                this.updateTestIndexName(name);
+            });
+        });
 
         this.canEditIndexName = ko.pureComputed(() => {
             return !this.isEditingExistingIndex();
@@ -518,7 +530,7 @@ class editIndex extends shardViewModelBase {
             event.preventDefault();
         })
         
-        this.testIndex().compositionComplete();
+        this.testIndex.compositionComplete();
     }
     
     private initValidation() {
@@ -678,7 +690,7 @@ class editIndex extends shardViewModelBase {
         
         // wait for animation
         setTimeout(() => {
-            this.testIndex().runTest(this.shardSelector ? this.shardSelector.location() : null);
+            this.testIndex.runTest(this.shardSelector ? this.shardSelector.location() : null, this.editedIndex());
         }, oldVisible ? 1 : 200);
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24054

### Additional description

`editedIndex` was used in pureComputed so it created testIndex on every name change

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
