### PR TITLE
RavenDB-23784 IncrementToken immediately in AnalyzerAdapter to avoid previously analyzed terms.

### DIFF
--- a/src/Corax/Querying/IndexSearcher.Search.cs
+++ b/src/Corax/Querying/IndexSearcher.Search.cs
@@ -378,7 +378,7 @@ public partial class IndexSearcher
         foreach (var word in values)
         {
             terms.Clear();
-            //When a word contains asterisks, it's not our responsibility to persist it; the analyzer should not remove them either.
+            var termType = GetTermType(word);
             EncodeAndApplyAnalyzerForMultipleTerms(field, word, ref terms);
             var tokensInWord = terms.Count;
             
@@ -386,13 +386,18 @@ public partial class IndexSearcher
                 continue;
 
             //single word
-            if (tokensInWord is 1)
+            if (tokensInWord is 1 || termType is Constants.Search.SearchMatchOptions.StartsWith)
             {
                 var value = terms[0];
-                var termType = GetTermType(value);
-                
+                var valueAsSpan = value.AsSpan();
+
+                //Adjustment to Lucene builder.
+                if (termType is not Constants.Search.SearchMatchOptions.StartsWith)
+                    termType = GetTermType(valueAsSpan);
+                    
                 (int startIncrement, int lengthIncrement) = termType switch
                 {
+                    Constants.Search.SearchMatchOptions.StartsWith when valueAsSpan[^1] != '*' => (0, 0),
                     Constants.Search.SearchMatchOptions.StartsWith => (0, -1),
                     Constants.Search.SearchMatchOptions.EndsWith => (1, 0),
                     Constants.Search.SearchMatchOptions.Contains => (1, -1),
@@ -404,8 +409,7 @@ public partial class IndexSearcher
                 //Rewrite term without asterisks.
                 if (termType is not (Constants.Search.SearchMatchOptions.Exists or Constants.Search.SearchMatchOptions.TermMatch))
                 {
-                    var span = value.AsSpan();
-                    Slice.From(Allocator, span.Slice(startIncrement, span.Length - startIncrement + lengthIncrement), ByteStringType.Immutable, out value);
+                    Slice.From(Allocator, valueAsSpan.Slice(startIncrement, valueAsSpan.Length - startIncrement + lengthIncrement), ByteStringType.Immutable, out value);
                 }
                 
                 if (termType is Constants.Search.SearchMatchOptions.TermMatch)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapterForQuerying.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapterForQuerying.cs
@@ -47,13 +47,16 @@ internal sealed unsafe class LuceneAnalyzerAdapterForQuerying : LuceneAnalyzerAd
             var currentTokenIdx = 0;
 
             var stream = analyzer.ReusableTokenStream(null, reader);
+            stream.Reset();
             if (ReferenceEquals(stream, Stream) == false)
             {
                 Stream = stream;
                 Offset = offset = stream.GetAttribute<IOffsetAttribute>();
                 Term = term = stream.GetAttribute<ITermAttribute>();
             }
-            do
+            
+            bool continueWork = stream.IncrementToken();
+            while (continueWork)
             {
                 int start = offset.StartOffset;
                 int length = offset.EndOffset - start;
@@ -71,7 +74,8 @@ internal sealed unsafe class LuceneAnalyzerAdapterForQuerying : LuceneAnalyzerAd
                 // Advance the current token output.
                 currentOutputIdx += outputLength;
                 currentTokenIdx++;
-            } while (stream.IncrementToken());
+                continueWork = stream.IncrementToken();
+            }
 
             output = output[..currentOutputIdx];
             tokens = tokens[..currentTokenIdx];

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapterForWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapterForWriter.cs
@@ -39,18 +39,22 @@ internal sealed unsafe class LuceneAnalyzerAdapterForWriter : LuceneAnalyzerAdap
             int currentOutputIdx = 0;
             var currentTokenIdx = 0;
             var stream = analyzer.ReusableTokenStream(null, reader);
+            stream.Reset();
             if (ReferenceEquals(stream, self._stream) == false)
             {
                 self._stream = stream;
                 self._offset = offset = stream.GetAttribute<IOffsetAttribute>();
                 self._term = term = stream.GetAttribute<ITermAttribute>();
             }
-            do
+
+            bool continueWork = stream.IncrementToken();
+            while (continueWork)
             {
                 int start = offset.StartOffset;
                 int length = offset.EndOffset - start;
                 if (length == 0)
                     continue; // We skip any empty token. 
+                
 
                 ReadOnlySpan<char> termChars = term.TermBuffer();
                 int outputLength = Encoding.UTF8.GetBytes(termChars[..term.TermLength()], output[currentOutputIdx..]);
@@ -63,7 +67,9 @@ internal sealed unsafe class LuceneAnalyzerAdapterForWriter : LuceneAnalyzerAdap
                 // Advance the current token output.
                 currentOutputIdx += outputLength;
                 currentTokenIdx++;
-            } while (stream.IncrementToken());
+                
+                continueWork = stream.IncrementToken();
+            }
 
             output = output[..currentOutputIdx];
             tokens = tokens[..currentTokenIdx];

--- a/test/SlowTests/Corax/RavenDB-23649.cs
+++ b/test/SlowTests/Corax/RavenDB-23649.cs
@@ -10,6 +10,37 @@ namespace SlowTests.Corax;
 public class RavenDB_23649(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TermIsNotLeakedToAnotherIndexEntryWhenUsingACustomAnalyzerViaLuceneAdapter(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            foreach (var dto in new List<Dto> { new() { Surname = "O'Cfirst" }, new() { Surname = "O'Second" }})
+                session.Store(dto);
+            
+            session.SaveChanges();
+        }
+
+        var index = new Index();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.RawQuery<Dto>(
+                    """
+                    from index 'Index'
+                              where exact(Surname == "O'Cfirst")
+                    """)
+                .ToList();
+            WaitForUserToContinueTheTest(store);
+            Assert.Equal(1, results.Count);
+            Assert.Equal("O'Cfirst", results[0].Surname);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void CanDynamicallyCreateExactAnalyzerForSearchWildcardQuery(Options options)
     {
@@ -32,12 +63,34 @@ public class RavenDB_23649(ITestOutputHelper output) : RavenTestBase(output)
             var results = session.Advanced.RawQuery<Dto>(
                     """
                     from index 'Index'
+                              where boost(search(Surname, $term), 10)
+                              order by score()
+                    """)
+                .AddParameter("term", "O'C*")
+                .ToList();
+            Assert.Equal(1, results.Count);
+            Assert.Equal("O'Cfirst", results[0].Surname);
+            
+            results = session.Advanced.RawQuery<Dto>(
+                    """
+                    from index 'Index'
+                              where search(SurnameAnalyzed, $term)
+                              order by score()
+                    """)
+                .AddParameter("term", "O'C*")
+                .ToList();
+            Assert.Equal(2, results.Count);
+            Assert.Equal("O'Cfirst", results[0].Surname);
+            Assert.Equal("O'Second", results[1].Surname);
+            
+            results = session.Advanced.RawQuery<Dto>(
+                    """
+                    from index 'Index'
                               where boost(search(Surname, $term), 10) or search(SurnameAnalyzed, $term)
                               order by score()
                     """)
                 .AddParameter("term", "O'C*")
                 .ToList();
-            
             Assert.Equal(2, results.Count);
             Assert.Equal("O'Cfirst", results[0].Surname);
             Assert.Equal("O'Second", results[1].Surname);

--- a/test/SlowTests/Issues/RavenDB-23784.cs
+++ b/test/SlowTests/Issues/RavenDB-23784.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using System.Linq;
+using Corax.Pipeline;
+using Raven.Server.Documents.Indexes.Persistence.Lucene;
+using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers.Collation.Cultures;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23784(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AnalyzerThatDoesNotOverrideTheTokenStreamWillReturnCorrectTerms(bool forWriter)
+    {
+        LuceneAnalyzerAdapter analyzer = forWriter 
+            ? LuceneAnalyzerAdapterForWriter.Create(new DeCollationAnalyzer())
+            : LuceneAnalyzerAdapterForQuerying.Create(new DeCollationAnalyzer());
+        Span<byte> dst = new byte[1024];
+        Span<Token> tks = new Token[1024];
+
+        for (int i = 0; i < 8; ++i)
+        {
+            var dstCpy = dst;
+            var tksCpy = tks;
+            analyzer.Execute("Ö"u8, ref dstCpy, ref tksCpy);
+            Assert.True(1 == tksCpy.Length, $"Expected 1 token, got: {tksCpy.Length} at iteration no. {i}.");
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void CanGenerateProperTermsViaAnalyzerThatDoesNotOverrideTokenStream(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new TestIndex());
+        
+        using (var session = store.OpenSession())
+        {
+            session.Store(new TestDocument { Name = "Z" });
+            session.Store(new TestDocument { Name = "Ö" });
+            session.Store(new TestDocument { Name = "Z" });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+            
+        using (var session = store.OpenSession())
+        {
+            var querySorted = session.Query<TestDocument, TestIndex>()
+                .OrderBy(x => x.Name)
+                .ProjectInto<TestIndex.Result>()
+                .ToList();
+            
+            var queryUnsorted = session.Query<TestDocument, TestIndex>()
+                .ProjectInto<TestIndex.Result>()
+                .ToList();
+                
+            Assert.Equal(queryUnsorted.Count, querySorted.Count);
+            Assert.StartsWith("Ö", querySorted[0].Name);
+        }
+    }
+
+    private class TestDocument
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class TestIndex : AbstractIndexCreationTask<TestDocument, TestIndex.Result>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+        }
+
+        public TestIndex()
+        {
+            Map = collection => from entity in collection
+                select new
+                {
+                    Name = entity.Name
+                };
+            
+            Analyze(x => x.Name, 
+                "Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers.Collation.Cultures.DeCollationAnalyzer, Raven.Server");
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_22937.cs
+++ b/test/SlowTests/Issues/RavenDB_22937.cs
@@ -237,10 +237,11 @@ public class RavenDB_22937 : RavenTestBase
         Assert.Contains($"Name:maciej)", explanations.GetExplanations(results[0].Id)[0]);
     }
     
-    [RavenFact(RavenTestCategory.Querying)]
-    public void CustomStandardAnalyzerSearchWillNotRestoreAsterisksCorax()
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CustomStandardAnalyzerSearchWillNotRestoreAsterisksCorax(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition()
         {
             Name = nameof(StandardAnalyzerWrapperAnalyzer), 
@@ -254,11 +255,13 @@ public class RavenDB_22937 : RavenTestBase
         session.Store(new Dto("Maciej"));
         session.Store(new Dto("RavenDB"));
         session.SaveChanges();
+
         //startsWith:
         var result = session.Query<Dto, FullTextSearchWithoutRemovingAsteriskIndex>()
             .Search(x => x.Name, "mac*")
             .FirstOrDefault();
-        Assert.Null(result);
+        Assert.NotNull(result);
+        Assert.Equal("Maciej", result.Name);
 
         //endsWith
         result = session.Query<Dto, FullTextSearchWithoutRemovingAsteriskIndex>()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23784

### Additional description

Prevents leaking term(s) from previous TokenStream.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
