### PR TITLE
RavenDB-23792 - Allow to query by a stored vector by specifying document id

### DIFF
--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -1,6 +1,16 @@
-﻿using Corax.Mappings;
+﻿using System;
+using System.Collections.Generic;
+using Corax.Indexing;
+using Corax.Mappings;
 using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
 using Corax.Utils;
+using Sparrow;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
+using Voron.Data.Graphs;
 
 namespace Corax.Querying;
 
@@ -10,6 +20,50 @@ public partial class IndexSearcher
     {
         return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
     }
+    
+    public IQueryMatch VectorSearch(in FieldMetadata metadata, in string documentId, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch)
+    {
+        var idField = _fieldsTree.CompactTreeFor(_fieldMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName);
+        string loweredDocumentId = documentId.ToLowerInvariant();
+        if (idField.TryGetValue(loweredDocumentId, out var rawId) is false || 
+            TryGetRootPageByFieldName(metadata.FieldName, out var vectorRootPage) is false)
+            return EmptyMatch();
+        var vectorsByHash = _transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
+        PortableExceptions.ThrowIf<InvalidOperationException>((rawId & (long)TermIdMask.EnsureIsSingleMask) != (long)TermIdMask.Single,
+            "The provided id must be a document id mapped to a single value, but got: " + documentId +", which maps to: " + rawId); 
+
+        Page page = default;
+        var singleEntryId = EntryIdEncodings.GetContainerId(rawId);
+        var reader = GetEntryTermsReader(singleEntryId, ref page);
+
+        var searchState = new Hnsw.SearchState(_transaction.LowLevelTransaction, metadata.FieldName);
+        
+        if (reader.FindNextStored(vectorRootPage) is false)
+            return EmptyMatch();
+        
+        PortableExceptions.ThrowIf<InvalidOperationException>(reader.IsVectorHash is false, "Expected vector field, but got " + metadata.FieldName + ", which isn't a vector");
+        
+        Span<byte> hash = reader.StoredField.Value.ToSpan();
+        if (vectorsByHash.TryGetValue(hash, out var vectorId) is false)
+            return EmptyMatch();
+        
+        var vectorSpan = Hnsw.NodeReader.ReadVector(vectorId, searchState);
+            
+        var vectorValue = new VectorValue(null, vectorSpan.AsMemory());
+        if (reader.FindNextStored(vectorRootPage) is false) // just a single vector
+            return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
+
+        List<VectorValue> vectors = [vectorValue]; 
+        do
+        {
+            vectorSpan = Hnsw.NodeReader.ReadVector(vectorId, searchState);
+            vectorValue = new VectorValue(null, vectorSpan.AsMemory());
+            vectors.Add(vectorValue);
+        } while (reader.FindNextStored(vectorRootPage));
+        
+        return new MultiVectorSearchMatch(this, metadata, vectors.ToArray(), minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
+    }
+
 
     public MultiVectorSearchMatch MultiVectorSearch(in FieldMetadata metadata, in VectorValue[] vectorValues, float minimumMatch, in int numberOfCandidates, bool isExact,
         bool isSingleVectorSearch) => new MultiVectorSearchMatch(this, metadata, vectorValues, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -118,18 +118,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
     }
 
-    public void GetEntryTermsReader(long id, ref Page p, out EntryTermsReader reader, CompactKey existingKey)
-    {
-        if (_entryIdToLocation.TryGetValue(id, out var loc) == false)
-            throw new InvalidOperationException("Unable to find entry id: " + id);
-
-        InitializeSpecialTermsMarkers();
-        
-        var item = Container.MaybeGetFromSamePage(_transaction.LowLevelTransaction, ref p, loc);
-        reader = new EntryTermsReader(_transaction.LowLevelTransaction, _nullTermsMarkers, _nonExistingTermsMarkers, item.Address, item.Length, _dictionaryId, _vectorFieldsMarkers);
-    }
-
-    public unsafe EntryTermsReader GetEntryTermsReader(long id, ref Page p)
+    public EntryTermsReader GetEntryTermsReader(long id, ref Page p)
     {
         if (_entryIdToLocation.TryGetValue(id, out var loc) == false)
             throw new InvalidOperationException("Unable to find entry id: " + id);

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -601,6 +601,7 @@ namespace Raven.Client
         {
             private const string EmbeddingPrefix = "embedding.";
 
+            internal const string EmbeddingForDocument = EmbeddingPrefix + "for";
             internal const string EmbeddingText = EmbeddingPrefix + "text";
             internal const string EmbeddingTextInt8 = EmbeddingPrefix + "text_i8";
             internal const string EmbeddingTextInt1 = EmbeddingPrefix + "text_i1";

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -596,12 +596,12 @@ namespace Raven.Client
                 public const string ThrowRevisionKeyTooBigFix = "ThrowRevisionKeyTooBigFix";
             }
         }
-        
+
         internal static class VectorSearch
         {
             private const string EmbeddingPrefix = "embedding.";
 
-            internal const string EmbeddingForDocument = EmbeddingPrefix + "for";
+            internal const string EmbeddingForDocument = EmbeddingPrefix + "forDoc";
             internal const string EmbeddingText = EmbeddingPrefix + "text";
             internal const string EmbeddingTextInt8 = EmbeddingPrefix + "text_i8";
             internal const string EmbeddingTextInt1 = EmbeddingPrefix + "text_i1";

--- a/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
@@ -210,6 +210,11 @@ public interface IVectorEmbeddingTextFieldValueFactory
     /// </summary>
     /// <param name="text">Queried text.</param>
     public void ByText(string text);
+
+    /// <summary>
+    /// Use specified vector for the provided document id  
+    /// </summary>
+    public void ForDocument(string documentId);
     
     /// <summary>
     /// Defines queried texts.
@@ -281,13 +286,17 @@ public interface IVectorEmbeddingFieldValueFactory
 
 public interface IVectorFieldValueFactory : IVectorEmbeddingTextFieldValueFactory, IVectorEmbeddingFieldValueFactory
 {
-    
+    /// <summary>
+    /// Use an existing vector belonging to the specified document
+    /// </summary>
+    public void ForDocument(string documentId);
 }
 
 public interface IVectorFieldValueFactoryAccessor
 {
     internal object Embeddings { get; set; }
     internal string Text { get; set; }
+    internal string ById { get; set; }
     internal IEnumerable<string> Texts { get; set; }
 }
 
@@ -295,6 +304,7 @@ internal class VectorFieldValueFactory : IVectorFieldValueFactory, IVectorFieldV
 {
     public object Embeddings { get; set; }
     public string Text { get; set; }
+    public string ById { get; set; }
     public IEnumerable<string> Texts { get; set; }
     
     void IVectorEmbeddingFieldValueFactory.ByEmbedding<T>(IEnumerable<T> embedding)
@@ -357,4 +367,8 @@ internal class VectorFieldValueFactory : IVectorFieldValueFactory, IVectorFieldV
         Embeddings = embedding;
     }
 
+    public void ForDocument(string documentId)
+    {
+        ById = documentId;
+    }
 }

--- a/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
@@ -286,10 +286,7 @@ public interface IVectorEmbeddingFieldValueFactory
 
 public interface IVectorFieldValueFactory : IVectorEmbeddingTextFieldValueFactory, IVectorEmbeddingFieldValueFactory
 {
-    /// <summary>
-    /// Use an existing vector belonging to the specified document
-    /// </summary>
-    public void ForDocument(string documentId);
+    
 }
 
 public interface IVectorFieldValueFactoryAccessor

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1532,8 +1532,9 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var text = fieldValueFactoryAccessor.Text;
             var texts = fieldValueFactoryAccessor.Texts;
             var embeddings = fieldValueFactoryAccessor.Embeddings;
+            var byId = fieldValueFactoryAccessor.ById;
 
-            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts,  embeddings, embeddingsGenerationTaskIdentifier);
+            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts,  embeddings, byId, embeddingsGenerationTaskIdentifier);
         }
         
         internal void VectorSearch(VectorEmbeddingFieldFactory<T> embeddingFieldFactory, VectorFieldValueFactory embeddingValueFactory,
@@ -1547,15 +1548,17 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var text = embeddingValueFactory.Text;
             var texts = embeddingValueFactory.Texts;
             var embeddings = embeddingValueFactory.Embeddings;
+            var byId = embeddingValueFactory.ById;
             
-            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts, embeddings, embeddingsGenerationTaskIdentifier);
+            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts, embeddings, byId, embeddingsGenerationTaskIdentifier);
         }
         
         private void VectorSearch(string fieldName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? minimumSimilarity,
-            int? numberOfCandidates, bool isExact, string text, IEnumerable<string> texts, object embeddings, string embeddingsGenerationTaskIdentifier = null)
+            int? numberOfCandidates, bool isExact, string text, IEnumerable<string> texts, object embeddings, string byId, string embeddingsGenerationTaskIdentifier = null)
         {
             string queryParameterName;
-            
+
+            bool isDocumentId = string.IsNullOrEmpty(byId) is false;
             if (text != null)
                 queryParameterName = AddQueryParameter(text);
             else if (texts != null)
@@ -1581,12 +1584,16 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                     _  => embeddings
                 });
             }
+            else if (isDocumentId)
+            {
+                queryParameterName = AddQueryParameter(byId);
+            }
             else
             {
-                throw new InvalidOperationException("Cannot use VectorSearch without text(s) or embedding(s).");
+                throw new InvalidOperationException("Cannot use VectorSearch without text(s), document id or embedding(s).");
             }
             
-            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, embeddingsGenerationTaskIdentifier);
+            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, isDocumentId, embeddingsGenerationTaskIdentifier);
 
             WhereTokens.AddLast(vectorSearchToken);
         }

--- a/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
@@ -14,11 +14,12 @@ public sealed class VectorSearchToken : WhereToken
     private readonly VectorEmbeddingType _sourceQuantizationType;
     private readonly VectorEmbeddingType _targetQuantizationType;
     private readonly int? _numberOfCandidatesForQuerying;
+    private readonly bool _isDocumentId;
     private readonly string _embeddingsGenerationTaskIdentifier;
 
     private static string AiTaskMethodName = "ai.task";
     
-    public VectorSearchToken(string fieldName, string parameterName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? similarityThreshold, int? numberOfCandidatesForQuerying, bool isExact, string embeddingsGenerationTaskIdentifier)
+    public VectorSearchToken(string fieldName, string parameterName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? similarityThreshold, int? numberOfCandidatesForQuerying, bool isExact, bool isDocumentId, string embeddingsGenerationTaskIdentifier)
     {
         FieldName = fieldName;
         ParameterName = parameterName;
@@ -29,6 +30,7 @@ public sealed class VectorSearchToken : WhereToken
         _similarityThreshold = similarityThreshold;
 
         _numberOfCandidatesForQuerying = numberOfCandidatesForQuerying;
+        _isDocumentId = isDocumentId;
         Options = new(isExact);
 
         _embeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
@@ -43,9 +45,11 @@ public sealed class VectorSearchToken : WhereToken
             writer.Append("exact(");
         
         writer.Append("vector.search(");
-        
+
         if (_sourceQuantizationType is VectorEmbeddingType.Single && _targetQuantizationType is VectorEmbeddingType.Single)
+        {
             writer.Append(FieldName);
+        }
         else
         {
             var methodName = Constants.VectorSearch.ConfigurationToMethodName(_sourceQuantizationType, _targetQuantizationType);
@@ -55,8 +59,16 @@ public sealed class VectorSearchToken : WhereToken
             else
                 writer.Append($"{methodName}({FieldName})");
         }
-        
-        writer.Append($", ${ParameterName}");
+        writer.Append(", ");
+
+        if (_isDocumentId)
+        {
+            writer.Append($"{Constants.VectorSearch.EmbeddingForDocument}(${ParameterName})");
+        }
+        else
+        {
+            writer.Append($"${ParameterName}");
+        }
 
         bool parametersAreDefault = _similarityThreshold is null &&
                                     _numberOfCandidatesForQuerying is null;

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -131,6 +131,9 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                      List<ReadOnlyMemory<byte>> cachedEmbeddingsBuffers = [];
                      foreach (var chunkedValue in TextChunker.Chunk(value, chunking))
                      {
+                         if(string.IsNullOrWhiteSpace(chunkedValue))
+                             continue; // this can happen if we have just spaces, or if we have an HTML with just <img/>, etc.
+                         
                          if (TryGetFromCache(documentsContext, chunkedValue, cacheDuration, ref expirationRefresh, out var cachedEntry))
                          {
                              cachedEmbeddingsBuffers.Add(cachedEntry);

--- a/src/Raven.Server/Documents/AI/TextChunker.cs
+++ b/src/Raven.Server/Documents/AI/TextChunker.cs
@@ -109,7 +109,7 @@ public static class TextChunker
     public static List<string> ChunkPlainText(string textualValue, int maxTokensPerChunk)
     {
         var text = textualValue.AsMemory();
-        var pos = Tokenizer.GetIndexByTokenCount(text.Span, maxTokensPerChunk, out var normalizedText, out var tokenCount,
+        var pos = Tokenizer.GetIndexByTokenCount(LimitTextSize(text, maxTokensPerChunk), maxTokensPerChunk, out var normalizedText, out var tokenCount,
             considerNormalization: false, considerPreTokenization: false);
         if (pos == text.Length) // avoid allocation if we can fit all tokens at once
         {
@@ -122,12 +122,24 @@ public static class TextChunker
             text = text[pos..];
             if (text.IsEmpty)
                 break;
-            pos = Tokenizer.GetIndexByTokenCount(text.Span, maxTokensPerChunk, out normalizedText, out tokenCount,
+            pos = Tokenizer.GetIndexByTokenCount(LimitTextSize(text, maxTokensPerChunk), maxTokensPerChunk, out normalizedText, out tokenCount,
                 considerNormalization: false, considerPreTokenization: false);
             results.Add(new(text[..pos].Span));
         } 
 
         return results;
     }
-    
+
+    private static ReadOnlySpan<char> LimitTextSize(ReadOnlyMemory<char> text, int maxTokens)
+    {
+        ReadOnlySpan<char> span = text.Span;
+        if (span.Length <= maxTokens * 6)
+            return span;
+        // the issue is that CountTokens() use the whole string, but if we have a value that is ~500Kb in size, 
+        // and 2048 tokens, we'll spend huge amounts of time just splitting the whole string, since CountTokens()
+        // has to work on the entire input we give it - therefor, we "guesstimate" the max size and pass that
+        // to the CountTokens() function - most embeddings use 3 - 4 chars per token, so by using 6, we ensure that the
+        // text we send will be longer than the max tokens
+        return span[..(maxTokens * 6)];
+    }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -21,14 +21,69 @@ public static partial class CoraxQueryBuilder
     private static IQueryMatch HandleVector(Parameters builderParameters, MethodExpression me, bool exact)
     {
         var metadata = builderParameters.Metadata;
-        var (value, valueType) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[1],
-            allowObjectsInParameters: false, allowArraysInParameters: true);
+        
+        var minimumMatch = builderParameters.Index.Configuration.CoraxVectorSearchDefaultMinimumSimilarity;
+        if (me.Arguments.Count > 2)
+        {
+            var (similarityValue, similiarityValueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters,
+                (ValueExpression)me.Arguments[2]);
+            minimumMatch = similiarityValueType switch
+            {
+                ValueTokenType.Null => builderParameters.Index.Configuration.CoraxVectorSearchDefaultMinimumSimilarity,
+                ValueTokenType.Long => (long)similarityValue,
+                ValueTokenType.Double => (float)(double)similarityValue,
+                _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + similiarityValueType)
+            };
+        }
 
+        int numberOfCandidates = builderParameters.Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForQuerying;
+        if (me.Arguments.Count > 3)
+        {
+            var (candidatesValue, candidatesValueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters,
+                (ValueExpression)me.Arguments[3]);
+            numberOfCandidates = candidatesValueType switch
+            {
+                ValueTokenType.Long => Convert.ToInt32(candidatesValue),
+                ValueTokenType.Double => Convert.ToInt32(candidatesValue),
+                ValueTokenType.Null => builderParameters.Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForQuerying,
+                _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + candidatesValueType)
+            };
+        }
+        
         var fieldName = metadata.IsDynamic == false
             ? QueryBuilderHelper.ExtractIndexFieldName(metadata.Query, builderParameters.QueryParameters, me.Arguments[0], metadata)
             : metadata.GetVectorFieldName(me, builderParameters.QueryParameters);
 
+        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out var numberOfDimensions) == false)
+            return builderParameters.IndexSearcher.EmptyMatch(); // no vector indexed
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters, fieldName, hasBoost: builderParameters.HasBoost);
+        QueryExpression srcVector = me.Arguments[1];
+        
+
+        if (srcVector is MethodExpression forId) // embedding.for(docId) ...
+        {
+            PortableExceptions.ThrowIf<InvalidDataException>(forId.Name != "embedding.for", "Expected embedding.for() method call, but got: " + forId.Name);
+
+            var (forIdValue, _) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)forId.Arguments[0],
+                allowObjectsInParameters: false, allowArraysInParameters: true);
+            
+            switch (forIdValue)
+            {
+                case string docId:
+                    return builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docId, minimumMatch, numberOfCandidates, exact,
+                        builderParameters.IsVectorSingleClause);
+                case StringSegment docIdSegment:
+                    return builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docIdSegment.Value, minimumMatch, numberOfCandidates, exact,
+                        builderParameters.IsVectorSingleClause);
+                case BlittableJsonReaderArray {Length:> 0} arr:
+                    break;
+            }
+            
+        }
+        
+        var (value, valueType) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)srcVector,
+            allowObjectsInParameters: false, allowArraysInParameters: true);
+
         (VectorValue? SingleVector, VectorValue[] MultiVector) transformedEmbeddings = (null, null);
         IndexField indexField;
 
@@ -93,36 +148,6 @@ public static partial class CoraxQueryBuilder
             }
         }
 
-        var minimumMatch = builderParameters.Index.Configuration.CoraxVectorSearchDefaultMinimumSimilarity;
-        if (me.Arguments.Count > 2)
-        {
-            (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters,
-                (ValueExpression)me.Arguments[2]);
-            minimumMatch = valueType switch
-            {
-                ValueTokenType.Null => builderParameters.Index.Configuration.CoraxVectorSearchDefaultMinimumSimilarity,
-                ValueTokenType.Long => (long)value,
-                ValueTokenType.Double => (float)(double)value,
-                _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + valueType)
-            };
-        }
-
-        int numberOfCandidates = builderParameters.Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForQuerying;
-        if (me.Arguments.Count > 3)
-        {
-            (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters,
-                (ValueExpression)me.Arguments[3]);
-            numberOfCandidates = valueType switch
-            {
-                ValueTokenType.Long => Convert.ToInt32(value),
-                ValueTokenType.Double => Convert.ToInt32(value),
-                ValueTokenType.Null => builderParameters.Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForQuerying,
-                _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + valueType)
-            };
-        }
-
-        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out var numberOfDimensions) == false)
-            return builderParameters.IndexSearcher.EmptyMatch(); // no vector indexed
 
         if (transformedEmbeddings.SingleVector != null)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
+using Raven.Client;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.AI.Embeddings;
@@ -54,15 +55,13 @@ public static partial class CoraxQueryBuilder
             ? QueryBuilderHelper.ExtractIndexFieldName(metadata.Query, builderParameters.QueryParameters, me.Arguments[0], metadata)
             : metadata.GetVectorFieldName(me, builderParameters.QueryParameters);
 
-        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out var numberOfDimensions) == false)
-            return builderParameters.IndexSearcher.EmptyMatch(); // no vector indexed
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters, fieldName, hasBoost: builderParameters.HasBoost);
         QueryExpression srcVector = me.Arguments[1];
-        
 
-        if (srcVector is MethodExpression forId) // embedding.for(docId) ...
+        if (srcVector is MethodExpression forId) // embedding.forDoc(docId) ...
         {
-            PortableExceptions.ThrowIf<InvalidDataException>(forId.Name != "embedding.for", "Expected embedding.for() method call, but got: " + forId.Name);
+            PortableExceptions.ThrowIf<InvalidDataException>(forId.Name != Constants.VectorSearch.EmbeddingForDocument,
+                $"Expected {Constants.VectorSearch.EmbeddingForDocument}() method call, but got: {forId.Name}");
 
             var (forIdValue, _) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)forId.Arguments[0],
                 allowObjectsInParameters: false, allowArraysInParameters: true);
@@ -148,6 +147,8 @@ public static partial class CoraxQueryBuilder
             }
         }
 
+        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out var numberOfDimensions) == false)
+            return builderParameters.IndexSearcher.EmptyMatch(); // no vector indexed
 
         if (transformedEmbeddings.SingleVector != null)
         {

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Queries.AST
         private static readonly string[] UnsupportedQueryMethodsInJavascript = {
             "Search","Boost","Lucene","Exact","Count","Sum","Circle","Wkt","Point","Within","Contains","Disjoint","Intersects","MoreLikeThis",
             "Spatial.Wkt", "Spatial.Point", "Spatial.Intersects", "Spatial.Contains", "Spatial.Disjoint", "Spatial.Sum", "Vector.Search", "Embedding.Text",
-            "Embedding.Text_I8", "Embedding.Text_I1", "Embedding.F32_I8", "Embedding.F32_I1", "Embedding.I8", "Embedding.I1"
+            "Embedding.Text_I8", "Embedding.Text_I1", "Embedding.F32_I8", "Embedding.F32_I1", "Embedding.I8", "Embedding.I1", "Embedding.For"
         };
 
         public JavascriptCodeQueryVisitor(StringBuilder sb, Query q)

--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Queries.AST
         private static readonly string[] UnsupportedQueryMethodsInJavascript = {
             "Search","Boost","Lucene","Exact","Count","Sum","Circle","Wkt","Point","Within","Contains","Disjoint","Intersects","MoreLikeThis",
             "Spatial.Wkt", "Spatial.Point", "Spatial.Intersects", "Spatial.Contains", "Spatial.Disjoint", "Spatial.Sum", "Vector.Search", "Embedding.Text",
-            "Embedding.Text_I8", "Embedding.Text_I1", "Embedding.F32_I8", "Embedding.F32_I1", "Embedding.I8", "Embedding.I1", "Embedding.For"
+            "Embedding.Text_I8", "Embedding.Text_I1", "Embedding.F32_I8", "Embedding.F32_I1", "Embedding.I8", "Embedding.I1", "Embedding.ForDoc"
         };
 
         public JavascriptCodeQueryVisitor(StringBuilder sb, Query q)

--- a/src/Raven.Studio/languageService/src/providers/keywords.ts
+++ b/src/Raven.Studio/languageService/src/providers/keywords.ts
@@ -227,6 +227,13 @@ export class AutocompleteKeywords extends BaseAutocompleteProvider implements Au
             meta: AUTOCOMPLETE_META.function,
             score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
             snippet: `embedding.text_i1(\${1}, ai.task('\${2}')), `
+            },
+        {
+            value: "embedding.forDor(",
+            caption: "embedding.forDor(docId)",
+            meta: AUTOCOMPLETE_META.function,
+            score: AUTOCOMPLETE_SCORING.function,
+            snippet: `embedding.forDor(\${1}) `
         }]
     }
     

--- a/src/Raven.Studio/languageService/src/providers/keywords.ts
+++ b/src/Raven.Studio/languageService/src/providers/keywords.ts
@@ -227,13 +227,6 @@ export class AutocompleteKeywords extends BaseAutocompleteProvider implements Au
             meta: AUTOCOMPLETE_META.function,
             score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
             snippet: `embedding.text_i1(\${1}, ai.task('\${2}')), `
-            },
-        {
-            value: "embedding.forDor(",
-            caption: "embedding.forDor(docId)",
-            meta: AUTOCOMPLETE_META.function,
-            score: AUTOCOMPLETE_SCORING.function,
-            snippet: `embedding.forDor(\${1}) `
         }]
     }
     
@@ -263,11 +256,11 @@ export class AutocompleteKeywords extends BaseAutocompleteProvider implements Au
                 score: AUTOCOMPLETE_SCORING.functionVectorTextual,
                 snippet: `$\${1} `
             },{
-                value: "embedding.for(",
-                caption: "embedding.for('documentId')",
+                value: "embedding.forDoc(",
+                caption: "embedding.forDoc('documentId')",
                 meta: AUTOCOMPLETE_META.function,
                 score: AUTOCOMPLETE_SCORING.functionVectorTextual,
-                snippet: `embedding.for('\${1}')`
+                snippet: `embedding.forDoc('\${1}')`
         }]
     }
     

--- a/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
@@ -30,7 +30,7 @@ describe("can complete where", function () {
 
     it("vector.search <- suggest field or embedding method  - collection doesn't have fields", async () => {
         const suggestions = await autocomplete("from CollectionWithoutDefinedFields where vector.search(|", new EmptyMetadataProvider());
-        for (let specialFunction of ['embedding.text(', 'embedding.text_i8(', 'embedding.text_i1(', 'embedding.f32_i8(', 'embedding.f32_i1(', 'embedding.i8(', 'embedding.i1']) {
+        for (let specialFunction of ['embedding.text(', 'embedding.for(','embedding.text_i8(', 'embedding.text_i1(', 'embedding.f32_i8(', 'embedding.f32_i1(', 'embedding.i8(', 'embedding.i1']) {
             const matchingItem = suggestions.find(x => x.value.startsWith(specialFunction));
             expect(matchingItem)
                 .toBeTruthy();

--- a/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
@@ -30,7 +30,7 @@ describe("can complete where", function () {
 
     it("vector.search <- suggest field or embedding method  - collection doesn't have fields", async () => {
         const suggestions = await autocomplete("from CollectionWithoutDefinedFields where vector.search(|", new EmptyMetadataProvider());
-        for (let specialFunction of ['embedding.text(', 'embedding.for(','embedding.text_i8(', 'embedding.text_i1(', 'embedding.f32_i8(', 'embedding.f32_i1(', 'embedding.i8(', 'embedding.i1']) {
+        for (let specialFunction of ['embedding.text(', 'embedding.forDoc(','embedding.text_i8(', 'embedding.text_i1(', 'embedding.f32_i8(', 'embedding.f32_i1(', 'embedding.i8(', 'embedding.i1']) {
             const matchingItem = suggestions.find(x => x.value.startsWith(specialFunction));
             expect(matchingItem)
                 .toBeTruthy();
@@ -46,9 +46,9 @@ describe("can complete where", function () {
         }
     });
 
-    it("vector.search(embedding.text(Name),  <- suggest embedding.for, parameter or string input", async () => {
+    it("vector.search(embedding.text(Name),  <- suggest embedding.forDoc, parameter or string input", async () => {
         const suggestions = await autocomplete("from CollectionWithoutDefinedFields where vector.search(embedding.text(Name), |", new EmptyMetadataProvider());
-        for (let specialFunction of ['embedding.for', 'parameter', 'textual value']) {
+        for (let specialFunction of ['embedding.forDoc', 'parameter', 'textual value']) {
             const matchingItem = suggestions.find(x => x.value.startsWith(specialFunction));
             expect(matchingItem)
                 .toBeTruthy();

--- a/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
@@ -30,7 +30,7 @@ describe("can complete where", function () {
 
     it("vector.search <- suggest field or embedding method  - collection doesn't have fields", async () => {
         const suggestions = await autocomplete("from CollectionWithoutDefinedFields where vector.search(|", new EmptyMetadataProvider());
-        for (let specialFunction of ['embedding.text(', 'embedding.forDoc(','embedding.text_i8(', 'embedding.text_i1(', 'embedding.f32_i8(', 'embedding.f32_i1(', 'embedding.i8(', 'embedding.i1']) {
+        for (let specialFunction of ['embedding.text(', 'embedding.text_i8(', 'embedding.text_i1(', 'embedding.f32_i8(', 'embedding.f32_i1(', 'embedding.i8(', 'embedding.i1']) {
             const matchingItem = suggestions.find(x => x.value.startsWith(specialFunction));
             expect(matchingItem)
                 .toBeTruthy();

--- a/src/Sparrow/UnmanagedPointer.cs
+++ b/src/Sparrow/UnmanagedPointer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Sparrow.Json;
 
 namespace Sparrow
 {
@@ -35,6 +36,8 @@ namespace Sparrow
         public readonly double Double;
 
         public UnmanagedMemoryStream ToStream() => new(Address, Length);
+        
+        public Memory<byte> AsMemory() => new UnmanagedMemoryManager(Address, Length).Memory;
 
         public override string ToString()
         {

--- a/src/Voron/Data/Graphs/Hnsw.Constants.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Constants.cs
@@ -9,7 +9,7 @@ public partial class Hnsw
     private static readonly Slice VectorsContainerIdSlice;
     private static readonly Slice NodeIdToLocationSlice;
     private static readonly Slice NodesByVectorIdSlice;
-    private static readonly Slice VectorsIdByHashSlice;
+    public static readonly Slice VectorsIdByHashSlice;
     private static readonly Slice HnswGlobalConfigSlice;
     internal static readonly Slice OptionsSlice;
     

--- a/test/SlowTests/Issues/RavenDB_23792.cs
+++ b/test/SlowTests/Issues/RavenDB_23792.cs
@@ -1,0 +1,70 @@
+﻿using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23792 : RavenTestBase
+{
+    public RavenDB_23792(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public record Item(RavenVector<float> Vector, string Name);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestRqlGeneration(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var q1 = session.Advanced.DocumentQuery<Item>()
+                    .VectorSearch(x => x.WithField(i=>i.Vector), 
+                        x=>x.ForDocument("items/1-A")).ToString();
+
+                Assert.Equal("from 'Items' where vector.search(Vector, embedding.for($p0))", q1);
+                
+                var q2 = session.Advanced.DocumentQuery<Item>()
+                    .VectorSearch(x => x.WithText(i=>i.Name),
+                        x =>x.ForDocument("items/1-A"))
+                    .ToString();
+                Assert.Equal("from 'Items' where vector.search(embedding.text(Name), embedding.for($p0))", q2);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CanQueryByDocumentVector(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Item(null,"Apple Pie"), "items/1-A");
+                session.Store(new Item(null,"Orange Cake"), "items/2-A");
+                session.Store(new Item(null,"Apple Juice"), "items/3-A");
+                session.Store(new Item(null,"Red Carpet"), "items/4-A");
+                session.SaveChanges();
+            }
+            using (var session = store.OpenSession())
+            {
+                var q1 = session.Advanced.DocumentQuery<Item>()
+                    .WaitForNonStaleResults()
+                    .VectorSearch(x => x.WithText(i=>i.Name),
+                        x =>x.ForDocument("items/1-A"))
+                    .Take(3)
+                    .ToList();
+WaitForUserToContinueTheTest(store);
+                var appleIdx = q1.FindIndex(x=>x.Name == "Apple Juice");
+                var orangeIdx = q1.FindIndex(x=>x.Name == "Orange Cake");
+
+                Assert.True(appleIdx < orangeIdx);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_23792.cs
+++ b/test/SlowTests/Issues/RavenDB_23792.cs
@@ -26,13 +26,13 @@ public class RavenDB_23792 : RavenTestBase
                     .VectorSearch(x => x.WithField(i=>i.Vector), 
                         x=>x.ForDocument("items/1-A")).ToString();
 
-                Assert.Equal("from 'Items' where vector.search(Vector, embedding.for($p0))", q1);
+                Assert.Equal("from 'Items' where vector.search(Vector, embedding.forDoc($p0))", q1);
                 
                 var q2 = session.Advanced.DocumentQuery<Item>()
                     .VectorSearch(x => x.WithText(i=>i.Name),
                         x =>x.ForDocument("items/1-A"))
                     .ToString();
-                Assert.Equal("from 'Items' where vector.search(embedding.text(Name), embedding.for($p0))", q2);
+                Assert.Equal("from 'Items' where vector.search(embedding.text(Name), embedding.forDoc($p0))", q2);
             }
         }
     }


### PR DESCRIPTION
- Allow to query vector searching using a document id

from 'Items' where vector.search(Vector, embedding.forDoc($p0))

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23792 


### Type of change

- [x] New feature

### How risky is the change?

- [x] Low 

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] No UI work is needed
