### PR TITLE
RavenDB-23715 Fix PowerBI / experimental error message confusion

### DIFF
--- a/src/Raven.Server/Exceptions/FeaturesAvailabilityException.cs
+++ b/src/Raven.Server/Exceptions/FeaturesAvailabilityException.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Exceptions
         public static void Throw(Feature feature)
         {
             throw new FeaturesAvailabilityException(
-                $"Can not use '{feature.GetDescription()}', as this is an experimental feature and the server does not support experimental features. " +
+                $"Can not use '{feature.GetDescription()}', as this is an experimental feature and the current server configuration does not allow to use experimental features. " +
                 $"Please enable experimental features by changing '{RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)}' configuration value to '{nameof(FeaturesAvailability.Experimental)}'.");
         }
 

--- a/src/Raven.Server/Integrations/PostgreSQL/Handlers/Processors/AbstractPostgreSqlIntegrationHandlerProcessor.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Handlers/Processors/AbstractPostgreSqlIntegrationHandlerProcessor.cs
@@ -24,10 +24,15 @@ internal abstract class AbstractPostgreSqlIntegrationHandlerProcessor<TRequestHa
 
         if (requestHandler.ServerStore.LicenseManager.CanUsePostgreSqlIntegration(withNotification: true))
         {
-            requestHandler.ServerStore.FeatureGuardian.Assert(Feature.PostgreSql, () =>
-                $"You have enabled the PostgreSQL integration via '{RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)}' configuration but " +
-                "this is an experimental feature and the server does not support experimental features. " +
-                $"Please enable experimental features by changing '{RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)}' configuration value to '{nameof(FeaturesAvailability.Experimental)}'.");
+            // if Postgres is enabled in config, we need to alert it's an experimental feature
+            if (requestHandler.ServerStore.Configuration.Integrations.PostgreSql.Enabled)
+            {
+                requestHandler.ServerStore.FeatureGuardian.Assert(Feature.PostgreSql, () =>
+                    $"You have enabled the PostgreSQL integration via '{RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)}' configuration but " +
+                    "this is an experimental feature and the current server configuration does not allow to use experimental features. " +
+                    $"Please enable experimental features by changing '{RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)}' configuration value to '{nameof(FeaturesAvailability.Experimental)}'.");
+            }
+            // if license check for Postgres passed, but it's still disabled in the configuration, we don't need to alert about anything yet
             return;
         }
 

--- a/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                     {
                         if (_logger.IsOperationsEnabled)
                             _logger.Operations($"You have enabled the PostgreSQL integration via '{RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)}' configuration but " +
-                                         "this is an experimental feature and the server does not support experimental features. " +
+                                         "this is an experimental feature and the current server configuration does not allow to use experimental features. " +
                                          $"Please enable experimental features by changing '{RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)}' configuration value to '{nameof(FeaturesAvailability.Experimental)}'.");
                     }
                 }

--- a/src/Raven.Server/Utils/Features/FeatureGuardian.cs
+++ b/src/Raven.Server/Utils/Features/FeatureGuardian.cs
@@ -20,7 +20,6 @@ public sealed class FeatureGuardian
     {
         switch (feature)
         {
-            case Feature.Corax:
             case Feature.PostgreSql:
                 AssertExperimental(feature, getExceptionMessage);
                 break;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23715/PowerBI-experimental-error-message-confusion

### Additional description

This weird error is fine. It was just displayed in too many cases. Added additional check for server configuration - if PostgreSQL is enabled. We will warn about the experimental nature of this feature only in that case. If it's unused but we have license for it, nothing happens, as it should.

Improved a bit error message clarity.

Also removed 'Corax' from experimental feature check. I believe that usages were deleted, but the case wasn't.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
