### PR TITLE
RavenDB-23811 - Revert how we calculate the AdditionalMemoryUsageSize

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -125,7 +125,7 @@ namespace Voron.Impl
         {
             get
             {
-                return new Size(_allocator._totalAllocated + TotalEncryptionBufferInBytes, SizeUnit.Bytes);
+                return new Size(DecompressedBufferBytes + TotalEncryptionBufferInBytes, SizeUnit.Bytes);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23811/StressTests.Issues.RavenDB13861.BatchMemorySizeLimitationShouldBeExactInEncryptedModeIn64Bit
https://issues.hibernatingrhinos.com/issue/RavenDB-23812/StressTests.Issues.RavenDB13861.BatchMemorySizeLimitationShouldBeExactIn64Bit
https://issues.hibernatingrhinos.com/issue/RavenDB-23813/StressTests.Issues.RavenDB13861.BatchMemorySizeLimitationShouldBeExactIn32Bit
https://issues.hibernatingrhinos.com/issue/RavenDB-23814/StressTests.Issues.RavenDB13861.BatchMemorySizeLimitationShouldBeExactInEncryptedModeIn32Bit

### Additional description

- The original change was introduced in https://github.com/ravendb/ravendb/pull/20178 to address a memory leak.
- This change made subscription batch sizes inconsistent.
- The memory leak was subsequently fixed in https://github.com/ravendb/ravendb/pull/20266.
- This calculation is no longer necessary and could potentially mask different memory leaks we might introduce in the future.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
