### PR TITLE
RavenDB-22767 More debugging info (in-memory only) - part 2. Removing ConfigureAwait, using AsTask() on ValueTasks

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -64,7 +64,10 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             TOperationContext context;
             using (ContextPool.AllocateOperationContext(out context))
             {
-                await ExecuteInternalAsync(context);
+                await ExecuteInternalAsync(context).AsTask();
+                
+                if (ReadTransaction != null)
+                    ReadTransaction.DebugInfo_Add($"Request completed. About to dispose / reset the context");
             }
 
             if (ReadTransaction != null)
@@ -135,7 +138,9 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             var revisions = GetRevisionsToInclude(parameters);
             var timeSeries = GetTimeSeriesToInclude(parameters);
 
-            responseWriteStats = await GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag);
+            responseWriteStats = await GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag).AsTask();
+            
+            ReadTransaction?.DebugInfo_Add($"Response write stats: count - {responseWriteStats.NumberOfResults}, size - {responseWriteStats.TotalDocumentsSizeInBytes} bytes");
         }
         else
         {
@@ -167,6 +172,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         {
             if (RequestHandler.ShouldAddPagingPerformanceHint(responseWriteStats.NumberOfResults))
             {
+                ReadTransaction?.DebugInfo_Add($"Adding performance hint");
+                
                 string details;
 
                 if (parameters.Ids is { Count: > 0 })
@@ -237,8 +244,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
     {
         var clusterWideTx = parameters.TxMode == TransactionMode.ClusterWide;
         var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag)
-                                .ConfigureAwait(false);
-
+                        .AsTask();
         ReadTransaction = result.ReadTx;
 
         ReadTransaction?.DebugInfo_Add($"Result status code: {result.StatusCode}");
@@ -264,8 +270,13 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
         HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + result.Etag + "\"";
 
-        return await WriteDocumentsByIdResultAsync(context, parameters.MetadataOnly, clusterWideTx, result)
-                        .ConfigureAwait(false);
+        ReadTransaction?.DebugInfo_Add("About to write results");
+        
+        var writeResult = await WriteDocumentsByIdResultAsync(context, parameters.MetadataOnly, clusterWideTx, result).AsTask();
+        
+        ReadTransaction?.DebugInfo_Add("Results written");
+
+        return writeResult;
     }
 
     private async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsByIdResultAsync(


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/[RavenDB-22767](https://issues.hibernatingrhinos.com/issue/RavenDB-22767)

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/20503. More debug logging.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
