### PR TITLE
RavenDB-24107 - (v7.0) Importing indexes in indexes causes infinite loop

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/migration/import/ImportIndexes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/migration/import/ImportIndexes.tsx
@@ -15,7 +15,7 @@ import ImportIndexesList from "components/pages/database/indexes/list/migration/
 import { useAppSelector } from "components/store";
 import { tryHandleSubmit } from "components/utils/common";
 import IndexUtils from "components/utils/IndexUtils";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAsync } from "react-async-hook";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import InputGroup from "react-bootstrap/InputGroup";
@@ -58,10 +58,9 @@ export function ImportIndexes(props: ImportIndexesProps) {
     });
     const { importMode, selectedDatabaseName, selectedIndexNames } = useWatch({ control });
 
-    const [disabledReason, setDisabledReason] = useState<string>();
-
+    const disabledReason = hasDatabaseAdminAccess ? null : "Creating a C# index requires database administrator access";
     const [indexDefinitions, setIndexDefinitions] = useState<IndexDefinition[]>([]);
-    const filteredIndexes = (() => {
+    const filteredIndexes = useMemo(() => {
         const sortedIndexes = [...indexDefinitions].sort((a, b) => a.Name.localeCompare(b.Name));
 
         const isAnyAutoIndex = sortedIndexes.some((x) => IndexUtils.isAutoIndex(x));
@@ -73,7 +72,6 @@ export function ImportIndexes(props: ImportIndexesProps) {
         if (!hasDatabaseAdminAccess) {
             availableIndexes = staticIndexes.filter((x) => !IndexUtils.isCsharpIndex(x));
             unavailableIndexes = staticIndexes.filter((x) => IndexUtils.isCsharpIndex(x));
-            setDisabledReason("Creating a C# index requires database administrator access");
         }
 
         setValue(
@@ -86,7 +84,7 @@ export function ImportIndexes(props: ImportIndexesProps) {
             unavailableIndexes,
             isAnyAutoIndex,
         };
-    })();
+    }, [setValue, indexDefinitions]);
 
     const clearIndexes = useCallback(() => {
         setIndexDefinitions([]);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24107

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
