### PR TITLE
RavenDB-23544 Archived flag should Not be removed when modifying an archived document

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Extensions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -176,6 +177,19 @@ namespace Raven.Server.Documents
                     var oldFlags = TableValueToFlags((int)DocumentsTable.Flags, ref oldValue);
 
                     newFlags = _documentsStorage.GetFlagsFromOldDocumentForPut(newFlags, oldFlags, nonPersistentFlags);
+                    
+                    // if doc was Archived and isn't currently unarchived, leave the Archived flag
+                    if (oldFlags.Contain(DocumentFlags.Archived))
+                    {
+                        if (document.TryGetMetadata(out BlittableJsonReaderObject newDocMetadata))
+                        {
+                            newDocMetadata.TryGet(Constants.Documents.Metadata.Archived, out bool isStillArchived);
+                            if (isStillArchived)
+                            {
+                                newFlags |= DocumentFlags.Archived;
+                            }
+                        }
+                    }
                 }
 
                 var result = _documentsStorage.BuildChangeVectorAndResolveConflicts(context, lowerId, newEtag, document, changeVector, expectedChangeVector, newFlags, oldChangeVector);

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
@@ -14,6 +14,7 @@ using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.DataArchival;
+using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
@@ -167,6 +168,93 @@ namespace SlowTests.Server.Documents.DataArchival
                     WaitForUserToContinueTheTest(store);
                     var companies = await session.Query<Company>().Where(x => x.Name == "Company Name").ToListAsync();
                     Assert.Equal(0, companies.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ArchiveFlagShouldNotBeRemoved()
+        {
+            using (var store = GetDocumentStore())
+            {
+                // Enable revisions
+                // ================
+                var usersConfig = new RevisionsCollectionConfiguration()
+                {
+                    MinimumRevisionsToKeep = int.MaxValue,
+                    Disabled = false
+                };
+                
+                var revisionsConfig = new RevisionsConfiguration()
+                {
+                    Default = new RevisionsCollectionConfiguration {Disabled = false},
+                    Collections = new Dictionary<string, RevisionsCollectionConfiguration>()
+                    {
+                        { "Users", usersConfig }
+                    }
+                };
+                
+                var configureRevisionsOp = new ConfigureRevisionsOperation(revisionsConfig);
+                store.Maintenance.Send(configureRevisionsOp);
+                
+                // Create document 
+                // ===============
+                var user = new User {Name = "aaa"};
+                var archiveAt = SystemTime.UtcNow.AddSeconds(30);
+                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(user);
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    metadata[Constants.Documents.Metadata.ArchiveAt] = archiveAt.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                    session.SaveChanges();
+                }
+                
+                // Activate the archival
+                await SetupDataArchival(store);
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                var documentsArchiver = database.DataArchivist;
+                await documentsArchiver.ArchiveDocs();
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                
+                // Verify that @flags contains the "Archived" flag
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<User>(user.Id);
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    
+                    var flagsValue = archivedUserMetadata["@flags"];
+                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                }
+                
+                // Modify the document AFTER it was archived
+                // =========================================
+                using (var session = store.OpenSession())
+                {
+                    user = session.Load<User>(user.Id);
+                    user.Name += " some text";
+                    session.SaveChanges();
+                }
+                
+                using (var session = store.OpenSession())
+                {
+                    // Check revisions:
+                    var revisions = session.Advanced.Revisions.GetFor<User>(user.Id);
+                    Assert.Equal(2, revisions.Count);
+                    
+                    // Check the content of @flags in the metadata:
+                    var archivedUser = session.Load<User>(user.Id);
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    
+                    var flagsValue = archivedUserMetadata["@flags"];
+                    Assert.True(flagsValue.ToString().Contains("HasRevisions"));
+                    
+                    Assert.True(flagsValue.ToString().Contains("Archived"));
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
@@ -172,7 +172,7 @@ namespace SlowTests.Server.Documents.DataArchival
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ExpirationRefresh | RavenTestCategory.Revisions)]
         public async Task ArchiveFlagShouldNotBeRemoved()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23544/Archived-flag-should-Not-be-removed-when-modifying-an-archived-document

### Additional description

The archived flag was dropped because `PutDocument` method is invoked without necessary flags at the beginning. Added a conditional check if there was an Archived flag before (only if the previous version of the doc exists - `(oldValue.Pointer != null)`), and if it's not "unarchive" patch operation (the `@archived` metadata flag is dropped then), we persist the `Archived` flag.

Added test from @Danielle9897  

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
