### PR TITLE
RavenDB-24104 - Deep paging is using high unmanaged memory

### DIFF
--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -553,7 +553,7 @@ namespace Voron.Data.Fixed
                     if (MoveNext(count) == false)
                         return false;
                 }
-                else
+                else if (count < 0)
                 {
                     if (MovePrev(-count) == false)
                         return false;

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -365,26 +365,24 @@ namespace Voron.Data.Fixed
                 if (_currentPage == null || _currentPage.IsLeaf == false)
                     throw new InvalidOperationException("No current page was set or is wasn't a leaf!");
 
-                var currentPageInfo = new CurrentPageInfo(_currentPage.PageHeader)
-                {
-                    LastSearchPosition = _currentPage.LastSearchPosition
-                };
+                var currentPageHeader = _currentPage.PageHeader;
+                var lastSearchPosition = _currentPage.LastSearchPosition;
 
                 while (skip >= 0)
                 {
-                    var skipInPage = (int)Math.Min(currentPageInfo.LastSearchPosition, skip);
+                    var skipInPage = (int)Math.Min(lastSearchPosition, skip);
                     skip -= skipInPage;
-                    currentPageInfo.LastSearchPosition -= skipInPage;
+                    lastSearchPosition -= skipInPage;
                     if (skip == 0)
                     {
                         // We've completed skipping the requested number of entries. Now we need to:
                         // 1. Set the _currentPage to the appropriate page based on the current page info
                         // 2. Update its LastSearchPosition to point to the correct entry
 
-                        if (_currentPage.PageNumber != currentPageInfo.PageNumber)
-                            _currentPage = _parent.GetReadOnlyPage(currentPageInfo.PageNumber);
+                        if (_currentPage.PageNumber != currentPageHeader.PageNumber)
+                            _currentPage = _parent.GetReadOnlyPage(currentPageHeader.PageNumber);
 
-                        _currentPage.LastSearchPosition = currentPageInfo.LastSearchPosition;
+                        _currentPage.LastSearchPosition = lastSearchPosition;
 
                         return true;
                     }
@@ -416,12 +414,8 @@ namespace Voron.Data.Fixed
                             continue;
                         }
 
-                        var pageInfo = new CurrentPageInfo(childPageHeader)
-                        {
-                            LastSearchPosition = childPageHeader.NumberOfEntries
-                        };
-
-                        currentPageInfo = pageInfo;
+                        currentPageHeader = childPageHeader;
+                        lastSearchPosition = childPageHeader.NumberOfEntries;
                         break;
                     }
                 }
@@ -437,16 +431,14 @@ namespace Voron.Data.Fixed
                 if (_currentPage == null || _currentPage.IsLeaf == false)
                     throw new InvalidOperationException("No current page was set or is wasn't a leaf!");
 
-                var currentPageInfo = new CurrentPageInfo(_currentPage.PageHeader)
-                {
-                    LastSearchPosition = _currentPage.LastSearchPosition
-                };
+                var currentPageHeader = _currentPage.PageHeader;
+                var lastSearchPosition = _currentPage.LastSearchPosition;
 
                 while (skip >= 0)
                 {
-                    var skipInPage = (int)Math.Min(currentPageInfo.NumberOfEntries - currentPageInfo.LastSearchPosition, skip);
+                    var skipInPage = (int)Math.Min(currentPageHeader.NumberOfEntries - lastSearchPosition, skip);
                     skip -= skipInPage;
-                    currentPageInfo.LastSearchPosition += skipInPage;
+                    lastSearchPosition += skipInPage;
 
                     if (skip == 0)
                     {
@@ -455,10 +447,10 @@ namespace Voron.Data.Fixed
                         // 2. Update its LastSearchPosition to point to the correct entry
                         // 3. Check if we've reached the end of the current page, and if so, move to the next page
 
-                        if (_currentPage.PageNumber != currentPageInfo.PageNumber)
-                            _currentPage = _parent.GetReadOnlyPage(currentPageInfo.PageNumber);
+                        if (_currentPage.PageNumber != currentPageHeader.PageNumber)
+                            _currentPage = _parent.GetReadOnlyPage(currentPageHeader.PageNumber);
 
-                        _currentPage.LastSearchPosition = currentPageInfo.LastSearchPosition;
+                        _currentPage.LastSearchPosition = lastSearchPosition;
 
                         if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
                             return MoveNext();
@@ -491,12 +483,8 @@ namespace Voron.Data.Fixed
                             continue;
                         }
 
-                        var pageInfo = new CurrentPageInfo(childPageHeader)
-                        {
-                            LastSearchPosition = 0
-                        };
-
-                        currentPageInfo = pageInfo;
+                        currentPageHeader = childPageHeader;
+                        lastSearchPosition = 0;
                         break;
                     }
                 }
@@ -563,20 +551,6 @@ namespace Voron.Data.Fixed
                 if (seek == false)
                     _currentPage = null;
                 return seek;
-            }
-
-            private class CurrentPageInfo
-            {
-                private readonly FixedSizeTreePageHeader _header;
-                public int LastSearchPosition;
-
-                public CurrentPageInfo(FixedSizeTreePageHeader header)
-                {
-                    _header = header;
-                }
-
-                public ushort NumberOfEntries => _header.NumberOfEntries;
-                public long PageNumber => _header.PageNumber;
             }
         }
     }

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -365,13 +365,27 @@ namespace Voron.Data.Fixed
                 if (_currentPage == null || _currentPage.IsLeaf == false)
                     throw new InvalidOperationException("No current page was set or is wasn't a leaf!");
 
+                var currentPageInfo = new CurrentPageInfo(_currentPage.PageHeader)
+                {
+                    LastSearchPosition = _currentPage.LastSearchPosition
+                };
+
                 while (skip >= 0)
                 {
-                    var skipInPage = (int)Math.Min(_currentPage.LastSearchPosition, skip);
+                    var skipInPage = (int)Math.Min(currentPageInfo.LastSearchPosition, skip);
                     skip -= skipInPage;
-                    _currentPage.LastSearchPosition -= skipInPage;
+                    currentPageInfo.LastSearchPosition -= skipInPage;
                     if (skip == 0)
                     {
+                        // We've completed skipping the requested number of entries. Now we need to:
+                        // 1. Set the _currentPage to the appropriate page based on the current page info
+                        // 2. Update its LastSearchPosition to point to the correct entry
+
+                        if (_currentPage.PageNumber != currentPageInfo.PageNumber)
+                            _currentPage = _parent.GetReadOnlyPage(currentPageInfo.PageNumber);
+
+                        _currentPage.LastSearchPosition = currentPageInfo.LastSearchPosition;
+
                         return true;
                     }
                     
@@ -389,18 +403,25 @@ namespace Voron.Data.Fixed
                         }
                         
                         var nextChildPageNumber = parent.GetEntry(parent.LastSearchPosition)->PageNumber;
-                        var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
-                        
-                        // we move one beyond the end of elements because in both cases
-                        // (branch and leaf) we first decrement and then run it
-                        childPage.LastSearchPosition = childPage.NumberOfEntries;
-                        if (childPage.IsBranch)
+                        var childPageHeader = _parent.GetPageHeader(nextChildPageNumber);
+                        if ((childPageHeader.TreeFlags & FixedSizeTreePageFlags.Branch) == FixedSizeTreePageFlags.Branch)
                         {
+                            var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
+
+                            // we move one beyond the end of elements because in both cases
+                            // (branch and leaf) we first decrement and then run it
+                            childPage.LastSearchPosition = childPage.NumberOfEntries;
+
                             _parent._cursor.Push(childPage);
                             continue;
                         }
 
-                        _currentPage = childPage;
+                        var pageInfo = new CurrentPageInfo(childPageHeader)
+                        {
+                            LastSearchPosition = childPageHeader.NumberOfEntries
+                        };
+
+                        currentPageInfo = pageInfo;
                         break;
                     }
                 }

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -7,7 +7,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Sparrow;
 using Sparrow.Server;
+using Sparrow.Utils;
 
 namespace Voron.Data.Fixed
 {
@@ -414,13 +416,29 @@ namespace Voron.Data.Fixed
                 if (_currentPage == null || _currentPage.IsLeaf == false)
                     throw new InvalidOperationException("No current page was set or is wasn't a leaf!");
 
+                var currentPageInfo = new CurrentPageInfo(_currentPage.PageHeader)
+                {
+                    LastSearchPosition = _currentPage.LastSearchPosition
+                };
+
                 while (skip >= 0)
                 {
-                    var skipInPage = (int)Math.Min(_currentPage.NumberOfEntries - _currentPage.LastSearchPosition, skip);
+                    var skipInPage = (int)Math.Min(currentPageInfo.NumberOfEntries - currentPageInfo.LastSearchPosition, skip);
                     skip -= skipInPage;
-                    _currentPage.LastSearchPosition += skipInPage;
+                    currentPageInfo.LastSearchPosition += skipInPage;
+
                     if (skip == 0)
                     {
+                        // We've completed skipping the requested number of entries. Now we need to:
+                        // 1. Set the _currentPage to the appropriate page based on the current page info
+                        // 2. Update its LastSearchPosition to point to the correct entry
+                        // 3. Check if we've reached the end of the current page, and if so, move to the next page
+
+                        if (_currentPage.PageNumber != currentPageInfo.PageNumber)
+                            _currentPage = _parent.GetReadOnlyPage(currentPageInfo.PageNumber);
+
+                        _currentPage.LastSearchPosition = currentPageInfo.LastSearchPosition;
+
                         if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
                             return MoveNext();
                         return true;
@@ -440,22 +458,24 @@ namespace Voron.Data.Fixed
                         }
                         
                         var nextChildPageNumber = parent.GetEntry(parent.LastSearchPosition)->PageNumber;
-                        var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
-
-                        if (childPage.IsBranch)
+                        var childPageHeader = _parent.GetPageHeader(nextChildPageNumber);
+                        if ((childPageHeader.TreeFlags & FixedSizeTreePageFlags.Branch) == FixedSizeTreePageFlags.Branch)
                         {
+                            var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
+
                             // we set it to negative one so the first
                             // call will increment that to zero
                             childPage.LastSearchPosition = -1;
                             _parent._cursor.Push(childPage);
                             continue;
                         }
-                        else
+
+                        var pageInfo = new CurrentPageInfo(childPageHeader)
                         {
-                            childPage.LastSearchPosition = 0;
-                        }
-                        
-                        _currentPage = childPage;
+                            LastSearchPosition = 0
+                        };
+
+                        currentPageInfo = pageInfo;
                         break;
                     }
                 }
@@ -463,7 +483,6 @@ namespace Voron.Data.Fixed
 
                 return false;
             }
-
 
             public bool MovePrev()
             {
@@ -523,6 +542,20 @@ namespace Voron.Data.Fixed
                 if (seek == false)
                     _currentPage = null;
                 return seek;
+            }
+
+            private class CurrentPageInfo
+            {
+                private readonly FixedSizeTreePageHeader _header;
+                public int LastSearchPosition;
+
+                public CurrentPageInfo(FixedSizeTreePageHeader header)
+                {
+                    _header = header;
+                }
+
+                public ushort NumberOfEntries => _header.NumberOfEntries;
+                public long PageNumber => _header.PageNumber;
             }
         }
     }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -408,7 +408,7 @@ namespace Voron.Data.Fixed
 
         internal FixedSizeTreePageHeader GetPageHeader(long pageNumber)
         {
-            return _tx.GetPageHeaderForDebug<FixedSizeTreePageHeader>(pageNumber);
+            return _tx.GetPageHeader<FixedSizeTreePageHeader>(pageNumber);
         }
 
         private FixedSizeTreePage<TVal> FindPageFor(TVal key)

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -406,6 +406,11 @@ namespace Voron.Data.Fixed
             return new FixedSizeTreePage<TVal>(readOnlyPage.Pointer, _entrySize, Constants.Storage.PageSize);
         }
 
+        internal FixedSizeTreePageHeader GetPageHeader(long pageNumber)
+        {
+            return _tx.GetPageHeaderForDebug<FixedSizeTreePageHeader>(pageNumber);
+        }
+
         private FixedSizeTreePage<TVal> FindPageFor(TVal key)
         {
             var header = (FixedSizeTreeHeader.Large*)_parent.DirectRead(_treeName);

--- a/src/Voron/Data/Fixed/FixedSizeTreePage.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreePage.cs
@@ -34,6 +34,12 @@ namespace Voron.Data.Fixed
             get { return (FixedSizeTreePageHeader*)_ptr; }
         }
 
+        public FixedSizeTreePageHeader PageHeader
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return *(FixedSizeTreePageHeader*)_ptr; }
+        }
+
         public long PageNumber
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -189,7 +189,7 @@ namespace Voron.Debugging
 
             foreach (PersistentDictionaryRootHeader dic in input.PersistentDictionaries)
             {
-                // cannot use GetPageHeaderForDebug since the header is at the data pointer
+                // cannot use GetPageHeader since the header is at the data pointer
                 Page page = _tx.GetPage(dic.PageNumber);
                 var header = (PersistentDictionaryHeader*)page.DataPointer;
 
@@ -513,7 +513,7 @@ namespace Voron.Debugging
                 var it = Container.GetAllPagesIterator(_tx, page);
                 while (it.MoveNext(out var pageNum))
                 {
-                    // cannot use GetPageHeaderForDebug since we are reading not just from the header
+                    // cannot use GetPageHeader since we are reading not just from the header
                     Page cur = _tx.GetPage(pageNum);
                     if (cur.IsOverflow)
                     {
@@ -530,7 +530,7 @@ namespace Voron.Debugging
             
             var (allPages, freePages) = Container.GetPagesFor(_tx, page);
             
-            // cannot use GetPageHeaderForDebug since we are reading not just from the header
+            // cannot use GetPageHeader since we are reading not just from the header
             var root = new Container(_tx.GetPage(page));
             double density = pageDensities?.Average() ?? -1;
             long totalPages = allPages.State.NumberOfEntries + root.Header.NumberOfOverflowPages + freePages.State.PageCount + allPages.State.PageCount;
@@ -785,7 +785,7 @@ namespace Voron.Debugging
             for (var i = 0; i < allPages.Count; i++)
             {
                 // we don't need the entire page contents in order to calculate the page density, just the header
-                var pageHeaderUnion = tree.Llt.GetPageHeaderForDebug<PageHeaderUnion>(allPages[i]);
+                var pageHeaderUnion = tree.Llt.GetPageHeader<PageHeaderUnion>(allPages[i]);
 
                 if ((pageHeaderUnion.PageHeader.Flags & PageFlags.Overflow) == PageFlags.Overflow)
                 {
@@ -825,7 +825,7 @@ namespace Voron.Debugging
 
             foreach (var p in allPages)
             {
-                // cannot use GetPageHeaderForDebug since we are reading not just from the header
+                // cannot use GetPageHeader since we are reading not just from the header
                 var page = postingList.Llt.GetPage(p);
                 var state = new PostingListCursorState { Page = page };
                 if (state.IsLeaf)
@@ -849,7 +849,7 @@ namespace Voron.Debugging
             var densities = new List<double>();
             foreach (var p in allPages)
             {
-                var lookupPageHeader = llt.GetPageHeaderForDebug<LookupPageHeader>(p);
+                var lookupPageHeader = llt.GetPageHeader<LookupPageHeader>(p);
                 densities.Add((double)lookupPageHeader.FreeSpace / Constants.Storage.PageSize);
             }
             return densities;
@@ -865,7 +865,7 @@ namespace Voron.Debugging
 
             foreach (var pageNumber in allPages)
             {
-                var fstph = tree.Llt.GetPageHeaderForDebug<FixedSizeTreePageHeader>(pageNumber);
+                var fstph = tree.Llt.GetPageHeader<FixedSizeTreePageHeader>(pageNumber);
                 var isLeaf = (fstph.TreeFlags & FixedSizeTreePageFlags.Leaf) == FixedSizeTreePageFlags.Leaf;
                 var sizeUsed = Constants.FixedSizeTree.PageHeaderSize +
                                fstph.NumberOfEntries * (isLeaf ? fstph.ValueSize + sizeof(long) : FixedSizeTree.BranchEntrySize);

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -498,7 +498,7 @@ namespace Voron.Impl.Journal
             return null;
         }
 
-        public T? ReadPageHeaderForDebug<T>(LowLevelTransaction tx, long pageNumber, Dictionary<int, PagerState> scratchPagerStates) where T : unmanaged
+        public T? ReadPageHeader<T>(LowLevelTransaction tx, long pageNumber, Dictionary<int, PagerState> scratchPagerStates) where T : unmanaged
         {
             // read transactions have to read from journal snapshots
             if (tx.Flags == TransactionFlags.Read)
@@ -508,7 +508,7 @@ namespace Voron.Impl.Journal
                 {
                     if (tx.JournalSnapshots[i].PageTranslationTable.TryGetValue(tx, pageNumber, out PagePosition value))
                     {
-                        var page = _env.ScratchBufferPool.ReadPageHeaderForDebug<T>(tx, value.ScratchNumber, value.ScratchPage, scratchPagerStates[value.ScratchNumber]);
+                        var page = _env.ScratchBufferPool.ReadPageHeader<T>(tx, value.ScratchNumber, value.ScratchPage, scratchPagerStates[value.ScratchNumber]);
                         return page;
                     }
                 }
@@ -524,7 +524,7 @@ namespace Voron.Impl.Journal
                 if (files[i].PageTranslationTable.TryGetValue(tx, pageNumber, out value))
                 {
                     // ReSharper disable once RedundantArgumentDefaultValue
-                    var page = _env.ScratchBufferPool.ReadPageHeaderForDebug<T>(tx, value.ScratchNumber, value.ScratchPage, pagerState: null);
+                    var page = _env.ScratchBufferPool.ReadPageHeader<T>(tx, value.ScratchNumber, value.ScratchPage, pagerState: null);
                     return page;
                 }
             }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -673,7 +673,7 @@ namespace Voron.Impl
             return p;
         }
 
-        public T GetPageHeaderForDebug<T>(long pageNumber) where T : unmanaged
+        public T GetPageHeader<T>(long pageNumber) where T : unmanaged
         {
             if (_txState != TxState.None)
                 ThrowObjectDisposed();
@@ -700,18 +700,18 @@ namespace Voron.Impl
                     }
                 }
 
-                result = _env.ScratchBufferPool.ReadPageHeaderForDebug<T>(this, value.ScratchFileNumber, value.PositionInScratchBuffer, state);
+                result = _env.ScratchBufferPool.ReadPageHeader<T>(this, value.ScratchFileNumber, value.PositionInScratchBuffer, state);
             }
             else
             {
-                var pageFromJournal = _journal.ReadPageHeaderForDebug<T>(this, pageNumber, _scratchPagerStates);
+                var pageFromJournal = _journal.ReadPageHeader<T>(this, pageNumber, _scratchPagerStates);
                 if (pageFromJournal != null)
                 {
                     result = pageFromJournal.Value;
                 }
                 else
                 {
-                    result = DataPager.AcquirePagePointerHeaderForDebug<T>(this, pageNumber);
+                    result = DataPager.AcquirePagePointerHeader<T>(this, pageNumber);
                 }
             }
 

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -352,7 +352,7 @@ namespace Voron.Impl.Paging
             return AcquirePagePointerInternal(tx, pageNumber, pagerState);
         }
         
-        public virtual T AcquirePagePointerHeaderForDebug<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null) where T : unmanaged
+        public virtual T AcquirePagePointerHeader<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null) where T : unmanaged
         {
             var pointer = AcquirePagePointer(tx, pageNumber, pagerState);
             return *(T*)pointer;

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -242,13 +242,13 @@ namespace Voron.Impl.Paging
             return buffer.Pointer;
         }
 
-        public override T AcquirePagePointerHeaderForDebug<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
+        public override T AcquirePagePointerHeader<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
         {
             var state = GetTransactionState(tx);
             if (state.TryGetValue(pageNumber, out var buffer))
                 return *(T*)buffer.Pointer;
 
-            return Inner.AcquirePagePointerHeaderForDebug<T>(tx, pageNumber, pagerState);
+            return Inner.AcquirePagePointerHeader<T>(tx, pageNumber, pagerState);
         }
 
         public override void TryReleasePage(IPagerLevelTransactionState tx, long page)

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -299,9 +299,9 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T ReadPageHeaderForDebug<T>(LowLevelTransaction tx, long p, PagerState pagerState = null) where T : unmanaged
+        public T ReadPageHeader<T>(LowLevelTransaction tx, long p, PagerState pagerState = null) where T : unmanaged
         {
-            return _scratchPager.AcquirePagePointerHeaderForDebug<T>(tx, p, pagerState);
+            return _scratchPager.AcquirePagePointerHeader<T>(tx, p, pagerState);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -383,12 +383,12 @@ namespace Voron.Impl.Scratch
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T ReadPageHeaderForDebug<T>(LowLevelTransaction tx, int scratchNumber, long p, PagerState pagerState = null) where T : unmanaged
+        public T ReadPageHeader<T>(LowLevelTransaction tx, int scratchNumber, long p, PagerState pagerState = null) where T : unmanaged
         {
             var item = GetScratchBufferFile(scratchNumber);
 
             ScratchBufferFile bufferFile = item.File;
-            return bufferFile.ReadPageHeaderForDebug<T>(tx, p, pagerState);
+            return bufferFile.ReadPageHeader<T>(tx, p, pagerState);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24104/Deep-paging-is-using-high-unmanaged-memory

### Additional description

Modified `MoveNext(count)` and `MovePrev(count)` to use page headers instead of loading full pages when skipping through records. For encrypted databases, this avoids unnecessary decryption of leaf page content when only the header information is needed for navigation, significantly reducing CPU overhead and allocations. The optimization dramatically improves performance, as shown in the benchmarks:
Before: `236,685` decrypted pages, `1.806 GB` Native Memory, `3,353 ms` duration.
After: `465` decrypted pages, `4.18 MB` Native Memory, `48 ms` duration.
This represents a `99.8%` reduction in decrypted pages, `99.8%` reduction in memory usage, and `70x` improvement in execution speed.

![image](https://github.com/user-attachments/assets/e063f1cc-7daa-4d9e-854d-1548c792a9d5)

Also added an explicit check for `count == 0` in the `Skip()` method to avoid unnecessary calls to `MovePrev(count)` when the count is zero.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
