### PR TITLE
RavenDB-23896: Update audit log message for one-time backup execution

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -478,7 +478,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     {
                         var backupKind = backupTask._isFullBackup ? BackupKind.Full : BackupKind.Incremental;
                         var configurationString = context.ReadObject(periodicBackup.Configuration.ToAuditJson(), nameof(PeriodicBackupConfiguration)).ToString();
-                        _auditLog.Info($"EXPORT {backupKind} backup executed automatically as scheduled with configuration: '{configurationString}'");
+                        _auditLog.Info($"BACKUP {backupKind} backup executed automatically as scheduled with configuration: '{configurationString}'");
                     }
                 }
             }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -548,7 +548,16 @@ namespace Raven.Server.Web.System
                         writer.WriteOperationIdAndNodeTag(context, operationId, ServerStore.NodeTag);
                     }
 
-                    LogTaskToAudit(BackupDatabaseOnceTag, operationId, json);
+                    if (LoggingSource.AuditLog.IsInfoEnabled)
+                    {
+                        var target = $"'{BackupDatabaseOnceTag}' with operation ID: '{operationId}'";
+
+                        var configurationJson = JsonDeserializationServer.BackupConfiguration(json).ToAuditJson();
+                        if (configurationJson != null)
+                            target += $" Configuration: {context.ReadObject(configurationJson, BackupDatabaseOnceTag)}";
+
+                        LogAuditFor(Database.Name, action: "BACKUP", target);
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23896

### Additional description

The keyword within the AuditLog record has been modified for one-time backups.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
