### PR TITLE
RavenDB-24072 Fix C# class generation for RavenVector fields

### DIFF
--- a/src/Raven.Server/Documents/JsonClassGenerator.cs
+++ b/src/Raven.Server/Documents/JsonClassGenerator.cs
@@ -295,14 +295,14 @@ namespace Raven.Server.Documents
                 foreach (var fieldPair in properties.ToList())
                 {
                     var field = fieldPair.Value;
-                    if (field.Name == root.Item1.Name)
+                    if (field.Name == root.ClassType.Name)
                     {
                         properties[fieldPair.Key] = new FieldType(name, field.IsArray, field.IsPrimitive);
                         changed = true;
                     }
                 }
 
-                if (@class.Name == root.Item1.Name)
+                if (@class.Name == root.ClassType.Name)
                 {
                     _generatedTypes[pair.Key] = new ClassType(name, properties);
                 }
@@ -316,7 +316,7 @@ namespace Raven.Server.Documents
             return _generatedTypes.Select(x => x.Value).ToList();
         }
 
-        internal (ClassType, Dictionary<string, FieldType>) GenerateClassTypesFromObject(string name, BlittableJsonReaderObject blittableObject)
+        internal (ClassType ClassType, Dictionary<string, FieldType> VectorFieldsToAdd) GenerateClassTypesFromObject(string name, BlittableJsonReaderObject blittableObject)
         {
             var fields = new Dictionary<string, FieldType>();
             var vectorFieldsToAdd = new Dictionary<string, FieldType>();
@@ -362,7 +362,9 @@ namespace Raven.Server.Documents
             // check if we can get the name from the metadata. 
             var classType = new ClassType(name, fields);
             classType = IncludeGeneratedClass(classType);
-            return (classType, vectorFieldsToAdd);
+            
+            // Clearing vector fields to add
+            return (classType, []);
         }
 
         private FieldType GetArrayField(BlittableJsonReaderArray array, string name)
@@ -433,7 +435,7 @@ namespace Raven.Server.Documents
                 case BlittableJsonToken.EmbeddedBlittable:
                 case BlittableJsonToken.StartObject:
                 case BlittableJsonToken.StartObject | BlittableJsonToken.OffsetSizeByte | BlittableJsonToken.PropertyIdSizeByte:
-                    return GenerateClassTypesFromObject(name, (BlittableJsonReaderObject)firstElement.Item1).Item1;
+                    return GenerateClassTypesFromObject(name, (BlittableJsonReaderObject)firstElement.Item1).ClassType;
                 case BlittableJsonToken.StartArray:
                 case BlittableJsonToken.StartArray | BlittableJsonToken.OffsetSizeByte:
                 case BlittableJsonToken.StartArray | BlittableJsonToken.OffsetSizeShort:

--- a/src/Raven.Server/Documents/JsonClassGenerator.cs
+++ b/src/Raven.Server/Documents/JsonClassGenerator.cs
@@ -295,14 +295,14 @@ namespace Raven.Server.Documents
                 foreach (var fieldPair in properties.ToList())
                 {
                     var field = fieldPair.Value;
-                    if (field.Name == root.Name)
+                    if (field.Name == root.Item1.Name)
                     {
                         properties[fieldPair.Key] = new FieldType(name, field.IsArray, field.IsPrimitive);
                         changed = true;
                     }
                 }
 
-                if (@class.Name == root.Name)
+                if (@class.Name == root.Item1.Name)
                 {
                     _generatedTypes[pair.Key] = new ClassType(name, properties);
                 }
@@ -316,9 +316,10 @@ namespace Raven.Server.Documents
             return _generatedTypes.Select(x => x.Value).ToList();
         }
 
-        internal ClassType GenerateClassTypesFromObject(string name, BlittableJsonReaderObject blittableObject)
+        internal (ClassType, Dictionary<string, FieldType>) GenerateClassTypesFromObject(string name, BlittableJsonReaderObject blittableObject)
         {
             var fields = new Dictionary<string, FieldType>();
+            var vectorFieldsToAdd = new Dictionary<string, FieldType>();
 
             for (var i = 0; i < blittableObject.Count; i++)
             {
@@ -333,23 +334,35 @@ namespace Raven.Server.Documents
                 {
                     case BlittableJsonToken.EmbeddedBlittable:
                     case BlittableJsonToken.StartObject:
-                        var type = GenerateClassTypesFromObject(prop.Name, (BlittableJsonReaderObject)prop.Value);
+                        var (type, newVectorFields) = GenerateClassTypesFromObject(prop.Name, (BlittableJsonReaderObject)prop.Value);
                         fields[prop.Name] = new FieldType(type.Name, type.IsArray);
+                        vectorFieldsToAdd = vectorFieldsToAdd.Concat(newVectorFields).ToDictionary(x => x.Key, x => x.Value);
                         break;
                     case BlittableJsonToken.StartArray:
                         var array = (BlittableJsonReaderArray)prop.Value;
                         fields[prop.Name] = GetArrayField(array, prop.Name);
                         break;
+                    case BlittableJsonToken.Vector:
+                        var vector = (BlittableJsonReaderVector)prop.Value;
+                        var vectorField = GetVectorField(vector);
+                        vectorFieldsToAdd[name] = vectorField;
+                        
+                        return (new ClassType(name, fields), vectorFieldsToAdd);
                     default:
                         fields[prop.Name] = GetTokenTypeFromPrimitiveType(prop.Token, prop.Value);
                         break;
                 }
             }
 
+            foreach (var field in vectorFieldsToAdd)
+            {
+                fields[field.Key] = field.Value;
+            }
+            
             // check if we can get the name from the metadata. 
-            var clazz = new ClassType(name, fields);
-            clazz = IncludeGeneratedClass(clazz);
-            return clazz;
+            var classType = new ClassType(name, fields);
+            classType = IncludeGeneratedClass(classType);
+            return (classType, vectorFieldsToAdd);
         }
 
         private FieldType GetArrayField(BlittableJsonReaderArray array, string name)
@@ -369,27 +382,46 @@ namespace Raven.Server.Documents
             return new FieldType(guessedType.Name, true, true);
         }
 
-        private ClassType IncludeGeneratedClass(ClassType clazz)
+        private FieldType GetVectorField(BlittableJsonReaderVector vector)
         {
-            var key = clazz.Name;
+            return vector.Type switch
+            {
+                BlittableVectorType.Float => new FieldType("RavenVector<float>"),
+                BlittableVectorType.Byte => new FieldType("RavenVector<byte>"),
+                BlittableVectorType.SByte => new FieldType("RavenVector<sbyte>"),
+                BlittableVectorType.UInt64 => new FieldType("RavenVector<ulong>"),
+                BlittableVectorType.UInt32 => new FieldType("RavenVector<uint>"),
+                BlittableVectorType.UInt16 => new FieldType("RavenVector<ushort>"),
+                BlittableVectorType.Int64 => new FieldType("RavenVector<long>"),
+                BlittableVectorType.Int32 => new FieldType("RavenVector<int>"),
+                BlittableVectorType.Int16 => new FieldType("RavenVector<short>"),
+                BlittableVectorType.Double => new FieldType("RavenVector<double>"),
+                BlittableVectorType.Half => new FieldType("RavenVector<Half>"),
+                _ => throw new NotSupportedException($"{vector.Type} is not a supported vector type.")
+            };
+        }
+
+        private ClassType IncludeGeneratedClass(ClassType classType)
+        {
+            var key = classType.Name;
 
             var i = 1;
             while (_generatedTypes.TryGetValue(key, out ClassType dummy))
             {
-                key = clazz.Name + i;
+                key = classType.Name + i;
                 i++;
             }
 
-            clazz = new ClassType(key, clazz.Properties);
+            classType = new ClassType(key, classType.Properties);
 
             foreach (var pair in _generatedTypes)
             {
-                if (pair.Value == clazz)
+                if (pair.Value == classType)
                     return pair.Value;
             }
 
-            _generatedTypes[key] = clazz;
-            return clazz;
+            _generatedTypes[key] = classType;
+            return classType;
         }
 
         private FieldType GuessTokenTypeFromArray(string name, BlittableJsonReaderArray array)
@@ -401,7 +433,7 @@ namespace Raven.Server.Documents
                 case BlittableJsonToken.EmbeddedBlittable:
                 case BlittableJsonToken.StartObject:
                 case BlittableJsonToken.StartObject | BlittableJsonToken.OffsetSizeByte | BlittableJsonToken.PropertyIdSizeByte:
-                    return GenerateClassTypesFromObject(name, (BlittableJsonReaderObject)firstElement.Item1);
+                    return GenerateClassTypesFromObject(name, (BlittableJsonReaderObject)firstElement.Item1).Item1;
                 case BlittableJsonToken.StartArray:
                 case BlittableJsonToken.StartArray | BlittableJsonToken.OffsetSizeByte:
                 case BlittableJsonToken.StartArray | BlittableJsonToken.OffsetSizeShort:

--- a/test/SlowTests/Issues/RavenDB-24072.cs
+++ b/test/SlowTests/Issues/RavenDB-24072.cs
@@ -26,7 +26,11 @@ public class RavenDB_24072 : RavenTestBase
                     Name = "TestName", 
                     FloatsVector = new RavenVector<float>([0.1f, 0.2f, 0.3f]), 
                     BytesVector = new RavenVector<byte>([21, 37]), 
-                    SbytesVector = new RavenVector<sbyte>([21, 37])
+                    SbytesVector = new RavenVector<sbyte>([21, 37]),
+                    SubDto = new SubDto()
+                    {
+                        Subvector = new RavenVector<float>([0.5f, 0.6f])
+                    }
                 };
                 
                 await session.StoreAsync(dto);
@@ -50,6 +54,12 @@ public class RavenDB_24072 : RavenTestBase
         public RavenVector<float> FloatsVector { get; set; }
         public RavenVector<byte> BytesVector { get; set; }
         public RavenVector<sbyte> SbytesVector { get; set; }
+        public SubDto SubDto { get; set; }
+    }
+
+    private class SubDto
+    {
+        public RavenVector<float> Subvector { get; set; }
     }
     
     private const string ExpectedResult = """
@@ -61,12 +71,18 @@ public class RavenDB_24072 : RavenTestBase
 
                                           namespace SlowTests.Issues
                                           {
+                                              public class SubDto
+                                              {
+                                                  public RavenVector<float> Subvector { get; set; } 
+                                              }
+                                          
                                               public class RavenDB_24072+Dto
                                               {
                                                   public RavenVector<sbyte> BytesVector { get; set; } 
                                                   public RavenVector<float> FloatsVector { get; set; } 
                                                   public string Name { get; set; } 
                                                   public RavenVector<sbyte> SbytesVector { get; set; } 
+                                                  public SubDto SubDto { get; set; } 
                                               }
                                           }
                                           """;

--- a/test/SlowTests/Issues/RavenDB-24072.cs
+++ b/test/SlowTests/Issues/RavenDB-24072.cs
@@ -1,0 +1,73 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Server.Documents.Commands;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24072 : RavenTestBase
+{
+    public RavenDB_24072(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public async Task CanGenerateClassWithRavenVector()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var dto = new Dto()
+                {
+                    Id = "dtos/1",
+                    Name = "TestName", 
+                    FloatsVector = new RavenVector<float>([0.1f, 0.2f, 0.3f]), 
+                    BytesVector = new RavenVector<byte>([21, 37]), 
+                    SbytesVector = new RavenVector<sbyte>([21, 37])
+                };
+                
+                await session.StoreAsync(dto);
+                await session.SaveChangesAsync();
+                
+                var command = new GenerateClassFromDocumentCommand("dtos/1", "csharp");
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command, session.Advanced.Context);
+
+                var @class = command.Result;
+
+                RavenTestHelper.AssertEqualRespectingNewLines(ExpectedResult, @class);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public RavenVector<float> FloatsVector { get; set; }
+        public RavenVector<byte> BytesVector { get; set; }
+        public RavenVector<sbyte> SbytesVector { get; set; }
+    }
+    
+    private const string ExpectedResult = """
+                                          using System;
+                                          using System.Collections.Generic;
+                                          using System.Linq;
+                                          using System.Text;
+                                          using System.Threading.Tasks;
+
+                                          namespace SlowTests.Issues
+                                          {
+                                              public class RavenDB_24072+Dto
+                                              {
+                                                  public RavenVector<sbyte> BytesVector { get; set; } 
+                                                  public RavenVector<float> FloatsVector { get; set; } 
+                                                  public string Name { get; set; } 
+                                                  public RavenVector<sbyte> SbytesVector { get; set; } 
+                                              }
+                                          }
+                                          """;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24072/Cannot-generate-C-Class-from-document

### Additional description

RavenVector fields should be properly handled during document to C# class conversion

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
