### PR TITLE
RavenDB-23710 Fix index fields display in fields studio view for auto indexes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -57,10 +57,10 @@ namespace Raven.Server.Documents.Indexes.Auto
                 .IndexFields
                 .Keys
                 .ToHashSet();
+            
+            staticEntries.Add(Constants.Documents.Indexing.Fields.DocumentIdFieldName);
 
             var dynamicEntries = GetDynamicEntriesFields(staticEntries);
-
-            staticEntries.Add(Constants.Documents.Indexing.Fields.DocumentIdFieldName);
 
             return (staticEntries, dynamicEntries);
         }

--- a/test/SlowTests/Issues/RavenDB-23710.cs
+++ b/test/SlowTests/Issues/RavenDB-23710.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23710 : RavenTestBase
+{
+    public RavenDB_23710(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task IdFieldShouldBeDisplayedAsStatic()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Dto() { Name = "SomeName" });
+                await session.SaveChangesAsync();
+
+                _ = await session.Query<Dto>()
+                    .Statistics(out var stats)
+                    .Where(x => x.Name == "SomeName")
+                    .ToListAsync();
+                
+                string url = $"{store.Urls.First()}/databases/{store.Database}/indexes/debug?name={stats.IndexName}&op=entries-fields&nodeTag=A";
+
+                using (var client = new HttpClient())
+                {
+                    var response = (await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url))).Content;
+                    var data = await response.ReadAsByteArrayAsync();
+                    Assert.NotNull(data);
+                    var indexFields = JsonConvert.DeserializeObject<Response>(Encodings.Utf8.GetString(data));
+
+                    Assert.Equal(2, indexFields.Static.Length);
+                    Assert.Equal(0, indexFields.Dynamic.Length);
+                    
+                    Assert.Contains("id()", indexFields.Static);
+                }
+            }
+        }
+    }
+    
+    private class Response
+    {
+        public string[] Static { get; set; }
+        public string[] Dynamic { get; set; }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }   
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23710/Automatic-index-for-vector-search-has-id-twice

### Additional description

`id()` should be displayed as static field in index fields studio view for auto indexes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
