### PR TITLE
RavenDB-24131 fix `/databases/*/admin/debug/cluster/txinfo`

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 context.Write(writer, new DynamicJsonValue
                 {
-                    ["Results"] = new DynamicJsonArray(ClusterTransactionCommand.ReadCommandsBatch(context, Database.Name, from, take))
+                    ["Results"] = new DynamicJsonArray(ClusterTransactionCommand.ReadCommandsBatch(context, Database.Name, from, take:take))
                 });
             }
         }

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.ServerWide.Commands
         //We take the current ticks in advance to ensure consistent results of the command execution on all nodes
         public long CommandCreationTicks = long.MinValue;
 
-        public class ClusterTransactionDataCommand : IDisposable
+        public class ClusterTransactionDataCommand : IDynamicJson, IDisposable
         {
             public CommandType Type;
             public string Id;
@@ -66,13 +66,26 @@ namespace Raven.Server.ServerWide.Commands
 
             public DynamicJsonValue ToJson(JsonOperationContext context)
             {
+                var djv = ToJsonInternal();
+                djv[nameof(Document)] = Document?.Clone(context);
+                return djv;
+            }
+
+            public DynamicJsonValue ToJson()
+            {
+                var djv = ToJsonInternal();
+                djv[nameof(Document)] = Document;
+                return djv;
+            }
+            
+            private DynamicJsonValue ToJsonInternal()
+            {
                 var djv = new DynamicJsonValue
                 {
                     [nameof(Type)] = Type,
                     [nameof(Id)] = Id,
                     [nameof(Index)] = Index,
                     [nameof(ChangeVector)] = ChangeVector,
-                    [nameof(Document)] = Document?.Clone(context),
                     [nameof(Error)] = Error
                 };
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Server.Replication;
 using FastTests.Utils;
+using Newtonsoft.Json;
 using Nito.AsyncEx;
 using Raven.Client;
 using Raven.Client.Documents;
@@ -2155,6 +2156,28 @@ select incl(c)"
             {
                 Assert.Equal(count, await session.Query<TestObj>().CountAsync());
             }
+        }
+        
+        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        public async Task TestCase()
+        {
+            using var store = GetDocumentStore();
+            using (var session = store.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide}))
+            {
+                await session.StoreAsync(new TestObj());
+                await session.SaveChangesAsync();
+            }
+            
+            var httpClient = store.GetRequestExecutor().HttpClient;
+            var response = await httpClient.GetAsync($"{store.Urls[0]}/databases/{store.Database}/admin/debug/cluster/txinfo");
+            var textResult = await response.Content.ReadAsStringAsync();
+            var result = JsonConvert.DeserializeObject<RequestResult>(textResult);
+            Assert.Equal(1, result.Results.Count());
+        }
+    
+        private class RequestResult
+        {
+            public IEnumerable<object> Results { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24131

### Additional description
The Commands in SingleClusterDatabaseCommand were changed from blittable to ClusterTransactionDataCommand but ClusterTransactionDataCommand is not recognized by our serializer.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
