### PR TITLE
RavenDB-23972 Use `InlineDataWithRandomSeed` instead of `Random.Shared` to retrieve the seed when the test fails.

### DIFF
--- a/test/FastTests/Sparrow/Memory.cs
+++ b/test/FastTests/Sparrow/Memory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using FastTests.Voron.FixedSize;
 using Sparrow;
 using Sparrow.Server;
 using Xunit;
@@ -208,11 +209,9 @@ namespace FastTests.Sparrow
 
             Assert.Equal(reference, Math.Sign(Memory.CompareSmallInlineNet7(ref first[0], ref second[0], length)));
         }
-
-        public static IEnumerable<object[]> RandomSeeds => new[] { new object[] { Random.Shared.Next() } };
-
+        
         [Theory]
-        [MemberData(nameof(RandomSeeds))]
+        [InlineDataWithRandomSeed]
         public void LoopDifferencesWithRandomData(int seed)
         {
             var s1 = new byte[1024];

--- a/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
+++ b/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
@@ -1,30 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using FastTests.Voron;
+using SlowTests.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Voron.CompactTrees
 {
-    public class FuzzyUpsertsTests : StorageTest
+    public class FuzzyUpsertsTests(ITestOutputHelper output) : StorageTest(output)
     {
-
-        public FuzzyUpsertsTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        public static IEnumerable<object[]> Configuration =>
-            new List<object[]>
-            {
-                new object[] { 500000, Random.Shared.Next(), 4096 },
-                new object[] { 100000, Random.Shared.Next(), 1024 },
-                new object[] { 10000, Random.Shared.Next(), 64 },
-            };
-
         [RavenTheory(RavenTestCategory.Voron)]
-        [MemberData("Configuration")]
-        public void RandomUpsertsWithoutRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
+        [InlineDataWithRandomSeed(500000, 4096)]
+        [InlineDataWithRandomSeed(100000, 1024)]
+        [InlineDataWithRandomSeed(10000, 64)]
+        public void RandomUpsertsWithoutRemoves(int treeSize, int transactionSize, int randomSeed)
         {
             var currentState = new Dictionary<long, long>();
             var keys = new List<long>();
@@ -88,8 +78,10 @@ namespace SlowTests.Voron.CompactTrees
 
 
         [RavenTheory(RavenTestCategory.Voron)]
-        [MemberData("Configuration")]
-        public void RandomUpsertsWithRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
+        [InlineDataWithRandomSeed(500000, 4096)]
+        [InlineDataWithRandomSeed(100000, 1024)]
+        [InlineDataWithRandomSeed(10000, 64)]
+        public void RandomUpsertsWithRemoves(int treeSize, int transactionSize, int randomSeed)
         {
             var currentState = new Dictionary<long, long>();
             var currentKeys = new List<long>();

--- a/test/StressTests/Client/MultiGet.cs
+++ b/test/StressTests/Client/MultiGet.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
+using FastTests.Voron.FixedSize;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,9 +16,11 @@ namespace StressTests.Client
         {
         }
 
-        [Fact]
-        public async Task MultiGetCanGetFromCache()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [InlineDataWithRandomSeed]
+        public async Task MultiGetCanGetFromCache(int seed)
         {
+            var random = new Random(seed);
             var store = GetDocumentStore();
 
             using (var bulk = store.BulkInsert())
@@ -33,8 +37,8 @@ namespace StressTests.Client
                 {
                     using (var session = store.OpenAsyncSession())
                     {
-                        var n1 = Random.Shared.Next(0, 10_000);
-                        var n2 = Random.Shared.Next(0, 10_000);
+                        var n1 = random.Next(0, 10_000);
+                        var n2 = random.Next(0, 10_000);
                         session.Advanced.Lazily.LoadAsync<User>($"Users/{n1}");
                         session.Advanced.Lazily.LoadAsync<User>($"Users/{n2}");
                         await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();

--- a/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
+++ b/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
@@ -1,26 +1,14 @@
 using System;
 using System.Collections.Generic;
+using SlowTests.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace StressTests.Corax.Bugs;
 
-public class PostingListTestsExtended : NoDisposalNoOutputNeeded
+public class PostingListTestsExtended(ITestOutputHelper output) : NoDisposalNoOutputNeeded(output)
 {
-    public PostingListTestsExtended(ITestOutputHelper output) : base(output)
-    {
-    }
-
-    public static IEnumerable<object[]> Configuration =>
-        new List<object[]>
-        {
-            new object[] {Random.Shared.Next(), Random.Shared.Next(20000000)},
-            new object[] {Random.Shared.Next(), Random.Shared.Next(2000000)},
-            new object[] {Random.Shared.Next(), Random.Shared.Next(200000)},
-            new object[] {Random.Shared.Next(), Random.Shared.Next(20000)},
-        };
-
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Voron)]
     [InlineData(1337, 200000)]
     [InlineData(1064156071, 796)]
@@ -30,10 +18,19 @@ public class PostingListTestsExtended : NoDisposalNoOutputNeeded
     public void CanDeleteAndInsertInRandomOrder(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
 
     [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Voron, RavenArchitecture.X64)]
-    [InlineData(1477187726, 1828658)]
-    [MemberData("Configuration")]
-    public void CanDeleteAndInsertInRandomOrderX64Only(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
-    
+    [InlineData(1477187726, true, 1828658)]
+    [InlineDataWithRandomSeed(20000000, false)]
+    [InlineDataWithRandomSeed(2000000, false)]
+    [InlineDataWithRandomSeed(200000, false)]
+    [InlineDataWithRandomSeed(20000, false)]
+    public void CanDeleteAndInsertInRandomOrderX64Only(int maxSize, bool maxSizeFinal, int seed)
+    {
+        var random = new Random(seed);
+        maxSize = maxSizeFinal ? maxSize : random.Next(maxSize);
+        
+        CanDeleteAndInsertInRandomOrderBase(seed, maxSize);
+    }
+
     [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Voron, RavenPlatform.Windows, RavenArchitecture.X64)]
     [InlineData(391060845, 31707323)]
     public void CanDeleteAndInsertInRandomOrderWindows(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23972
### Additional description

Using `InlineDataWithRandomSeed` give us ability to retrieve the seed used in fuzzy test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
