### PR TITLE
RavenDB-23487 Add export to stream overload for smuggler

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -103,6 +103,14 @@ namespace Raven.Client.Documents.Smuggler
             }, tcs.Task, token);
         }
 
+        public Task<Operation> ExportAsync(DatabaseSmugglerExportOptions options, Stream toStream, CancellationToken token = default)
+        {
+            return ExportAsync(options, async stream =>
+            {
+                await stream.CopyToAsync(toStream, 8192, token).ConfigureAwait(false);
+            }, token);
+        }
+
         private async Task<Operation> ExportAsync(DatabaseSmugglerExportOptions options, Func<Stream, Task> handleStreamResponse, Task additionalTask, CancellationToken token = default)
         {
             if (options == null)

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -105,10 +105,24 @@ namespace Raven.Client.Documents.Smuggler
 
         public Task<Operation> ExportAsync(DatabaseSmugglerExportOptions options, Stream toStream, CancellationToken token = default)
         {
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             return ExportAsync(options, async stream =>
             {
-                await stream.CopyToAsync(toStream, 8192, token).ConfigureAwait(false);
-            }, token);
+                try
+                {
+                    await stream.CopyToAsync(toStream, 8192, token).ConfigureAwait(false);
+                    tcs.TrySetResult(null);
+                }
+                catch (Exception e)
+                {
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Could not export to provided stream.", e);
+
+                    tcs.TrySetException(e);
+                    throw new InvalidOperationException("Could not export to provided stream.", e);
+                }
+            }, tcs.Task, token);
         }
 
         private async Task<Operation> ExportAsync(DatabaseSmugglerExportOptions options, Func<Stream, Task> handleStreamResponse, Task additionalTask, CancellationToken token = default)

--- a/test/SlowTests/Issues/RavenDB_23487.cs
+++ b/test/SlowTests/Issues/RavenDB_23487.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Smuggler;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23487 : RavenTestBase
+    {
+        public RavenDB_23487(ITestOutputHelper output) : base(output)
+        {
+        }
+        private class User
+        {
+            public string Name { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        public async Task ExportToStream_CanBeImportedIntoAnotherDatabase()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User { Name = "Bob" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var ms = new MemoryStream())
+                {
+                    var exportOp = await src.Smuggler.ExportAsync(
+                        new DatabaseSmugglerExportOptions(), ms);
+                    await exportOp.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                    ms.Position = 0;
+
+                    var importOp = await dest.Smuggler.ImportAsync(
+                        new DatabaseSmugglerImportOptions(), ms);
+                    await importOp.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                }
+
+                using (var session = dest.OpenSession())
+                {
+                    var imported = session.Load<User>("users/1");
+                    Assert.NotNull(imported);
+                    Assert.Equal("Bob", imported.Name);
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23487/Add-export-to-stream-overload-for-smuggler

### Additional description

Exposes a public ExportAsync(options, Stream toStream, …) overload

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
