### PR TITLE
RavenDB-24101: Fixes for embedded startup hang and testing of `ThrowOnInvalidOrMissingLicense` for `RavenTestDriver`

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -275,7 +275,6 @@ namespace Raven.Embedded
             string? url = null;
             var startupDuration = Stopwatch.StartNew();
 
-            var errorLock = new object();
             var stderrBuilder = new StringBuilder();
             var errorTcs  = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -284,14 +283,14 @@ namespace Raven.Embedded
                 if (receivedEventArgs.Data == null)
                 {
                     string final;
-                    lock (errorLock)
+                    lock (stderrBuilder)
                         final = stderrBuilder.ToString();
 
                     errorTcs.TrySetResult(final);
                     return;
                 }
 
-                lock (errorLock)
+                lock (stderrBuilder)
                     stderrBuilder.AppendLine(receivedEventArgs.Data);
             };
             process.BeginErrorReadLine();
@@ -319,7 +318,7 @@ namespace Raven.Embedded
             }
             else
             {
-                lock (errorLock)
+                lock (stderrBuilder)
                     stderrString = stderrBuilder.ToString();
             }
 

--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -272,11 +272,11 @@ namespace Raven.Embedded
             if (domainBind == false)
                 throw new InvalidOperationException("Should not happen!");
 
-            string? url = null;
-            var startupDuration = Stopwatch.StartNew();
-
             var stderrBuilder = new StringBuilder();
-            var errorTcs  = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var stdoutBuilder = new StringBuilder();
+
+            var stderrTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var stdoutTcs = new TaskCompletionSource<(string Url, string Stdout)>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // DataReceived callbacks run on ThreadPool threads → can overlap.
             // Lock prevents AppendLine/ToString races.
@@ -288,50 +288,72 @@ namespace Raven.Embedded
                     lock (stderrBuilder)
                         final = stderrBuilder.ToString();
 
-                    errorTcs.TrySetResult(final);
+                    stderrTcs.TrySetResult(final);
                     return;
                 }
 
                 lock (stderrBuilder)
                     stderrBuilder.AppendLine(receivedEventArgs.Data);
             };
-            process.BeginErrorReadLine();
 
-            var stdoutTask = ProcessHelper.ReadOutputAsync(process.StandardOutput, startupDuration, _serverOptions, (line, _) =>
+            process.OutputDataReceived += (_, receivedEventArgs) =>
             {
+                if (receivedEventArgs.Data == null)
+                    return;
+
+                lock (stdoutBuilder)
+                    stdoutBuilder.AppendLine(receivedEventArgs.Data);
+
                 const string prefix = "Server available on: ";
-                if (line.StartsWith(prefix) == false)
-                    return Task.FromResult(false);
+                if (receivedEventArgs.Data.StartsWith(prefix) == false)
+                    return;
 
-                url = line.Substring(prefix.Length);
-                return Task.FromResult(true);
-            });
+                var url = receivedEventArgs.Data.Substring(prefix.Length);
+                string final;
+                lock (stdoutBuilder)
+                    final = stdoutBuilder.ToString();
 
-            var stdoutString = await stdoutTask.ConfigureAwait(false);
+                stdoutTcs.TrySetResult((url, Stdout: final));
+            };
 
-            if (url != null)
+            process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+
+            var timeoutTask = Task.Delay(_serverOptions.MaxServerStartupTimeDuration);
+
+            var firstCompletedTask = await Task.WhenAny(stdoutTcs.Task, stderrTcs.Task, timeoutTask).ConfigureAwait(false);
+            if (firstCompletedTask == stdoutTcs.Task)
+            {
+                (string? url, _) = stdoutTcs.Task.Result;
                 return (new Uri(url), process);
+            }
+
+            string stdoutString;
+            lock (stdoutBuilder)
+                stdoutString = stdoutBuilder.ToString();
 
             string stderrString;
-            var completedTask = await Task.WhenAny(errorTcs.Task, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
-            if (completedTask == errorTcs.Task)
+            if (firstCompletedTask == stderrTcs.Task)
             {
-                stderrString = errorTcs.Task.Result;
+                stderrString = stderrTcs.Task.Result;
+                await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(5)), stdoutTcs.Task).ConfigureAwait(false); // extra 5 sec grace in case more error lines still arrive
             }
-            else
+            else // timeout
             {
                 lock (stderrBuilder)
                     stderrString = stderrBuilder.ToString();
             }
 
             ShutdownServerProcess(process);
-            throw new InvalidOperationException(BuildStartupExceptionMessage(stdoutString, stderrString));
+            throw BuildServerStartupException(stdoutString, stderrString, isTimeout: firstCompletedTask == timeoutTask);
         }
 
-        private static string BuildStartupExceptionMessage(string? outputString, string? errorString)
+        private Exception BuildServerStartupException(string? outputString, string? errorString, bool isTimeout)
         {
             var sb = new StringBuilder();
-            sb.AppendLine("Unable to start the RavenDB Server");
+            sb.AppendLine(isTimeout
+                ? $"Server failed to start in {_serverOptions?.MaxServerStartupTimeDuration.TotalSeconds} s."
+                : "Unable to start the RavenDB Server");
 
             if (string.IsNullOrWhiteSpace(errorString) == false)
             {
@@ -345,7 +367,9 @@ namespace Raven.Embedded
                 sb.AppendLine(outputString);
             }
 
-            return sb.ToString();
+            return isTimeout
+                ? new TimeoutException(sb.ToString())
+                : new InvalidOperationException(sb.ToString());
         }
 
         public void OpenStudioInBrowser()

--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -275,15 +275,28 @@ namespace Raven.Embedded
             string? url = null;
             var startupDuration = Stopwatch.StartNew();
 
+            var errorLock = new object();
             var stderrBuilder = new StringBuilder();
+            var errorTcs  = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             process.ErrorDataReceived += (_, receivedEventArgs) =>
             {
-                if (receivedEventArgs.Data != null)
+                if (receivedEventArgs.Data == null)
+                {
+                    string final;
+                    lock (errorLock)
+                        final = stderrBuilder.ToString();
+
+                    errorTcs.TrySetResult(final);
+                    return;
+                }
+
+                lock (errorLock)
                     stderrBuilder.AppendLine(receivedEventArgs.Data);
             };
             process.BeginErrorReadLine();
 
-            var stdoutString = await ProcessHelper.ReadOutput(process.StandardOutput, startupDuration, _serverOptions, (line, _) =>
+            var stdoutTask = ProcessHelper.ReadOutputAsync(process.StandardOutput, startupDuration, _serverOptions, (line, _) =>
             {
                 const string prefix = "Server available on: ";
                 if (line.StartsWith(prefix) == false)
@@ -291,17 +304,26 @@ namespace Raven.Embedded
 
                 url = line.Substring(prefix.Length);
                 return Task.FromResult(true);
+            });
 
-            }).ConfigureAwait(false);
+            var stdoutString = await stdoutTask.ConfigureAwait(false);
 
             if (url != null)
-                return (ServerUrl: new Uri(url), process);
+                return (new Uri(url), process);
 
-            process.CancelErrorRead();
-            var stderrString = stderrBuilder.ToString();
+            string stderrString;
+            var completedTask = await Task.WhenAny(errorTcs.Task, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+            if (completedTask == errorTcs.Task)
+            {
+                stderrString = errorTcs.Task.Result;
+            }
+            else
+            {
+                lock (errorLock)
+                    stderrString = stderrBuilder.ToString();
+            }
 
             ShutdownServerProcess(process);
-
             throw new InvalidOperationException(BuildStartupExceptionMessage(stdoutString, stderrString));
         }
 

--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -275,37 +275,34 @@ namespace Raven.Embedded
             string? url = null;
             var startupDuration = Stopwatch.StartNew();
 
-            var outputString = await ProcessHelper.ReadOutput(process.StandardOutput, startupDuration, _serverOptions, async (line, builder) =>
+            var stderrBuilder = new StringBuilder();
+            process.ErrorDataReceived += (_, receivedEventArgs) =>
             {
-                if (line == null)
-                {
-                    var errorString = await ProcessHelper.ReadOutput(process.StandardError, startupDuration, _serverOptions, null).ConfigureAwait(false);
+                if (receivedEventArgs.Data != null)
+                    stderrBuilder.AppendLine(receivedEventArgs.Data);
+            };
+            process.BeginErrorReadLine();
 
-                    ShutdownServerProcess(process);
-
-                    throw new InvalidOperationException(BuildStartupExceptionMessage(builder.ToString(), errorString));
-                }
-
+            var stdoutString = await ProcessHelper.ReadOutput(process.StandardOutput, startupDuration, _serverOptions, (line, _) =>
+            {
                 const string prefix = "Server available on: ";
-                if (line.StartsWith(prefix))
-                {
-                    url = line.Substring(prefix.Length);
-                    return true;
-                }
+                if (line.StartsWith(prefix) == false)
+                    return Task.FromResult(false);
 
-                return false;
+                url = line.Substring(prefix.Length);
+                return Task.FromResult(true);
+
             }).ConfigureAwait(false);
 
-            if (url == null)
-            {
-                var errorString = await ProcessHelper.ReadOutput(process.StandardError, startupDuration, _serverOptions, null).ConfigureAwait(false);
+            if (url != null)
+                return (ServerUrl: new Uri(url), process);
 
-                ShutdownServerProcess(process);
+            process.CancelErrorRead();
+            var stderrString = stderrBuilder.ToString();
 
-                throw new InvalidOperationException(BuildStartupExceptionMessage(outputString, errorString));
-            }
+            ShutdownServerProcess(process);
 
-            return (new Uri(url), process);
+            throw new InvalidOperationException(BuildStartupExceptionMessage(stdoutString, stderrString));
         }
 
         private static string BuildStartupExceptionMessage(string? outputString, string? errorString)

--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -278,6 +278,8 @@ namespace Raven.Embedded
             var stderrBuilder = new StringBuilder();
             var errorTcs  = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+            // DataReceived callbacks run on ThreadPool threads → can overlap.
+            // Lock prevents AppendLine/ToString races.
             process.ErrorDataReceived += (_, receivedEventArgs) =>
             {
                 if (receivedEventArgs.Data == null)

--- a/src/Raven.Embedded/ProcessHelper.cs
+++ b/src/Raven.Embedded/ProcessHelper.cs
@@ -10,7 +10,7 @@ namespace Raven.Embedded
 {
     internal static class ProcessHelper
     {
-        internal static async Task<string?> ReadOutput(StreamReader output, Stopwatch elapsed, ServerOptions options, Func<string, StringBuilder, Task<bool>>? onLine)
+        internal static async Task<string?> ReadOutputAsync(StreamReader output, Stopwatch elapsed, ServerOptions options, Func<string, StringBuilder, Task<bool>>? onLine)
         {
             var sb = new StringBuilder();
 

--- a/src/Raven.Embedded/RuntimeFrameworkVersionMatcher.cs
+++ b/src/Raven.Embedded/RuntimeFrameworkVersionMatcher.cs
@@ -88,7 +88,7 @@ namespace Raven.Embedded
 
             var insideRuntimes = false;
             var runtimeLines = new List<string>();
-            await ProcessHelper.ReadOutput(process.StandardOutput, elapsed: null, options, (line, builder) =>
+            await ProcessHelper.ReadOutputAsync(process.StandardOutput, elapsed: null, options, (line, builder) =>
             {
                 line = line.Trim();
 

--- a/test/LicenseTests/LicenseOptionsEmbeddedTests.cs
+++ b/test/LicenseTests/LicenseOptionsEmbeddedTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using EmbeddedTests;
@@ -289,6 +290,19 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertInnerLicenseVerificationException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ShouldThrowImmediately()
+    {
+        var sw = Stopwatch.StartNew();
+
+        ServerOptions options = null;
+        Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        Assert.True(sw.ElapsedMilliseconds < options.MaxServerStartupTimeDuration.TotalMilliseconds,
+            $"The server should throw an error as soon as possible, without reaching the maximum server startup time (ServerOptions.MaxServerStartupTimeDuration = {options.MaxServerStartupTimeDuration}), but it took {sw.ElapsedMilliseconds}ms.");
     }
 
     private void StartEmbeddedServerLicenseOptionTest(bool? throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24101

### Additional description

Starting from **RavenDB 7.0**, running the **TestDriver** with `ThrowOnInvalidOrMissingLicense = true` and an **invalid / missing license** caused the embedded server to stall for \~90 seconds and eventually surface only the generic message

```
Unable to start the RavenDB Server
```

instead of the detailed license-validation exception shown in **6.2**.

Investigation showed that in 7.0 the server’s `Fatal` path (now routed through **NLog**) writes the full error to **`Console.Error`**:

```csharp
Console.Error.WriteLine(message + Environment.NewLine + exception);
```

The host (`EmbeddedServer.RunServer`) redirected *but never read* `StandardError`; it only tailed `StandardOutput` while waiting for the “Server available on:” banner. As soon as the server hit the fatal path, the OS pipe buffer for `stderr` ([--64 KB on Windows](https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-transactnamedpipe?utm_source=chatgpt.com#remarks)) filled up, blocking `Console.Error.WriteLine`. The server process therefore stopped making progress, and the host waited out both `MaxServerStartupTimeDuration` (60 s) and `GracefulShutdownTimeout` (30 s) before giving up.

#### Fix

`RunServer` now consumes **both** output streams concurrently:

* `StandardOutput` is still parsed for the ready URL.
* `StandardError` is read with `BeginErrorReadLine` into a `StringBuilder` from process start.

If the URL is never seen, the method now:
1. Cancels the `stderr` reader,
2. Shuts the process down, and
3. Throws an `InvalidOperationException` that concatenates the captured **stdout** and **stderr**, restoring the full license error message.

#### Within this pull request also:
1. A non-static internal method, `ConfigureScopedServer`, was added to `RavenTestDriver`. This allows for creating a non-static, scoped instance of `EmbeddedServer`, internal only to make the class testable.
2. `GetDocumentStore` was `protected`, but is now `protected internal`, which also makes `RavenTestDriver` testable.
3. All tests that were *supposed* to test `RavenTestDriver` but weren't actually doing so have been completely rewritten.
4. This pull request contains the same changes as https://github.com/ravendb/ravendb/pull/20540, but accounts for the fact that starting with version 6.2, we are changing the default value for `ThrowOnInvalidOrMissingLicense` to `false`, and the test suites need to be adapted accordingly.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
