### PR TITLE
RavenDB-23870 Index in pause state cannot be re-started

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -17,7 +17,7 @@ import useInterval from "hooks/useInterval";
 import messagePublisher from "common/messagePublisher";
 import IndexUtils from "components/utils/IndexUtils";
 import genUtils from "common/generalUtils";
-import { delay } from "components/utils/common";
+import { databaseLocationComparator, delay } from "components/utils/common";
 import { useServices } from "hooks/useServices";
 import { useEventsCollector } from "hooks/useEventsCollector";
 import { useChanges } from "hooks/useChanges";
@@ -286,8 +286,9 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
                     const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
 
                     for (const location of locations) {
-                        const indexStatus = index.nodesInfo.find((x) => _.isEqual(x.location, location))?.details
-                            ?.status;
+                        const indexStatus = index.nodesInfo.find((x) =>
+                            databaseLocationComparator(x.location, location)
+                        )?.details?.status;
 
                         if (indexStatus === "Disabled") {
                             continue;
@@ -334,8 +335,9 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
                     const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
 
                     for (const location of locations) {
-                        const indexStatus = index.nodesInfo.find((x) => _.isEqual(x.location, location))?.details
-                            ?.status;
+                        const indexStatus = index.nodesInfo.find((x) =>
+                            databaseLocationComparator(x.location, location)
+                        )?.details?.status;
 
                         if (indexStatus === "Paused" || indexStatus === "Disabled") {
                             continue;
@@ -382,7 +384,9 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
                     const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
 
                     for (const location of locations) {
-                        const details = index.nodesInfo.find((x) => _.isEqual(x.location, location))?.details;
+                        const details = index.nodesInfo.find((x) =>
+                            databaseLocationComparator(x.location, location)
+                        )?.details;
 
                         if (details?.status === "Paused" && details?.state !== "Error") {
                             startRequests.push(


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/projects/RavenDB/issues/RavenDB-23870/Index-in-pause-state-cannot-be-re-started

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
