### PR TITLE
RavenDB-24082 InsertVectorsToGraph should only process additions

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -236,6 +236,7 @@ public unsafe partial class Hnsw
         private readonly PriorityQueue<int, float> _nearestEdgesQ = new();
         private readonly Dictionary<long, int> _nodeIdToIdx = new();
         private NativeList<Node> _nodes = default;
+        private NativeList<int> _newNodes = default;
         private readonly Tree _tree;
         private readonly Lookup<Int64LookupKey> _nodeIdToLocations;
         public readonly LowLevelTransaction Llt;
@@ -243,11 +244,10 @@ public unsafe partial class Hnsw
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
         
-        
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
 
-        public int CreatedNodesCount;
+        public Span<int> CreatedNodes => _newNodes.ToSpan();
 
         public Options Options;
 
@@ -339,8 +339,9 @@ public unsafe partial class Hnsw
         
         public int RegisterVectorNode(long newNodeId, long vectorId)
         {
-            CreatedNodesCount++;
             int nodeIndex = AllocateNodeIndex(newNodeId);
+            
+            _newNodes.Add(Llt.Allocator, nodeIndex);
             _nodes[nodeIndex].VectorId = vectorId;
 
             _nodeIdToIdx[newNodeId] = nodeIndex;
@@ -1104,13 +1105,14 @@ public unsafe partial class Hnsw
             _searchState.RegisterNodeLocation(node.NodeId, locationId);
             encoded.CopyTo(storage);
         }
-
-
+        
         void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer)
         {
+            var createdNodesIndexes = _searchState.CreatedNodes;
+            
             if (_searchState.TryGetLocationForNode(EntryPointId, out var entryPointNode) is false)
             {
-                if (_searchState.CreatedNodesCount == 0)
+                if (createdNodesIndexes.IsEmpty)
                     return;
 
                 ref Node startingNode = ref _searchState.Nodes[0];
@@ -1126,11 +1128,12 @@ public unsafe partial class Hnsw
 
             nearestNodesByLevel.EnsureCapacityFor(_searchState.Llt.Allocator, _searchState.Options.MaxLevel + 1);
 
-            for (int currentNodeIndex = 0; currentNodeIndex < _searchState.CreatedNodesCount; currentNodeIndex++)
+            for (int createdNodeIndex = 0; createdNodeIndex < createdNodesIndexes.Length; createdNodeIndex++)
             {
                 nearestNodesByLevel.Clear();
-
-                var currentMaxLevel = _searchState.Options.CurrentMaxLevel(_searchState.CreatedNodesCount - currentNodeIndex);
+                
+                var currentNodeIndex = createdNodesIndexes[createdNodeIndex];
+                var currentMaxLevel = _searchState.Options.CurrentMaxLevel(createdNodesIndexes.Length - createdNodeIndex);
                 int nodeRandomLevel = GetLevelForNewNode(currentMaxLevel);
                 Span<byte> vector;
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24082/SlowTests.Issues.RavenDB23962.ReferencedCollectionsShouldWorkWithStalenessHandling

Additionally it fixes
https://issues.hibernatingrhinos.com/issue/RavenDB-24081/SlowTests.Server.Documents.AI.Embeddings.QueryingTests.WillFindUpdatedEmbeddingValuesoptions-DatabaseMode-Single

### Additional description

InsertVectorsToGraph should only process additions when doing its work

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
