### PR TITLE
RavenDB-24134 Enhance the replication debug endpoint functionality

### DIFF
--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -1,6 +1,17 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Raven.Client;
+using Raven.Client.Exceptions;
+using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Processors.Replication;
+using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Routing;
@@ -94,9 +105,13 @@ namespace Raven.Server.Documents.Handlers
         {
             var etag = GetLongQueryString("etag", required: false) ?? 0L;
             var pageSize = GetPageSize();
+            var types = GetStringValuesQueryString("type", required: false)
+                .Select(x => Enum.Parse<ReplicationBatchItem.ReplicationItemType>(x, ignoreCase: true))
+                .ToHashSet();
+            var format = (GetStringQueryString("format", required: false) ?? "json").ToLower();
+            var columns = GetStringValuesQueryString("column", required: false).ToArray();
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             using (context.OpenReadTransaction())
             {
                 var runStats = new OutgoingReplicationRunStats();
@@ -117,17 +132,73 @@ namespace Raven.Server.Documents.Handlers
                     RevisionTombstonesWithId = true
                 };
 
-                var items = ReplicationDocumentSenderBase.GetReplicationItems(Database, context, etag, stats, supportedFeatures)
-                    .Take(pageSize);
+                var items = ReplicationDocumentSenderBase.GetReplicationItems(Database, context, etag: etag == 0 ? 0 : etag - 1, stats, supportedFeatures);
+                if (types.Count > 0)
+                    items = items.Where(x => types.Contains(x.Type));
+                items = items.Take(pageSize);
 
+                var debugItems = items.Select(x => x.ToDebugJson());
+
+                switch (format)
+                {
+                    case "json":
+                        await WriteJsonReplicationItems(context, debugItems);
+                        break;
+                    case "csv":
+                        await WriteCsvReplicationItems(columns, debugItems);
+                        break; 
+                    default:
+                        throw new BadRequestException($"Unknown format: '{format}'. Supported formats are 'json' and 'csv'.");
+                }
+            }
+        }
+
+        private async Task WriteCsvReplicationItems(string[] columns, IEnumerable<DynamicJsonValue> debugItems)
+        {
+            if (columns.Length == 0)
+                columns =
+                [
+                    nameof(ReplicationBatchItem.Type), nameof(ReplicationBatchItem.Etag), nameof(ReplicationBatchItem.ChangeVector),
+                    nameof(ReplicationBatchItem.LastModifiedTicks), nameof(ReplicationBatchItem.TransactionMarker), nameof(ReplicationBatchItem.Size)
+                ];
+            var encodedCsvFileName = Uri.EscapeDataString($"replication-all-items_{SystemTime.UtcNow.ToString("yyyyMMdd_HHmm", CultureInfo.InvariantCulture)}.csv");
+
+            HttpContext.Response.Headers.ContentDisposition = $"attachment; filename=\"{encodedCsvFileName}\"; filename*=UTF-8''{encodedCsvFileName}";
+            HttpContext.Response.Headers[Constants.Headers.ContentType] = "text/csv";
+
+            await using (var writer = new StreamWriter(HttpContext.Response.Body, Encoding.UTF8))
+            await using (var csvWriter = new CsvWriter(writer, new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = "," }))
+            {
+                foreach (string column in columns)
+                {
+                    csvWriter.WriteField(column);
+                }
+
+                await csvWriter.NextRecordAsync();
+                foreach (var item in debugItems)
+                {
+                    foreach (string column in columns)
+                    {
+                        var value = item[column];
+                        csvWriter.WriteField(field: value?.ToString());
+                    }
+
+                    await csvWriter.NextRecordAsync();
+                }
+            }
+        }
+
+        private async Task WriteJsonReplicationItems(DocumentsOperationContext context, IEnumerable<DynamicJsonValue> debugItems)
+        {
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+            {
                 context.Write(writer, new DynamicJsonValue
                 {
-                    ["Results"] = new DynamicJsonArray(items.Select(x => x.ToDebugJson())),
+                    ["Results"] = new DynamicJsonArray(debugItems),
                     ["DatabaseChangeVector"] = DocumentsStorage.GetFullDatabaseChangeVector(context)
                 });
             }
         }
-
 
         [RavenAction("/databases/*/replication/progress", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task GetReplicationProgress()

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             djv[nameof(Collection)] = Collection?.ToString(CultureInfo.InvariantCulture) ?? CollectionName.GetCollectionName(Data);
             djv[nameof(Id)] = Id.ToString(CultureInfo.InvariantCulture);
             djv[nameof(Flags)] = Flags;
+            djv["DataSize"] = Data?.Size ?? 0;
+            
             return djv;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24134

### Additional description
This PR introduces enhancements to the `/debug/replication/all-items` endpoint to improve usability and debugging flexibility:

##### Key Changes

- **Added `DataSize` column** for document items to help assess the size of each item.
- **Enabled filtering by item types** using the `types` query parameter (e.g., `types=Document&types=Attachment`).
- **Added support for CSV output** via the `format=csv` query parameter.
- **Customizable columns** in the CSV output using `column` parameters (e.g., `column=Etag&column=Id&column=DataSize`).

Example usage:
```
{server.Url}/databases/{database.Name}/debug/replication/all-items?format=csv&types=Document&column=Etag&column=Id&column=DataSize
```

- Although ReplicationDocumentSender.GetReplicationItems uses the ETag parameter as the last replicated ETag.
 In the context of the debug endpoint, it is more reasonable to use it as the first ETag to get the data.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
