### PR TITLE
RavenDB-24133 Fix the attachment key data extraction

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1279,12 +1279,12 @@ namespace Raven.Server.Documents
                 {
                     case DocType:
                         attachmentNameIndex = thirdPartIndex;
-                        sizeOfAttachmentName = attachmentNameIndex - endOfThirdPart;
+                        sizeOfAttachmentName = endOfThirdPart - attachmentNameIndex;
                         type = AttachmentType.Document;
                         break;
                     case RevisionType:
                         attachmentNameIndex = endOfThirdPart + 1;
-                        sizeOfAttachmentName = attachmentNameIndex - FindNextSeparator(key, thirdPartIndex);;
+                        sizeOfAttachmentName = FindNextSeparator(key, thirdPartIndex) - attachmentNameIndex;
                         type = AttachmentType.Revision;
                         break;
                     default:

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Attachments;
@@ -134,7 +135,7 @@ namespace Raven.Server.Documents
 
                 var stream = GetAttachmentStream(context, attachment.Base64Hash);
                 if (stream == null)
-                    ThrowMissingAttachment(GetDocIdAndAttachmentName(context, attachment.Key));
+                    ThrowMissingAttachment(context, attachment.Key);
 
                 attachment.Stream = stream;
 
@@ -151,7 +152,7 @@ namespace Raven.Server.Documents
         public IEnumerable<DynamicJsonValue> GetAttachmentsMetadataForDocumentWithCounts(DocumentsOperationContext context, string lowerDocumentId)
         {
             using (Slice.From(context.Allocator, lowerDocumentId, out Slice lowerDocumentIdSlice))
-            using (GetAttachmentPrefix(context, lowerDocumentIdSlice, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
+            using (AttachmentKey.GetPrefix(context, lowerDocumentIdSlice, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
             {
                 foreach (var attachment in GetAttachmentsForDocument(context, prefixSlice))
                 {
@@ -196,7 +197,7 @@ namespace Raven.Server.Documents
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, name, out Slice lowerName, out Slice namePtr))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypePtr))
                 using (Slice.From(context.Allocator, hash, out Slice base64Hash)) // Hash is a base64 string, so this is a special case that we do not need to escape
-                using (GetAttachmentKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size, base64Hash,
+                using (AttachmentKey.GetKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size, base64Hash,
                     lowerContentType.Content.Ptr, lowerContentType.Size, AttachmentType.Document, Slices.Empty, out Slice keySlice))
                 {
                     Debug.Assert(base64Hash.Size == 44, $"Hash size should be 44 but was: {keySlice.Size}");
@@ -243,7 +244,7 @@ namespace Raven.Server.Documents
                         var attachmentExists = false;
 
                         // We already asserted that the document is not in conflict, so we might have just one partial key, not more.
-                        using (GetAttachmentPartialKey(context, keySlice, base64Hash.Size, lowerContentType.Size, out Slice partialKeySlice))
+                        using (AttachmentKey.GetPartialKey(context, keySlice, base64Hash.Size, lowerContentType.Size, out Slice partialKeySlice))
                         {
                             if (table.SeekOnePrimaryKeyPrefix(partialKeySlice, out TableValueReader partialTvr))
                             {
@@ -454,8 +455,8 @@ namespace Raven.Server.Documents
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, lowerDocId, out Slice lowerId, out Slice idSlice))
             {
-                GetAttachmentKeyInternal(context, lowerId.Content.Ptr, lowerId.Content.Length, default, default, default(Slice), null, 0,
-                    KeyType.Prefix, AttachmentType.Document, default, out var key);
+                AttachmentKey.GetKeyInternal(context, lowerId.Content.Ptr, lowerId.Content.Length, default, default, default(Slice), null, 0,
+                    AttachmentKey.KeyType.Prefix, AttachmentType.Document, default, out var key);
                 table.DeleteByPrimaryKeyPrefix(key);
             }
         }
@@ -494,7 +495,7 @@ namespace Raven.Server.Documents
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, name, out Slice lowerName, out Slice nameSlice))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypeSlice))
                 using (Slice.External(context.Allocator, hash, out Slice base64Hash))
-                using (GetAttachmentKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size,
+                using (AttachmentKey.GetKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size,
                     base64Hash, lowerContentType.Content.Ptr, lowerContentType.Size, type, cv, out Slice keySlice))
                 {
                     PutDirect(context, keySlice, nameSlice, contentTypeSlice, base64Hash);
@@ -511,7 +512,7 @@ namespace Raven.Server.Documents
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, attachment.Name, out Slice lowerName, out Slice namePtr))
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, attachment.ContentType, out Slice lowerContentType, out Slice contentTypePtr))
             using (Slice.From(context.Allocator, attachment.Hash, out var hashSlice))
-            using (GetAttachmentKey(context, lowerId, lowerIdSize, lowerName.Content.Ptr, lowerName.Size, hashSlice,
+            using (AttachmentKey.GetKey(context, lowerId, lowerIdSize, lowerName.Content.Ptr, lowerName.Size, hashSlice,
                 lowerContentType.Content.Ptr, lowerContentType.Size, AttachmentType.Revision, changeVector, out Slice keySlice))
             using (table.Allocate(out TableValueBuilder tvb))
             {
@@ -585,7 +586,7 @@ namespace Raven.Server.Documents
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
             using (DocumentIdWorker.GetLower(context.Allocator, documentId, out var lowerDocumentIdSlice))
             using (Slice.From(context.Allocator, changeVector, out var changeVectorSlice))
-            using (GetAttachmentPrefix(context, lowerDocumentIdSlice, type, type == AttachmentType.Document ? Slices.Empty : changeVectorSlice, out Slice prefixSlice))
+            using (AttachmentKey.GetPrefix(context, lowerDocumentIdSlice, type, type == AttachmentType.Document ? Slices.Empty : changeVectorSlice, out Slice prefixSlice))
             {
                 foreach (var sr in table.SeekByPrimaryKeyPrefix(prefixSlice, Slices.Empty, 0))
                 {
@@ -603,7 +604,7 @@ namespace Raven.Server.Documents
         public DynamicJsonArray GetAttachmentsMetadataForDocument(DocumentsOperationContext context, Slice lowerDocumentId)
         {
             var attachments = new DynamicJsonArray();
-            using (GetAttachmentPrefix(context, lowerDocumentId, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
+            using (AttachmentKey.GetPrefix(context, lowerDocumentId, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
             {
                 foreach (var attachment in GetAttachmentsForDocument(context, prefixSlice))
                 {
@@ -622,7 +623,7 @@ namespace Raven.Server.Documents
         public List<AttachmentDetails> GetAttachmentDetailsForDocument(DocumentsOperationContext context, Slice lowerDocumentId)
         {
             var attachments = new List<AttachmentDetails>();
-            using (GetAttachmentPrefix(context, lowerDocumentId, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
+            using (AttachmentKey.GetPrefix(context, lowerDocumentId, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
             {
                 foreach (var attachment in GetAttachmentsForDocument(context, prefixSlice))
                 {
@@ -730,14 +731,14 @@ namespace Raven.Server.Documents
                 ByteStringContext<ByteStringMemoryCache>.InternalScope scope;
                 if (usePartialKey)
                 {
-                    scope = GetAttachmentPartialKey(context, lowerId.Content.Ptr, lowerId.Size, lowerName.Content.Ptr, lowerName.Size, type, changeVector, out keySlice);
+                    scope = AttachmentKey.GetPartialKey(context, lowerId.Content.Ptr, lowerId.Size, lowerName.Content.Ptr, lowerName.Size, type, changeVector, out keySlice);
                 }
                 else
                 {
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypePtr))
                     using (Slice.From(context.Allocator, hash, out Slice base64Hash))
                     {
-                        scope = GetAttachmentKey(context, lowerId.Content.Ptr, lowerId.Size, lowerName.Content.Ptr, lowerName.Size, base64Hash, lowerContentType.Content.Ptr,
+                        scope = AttachmentKey.GetKey(context, lowerId.Content.Ptr, lowerId.Size, lowerName.Content.Ptr, lowerName.Size, base64Hash, lowerContentType.Content.Ptr,
                             lowerContentType.Size, AttachmentType.Document, Slices.Empty, out keySlice);
                     }
                 }
@@ -785,169 +786,6 @@ namespace Raven.Server.Documents
             return info->TotalSize;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ByteStringContext.InternalScope GetAttachmentKey(DocumentsOperationContext context, byte* lowerId, int lowerIdSize,
-            byte* lowerName, int lowerNameSize, Slice base64Hash, byte* lowerContentTypePtr, int lowerContentTypeSize,
-            AttachmentType type, Slice changeVector, out Slice keySlice)
-        {
-            return GetAttachmentKeyInternal(context, lowerId, lowerIdSize, lowerName, lowerNameSize, base64Hash, lowerContentTypePtr, lowerContentTypeSize, KeyType.Key, type, changeVector, out keySlice);
-        }
-
-        // NOTE: GetAttachmentPartialKey should be called only when the document's that hold the attachment does not have a conflict.
-        // In this specific case it is ensured that we have a unique partial keys.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ByteStringContext.InternalScope GetAttachmentPartialKey(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, byte
-            * lowerName, int lowerNameSize, AttachmentType type, string changeVector, out Slice partialKeySlice)
-        {
-            Slice cvSlice;
-            ByteStringContext.InternalScope cvDispose;
-            if (changeVector == null)
-            {
-                cvSlice = Slices.Empty;
-                cvDispose = default(ByteStringContext.InternalScope);
-            }
-            else
-            {
-                cvDispose = Slice.From(context.Allocator, changeVector, out cvSlice);
-            }
-
-            using (cvDispose)
-            {
-                return GetAttachmentKeyInternal(context, lowerId, lowerIdSize, lowerName, lowerNameSize, default(Slice), null, 0,
-                    KeyType.PartialKey, type, cvSlice, out partialKeySlice);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ByteStringContext.ExternalScope GetAttachmentPartialKey(DocumentsOperationContext context, Slice key,
-            int base64HashSize, int lowerContentTypeSize, out Slice partialKeySlice)
-        {
-            return Slice.External(context.Allocator, key.Content, 0, key.Size - base64HashSize - 1 - lowerContentTypeSize, out partialKeySlice);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ByteStringContext.InternalScope GetAttachmentPrefix(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, AttachmentType type, Slice changeVector, out Slice prefixSlice)
-        {
-            return GetAttachmentKeyInternal(context, lowerId, lowerIdSize, null, 0, default(Slice), null, 0, KeyType.Prefix, type, changeVector, out prefixSlice);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ByteStringContext.InternalScope GetAttachmentPrefix(DocumentsOperationContext context, Slice lowerId, AttachmentType type, Slice changeVector, out Slice prefixSlice)
-        {
-            return GetAttachmentKeyInternal(context, lowerId.Content.Ptr, lowerId.Size, null, 0, default(Slice), null, 0, KeyType.Prefix, type, changeVector, out prefixSlice);
-        }
-
-        /*
-        // Document key: {lowerDocumentId|d|lowerName|hash|lowerContentType}
-        // Revision key: {lowerDocumentId|r|changeVector|lowerName|hash|lowerContentType}
-        //
-        // Document partial key: {lowerDocumentId|d|lowerName|}
-        // Revision partial key: {lowerDocumentId|r|changeVector|}
-        //
-        // Document prefix: {lowerDocumentId|d|}
-        // Revision prefix: {lowerDocumentId|r|changeVector|}
-        */
-
-        private ByteStringContext.InternalScope GetAttachmentKeyInternal(
-            DocumentsOperationContext context, byte* lowerId, int lowerIdSize, byte* lowerName, int lowerNameSize,
-            Slice base64Hash, byte* lowerContentTypePtr, int lowerContentTypeSize, KeyType keyType, AttachmentType type,
-            Slice changeVector, out Slice keySlice)
-        {
-            var size = lowerIdSize + 3;
-            if (type != AttachmentType.Document)
-            {
-                size += changeVector.Size + 1;
-            }
-            if (keyType == KeyType.Key)
-            {
-                size += lowerNameSize + 1 + base64Hash.Size + 1 + lowerContentTypeSize;
-            }
-            else if (keyType == KeyType.PartialKey)
-            {
-                size += lowerNameSize + 1;
-            }
-
-            var scope = context.Allocator.Allocate(size, out ByteString keyMem);
-
-            Memory.Copy(keyMem.Ptr, lowerId, lowerIdSize);
-            var pos = lowerIdSize;
-            keyMem.Ptr[pos++] = SpecialChars.RecordSeparator;
-
-            switch (type)
-            {
-                case AttachmentType.Document:
-                    keyMem.Ptr[pos++] = (byte)'d';
-                    break;
-
-                case AttachmentType.Revision:
-                    keyMem.Ptr[pos++] = (byte)'r';
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
-            }
-            keyMem.Ptr[pos++] = SpecialChars.RecordSeparator;
-
-            if (type != AttachmentType.Document)
-            {
-                Memory.Copy(keyMem.Ptr + pos, changeVector.Content.Ptr, changeVector.Size);
-                pos += changeVector.Size;
-                keyMem.Ptr[pos++] = SpecialChars.RecordSeparator;
-            }
-
-            if (keyType != KeyType.Prefix)
-            {
-                Memory.Copy(keyMem.Ptr + pos, lowerName, lowerNameSize);
-                pos += lowerNameSize;
-                keyMem.Ptr[pos++] = SpecialChars.RecordSeparator;
-
-                if (keyType == KeyType.Key)
-                {
-                    base64Hash.CopyTo(keyMem.Ptr + pos);
-                    pos += base64Hash.Size;
-                    keyMem.Ptr[pos++] = SpecialChars.RecordSeparator;
-
-                    Memory.Copy(keyMem.Ptr + pos, lowerContentTypePtr, lowerContentTypeSize);
-                }
-            }
-
-            keySlice = new Slice(SliceOptions.Key, keyMem);
-            return scope;
-        }
-
-        public static AttachmentType GetAttachmentTypeByKey(Slice keySlice)
-        {
-            var index = 0;
-            var found = false;
-            for (int i = 0; i < keySlice.Size; i++)
-            {
-                if (Convert.ToChar(keySlice[i]) == SpecialChars.RecordSeparator)
-                {
-                    index = i;
-                    found = true;
-                    break;
-                }
-            }
-
-            if (found == false)
-                throw new InvalidOperationException($"Could not parse {nameof(keySlice)}");
-
-            var b = keySlice[index + 1];
-            var c = Convert.ToChar(b);
-            if (c == 'r')
-                return AttachmentType.Revision;
-
-            Debug.Assert(c == 'd');
-            return AttachmentType.Document;
-        }
-
-        private enum KeyType
-        {
-            Key,
-            PartialKey,
-            Prefix
-        }
-
         private static Attachment TableValueToAttachment(DocumentsOperationContext context, ref TableValueReader tvr)
         {
             var result = new Attachment
@@ -967,9 +805,11 @@ namespace Raven.Server.Documents
             return result;
         }
 
-        private static void ThrowMissingAttachment((LazyStringValue DocId, LazyStringValue AttachmentName) details)
+        [DoesNotReturn]
+        private static void ThrowMissingAttachment(DocumentsOperationContext context, LazyStringValue attachmentKey)
         {
-            throw new FileNotFoundException($"Attachment's stream for file '{details.AttachmentName}' in document '{details.DocId}' was not found. This should never happen.");
+            var (attachmentName, docId) = AttachmentKey.ExtractDocIdAndAttachmentName(context, attachmentKey);
+            throw new FileNotFoundException($"Attachment's stream for file '{attachmentName}' in document '{docId}' was not found. This should never happen. AttachmentKey:{attachmentKey}");
         }
 
         private static void ThrowConcurrentException(string documentId, string name, string expectedChangeVector, string oldChangeVector)
@@ -1052,7 +892,7 @@ namespace Raven.Server.Documents
             while (true)
             {
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, newName, out Slice lowerName, out _))
-                using (GetAttachmentPartialKey(context, lowerId.Content.Ptr, lowerId.Size, lowerName.Content.Ptr, lowerName.Size, AttachmentType.Document, changeVector: null, out Slice partialKeySlice))
+                using (AttachmentKey.GetPartialKey(context, lowerId.Content.Ptr, lowerId.Size, lowerName.Content.Ptr, lowerName.Size, AttachmentType.Document, changeVector: null, out Slice partialKeySlice))
                 {
                     if (table.SeekOnePrimaryKeyPrefix(partialKeySlice, out _) == false)
                         break;
@@ -1103,14 +943,14 @@ namespace Raven.Server.Documents
                     ByteStringContext<ByteStringMemoryCache>.InternalScope scope;
                     if (usePartialKey)
                     {
-                        scope = GetAttachmentPartialKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size, AttachmentType.Document, null, out keySlice);
+                        scope = AttachmentKey.GetPartialKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size, AttachmentType.Document, null, out keySlice);
                     }
                     else
                     {
                         using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypePtr))
                         using (Slice.From(context.Allocator, hash, out Slice base64Hash))
                         {
-                            scope = GetAttachmentKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size, base64Hash, lowerContentType.Content.Ptr,
+                            scope = AttachmentKey.GetKey(context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size, base64Hash, lowerContentType.Content.Ptr,
                                 lowerContentType.Size, AttachmentType.Document, Slices.Empty, out keySlice);
                         }
                     }
@@ -1186,7 +1026,7 @@ namespace Raven.Server.Documents
             using (DocumentIdWorker.GetSliceFromId(context, conflictName, out Slice lowerName))
             using (DocumentIdWorker.GetSliceFromId(context, conflictContentType, out Slice lowerContentType))
             using (Slice.External(context.Allocator, conflictHash, out Slice base64Hash))
-            using (_documentsStorage.AttachmentsStorage.GetAttachmentKey(context, lowerId.Content.Ptr, lowerId.Size,
+            using (AttachmentKey.GetKey(context, lowerId.Content.Ptr, lowerId.Size,
                 lowerName.Content.Ptr, lowerName.Size,
                 base64Hash, lowerContentType.Content.Ptr, lowerContentType.Size, AttachmentType.Document, Slices.Empty, out Slice keySlice))
             {
@@ -1330,7 +1170,7 @@ namespace Raven.Server.Documents
         public void DeleteRevisionAttachments(DocumentsOperationContext context, Document revision, string changeVector, long lastModifiedTicks)
         {
             using (Slice.From(context.Allocator, revision.ChangeVector, out Slice changeVectorSlice))
-            using (GetAttachmentPrefix(context, revision.LowerId.Buffer, revision.LowerId.Size, AttachmentType.Revision, changeVectorSlice, out Slice prefixSlice))
+            using (AttachmentKey.GetPrefix(context, revision.LowerId.Buffer, revision.LowerId.Size, AttachmentType.Revision, changeVectorSlice, out Slice prefixSlice))
             {
                 DeleteAttachmentsOfDocumentInternal(context, prefixSlice, changeVector, lastModifiedTicks);
             }
@@ -1338,7 +1178,7 @@ namespace Raven.Server.Documents
 
         public void DeleteAttachmentsOfDocument(DocumentsOperationContext context, Slice lowerId, string changeVector, long lastModifiedTicks)
         {
-            using (GetAttachmentPrefix(context, lowerId.Content.Ptr, lowerId.Size, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
+            using (AttachmentKey.GetPrefix(context, lowerId.Content.Ptr, lowerId.Size, AttachmentType.Document, Slices.Empty, out Slice prefixSlice))
             {
                 DeleteAttachmentsOfDocumentInternal(context, prefixSlice, changeVector, lastModifiedTicks);
             }
@@ -1350,38 +1190,6 @@ namespace Raven.Server.Documents
             var tempPath = _documentsStorage.Environment.Options.DataPager.Options.TempPath.Combine(name);
 
             return new StreamsTempFile(tempPath.FullPath, _documentDatabase.DocumentsStorage.Environment);
-        }
-
-        public static (LazyStringValue DocId, LazyStringValue AttachmentName) GetDocIdAndAttachmentName(JsonOperationContext context,
-            LazyStringValue attachmentKey)
-        {
-            var p = attachmentKey.Buffer;
-            var size = attachmentKey.Size;
-
-            int sizeOfDocId = 0;
-            for (; sizeOfDocId < size; sizeOfDocId++)
-            {
-                if (p[sizeOfDocId] == SpecialChars.RecordSeparator)
-                    break;
-            }
-
-            var attachmentNameIndex = sizeOfDocId +
-                                      1 + // separator
-                                      1 + // type: d
-                                      1; // separator
-
-            int sizeOfAttachmentName = 0;
-
-            for (; sizeOfAttachmentName < size - (sizeOfDocId + 3); sizeOfAttachmentName++)
-            {
-                if (p[attachmentNameIndex + sizeOfAttachmentName] == SpecialChars.RecordSeparator)
-                    break;
-            }
-
-            var doc = context.AllocateStringValue(null, p, sizeOfDocId);
-            var name = context.AllocateStringValue(null, p + attachmentNameIndex, sizeOfAttachmentName);
-
-            return (doc, name);
         }
 
         public static IEnumerable<BlittableJsonReaderObject> GetAttachmentsFromDocumentMetadata(BlittableJsonReaderObject document)
@@ -1405,6 +1213,228 @@ namespace Raven.Server.Documents
                 {
                     tree.DeleteStream(hash);
                 }
+            }
+        }
+        
+        public static class AttachmentKey
+        {
+            /*
+            // Document key: {lowerDocumentId|d|lowerName|hash|lowerContentType}
+            // Revision key: {lowerDocumentId|r|changeVector|lowerName|hash|lowerContentType}
+            //
+            // Document partial key: {lowerDocumentId|d|lowerName|}
+            // Revision partial key: {lowerDocumentId|r|changeVector|}
+            //
+            // Document prefix: {lowerDocumentId|d|}
+            // Revision prefix: {lowerDocumentId|r|changeVector|}
+            */
+
+            public enum KeyType
+            {
+                Key,
+                PartialKey,
+                Prefix
+            }
+            
+            private const byte RecordSeparator = SpecialChars.RecordSeparator;
+            private const byte DocType = (byte)'d';
+            private const byte RevisionType = (byte)'r';
+
+            public static (LazyStringValue DocId, LazyStringValue AttachmentName) ExtractDocIdAndAttachmentName(JsonOperationContext context,
+                LazyStringValue key)
+            {
+                var spanKey = key.AsReadOnlySpan();
+                ExtractDocIdAndAttachmentName(spanKey, out int sizeOfDocId, out int attachmentNameIndex, out int sizeOfAttachmentName, out _);
+
+                var doc = context.AllocateStringValue(null, key.Buffer, sizeOfDocId);
+                var name = context.AllocateStringValue(null, key.Buffer + attachmentNameIndex, sizeOfAttachmentName);
+
+                return (doc, name);
+            }
+
+            public static (string DocId, string AttachmentName) ExtractDocIdAndAttachmentName(Slice key)
+            {
+                var spanKey = key.AsReadOnlySpan();
+                ExtractDocIdAndAttachmentName(spanKey, out int sizeOfDocId, out int attachmentNameIndex, out int sizeOfAttachmentName, out _);
+
+                var docId = Encodings.Utf8.GetString(spanKey[..sizeOfDocId]);
+                var attachmentName = Encodings.Utf8.GetString(spanKey.Slice(attachmentNameIndex, sizeOfAttachmentName));
+
+                return (docId, attachmentName);
+            }
+
+            private static void ExtractDocIdAndAttachmentName(ReadOnlySpan<byte> key, out int sizeOfDocId, out int attachmentNameIndex,
+                out int sizeOfAttachmentName, out AttachmentType type)
+            {
+                sizeOfDocId = FindNextSeparator(key, 0);
+
+                var thirdPartIndex = sizeOfDocId +
+                                      1 + // separator
+                                      1 + // type: d
+                                      1;
+
+                int endOfThirdPart = FindNextSeparator(key, thirdPartIndex);
+                byte keyType = key[sizeOfDocId + 1];
+                switch (keyType)
+                {
+                    case DocType:
+                        attachmentNameIndex = thirdPartIndex;
+                        sizeOfAttachmentName = attachmentNameIndex - endOfThirdPart;
+                        type = AttachmentType.Document;
+                        break;
+                    case RevisionType:
+                        attachmentNameIndex = endOfThirdPart + 1;
+                        sizeOfAttachmentName = attachmentNameIndex - FindNextSeparator(key, thirdPartIndex);;
+                        type = AttachmentType.Revision;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Invalid attachment key type {(char)keyType}({keyType:X}). Key {Encodings.Utf8.GetString(key)}");
+                }
+            }
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ByteStringContext.InternalScope GetKey(DocumentsOperationContext context, byte* lowerId, int lowerIdSize,
+                byte* lowerName, int lowerNameSize, Slice base64Hash, byte* lowerContentTypePtr, int lowerContentTypeSize,
+                AttachmentType type, Slice changeVector, out Slice keySlice)
+            {
+                return GetKeyInternal(context, lowerId, lowerIdSize, lowerName, lowerNameSize, base64Hash, lowerContentTypePtr, lowerContentTypeSize,
+                    KeyType.Key, type, changeVector, out keySlice);
+            }
+
+            // NOTE: GetAttachmentPartialKey should be called only when the document's that hold the attachment does not have a conflict.
+            // In this specific case it is ensured that we have a unique partial keys.
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ByteStringContext.InternalScope GetPartialKey(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, byte
+                * lowerName, int lowerNameSize, AttachmentType type, string changeVector, out Slice partialKeySlice)
+            {
+                Slice cvSlice;
+                ByteStringContext.InternalScope cvDispose;
+                if (changeVector == null)
+                {
+                    cvSlice = Slices.Empty;
+                    cvDispose = default(ByteStringContext.InternalScope);
+                }
+                else
+                {
+                    cvDispose = Slice.From(context.Allocator, changeVector, out cvSlice);
+                }
+
+                using (cvDispose)
+                {
+                    return GetKeyInternal(context, lowerId, lowerIdSize, lowerName, lowerNameSize, default(Slice), null, 0,
+                        KeyType.PartialKey, type, cvSlice, out partialKeySlice);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ByteStringContext.ExternalScope GetPartialKey(DocumentsOperationContext context, Slice key,
+                int base64HashSize, int lowerContentTypeSize, out Slice partialKeySlice)
+            {
+                return Slice.External(context.Allocator, key.Content, 0, key.Size - base64HashSize - 1 - lowerContentTypeSize, out partialKeySlice);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ByteStringContext.InternalScope GetPrefix(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, AttachmentType type,
+                Slice changeVector, out Slice prefixSlice)
+            {
+                return GetKeyInternal(context, lowerId, lowerIdSize, null, 0, default(Slice), null, 0, KeyType.Prefix, type, changeVector, out prefixSlice);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ByteStringContext.InternalScope GetPrefix(DocumentsOperationContext context, Slice lowerId, AttachmentType type, Slice changeVector,
+                out Slice prefixSlice)
+            {
+                return GetKeyInternal(context, lowerId.Content.Ptr, lowerId.Size, null, 0, default(Slice), null, 0, KeyType.Prefix, type, changeVector,
+                    out prefixSlice);
+            }
+
+            public static ByteStringContext.InternalScope GetKeyInternal(
+                DocumentsOperationContext context, byte* lowerId, int lowerIdSize, byte* lowerName, int lowerNameSize,
+                Slice base64Hash, byte* lowerContentTypePtr, int lowerContentTypeSize, KeyType keyType, AttachmentType type,
+                Slice changeVector, out Slice keySlice)
+            {
+                var size = lowerIdSize + 3;
+                if (type != AttachmentType.Document)
+                {
+                    size += changeVector.Size + 1;
+                }
+
+                if (keyType == KeyType.Key)
+                {
+                    size += lowerNameSize + 1 + base64Hash.Size + 1 + lowerContentTypeSize;
+                }
+                else if (keyType == KeyType.PartialKey)
+                {
+                    size += lowerNameSize + 1;
+                }
+
+                var scope = context.Allocator.Allocate(size, out ByteString keyMem);
+
+                Memory.Copy(keyMem.Ptr, lowerId, lowerIdSize);
+                var pos = lowerIdSize;
+                keyMem.Ptr[pos++] = RecordSeparator;
+
+                keyMem.Ptr[pos++] = type switch
+                {
+                    AttachmentType.Document => DocType,
+                    AttachmentType.Revision => RevisionType,
+                    _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+                };
+
+                keyMem.Ptr[pos++] = RecordSeparator;
+
+                if (type != AttachmentType.Document)
+                {
+                    Memory.Copy(keyMem.Ptr + pos, changeVector.Content.Ptr, changeVector.Size);
+                    pos += changeVector.Size;
+                    keyMem.Ptr[pos++] = RecordSeparator;
+                }
+
+                if (keyType != KeyType.Prefix)
+                {
+                    Memory.Copy(keyMem.Ptr + pos, lowerName, lowerNameSize);
+                    pos += lowerNameSize;
+                    keyMem.Ptr[pos++] = RecordSeparator;
+
+                    if (keyType == KeyType.Key)
+                    {
+                        base64Hash.CopyTo(keyMem.Ptr + pos);
+                        pos += base64Hash.Size;
+                        keyMem.Ptr[pos++] = RecordSeparator;
+
+                        Memory.Copy(keyMem.Ptr + pos, lowerContentTypePtr, lowerContentTypeSize);
+                    }
+                }
+
+                keySlice = new Slice(SliceOptions.Key, keyMem);
+                return scope;
+            }
+
+            public static AttachmentType GetAttachmentType(Slice key)
+            {
+                var separatorIndex = FindNextSeparator(key.AsReadOnlySpan(), 0);
+                var typeIndex = separatorIndex + 1;
+                
+                if (typeIndex >= key.Size)
+                    throw new InvalidOperationException($"Could not parse {nameof(key)}");
+
+                var c = key[typeIndex];
+                if (c == RevisionType)
+                    return AttachmentType.Revision;
+
+                Debug.Assert(c == DocType);
+                return AttachmentType.Document;
+            }
+            
+            private static int FindNextSeparator(ReadOnlySpan<byte> key, int start)
+            {
+                for (var i = start; i < key.Length; i++)
+                {
+                    if (key[i] == RecordSeparator)
+                        return i;
+                }
+
+                return key.Length;
             }
         }
     }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/AttachmentTombstonesToRavenEtlItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/AttachmentTombstonesToRavenEtlItems.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven.Enumerators
 
         public static bool FilterAttachment(DocumentsOperationContext context, RavenEtlItem item)
         {
-            var documentId = AttachmentsStorage.GetDocIdAndAttachmentName(context, item.AttachmentTombstoneId).DocId;
+            var documentId = AttachmentsStorage.AttachmentKey.ExtractDocIdAndAttachmentName(context, item.AttachmentTombstoneId).DocId;
             var document = context.DocumentDatabase.DocumentsStorage.Get(context, documentId);
             if (document == null)
                 return true; // document could be deleted, no need to send DELETE of tombstone, we can filter it out

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -325,7 +325,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                             }
                             else
                             {
-                                var (doc, attachmentName) = AttachmentsStorage.GetDocIdAndAttachmentName(Context, item.AttachmentTombstoneId);
+                                var (doc, attachmentName) = AttachmentsStorage.AttachmentKey.ExtractDocIdAndAttachmentName(Context, item.AttachmentTombstoneId);
                                 _currentRun.DeleteAttachment(doc, attachmentName);
                             }
                         }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1184,7 +1184,7 @@ namespace Raven.Server.Documents.Replication
                                 {
                                     if (database.DocumentsStorage.AttachmentsStorage.AttachmentExists(context, attachment.Base64Hash) == false)
                                     {
-                                        Debug.Assert(result.Attachment == null || AttachmentsStorage.GetAttachmentTypeByKey(attachment.Key) != AttachmentType.Revision,
+                                        Debug.Assert(result.Attachment == null || AttachmentsStorage.AttachmentKey.GetAttachmentType(attachment.Key) != AttachmentType.Revision,
                                             "the stream should have been written when the revision was added by the document");
                                         database.DocumentsStorage.AttachmentsStorage.PutAttachmentStream(context, attachment.Key, attachmentStream.Base64Hash, attachmentStream.Stream);
                                     }

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -809,7 +809,7 @@ namespace Raven.Server.Documents.Replication
                     if (MissingAttachmentsInLastBatch)
                         return false;
 
-                    var type = AttachmentsStorage.GetAttachmentTypeByKey(attachment.Key);
+                    var type = AttachmentsStorage.AttachmentKey.GetAttachmentType(attachment.Key);
                     if (type == AttachmentType.Revision)
                     {
                         return false;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1822,7 +1822,7 @@ namespace Raven.Server.Smuggler.Documents
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(_context, contentType, out Slice lowerContentType, out Slice contentTypeSlice))
                     using (Slice.External(_context.Allocator, hash, out Slice base64Hash))
                     using (Slice.From(_context.Allocator, document.ChangeVector, out Slice cv))
-                    using (attachmentsStorage.GetAttachmentKey(_context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size,
+                    using (AttachmentsStorage.AttachmentKey.GetKey(_context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size,
                                base64Hash, lowerContentType.Content.Ptr, lowerContentType.Size, type, cv, out Slice keySlice))
                     {
                         attachmentsStorage.PutDirect(context, keySlice, nameSlice, contentTypeSlice, base64Hash);

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11379.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11379.cs
@@ -151,7 +151,6 @@ for (var i = 0; i < attachments.length; i++) {
                         session.SaveChanges();
                     }
                 }
-                WaitForUserToContinueTheTest(dest);
                 var etlDone2 = WaitForEtl(src, (n, s) => s.LoadSuccesses >= numberOfDocs * 4);
                 Assert.True(etlDone2.Wait(TimeSpan.FromMinutes(1)));
 
@@ -228,7 +227,6 @@ for (var i = 0; i < attachments.length; i++) {
 
                     session.SaveChanges();
                 }
-                WaitForUserToContinueTheTest(dest);
 
                 var etlDone2 = WaitForEtl(src, (n, s) => s.LoadSuccesses >= numberOfDocs * 2);
                 Assert.True(etlDone2.Wait(TimeSpan.FromMinutes(1)));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24133

### Additional description
This PR addresses an issue with the `ThrowMissingAttachment` method, which previously returned the change vector instead of the attachment name in case of revision.

##### Key Changes
- Moved attachment-related functions to a dedicated class.
- Updated `ExtractDocIdAndAttachmentName` to also account for the attachment type (revision or not).
- The full attachment key was included in the `ThrowMissingAttachment` exception.

Most of the visible changes are from moving code; functional modifications have been kept minimal.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
