### PR TITLE
RavenDB-24141: Fix to handle cancellation gracefully in LogTrafficWatch and prevent immediate exit in Raven.Debug `traffic` command

### DIFF
--- a/tools/Raven.Debug/CommandLineApp.cs
+++ b/tools/Raven.Debug/CommandLineApp.cs
@@ -309,7 +309,11 @@ namespace Raven.Debug
 
                     var logTrafficWatch = new LogTrafficWatch.LogTrafficWatch(path, url, cert, certPass, database, changeTypes?.ToArray(), verboseArg.HasValue());
 
-                    Console.CancelKeyPress += (sender, args) => logTrafficWatch.Stop();
+                    Console.CancelKeyPress += (_, args) =>
+                    {
+                        args.Cancel = true;
+                        logTrafficWatch.Stop();
+                    };
 
                     using (logTrafficWatch)
                         logTrafficWatch.Connect().Wait();

--- a/tools/Raven.Debug/LogTrafficWatch/LogTrafficWatch.cs
+++ b/tools/Raven.Debug/LogTrafficWatch/LogTrafficWatch.cs
@@ -74,7 +74,6 @@ namespace Raven.Debug.LogTrafficWatch
         {
             Console.WriteLine("Stop collection traffic watch. Exiting...");
             Dispose();
-            Environment.Exit(0);
         }
 
         public static string ToWebSocketPath(string path)
@@ -87,13 +86,16 @@ namespace Raven.Debug.LogTrafficWatch
 
         public async Task Connect()
         {
-
-            while (true)
+            while (_cancellationTokenSource.Token.IsCancellationRequested == false)
             {
                 try
                 {
                     _runningTask = ConnectInternal();
                     await _runningTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (_cancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    return;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24141

### Additional description

Graceful shutdown for `Raven.Debug traffic` command so that pressing `Ctrl + C` no longer corrupts the captured archive:
1. Handle `Ctrl + C` without killing the process
   `Console.CancelKeyPress` now sets `args.Cancel = true`, allowing our own cleanup code to run before the CLR exits.

2. Remove the forced `Environment.Exit(0)`
   `LogTrafficWatch.Stop()` now waits for disposals/flushing to complete and lets the app exit naturally.

3. Honor cancellation in the WebSocket loop
   `Connect()` checks `CancellationToken.IsCancellationRequested` and returns immediately instead of retrying.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
