### PR TITLE
RavenDB-21083 - Enable support for multi-part uploads up to 5TB

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -22,8 +22,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
     {
         private readonly Progress _progress;
         private readonly CancellationToken _cancellationToken;
-        internal Size MaxUploadPutObject = new Size(256, SizeUnit.Megabytes);
-        internal Size MinOnePartUploadSizeLimit = new Size(100, SizeUnit.Megabytes);
+        internal Size MaxUploadPutObject = new Size(1, SizeUnit.Gigabytes);
+        internal Size MinOnePartUploadSizeLimit = new Size(512, SizeUnit.Megabytes);
         internal readonly AmazonS3Config Config;
 
         private static readonly Size TotalBlocksSizeLimit = new Size(5, SizeUnit.Terabytes);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21083

### Additional description

AWS S3 supports multipart uploads with up to 10,000 parts. With this change:

Files under `1GB`: Uploaded as a single part
Files over `1GB`: Split into multiple parts (up to 10,000)
Maximum file size: `512MB` × 10,000 = `5TB`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
