### PR TITLE
RavenDB-23260 Lookup optimizations - v7.0 port.

### DIFF
--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -123,29 +123,21 @@ namespace Voron.Data.Lookups
                 if (_cursor._pos < 0)
                     return 0;
                 ref var state = ref _cursor._stk[_cursor._pos];
-                int totalRead = 0;
-                while (results.IsEmpty is false)
+                while (true)
                 {
                     Debug.Assert(state.Header->PageFlags.HasFlag(LookupPageFlags.Leaf));
                     if (state.LastSearchPosition < state.Header->NumberOfEntries)
                     {
                         var read = Math.Min(results.Length, state.Header->NumberOfEntries - state.LastSearchPosition);
-                        totalRead += read;
-                        for (int i = 0; i < read; i++)
-                        {
-                            results[i] = GetKeyData(ref state, state.LastSearchPosition++);
-                        }
-
-                        results = results[read..];
-                        continue;
+                        GetKeyDataInBulk(ref state, state.LastSearchPosition, results.Slice(0, read));
+                        return read;
                     }
                     if (_tree.GoToNextPage(ref _cursor) == false)
                     {
-                        break;
+                        return 0;
                     }
                     state = ref _cursor._stk[_cursor._pos];
                 }
-                return totalRead;
             }
 
             public int Fill(Span<long> results, long lastId = long.MaxValue, bool includeMax = true)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23260

### Additional description
Original PR: https://github.com/ravendb/ravendb/pull/20472

v7.0 was reading keys to fulfill the buffer (multiple pages), whereas in v6.2 we were reading only 1 page per call (or less if buffer was insufficient). I benchmarked this approach against the optimized algorithm from v6.2, and it seems slightly worse (around 3% slower - 3 calls with a 400M element index).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
