### PR TITLE
RavenDB-23855 - Slow restore of a backup with revisions (v6.2)

### DIFF
--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -201,6 +201,8 @@ namespace Voron.Data.Tables
                         {
                             if (TryMoveNextCyclic(it, startPage) == false)
                                 break;
+
+                            continue;
                         }
 
                         for (int i = 0; i < BitmapSize*8; i++)
@@ -213,9 +215,6 @@ namespace Voron.Data.Tables
                                 
                             return _llt.ModifyPage(currentSectionStart + i);
                         }
-
-                        if (TryMoveNextCyclic(it, startPage) == false)
-                            break;
                     }
                 }
                 page = AllocateMoreSpace(fst);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23855/Slow-restore-of-a-backup-with-revisions

### Additional description

When importing revisions, we have a lot of calls to `AllocateSinglePage`.
It turned out that even when the buffer we pull from the `AllocationStorage` fixed-size tree, which represent chunk of the bitmap (of the free/occupied pages) is all set (full of 1s - has no 0), the code still search for unset bit.
**Improvement (dottrace):**
![image](https://github.com/user-attachments/assets/c8451e92-ff47-45ca-b0cb-6c1ea1501b90)


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
