### PR TITLE
RavenDB-14251 Log while waiting for retention to ensure compression thread is awake

### DIFF
--- a/test/SlowTests/SparrowTests/LoggingSourceTests.cs
+++ b/test/SlowTests/SparrowTests/LoggingSourceTests.cs
@@ -354,6 +354,8 @@ namespace SlowTests.SparrowTests
             var logDirectory = new DirectoryInfo(path);
             var isRetentionPolicyApplied = WaitForValue(() =>
             {
+                logger.Operations($"somelog");
+
                 logDirectory.Refresh();
                 afterEndFiles = logDirectory.GetFiles();
                 AssertNoFileMissing(afterEndFiles.Select(f => f.Name).ToArray());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14251

### Additional description
I believe the issue here is that the compression thread only wakes up when new logs are written.

If the compression thread, which also applies retention, retrieves the state of the files on disk before all the logs in the test are written, but finishes after they are all written, it won’t be triggered to wake up again.

To avoid this situation in the test, I added logging during the wait for retention.

If this is indeed what’s happening, it’s not a production scenario but rather a test-specific issue.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Fix test

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
