### PR TITLE
RavenDB-23989 - replace 'react-dnd' with '@dnd-kit/core'

### DIFF
--- a/src/Raven.Studio/package-lock.json
+++ b/src/Raven.Studio/package-lock.json
@@ -8,6 +8,8 @@
             "name": "Raven.Studio",
             "version": "1.0.0",
             "dependencies": {
+                "@dnd-kit/core": "^6.3.1",
+                "@dnd-kit/sortable": "^10.0.0",
                 "@hookform/resolvers": "^3.9.0",
                 "@reduxjs/toolkit": "^2.2.6",
                 "@tanstack/react-table": "^8.19.3",
@@ -760,6 +762,59 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@dnd-kit/accessibility": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+            "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/core": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+            "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/accessibility": "^3.1.1",
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/sortable": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+            "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@dnd-kit/core": "^6.3.0",
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/utilities": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+            "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
             }
         },
         "node_modules/@emotion/babel-plugin": {

--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -108,6 +108,8 @@
         "zip-webpack-plugin": "^4.0.1"
     },
     "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@hookform/resolvers": "^3.9.0",
         "@reduxjs/toolkit": "^2.2.6",
         "@tanstack/react-table": "^8.19.3",

--- a/src/Raven.Studio/typescript/components/hooks/useSortableStyles.tsx
+++ b/src/Raven.Studio/typescript/components/hooks/useSortableStyles.tsx
@@ -1,0 +1,14 @@
+import { CSSProperties } from "react";
+import { CSS } from "@dnd-kit/utilities";
+import { useSortable } from "@dnd-kit/sortable";
+
+export function useSortableStyles({ transform, isDragging, transition }: ReturnType<typeof useSortable>) {
+    const style: CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        cursor: isDragging ? "grabbing" : "grab",
+        opacity: isDragging ? 0.5 : 1,
+        transition,
+    };
+
+    return style;
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeGroup.tsx
@@ -1,7 +1,5 @@
 ﻿import React, { useCallback } from "react";
 import Button from "react-bootstrap/Button";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 import {
     ReorderNodes,
     ReorderNodesControls,
@@ -116,14 +114,12 @@ export function NodeGroup(props: NodeGroupProps) {
             </RichPanelHeader>
 
             {sortableMode ? (
-                <DndProvider backend={HTML5Backend}>
-                    <ReorderNodes
-                        fixOrder={fixOrder}
-                        setFixOrder={setFixOrder}
-                        newOrder={newOrder}
-                        setNewOrder={setNewOrder}
-                    />
-                </DndProvider>
+                <ReorderNodes
+                    fixOrder={fixOrder}
+                    setFixOrder={setFixOrder}
+                    newOrder={newOrder}
+                    setNewOrder={setNewOrder}
+                />
             ) : (
                 <React.Fragment>
                     <DatabaseGroup>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
@@ -1,7 +1,6 @@
-﻿import React from "react";
+﻿import React, { CSSProperties } from "react";
 import Button from "react-bootstrap/Button";
 import useUniqueId from "components/hooks/useUniqueId";
-import { useDraggableItem } from "hooks/useDraggableItem";
 import { DatabaseSharedInfo, NodeInfo } from "components/models/databases";
 import appUrl from "common/appUrl";
 import {
@@ -21,6 +20,8 @@ import { useAppSelector } from "components/store";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import Dropdown from "react-bootstrap/Dropdown";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 interface OrchestratorInfoComponentProps {
     node: NodeInfo;
@@ -269,22 +270,35 @@ interface NodeInfoReorderComponentProps {
     setOrder: (order: React.SetStateAction<NodeInfo[]>) => void;
 }
 
-const tagExtractor = (node: NodeInfo) => node.tag;
-
 export function NodeInfoReorderComponent(props: NodeInfoReorderComponentProps) {
-    const { node, setOrder, findCardIndex } = props;
+    const { node } = props;
 
-    const { drag, drop, isDragging } = useDraggableItem("node", node, tagExtractor, findCardIndex, setOrder);
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: node.tag,
+    });
 
-    const opacity = isDragging ? 0.5 : 1;
+    const style: CSSProperties = {
+        cursor: isDragging ? "grabbing" : "grab",
+        opacity: isDragging ? 0.5 : 1,
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
 
     return (
-        <div ref={(node) => drag(drop(node)) as TODO} style={{ opacity }}>
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
             <DatabaseGroupItem className="item-reorder">
                 <DatabaseGroupNode>{node.tag}</DatabaseGroupNode>
-
                 <DatabaseGroupType node={node} />
             </DatabaseGroupItem>
         </div>
+    );
+}
+
+export function NodeInfoReorderPreview({ node }: { node: NodeInfo }) {
+    return (
+        <DatabaseGroupItem className="item-reorder">
+            <DatabaseGroupNode>{node.tag}</DatabaseGroupNode>
+            <DatabaseGroupType node={node} />
+        </DatabaseGroupItem>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
@@ -21,7 +21,7 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import Dropdown from "react-bootstrap/Dropdown";
 import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { useSortableStyles } from "hooks/useSortableStyles";
 
 interface OrchestratorInfoComponentProps {
     node: NodeInfo;
@@ -269,23 +269,16 @@ interface NodeInfoReorderComponentProps {
 }
 
 export function NodeInfoReorderComponent({ node }: NodeInfoReorderComponentProps) {
-    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    const sortable = useSortable({
         id: node.tag,
     });
+    const style = useSortableStyles(sortable);
 
-    const style: CSSProperties = {
-        cursor: isDragging ? "grabbing" : "grab",
-        opacity: isDragging ? 0.5 : 1,
-        transform: CSS.Transform.toString(transform),
-        transition,
-    };
+    const { attributes, listeners, setNodeRef } = sortable;
 
     return (
         <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-            <DatabaseGroupItem className="item-reorder">
-                <DatabaseGroupNode>{node.tag}</DatabaseGroupNode>
-                <DatabaseGroupType node={node} />
-            </DatabaseGroupItem>
+            <NodeInfoReorderPreview node={node} />
         </div>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
@@ -266,13 +266,9 @@ export function ShardInfoComponent(props: ShardInfoComponentProps) {
 
 interface NodeInfoReorderComponentProps {
     node: NodeInfo;
-    findCardIndex: (node: NodeInfo) => number;
-    setOrder: (order: React.SetStateAction<NodeInfo[]>) => void;
 }
 
-export function NodeInfoReorderComponent(props: NodeInfoReorderComponentProps) {
-    const { node } = props;
-
+export function NodeInfoReorderComponent({ node }: NodeInfoReorderComponentProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
         id: node.tag,
     });

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/OrchestratorsGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/OrchestratorsGroup.tsx
@@ -1,7 +1,5 @@
 ﻿import React, { useCallback } from "react";
 import Button from "react-bootstrap/Button";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 import {
     ReorderNodes,
     ReorderNodesControls,
@@ -113,14 +111,12 @@ export function OrchestratorsGroup() {
             </RichPanelHeader>
 
             {sortableMode ? (
-                <DndProvider backend={HTML5Backend}>
-                    <ReorderNodes
-                        fixOrder={fixOrder}
-                        setFixOrder={setFixOrder}
-                        newOrder={newOrder}
-                        setNewOrder={setNewOrder}
-                    />
-                </DndProvider>
+                <ReorderNodes
+                    fixOrder={fixOrder}
+                    setFixOrder={setFixOrder}
+                    newOrder={newOrder}
+                    setNewOrder={setNewOrder}
+                />
             ) : (
                 <React.Fragment>
                     <DatabaseGroup>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
@@ -75,16 +75,30 @@ interface ReorderNodesProps {
 export function ReorderNodes(props: ReorderNodesProps) {
     const { fixOrder, setFixOrder, newOrder, setNewOrder } = props;
 
-    const {
-        activeNode,
-        sensors,
-        handleDragStart,
-        handleDragEnd,
-        handleDragCancel,
-        leftRadioToggleItem,
-        rightRadioToggleItem,
-        radioToggleSelectedItem,
-    } = useReorderNodes({ fixOrder, newOrder, setNewOrder });
+    const { activeNode, sensors, handleDragStart, handleDragEnd, handleDragCancel } = useReorderNodes({
+        newOrder,
+        setNewOrder,
+    });
+
+    const leftRadioToggleItem: RadioToggleWithIconInputItem = {
+        label: (
+            <>
+                Shuffle nodes order
+                <br />
+                after failure recovery
+            </>
+        ),
+        value: "shuffle",
+        iconName: "shuffle",
+    };
+
+    const rightRadioToggleItem: RadioToggleWithIconInputItem = {
+        label: "Try to maintain nodes order",
+        value: "order",
+        iconName: "order",
+    };
+
+    const radioToggleSelectedItem = fixOrder ? rightRadioToggleItem.value : leftRadioToggleItem.value;
 
     const newOrderWithId = newOrder.map((node) => ({
         ...node,
@@ -127,20 +141,14 @@ export function ReorderNodes(props: ReorderNodesProps) {
 }
 
 interface UseReorderNodesProps {
-    fixOrder: boolean;
     newOrder: NodeInfo[];
     setNewOrder: (newOrder: React.SetStateAction<NodeInfo[]>) => void;
 }
 
-function useReorderNodes({ fixOrder, newOrder, setNewOrder }: UseReorderNodesProps) {
+function useReorderNodes({ newOrder, setNewOrder }: UseReorderNodesProps) {
     const [activeNode, setActiveNode] = useState<NodeInfo | null>(null);
 
-    const sensors = useSensors(
-        useSensor(PointerSensor),
-        useSensor(KeyboardSensor, {
-            coordinateGetter: sortableKeyboardCoordinates,
-        })
-    );
+    const sensors = useSensors(useSensor(PointerSensor));
 
     const handleDragStart: DndContextProps["onDragStart"] = (event) => {
         const { active } = event;
@@ -165,34 +173,11 @@ function useReorderNodes({ fixOrder, newOrder, setNewOrder }: UseReorderNodesPro
         setActiveNode(null);
     };
 
-    const leftRadioToggleItem: RadioToggleWithIconInputItem = {
-        label: (
-            <>
-                Shuffle nodes order
-                <br />
-                after failure recovery
-            </>
-        ),
-        value: "shuffle",
-        iconName: "shuffle",
-    };
-
-    const rightRadioToggleItem: RadioToggleWithIconInputItem = {
-        label: "Try to maintain nodes order",
-        value: "order",
-        iconName: "order",
-    };
-
-    const radioToggleSelectedItem = fixOrder ? rightRadioToggleItem.value : leftRadioToggleItem.value;
-
     return {
         activeNode,
         sensors,
         handleDragStart,
         handleDragEnd,
         handleDragCancel,
-        leftRadioToggleItem,
-        rightRadioToggleItem,
-        radioToggleSelectedItem,
     };
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
@@ -1,12 +1,30 @@
 ﻿import React, { useCallback, useState } from "react";
 import Button from "react-bootstrap/Button";
-import { NodeInfoReorderComponent } from "components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent";
-import { useDrop } from "react-dnd";
+import {
+    NodeInfoReorderComponent,
+    NodeInfoReorderPreview,
+} from "components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent";
 import { NodeInfo } from "components/models/databases";
 import { DatabaseGroup, DatabaseGroupList } from "components/common/DatabaseGroup";
 import { Icon } from "components/common/Icon";
 import { RadioToggleWithIcon, RadioToggleWithIconInputItem } from "components/common/toggles/RadioToggle";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import {
+    closestCenter,
+    DndContext,
+    DndContextProps,
+    DragOverlay,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    horizontalListSortingStrategy,
+    SortableContext,
+    sortableKeyboardCoordinates,
+    arrayMove,
+} from "@dnd-kit/sortable";
 
 interface ReorderNodesControlsProps {
     sortableMode: boolean;
@@ -57,9 +75,102 @@ interface ReorderNodesProps {
 export function ReorderNodes(props: ReorderNodesProps) {
     const { fixOrder, setFixOrder, newOrder, setNewOrder } = props;
 
-    const [, drop] = useDrop(() => ({ accept: "node" }));
+    const {
+        activeNode,
+        sensors,
+        handleDragStart,
+        handleDragEnd,
+        handleDragCancel,
+        leftRadioToggleItem,
+        rightRadioToggleItem,
+        radioToggleSelectedItem,
+    } = useReorderNodes({ fixOrder, newOrder, setNewOrder });
 
     const findCardIndex = useCallback((node: NodeInfo) => newOrder.findIndex((x) => x.tag === node.tag), [newOrder]);
+
+    const newOrderWithId = newOrder.map((node) => ({
+        ...node,
+        id: node.tag,
+    }));
+
+    return (
+        <div>
+            <div className="px-3 pt-3">
+                <RadioToggleWithIcon
+                    name="after-recovery"
+                    leftItem={leftRadioToggleItem}
+                    rightItem={rightRadioToggleItem}
+                    selectedValue={radioToggleSelectedItem}
+                    setSelectedValue={(x) => setFixOrder(x !== leftRadioToggleItem.value)}
+                />
+            </div>
+            <DatabaseGroup>
+                <DatabaseGroupList>
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragStart={handleDragStart}
+                        onDragEnd={handleDragEnd}
+                        onDragCancel={handleDragCancel}
+                    >
+                        <SortableContext strategy={horizontalListSortingStrategy} items={newOrderWithId}>
+                            {newOrder.map((node) => (
+                                <NodeInfoReorderComponent
+                                    key={node.tag}
+                                    node={node}
+                                    setOrder={setNewOrder}
+                                    findCardIndex={findCardIndex}
+                                />
+                            ))}
+                        </SortableContext>
+                        <DragOverlay adjustScale>
+                            {activeNode ? <NodeInfoReorderPreview node={activeNode} /> : null}
+                        </DragOverlay>
+                    </DndContext>
+                </DatabaseGroupList>
+            </DatabaseGroup>
+        </div>
+    );
+}
+
+interface UseReorderNodesProps {
+    fixOrder: boolean;
+    newOrder: NodeInfo[];
+    setNewOrder: (newOrder: React.SetStateAction<NodeInfo[]>) => void;
+}
+
+function useReorderNodes({ fixOrder, newOrder, setNewOrder }: UseReorderNodesProps) {
+    const [activeNode, setActiveNode] = useState<NodeInfo | null>(null);
+
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        })
+    );
+
+    const handleDragStart: DndContextProps["onDragStart"] = (event) => {
+        const { active } = event;
+        const activeNode = newOrder.find((node) => node.tag === active.id);
+        setActiveNode(activeNode || null);
+    };
+
+    const handleDragEnd: DndContextProps["onDragEnd"] = (event) => {
+        const { active, over } = event;
+
+        if (active.id !== over.id) {
+            const oldIndex = newOrder.findIndex((node) => node.tag === active.id);
+            const newIndex = newOrder.findIndex((node) => node.tag === over.id);
+
+            setNewOrder((items) => arrayMove(items, oldIndex, newIndex));
+        }
+
+        setActiveNode(null);
+    };
+
+    const handleDragCancel = () => {
+        setActiveNode(null);
+    };
 
     const leftRadioToggleItem: RadioToggleWithIconInputItem = {
         label: (
@@ -81,29 +192,14 @@ export function ReorderNodes(props: ReorderNodesProps) {
 
     const radioToggleSelectedItem = fixOrder ? rightRadioToggleItem.value : leftRadioToggleItem.value;
 
-    return (
-        <div ref={drop as TODO}>
-            <div className="px-3 pt-3">
-                <RadioToggleWithIcon
-                    name="after-recovery"
-                    leftItem={leftRadioToggleItem}
-                    rightItem={rightRadioToggleItem}
-                    selectedValue={radioToggleSelectedItem}
-                    setSelectedValue={(x) => setFixOrder(x !== leftRadioToggleItem.value)}
-                />
-            </div>
-            <DatabaseGroup>
-                <DatabaseGroupList>
-                    {newOrder.map((node) => (
-                        <NodeInfoReorderComponent
-                            key={node.tag}
-                            node={node}
-                            setOrder={setNewOrder}
-                            findCardIndex={findCardIndex}
-                        />
-                    ))}
-                </DatabaseGroupList>
-            </DatabaseGroup>
-        </div>
-    );
+    return {
+        activeNode,
+        sensors,
+        handleDragStart,
+        handleDragEnd,
+        handleDragCancel,
+        leftRadioToggleItem,
+        rightRadioToggleItem,
+        radioToggleSelectedItem,
+    };
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ReorderNodes.tsx
@@ -86,8 +86,6 @@ export function ReorderNodes(props: ReorderNodesProps) {
         radioToggleSelectedItem,
     } = useReorderNodes({ fixOrder, newOrder, setNewOrder });
 
-    const findCardIndex = useCallback((node: NodeInfo) => newOrder.findIndex((x) => x.tag === node.tag), [newOrder]);
-
     const newOrderWithId = newOrder.map((node) => ({
         ...node,
         id: node.tag,
@@ -115,12 +113,7 @@ export function ReorderNodes(props: ReorderNodesProps) {
                     >
                         <SortableContext strategy={horizontalListSortingStrategy} items={newOrderWithId}>
                             {newOrder.map((node) => (
-                                <NodeInfoReorderComponent
-                                    key={node.tag}
-                                    node={node}
-                                    setOrder={setNewOrder}
-                                    findCardIndex={findCardIndex}
-                                />
+                                <NodeInfoReorderComponent key={node.tag} node={node} />
                             ))}
                         </SortableContext>
                         <DragOverlay adjustScale>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ShardsGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/ShardsGroup.tsx
@@ -1,7 +1,5 @@
 ﻿import React, { useCallback } from "react";
 import Button from "react-bootstrap/Button";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 import {
     ReorderNodes,
     ReorderNodesControls,
@@ -120,14 +118,12 @@ export function ShardsGroup(props: ShardsGroupProps) {
             </RichPanelHeader>
 
             {sortableMode ? (
-                <DndProvider backend={HTML5Backend}>
-                    <ReorderNodes
-                        fixOrder={fixOrder}
-                        setFixOrder={setFixOrder}
-                        newOrder={newOrder}
-                        setNewOrder={setNewOrder}
-                    />
-                </DndProvider>
+                <ReorderNodes
+                    fixOrder={fixOrder}
+                    setFixOrder={setFixOrder}
+                    newOrder={newOrder}
+                    setNewOrder={setNewOrder}
+                />
             ) : (
                 <React.Fragment>
                     <DatabaseGroup>


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23989

### Additional description

First pull request targets `v6.2`.
The next pull request will target `v7.0`, after merging `v6.2` with `v7.0` and applying the necessary fixes.
Once those fixes have been successfully merged into `v7.0`, I’ll open a pull request to remove the `react-dnd` package from `v6.2`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
