### PR TITLE
RavenDB-22767 More debugging info (in-memory only)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -87,6 +87,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.DecompressedBufferSize)] = new Size(lowLevelTransaction.DecompressedBufferBytes, SizeUnit.Bytes).ToString(),
                 [nameof(TxInfoResult.TotalEncryptionBufferSize)] = lowLevelTransaction.TotalEncryptionBufferInBytes.ToString(),
                 [nameof(TxInfoResult.IsDisposed)] = lowLevelTransaction.IsDisposed,
+                [nameof(TxInfoResult.DebugInfo)] = lowLevelTransaction.DebugInfo,
             };
         }
     }
@@ -108,5 +109,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public string DecompressedBufferSize;
         public string TotalEncryptionBufferSize;
         public bool IsDisposed;
+        public string DebugInfo;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -67,8 +67,14 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                 await ExecuteInternalAsync(context);
             }
 
+            if (ReadTransaction != null)
+                    ReadTransaction.DebugInfo_Add($"Request completed. Context disposed: {context.Disposed}, in pool: {context.InPoolSince:O}, in use: {context.InUse.IsRaised()}");
+
             if (context is DocumentsOperationContext documentsOperationContext)
             {
+                if (ReadTransaction != null)
+                    ReadTransaction.DebugInfo_Add($"Context's transaction {documentsOperationContext.Transaction}");
+
                 if (documentsOperationContext.Transaction != null)
                 {
                     if (Logger.IsOperationsEnabled)
@@ -76,9 +82,11 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                 }
             }
             
-            if (ReadTransaction != null && ReadTransaction.IsDisposed == false)
+            if (ReadTransaction != null)
             {
-                if (Logger.IsOperationsEnabled)
+                ReadTransaction.DebugInfo_Add("After closing the context");
+
+                if (Logger.IsOperationsEnabled && ReadTransaction.IsDisposed == false)
                     Logger.Operations("Not disposed LowLevel read transaction - Document");
             }
         }
@@ -86,6 +94,10 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         {
             if (Logger.IsOperationsEnabled)
                 Logger.Operations("Failed to handle GET request - Document", e);
+
+            if (ReadTransaction != null)
+                ReadTransaction.DebugInfo_Add($"Exception: {e}");
+
             throw;
         }
     }
@@ -227,8 +239,10 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag)
                                 .ConfigureAwait(false);
 
-        ReadTransaction = result.ReadTx?.InnerTransaction?.LowLevelTransaction;
-        
+        ReadTransaction = result.ReadTx;
+
+        ReadTransaction?.DebugInfo_Add($"Result status code: {result.StatusCode}");
+
         if (result.StatusCode == HttpStatusCode.NotFound)
         {
             if (etag == HttpCache.NotFoundResponse)
@@ -242,6 +256,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         if (etag == result.Etag)
         {
             HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+
+            ReadTransaction?.DebugInfo_Add($"Same etag. Result status code: {HttpStatusCode.NotModified})");
 
             return NoResults;
         }
@@ -512,7 +528,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
     protected sealed class DocumentsByIdResult<T>
     {
-        public DocumentsTransaction ReadTx { get; set; }
+        public LowLevelTransaction ReadTx { get; set; }
         public List<T> Documents { get; set; }
 
         public List<T> Includes { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Primitives;
 using Raven.Client;
@@ -77,6 +78,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         try
         {
             readTx = context.OpenReadTransaction();
+
+            readTx.InnerTransaction.LowLevelTransaction.DebugInfo_Add($"is cluster tx: {clusterWideTx}");
         }
         catch (Exception e)
         {
@@ -94,6 +97,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             {
                 document = RequestHandler.Database.DocumentsStorage.Get(context, id);
             }
+
+            readTx.InnerTransaction.LowLevelTransaction.DebugInfo_Add($"doc: {id} (found: {(document != null)})");
 
             if (document == null)
             {
@@ -158,6 +163,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             }
         }
 
+        readTx.InnerTransaction.LowLevelTransaction.DebugInfo_Add($"Return result");
+
         return new ValueTask<DocumentsByIdResult<Document>>(new DocumentsByIdResult<Document>
         {
             Etag = actualEtag,
@@ -167,7 +174,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             CounterIncludes = includeCounters,
             TimeSeriesIncludes = includeTimeSeries,
             CompareExchangeIncludes = includeCompareExchangeValues?.Results,
-            ReadTx = readTx,
+            ReadTx = readTx?.InnerTransaction?.LowLevelTransaction,
         });
     }
 

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Runtime.CompilerServices;
 using Raven.Server.Utils;
 using Sparrow.Collections;
@@ -157,12 +158,18 @@ namespace Raven.Server.ServerWide.Context
 
         public void CloseTransaction()
         {
+            if (Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo != null)
+                Transaction?.InnerTransaction.LowLevelTransaction.DebugInfo_Add($"Closing {Transaction.GetType().Name}");
+
             Transaction?.Dispose();
             Transaction = null;
         }
 
         public override void Dispose()
         {
+            if (Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo != null)
+                Transaction?.InnerTransaction.LowLevelTransaction.DebugInfo_Add($"Disposing {this.GetType().Name} context");
+
             base.Dispose();
 
             Allocator.Dispose();
@@ -193,6 +200,9 @@ namespace Raven.Server.ServerWide.Context
 
         protected internal override void Reset(bool forceResetLongLivedAllocator = false)
         {
+            if (Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo != null)
+                Transaction?.InnerTransaction.LowLevelTransaction.DebugInfo_Add($"Resetting {this.GetType().Name} context");
+
             CloseTransaction();
 
             base.Reset(forceResetLongLivedAllocator);

--- a/src/Raven.Server/ServerWide/RavenTransaction.cs
+++ b/src/Raven.Server/ServerWide/RavenTransaction.cs
@@ -44,8 +44,18 @@ namespace Raven.Server.ServerWide
 
             var committed = InnerTransaction.LowLevelTransaction.Committed;
 
+            var llt = InnerTransaction?.LowLevelTransaction;
+            if (llt?.DebugInfo != null)
+                llt.DebugInfo_Add("Disposing LLT from RavenTransaction");
+
             InnerTransaction?.Dispose();
+
+            if (llt?.DebugInfo != null)
+                llt.DebugInfo_Add("Disposed LLT from RavenTransaction");
+
             InnerTransaction = null;
+
+            
 
             if (committed)
                 AfterCommit();

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -961,6 +961,15 @@ namespace Voron.Impl
         }
 
         public string CallerName { get; set; }
+        public string DebugInfo { get; set; }
+
+        public void DebugInfo_Add(string msg)
+        {
+            if (DebugInfo == null)
+                DebugInfo = msg;
+            else
+                DebugInfo += $" {msg}{System.Environment.NewLine}";
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767/Scratch-buffers-arent-released

### Additional description

More debugging logs

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
