### PR TITLE
RavenDB-24065 properly sync header with the journals on database creation

### DIFF
--- a/src/Raven.Server/Documents/Indexes/SharedIndexJournals.cs
+++ b/src/Raven.Server/Documents/Indexes/SharedIndexJournals.cs
@@ -50,6 +50,11 @@ public class SharedIndexJournals : IJournalMerger, IDisposable
         options.MinimumSharedJournalsMergeCount = documentDatabase.Configuration.Storage.MinimumSharedJournalsMergeCount;
         options.MaxLogFileSize = documentDatabase.Configuration.Storage.MaxJournalFileSize.GetValue(SizeUnit.Bytes);
 
+        options.OnNonDurableFileSystemError += documentDatabase.HandleNonDurableFileSystemError;
+        options.OnRecoveryError += (s, e) => documentDatabase.HandleOnIndexRecoveryError("JournalsForIndexing", s, e);
+        options.OnIntegrityErrorOfAlreadySyncedData += (s, e) => documentDatabase.HandleOnIndexIntegrityErrorOfAlreadySyncedData("JournalsForIndexing", s, e);
+        options.OnRecoverableFailure += documentDatabase.HandleRecoverableFailure;
+
         _env = new StorageEnvironment(options);
         _env.Journal.BranchJournalMerger = this;
         _scopeForSharedJournals = _env.Journal.SharedJournalsScope();

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -260,13 +260,11 @@ namespace Voron.Impl.Backup
             try
             {
                 options.ManualFlushing = true;
-                bool shouldDeleteInitialJournal = false;
                 using (var env = new StorageEnvironment(options))
                 {
                     // We create a completely new environment... 
                     if (env.CurrentReadTransactionId is 1)
                     {
-                        shouldDeleteInitialJournal = true;
                         env.HeaderAccessor.Modify((ref FileHeader header) =>
                         {
                             // The journal id should come from the first
@@ -279,11 +277,6 @@ namespace Voron.Impl.Backup
                     {
                         Restore(env, backupPath);
                     }
-                }
-                if (shouldDeleteInitialJournal)
-                {
-                    options.TryDeleteJournal(0);
-
                 }
             }
             finally

--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -154,7 +154,7 @@ namespace Voron.Impl.FileHeaders
                 if (_disposed)
                     throw new ObjectDisposedException("Cannot access the header after it was disposed");
 
-                modifyAction(ref _theHeader);
+                modifyAction?.Invoke(ref _theHeader);
           
                 _revision++;
                 _theHeader.HeaderRevision = _revision;
@@ -193,6 +193,8 @@ namespace Voron.Impl.FileHeaders
             var buffer = MemoryMarshal.AsBytes(new Span<FileHeader>(ref header));
             header.Hash = Hashing.XXHash64.CalculateInline(buffer[..^sizeof(ulong)], (ulong)header.TransactionId);
         }
+
+        public void PersistHeader() => Modify(modifyAction: null);
 
         private bool IsEmptyHeader(in FileHeader header)
         {

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -310,7 +310,8 @@ namespace Voron.Impl.Journal
             using var _ = fileHandle;
             while (ReadOneTransactionToDataFile(ref dataPagerState, ref recoveryPagerState, ref txState, fileHandle, options))
             {
-                Debug.Assert(transactionHeaders.Count == 0 || LastTransactionHeader->TransactionId > transactionHeaders.Last().TransactionId);
+                Debug.Assert(transactionHeaders.Count == 0 || LastTransactionHeader->TransactionId > transactionHeaders.Last().TransactionId, 
+                    $"LastTransactionHeader->TransactionId: {LastTransactionHeader->TransactionId}, transactionHeaders.Last().TransactionId: {transactionHeaders.Last().TransactionId}");
 
                 if (LastTransactionHeader != null)
                     transactionHeaders.Add(*LastTransactionHeader);

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -334,11 +334,6 @@ namespace Voron.Impl.Journal
             var deleteLastJournal = false;
 
             var lastJournal = _env.Options.GetLatestJournalNumber();
-            if (lastJournal.HasValue == false && journalToStartReadingFrom == 0)
-            {
-                goto FinishJournalRecovery;
-            }
-
             lastJournal ??= journalToStartReadingFrom;
 
             for (var journalNumber = journalToStartReadingFrom; journalNumber <= lastJournal.Value; journalNumber++)
@@ -443,7 +438,6 @@ namespace Voron.Impl.Journal
                 }
             }
 
-FinishJournalRecovery:
             if (_env.Options.Encryption.IsEnabled == false) // for encryption, we already use AEAD, so no need
             {
                 // here we want to check that the checksum on all the modified pages is valid

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -501,13 +501,10 @@ namespace Voron
 
                     tx.Commit();
                 }
+
                 // we *must* modify the header after the first transaction is committed
                 // since that is the marker that tells us that this is an existing database...
-                _headerAccessor.Modify((ref FileHeader header) =>
-                {
-                    header.Journal.LastSyncedTransactionId = 0;
-                    header.Journal.LastSyncedJournal = 0;
-                });
+                _headerAccessor.PersistHeader();
             }
 
             Options.AfterDatabaseCreation?.Invoke(this);

--- a/test/FastTests/Voron/NextGenPagers/BasicNextGen.cs
+++ b/test/FastTests/Voron/NextGenPagers/BasicNextGen.cs
@@ -40,12 +40,12 @@ public class BasicNextGen : StorageTest
         var last = LatestJournalNumber();
         Env.Options.TryDeleteJournal(last);
 
-        var e = Assert.Throws<VoronUnrecoverableErrorException>(StartDatabase);
-        Assert.Contains("First transaction initializing the struct", e.Message);
+        var e = Assert.Throws<InvalidJournalException>(StartDatabase);
+        Assert.Contains("No such journal", e.Message);
     }
 
     [RavenFact(RavenTestCategory.Voron)]
-    public void RecoverWhenDataSyncedButJournalsAreGone()
+    public void CannotRecoverEvenAfterDataSyncedWhenJournalsAreGone()
     {
         RequireFileBasedPager();
 
@@ -54,12 +54,10 @@ public class BasicNextGen : StorageTest
         
         StartDatabase();
 
-        long pageId;
-        using (var tx2 = Env.WriteTransaction())
+        using (var tx = Env.WriteTransaction())
         {
-            var allocatePage = tx2.LowLevelTransaction.AllocatePage(1);
-            pageId = allocatePage.PageNumber;
-            tx2.Commit();
+            tx.LowLevelTransaction.AllocatePage(1);
+            tx.Commit();
         }
         
         Env.FlushLogToDataFile();
@@ -70,12 +68,8 @@ public class BasicNextGen : StorageTest
         var last = LatestJournalNumber();
         Env.Options.TryDeleteJournal(last);
 
-        StartDatabase();
-
-        using (var tx2 = Env.WriteTransaction())
-        {
-            tx2.LowLevelTransaction.GetPage(pageId);
-        }
+        var e = Assert.Throws<InvalidJournalException>(StartDatabase);
+        Assert.Contains("No such journal", e.Message);
     }
 
     [RavenFact(RavenTestCategory.Voron)]
@@ -105,8 +99,8 @@ public class BasicNextGen : StorageTest
         var last = LatestJournalNumber();
         Env.Options.TryDeleteJournal(last);
 
-        var e = Assert.Throws<VoronUnrecoverableErrorException>(StartDatabase);
-        Assert.Contains("First transaction initializing the struct", e.Message);
+        var e = Assert.Throws<InvalidJournalException>(StartDatabase);
+        Assert.Contains("No such journal", e.Message);
     }
 
     [RavenFact(RavenTestCategory.Voron)]
@@ -136,8 +130,8 @@ public class BasicNextGen : StorageTest
         var last = LatestJournalNumber();
         Env.Options.TryDeleteJournal(last);
 
-        var e = Assert.Throws<VoronUnrecoverableErrorException>(StartDatabase);
-        Assert.Contains("First transaction initializing the struct", e.Message);
+        var e = Assert.Throws<InvalidJournalException>(StartDatabase);
+        Assert.Contains("No such journal", e.Message);
     }
 
     [RavenMultiplatformFact(RavenTestCategory.Voron, RavenArchitecture.All64Bits)]

--- a/test/FastTests/Voron/NextGenPagers/BasicNextGen.cs
+++ b/test/FastTests/Voron/NextGenPagers/BasicNextGen.cs
@@ -10,6 +10,7 @@ using Sparrow.Platform;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Tables;
+using Voron.Exceptions;
 using Voron.Global;
 using Voron.Impl;
 using Xunit;
@@ -24,6 +25,120 @@ public class BasicNextGen : StorageTest
     }
 
     private unsafe static Span<byte> AsSpan(Page p) => new Span<byte>(p.Pointer, Constants.Storage.PageSize);
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CannotRecoverWhenDataNotSyncedAndJournalsAreGone()
+    {
+        RequireFileBasedPager();
+
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+        
+        StartDatabase();
+        StopDatabase(shouldDisposeOptions: true);
+
+        var last = LatestJournalNumber();
+        Env.Options.TryDeleteJournal(last);
+
+        var e = Assert.Throws<VoronUnrecoverableErrorException>(StartDatabase);
+        Assert.Contains("First transaction initializing the struct", e.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void RecoverWhenDataSyncedButJournalsAreGone()
+    {
+        RequireFileBasedPager();
+
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+        
+        StartDatabase();
+
+        long pageId;
+        using (var tx2 = Env.WriteTransaction())
+        {
+            var allocatePage = tx2.LowLevelTransaction.AllocatePage(1);
+            pageId = allocatePage.PageNumber;
+            tx2.Commit();
+        }
+        
+        Env.FlushLogToDataFile();
+        Env.SyncDataFileImmediately();
+
+        StopDatabase(shouldDisposeOptions: true);
+
+        var last = LatestJournalNumber();
+        Env.Options.TryDeleteJournal(last);
+
+        StartDatabase();
+
+        using (var tx2 = Env.WriteTransaction())
+        {
+            tx2.LowLevelTransaction.GetPage(pageId);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CannotRecoverAfterTxWhenDataNotSyncedAndJournalsAreGone()
+    {
+        RequireFileBasedPager();
+
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+        
+        StartDatabase();
+
+        long pageId;
+        using (var tx2 = Env.WriteTransaction())
+        {
+            var allocatePage = tx2.LowLevelTransaction.AllocatePage(1);
+            pageId = allocatePage.PageNumber;
+            tx2.Commit();
+        }
+
+        // we aren't doing flush here to ensure we fail on the start 
+        // Env.FlushLogToDataFile();
+        // Env.SyncDataFileImmediately();
+
+        StopDatabase(shouldDisposeOptions: true);
+
+        var last = LatestJournalNumber();
+        Env.Options.TryDeleteJournal(last);
+
+        var e = Assert.Throws<VoronUnrecoverableErrorException>(StartDatabase);
+        Assert.Contains("First transaction initializing the struct", e.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CannotRecoverAfterTxWhenDataNotSyncedAndJournalsAreGone2()
+    {
+        RequireFileBasedPager();
+
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+        
+        StartDatabase();
+
+        long pageId;
+        using (var tx2 = Env.WriteTransaction())
+        {
+            var allocatePage = tx2.LowLevelTransaction.AllocatePage(1);
+            pageId = allocatePage.PageNumber;
+            tx2.Commit();
+        }
+
+        // we aren't doing flush here to ensure we fail on the start 
+        Env.FlushLogToDataFile();
+        // Env.SyncDataFileImmediately();
+
+        StopDatabase(shouldDisposeOptions: true);
+
+        var last = LatestJournalNumber();
+        Env.Options.TryDeleteJournal(last);
+
+        var e = Assert.Throws<VoronUnrecoverableErrorException>(StartDatabase);
+        Assert.Contains("First transaction initializing the struct", e.Message);
+    }
 
     [RavenMultiplatformFact(RavenTestCategory.Voron, RavenArchitecture.All64Bits)]
     public void WithAsyncCommit()

--- a/test/FastTests/Voron/NextGenPagers/BasicNextGen.cs
+++ b/test/FastTests/Voron/NextGenPagers/BasicNextGen.cs
@@ -27,7 +27,7 @@ public class BasicNextGen : StorageTest
     private unsafe static Span<byte> AsSpan(Page p) => new Span<byte>(p.Pointer, Constants.Storage.PageSize);
 
     [RavenFact(RavenTestCategory.Voron)]
-    public void CannotRecoverWhenDataNotSyncedAndJournalsAreGone()
+    public void CannotRecoverWhenJournalsAreGone()
     {
         RequireFileBasedPager();
 
@@ -44,8 +44,11 @@ public class BasicNextGen : StorageTest
         Assert.Contains("No such journal", e.Message);
     }
 
-    [RavenFact(RavenTestCategory.Voron)]
-    public void CannotRecoverEvenAfterDataSyncedWhenJournalsAreGone()
+    [RavenTheory(RavenTestCategory.Voron)]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void CannotRecoverWhenJournalsAreGone(bool flush, bool sync)
     {
         RequireFileBasedPager();
 
@@ -59,71 +62,12 @@ public class BasicNextGen : StorageTest
             tx.LowLevelTransaction.AllocatePage(1);
             tx.Commit();
         }
-        
-        Env.FlushLogToDataFile();
-        Env.SyncDataFileImmediately();
 
-        StopDatabase(shouldDisposeOptions: true);
+        if (flush)
+            Env.FlushLogToDataFile();
 
-        var last = LatestJournalNumber();
-        Env.Options.TryDeleteJournal(last);
-
-        var e = Assert.Throws<InvalidJournalException>(StartDatabase);
-        Assert.Contains("No such journal", e.Message);
-    }
-
-    [RavenFact(RavenTestCategory.Voron)]
-    public void CannotRecoverAfterTxWhenDataNotSyncedAndJournalsAreGone()
-    {
-        RequireFileBasedPager();
-
-        Options.ManualFlushing = true;
-        Options.ManualSyncing = true;
-        
-        StartDatabase();
-
-        long pageId;
-        using (var tx2 = Env.WriteTransaction())
-        {
-            var allocatePage = tx2.LowLevelTransaction.AllocatePage(1);
-            pageId = allocatePage.PageNumber;
-            tx2.Commit();
-        }
-
-        // we aren't doing flush here to ensure we fail on the start 
-        // Env.FlushLogToDataFile();
-        // Env.SyncDataFileImmediately();
-
-        StopDatabase(shouldDisposeOptions: true);
-
-        var last = LatestJournalNumber();
-        Env.Options.TryDeleteJournal(last);
-
-        var e = Assert.Throws<InvalidJournalException>(StartDatabase);
-        Assert.Contains("No such journal", e.Message);
-    }
-
-    [RavenFact(RavenTestCategory.Voron)]
-    public void CannotRecoverAfterTxWhenDataNotSyncedAndJournalsAreGone2()
-    {
-        RequireFileBasedPager();
-
-        Options.ManualFlushing = true;
-        Options.ManualSyncing = true;
-        
-        StartDatabase();
-
-        long pageId;
-        using (var tx2 = Env.WriteTransaction())
-        {
-            var allocatePage = tx2.LowLevelTransaction.AllocatePage(1);
-            pageId = allocatePage.PageNumber;
-            tx2.Commit();
-        }
-
-        // we aren't doing flush here to ensure we fail on the start 
-        Env.FlushLogToDataFile();
-        // Env.SyncDataFileImmediately();
+        if (sync)
+            Env.SyncDataFileImmediately();
 
         StopDatabase(shouldDisposeOptions: true);
 

--- a/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
+++ b/test/FastTests/Voron/SharedJournal/SharedJournalTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -830,6 +832,34 @@ public class SharedJournalTests(ITestOutputHelper output) : RavenTestBase(output
                 var x = await session.Query<User, Users_ByName>().ToListAsync();
                 Assert.Equal(3, x.Count);
             }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+    public async Task SharedJournalsEventsConfig()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            var options = database.IndexStore.SharedJournals.Env.Options;
+
+            EventHandlerHasInvocations<StorageEnvironmentOptions>(options, ["OnDirectoryInitialize"]);
+        }
+    }
+
+    public static void EventHandlerHasInvocations<T>(object target, HashSet<string> exclude = null)
+    {
+        Assert.True(typeof(T).IsAssignableFrom(target.GetType()));
+
+        var events = typeof(T).GetEvents();
+        foreach (var @event in events)
+        {
+            if (exclude?.Contains(@event.Name) == true)
+                continue;
+
+            var fieldInfo = typeof(T).GetField(@event.Name, BindingFlags.NonPublic | BindingFlags.Instance);
+            var delegateValue = fieldInfo?.GetValue(target) as MulticastDelegate;
+            Assert.True(delegateValue?.GetInvocationList().Length > 0, $"{@event.Name} is not wired");
         }
     }
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -294,7 +294,11 @@ namespace FastTests
                 {
                     if (_globalServer == null || _globalServer.Disposed)
                     {
-                        var globalServer = GetNewServer(new ServerCreationOptions { RegisterForDisposal = false }, "Global");
+                        var globalServer = GetNewServer(new ServerCreationOptions
+                        {
+                            ServerUsage = ServerCreationOptions.Usage.Global,
+                            RegisterForDisposal = false
+                        }, "Global");
                         using (var currentProcess = Process.GetCurrentProcess())
                         {
                             Console.WriteLine(
@@ -576,6 +580,13 @@ namespace FastTests
             public static ServerCreationOptions Default => _default.Value;
 
             public Action<ServerStore> BeforeDatabasesStartup;
+
+            public Usage ServerUsage = Usage.Local;
+            public enum Usage
+            {
+                Local,
+                Global
+            }
         }
 
         private static readonly ConcurrentDictionary<RavenServer, string> LeakedServers = new();
@@ -632,7 +643,7 @@ namespace FastTests
                 {
                     string dataDirectory = null;
                     if (options.DataDirectory == null)
-                        dataDirectory = NewDataPath(prefix: $"GetNewServer-{options.NodeTag}", forceCreateDir: true);
+                        dataDirectory = NewDataPath(prefix: $"GetNewServer-{options.NodeTag}", forceCreateDir: true, usage: options.ServerUsage);
                     else
                     {
                         if (Path.IsPathRooted(options.DataDirectory) == false)
@@ -732,14 +743,23 @@ namespace FastTests
             Process.Start("xdg-open", url);
         }
 
-        protected string NewDataPath([CallerMemberName] string prefix = null, string suffix = null, bool forceCreateDir = false)
+        protected string NewDataPath([CallerMemberName] string prefix = null, string suffix = null, bool forceCreateDir = false, ServerCreationOptions.Usage usage = ServerCreationOptions.Usage.Local)
         {
             if (suffix != null)
                 prefix += suffix;
             var path = RavenTestHelper.NewDataPath(prefix, 0, forceCreateDir);
 
-            GlobalPathsToDelete.Add(path);
-            _localPathsToDelete.Add(path);
+            switch (usage)
+            {
+                case ServerCreationOptions.Usage.Local:
+                    _localPathsToDelete.Add(path);
+                    break;
+                case ServerCreationOptions.Usage.Global:
+                    GlobalPathsToDelete.Add(path);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(usage), usage, null);
+            }
 
             return path;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24065

### Additional description

On the very first tx, when we just create the env the SyncedJounral and TxId cannot be 0, since journal 0 wasn't synced.
This can cause inconsistency when the journals are gone. 
In such case, we can't determine the state of the database, so we can't recover and should throw.


~~In contrary to 7.0, where we would get the `InvalidJournalException` exception from here~~
https://github.com/ravendb/ravendb/blob/c898074d72493c2153cac22d16f2b5bc1f123c6b/src/Voron/StorageEnvironmentOptions.cs#L910

~~We now getting this one instead~~ https://github.com/ravendb/ravendb/blob/c898074d72493c2153cac22d16f2b5bc1f123c6b/src/Voron/Impl/Journal/WriteAheadJournal.cs#L322
~~because we no longer have the notion of `CurrentJournal` in the `JournalInfo`~~

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
