### PR TITLE
RavenDB-23909 Fix auto vector search indexes that use quantization and load embeddings from AI task

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -726,7 +726,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
 
     public VectorEmbeddingType GetQuantizationOf(EmbeddingsGenerationTaskIdentifier taskId)
     {
-        if(_workers.TryGetValue(taskId, out var worker)is false)
+        if (_workers.TryGetValue(taskId, out var worker) is false)
             return VectorEmbeddingType.Single;
         return worker.Configuration.Quantization;
     }
@@ -737,7 +737,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         params ReadOnlySpan<string> values)
     {
         var valueTask = GetEmbeddingsForQueryAsync(documentsContext, taskId, values);
-        if(valueTask.IsCompletedSuccessfully)
+        if (valueTask.IsCompletedSuccessfully)
             return valueTask.Result;
         
         return valueTask.AsTask().GetAwaiter().GetResult();
@@ -748,7 +748,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
         EmbeddingsGenerationTaskIdentifier taskId,
         params ReadOnlySpan<string> values)
     {
-        if(_workers.TryGetValue(taskId, out var worker) is false)
+        if (_workers.TryGetValue(taskId, out var worker) is false)
         {
             throw new InvalidQueryException($"Couldn't find Embeddings Generation task with '{taskId.Value}' identifier");
         }

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsHelper.cs
@@ -81,7 +81,8 @@ public static class EmbeddingsHelper
             case VectorEmbeddingType.Single:
                 return MemoryMarshalEx.Cast<float, byte>(embedding);
             case VectorEmbeddingType.Int8:
-            {   var dest = MemoryMarshal.Cast<float, sbyte>(embedding.Span);
+            {   
+                var dest = MemoryMarshal.Cast<float, sbyte>(embedding.Span);
                 if (VectorQuantizer.TryToInt8(embedding.Span, dest, out int usedBytes) == false)
                 {
                     var newMemory = new ReadOnlyMemory<float>(new float[embedding.Length + 1]);

--- a/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
@@ -143,31 +143,31 @@ namespace Raven.Server.Documents.Indexes
             _vectorSourceEmbeddingTypeToWrite.Add(fieldName, embeddingType);
         }
         
-        internal void SetFieldEmbeddingDimension(string fieldName, int dimensions, VectorEmbeddingType destinationEmbeddingType)
+        internal void SetFieldEmbeddingDimension(string fieldName, int embeddingLengthInBytes, VectorEmbeddingType destinationEmbeddingType)
         {
             _vectorFieldsDimensionsToWrite ??= new Dictionary<string, int>();
             
             if (_vectorFieldsDimensions.TryGetValue(fieldName, out int storedDimensions) || _vectorFieldsDimensionsToWrite.TryGetValue(fieldName, out storedDimensions))
             {
-                if (storedDimensions == dimensions)
+                if (storedDimensions == embeddingLengthInBytes)
                     return;
                 
                 if (destinationEmbeddingType == VectorEmbeddingType.Binary)
-                    throw new InvalidDataException($"Field {fieldName} contains embeddings with different number of dimensions.");
+                    throw new InvalidDataException($"Field {fieldName} contains embeddings with different number of dimensions than currently processed embedding.");
 
                 // Because dimensions number we get as a parameter is a length of a vector after the quantization and cast to bytes, we have to restore original 
                 // length for exception message
                 var (originalInputDimensions, originalDimensions) = destinationEmbeddingType switch
                 {
-                    VectorEmbeddingType.Single => (storedDimensions / sizeof(float), dimensions / sizeof(float)),
-                    VectorEmbeddingType.Int8 => (storedDimensions - sizeof(float), dimensions - sizeof(float)),
+                    VectorEmbeddingType.Single => (storedDimensions / sizeof(float), embeddingLengthInBytes / sizeof(float)),
+                    VectorEmbeddingType.Int8 => (storedDimensions - sizeof(float), embeddingLengthInBytes - sizeof(float)),
                     _ => throw new InvalidDataException($"Unexpected embedding type - {destinationEmbeddingType}.")
                 };
 
                 throw new InvalidDataException($"Attempted to index embedding with {originalDimensions} dimensions, but field {fieldName} already contains indexed embedding with {originalInputDimensions} dimensions, or was explicitly configured for embeddings with {originalInputDimensions} dimensions.");
             }
             
-            _vectorFieldsDimensionsToWrite.Add(fieldName, dimensions);
+            _vectorFieldsDimensionsToWrite.Add(fieldName, embeddingLengthInBytes);
         }
         
         internal void Persist(TransactionOperationContext indexContext)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -308,18 +308,18 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                 break;
             
             case ValueType.Vector:
-                using (var vectorField = (VectorValue)value)
+                using (var vectorValue = (VectorValue)value)
                 {
-                    if (vectorField.IsNull)
+                    if (vectorValue.IsNull)
                     {
                         builder.WriteNull(fieldId, path);
                         break;
                     }
                     
-                    var embedding = vectorField.GetEmbedding();
+                    var embedding = vectorValue.GetEmbedding();
                     var destinationEmbeddingType = field.Vector.DestinationEmbeddingType;
                     
-                    _index.IndexFieldsPersistence.SetFieldEmbeddingDimension(field.Name, vectorField.Length, destinationEmbeddingType);
+                    _index.IndexFieldsPersistence.SetFieldEmbeddingDimension(field.Name, vectorValue.Length, destinationEmbeddingType);
                     
                     builder.WriteVector(fieldId, path, embedding);
                 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -330,9 +330,21 @@ public static partial class CoraxQueryBuilder
 
             // Quantized dynamic field indicates that the task generated embeddings with different quantization than requested in the index
             // In this case we want to use quantization defined in dynamic field (which was set in CurrentIndexingScope.GetLoadVectorField)
-            var destinationEmbeddingType = builderParameters.Metadata.IsDynamic 
-                ? (sourceEmbeddingType is not VectorEmbeddingType.Single ? sourceEmbeddingType : vectorOptions!.DestinationEmbeddingType)
-                : (vectorOptions?.DestinationEmbeddingType ?? sourceEmbeddingType);
+            VectorEmbeddingType destinationEmbeddingType;
+            if (builderParameters.Metadata.IsDynamic)
+            {
+                if (sourceEmbeddingType is not VectorEmbeddingType.Single)
+                    destinationEmbeddingType = sourceEmbeddingType;
+                else
+                    destinationEmbeddingType = vectorOptions!.DestinationEmbeddingType;
+            }
+            else
+            {
+                if (vectorOptions?.DestinationEmbeddingType is not null)
+                    destinationEmbeddingType = vectorOptions!.DestinationEmbeddingType;
+                else
+                    destinationEmbeddingType = sourceEmbeddingType;
+            }
             
             ReadOnlyMemory<ReadOnlyMemory<byte>> embeddingValues;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -323,8 +323,7 @@ public static partial class CoraxQueryBuilder
             var database = builderParameters.Index.DocumentDatabase;
             
             var embeddingsTaskId = new EmbeddingsGenerationTaskIdentifier(embeddingsGenerationTaskIdentifier);
-
-
+            
             var embeddingsGenerator = database.EmbeddingsGeneratorQueries;
             
             var sourceEmbeddingType = embeddingsGenerator.GetQuantizationOf(embeddingsTaskId);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -328,7 +328,11 @@ public static partial class CoraxQueryBuilder
             
             var sourceEmbeddingType = embeddingsGenerator.GetQuantizationOf(embeddingsTaskId);
 
-            var destinationEmbeddingType = vectorOptions?.DestinationEmbeddingType ?? sourceEmbeddingType;
+            // Quantized dynamic field indicates that the task generated embeddings with different quantization than requested in the index
+            // In this case we want to use quantization defined in dynamic field (which was set in CurrentIndexingScope.GetLoadVectorField)
+            var destinationEmbeddingType = builderParameters.Metadata.IsDynamic 
+                ? (sourceEmbeddingType is not VectorEmbeddingType.Single ? sourceEmbeddingType : vectorOptions!.DestinationEmbeddingType)
+                : (vectorOptions?.DestinationEmbeddingType ?? sourceEmbeddingType);
             
             ReadOnlyMemory<ReadOnlyMemory<byte>> embeddingValues;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -293,13 +293,14 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                     var path = pathOfEmbeddingJsv.AsString();
                     
                     object objectForIndexing = AbstractStaticIndexBase.LoadVectorJs(field.Name, path, embeddingGeneratorName, out var indexField);
-                    
-                    if (objectForIndexing is CoraxDynamicItem dynamicItem)
-                        indexField = dynamicItem.Field;
 
-                    // Means we're in dictionary training phase
+                    if (objectForIndexing is CoraxDynamicItem dynamicItem)
+                    {
+                        indexField = dynamicItem.Field;
+                    }
                     else if (indexField is null)
                     {
+                        // Means we're in dictionary training phase
                         shouldProcessAsBlittable = false;
                         return;
                     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -292,8 +292,18 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                     var embeddingGeneratorName = nameofEmbeddingsGeneratorJsv.AsString();
                     var path = pathOfEmbeddingJsv.AsString();
                     
-                    // todo pass id
                     object objectForIndexing = AbstractStaticIndexBase.LoadVectorJs(field.Name, path, embeddingGeneratorName, out var indexField);
+                    
+                    if (objectForIndexing is CoraxDynamicItem dynamicItem)
+                        indexField = dynamicItem.Field;
+
+                    // Means we're in dictionary training phase
+                    else if (indexField is null)
+                    {
+                        shouldProcessAsBlittable = false;
+                        return;
+                    }
+                    
                     InsertRegularField(indexField, objectForIndexing, indexContext, builder, sourceDocument, out shouldSkip);
                     shouldProcessAsBlittable = false;
                     return;

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -474,21 +474,70 @@ namespace Raven.Server.Documents.Indexes.Static
             
             Debug.Assert(embeddingsGenerationTaskIdentifier.Value is not null);
             var fieldExists = Index.Definition.MapFields.TryGetValue(fieldName, out var mapField);
-            var fieldHasVector = fieldExists && mapField is IndexField { Vector: not null };
-
+            var fieldHasVector = fieldExists && mapField is IndexField { Vector: not null } or AutoIndexField { Vector: not null };
+            
+            // vectorEmbeddingTypeInDocument is the quantization (destination EmbeddingType) of task used for embeddings generation
+            // If auto field should use a different quantization, we have to override the index field by making a dynamic field with new configuration 
+            var autoIndexFieldRequiresQuantization =
+                fieldHasVector && mapField is AutoIndexField aif && aif.Vector.DestinationEmbeddingType != vectorEmbeddingTypeInDocument;
+            
             IndexField vectorField;
-            switch (FieldExists: fieldExists, FieldHasVector: fieldHasVector)
+            switch (FieldExists: fieldExists, FieldHasVector: fieldHasVector, AutoIndexFieldRequiresQuantization: autoIndexFieldRequiresQuantization)
             {
-                case (FieldExists: true, FieldHasVector: true):
+                case (FieldExists: true, FieldHasVector: true, AutoIndexFieldRequiresQuantization: true):
                 {
-                    field = (IndexField)mapField;
-                    PortableExceptions.ThrowIfNot<InvalidOperationException>(vectorEmbeddingTypeInDocument == field!.Vector.SourceEmbeddingType, $"Document contains vector in format '{vectorEmbeddingTypeInDocument}' but field '{fieldName}' is configured to source: '{field.Vector.SourceEmbeddingType}'");
+                    AutoIndexField autoField = mapField as AutoIndexField;
+                    var destinationTargetEmbeddingType = autoField!.Vector.DestinationEmbeddingType;
                     
-                    vectorField =  field;
+                    // The task produced quantized embeddings, but auto index field has F32 set (default value)
+                    // This means the same quantization as in task should be used
+                    if (vectorEmbeddingTypeInDocument is not VectorEmbeddingType.Single && destinationTargetEmbeddingType is VectorEmbeddingType.Single)
+                        destinationTargetEmbeddingType = vectorEmbeddingTypeInDocument;
+                    
+                    vectorField = IndexField.Create(fieldName,
+                        new IndexFieldOptions()
+                        {
+                            Vector = new VectorOptions()
+                            {
+                                SourceEmbeddingType = vectorEmbeddingTypeInDocument,
+                                DestinationEmbeddingType = destinationTargetEmbeddingType,
+                                Dimensions = VectorOptions.DefaultText.Dimensions,
+                                NumberOfEdges = Index.Configuration.CoraxVectorDefaultNumberOfEdges,
+                                NumberOfCandidatesForIndexing = Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForIndexing,
+                            }
+                        }, null, Corax.Constants.IndexWriter.DynamicField);
+                    
+                    vectorField.Vector.Validate();
                     break;
                 }
-                case (FieldExists: true, FieldHasVector: false):
-                case (FieldExists: false, _):
+                case (FieldExists: true, FieldHasVector: true, AutoIndexFieldRequiresQuantization: false):
+                {
+                    if (mapField is AutoIndexField)
+                    {
+                        vectorField = IndexField.Create(fieldName,
+                            new IndexFieldOptions()
+                            {
+                                Vector = new VectorOptions()
+                                {
+                                    SourceEmbeddingType = vectorEmbeddingTypeInDocument,
+                                    DestinationEmbeddingType = vectorEmbeddingTypeInDocument,
+                                    Dimensions = VectorOptions.DefaultText.Dimensions,
+                                    NumberOfEdges = Index.Configuration.CoraxVectorDefaultNumberOfEdges,
+                                    NumberOfCandidatesForIndexing = Index.Configuration.CoraxVectorDefaultNumberOfCandidatesForIndexing,
+                                }
+                            }, null, Corax.Constants.IndexWriter.DynamicField);
+                    }
+
+                    else
+                        vectorField = (IndexField)mapField;
+
+                    var fieldVectorOptions = vectorField!.Vector;
+                    PortableExceptions.ThrowIfNot<InvalidOperationException>(vectorEmbeddingTypeInDocument == fieldVectorOptions.SourceEmbeddingType, $"Document contains vector in format '{vectorEmbeddingTypeInDocument}' but field '{fieldName}' is configured to source: '{fieldVectorOptions.SourceEmbeddingType}'");
+                    
+                    break;
+                }
+                case (FieldExists: true, FieldHasVector: false, AutoIndexFieldRequiresQuantization: _):
+                case (FieldExists: false, _, _):
                 {
                     vectorField = IndexField.Create(fieldName,
                         new IndexFieldOptions()

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -489,8 +489,14 @@ namespace Raven.Server.Documents.Indexes.Static
                     AutoIndexField autoField = mapField as AutoIndexField;
                     var destinationTargetEmbeddingType = autoField!.Vector.DestinationEmbeddingType;
                     
-                    // The task produced quantized embeddings, but auto index field has F32 set (default value)
-                    // This means the same quantization as in task should be used
+                    // The embeddings generation task used by this index field produced quantized (I8 or I1) embeddings, but field settings assume no quantization
+                    // (F32 - default value), which was set because query syntax isn't aware of embeddings generation task settings.
+                    //
+                    // This means we have to set the correct source quantization type for currently processed auto index field (equal to destination quantization type
+                    // of embeddings generation task used by this field).
+                    //
+                    // We can't handle this when creating index fields based on query syntax (in dynamic query matcher & runner), it would require us to read database
+                    // record every time we do the query. Instead, we have to rewrite it here by creating a dynamic field with updated quantization type.
                     if (vectorEmbeddingTypeInDocument is not VectorEmbeddingType.Single && destinationTargetEmbeddingType is VectorEmbeddingType.Single)
                         destinationTargetEmbeddingType = vectorEmbeddingTypeInDocument;
                     

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
@@ -523,7 +523,7 @@ public partial class AbstractStaticIndexBase
         
         var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskName, out vectorField);
 
-        //for js indexes we've no choice than create dynamic field, in such cases let's assume it is single. 
+        // for js indexes we've no choice than create dynamic field, in such cases let's assume it is single. 
         if (vectorField == null)
         {
             vectorField = RetrieveCreateVectorField(fieldName, null);
@@ -585,8 +585,8 @@ public partial class AbstractStaticIndexBase
                 if (Enum.TryParse(enumAsStr.AsSpan(), out expectedVectorType) == false)
                     expectedVectorType = VectorEmbeddingType.Single;
             }
-        
-            indexField = currentIndexingScope.GetLoadVectorField(fieldName, embeddingGenerationTaskIdentifier,  expectedVectorType);
+
+            indexField = currentIndexingScope.GetLoadVectorField(fieldName, embeddingGenerationTaskIdentifier, expectedVectorType);
         }
         
         if (embeddingContainerObject is BlittableJsonReaderArray bjra)

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -162,10 +162,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
             var defaultAutoIndexingEngineType = Database.Configuration.Indexing.AutoIndexingEngineType;
             
             var map = DynamicQueryMapping.Create(query, defaultAutoIndexingEngineType);
-
-            if (query.Metadata.HasVectorSearch)
-                ValidateVectorFields();
-
+            
             (long? Index, Index Instance) result = default;
 
             while (TryMatchExistingIndexToQuery(map, out result.Instance) == false)
@@ -176,6 +173,9 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 if (query.DisableAutoIndexCreation)
                     throw new InvalidOperationException("Creation of Auto Indexes was disabled and no Auto Index matching the given query was found.");
 
+                if (query.Metadata.HasVectorSearch)
+                    ValidateVectorFields();
+                
                 var definition = map.CreateAutoIndexDefinition();
                 result = await _indexStore.CreateIndex(definition, RaftIdGenerator.NewId());
                 var index = result.Instance;

--- a/test/SlowTests/Issues/RavenDB-22076.cs
+++ b/test/SlowTests/Issues/RavenDB-22076.cs
@@ -330,7 +330,7 @@ public class RavenDB_22076 : RavenTestBase
                 var indexErrors = Indexes.WaitForIndexingErrors(store);
 
                 Assert.Equal(1, indexErrors.Length);
-                Assert.Contains("Field Binary contains embeddings with different number of dimensions.", indexErrors[0].Errors[0].Error);
+                Assert.Contains("Field Binary contains embeddings with different number of dimensions than currently processed embedding.", indexErrors[0].Errors[0].Error);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-23909.cs
+++ b/test/SlowTests/Issues/RavenDB-23909.cs
@@ -1,0 +1,191 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.Indexes;
+using SlowTests.Server.Documents.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23909(ITestOutputHelper output) : GenerateEmbeddingsTests(output)
+{
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void Auto(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var (configuration, _) = AddEmbeddingsGenerationTask(store);
+
+            using (var session = store.OpenSession())
+            {
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+                
+                session.Store(new Dto() { Name = "fruit" });
+                session.SaveChanges();
+                
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                var result = session.Query<Dto>()
+                    .VectorSearch(x => 
+                        x.WithText("Name")
+                            .UsingTask(configuration.Identifier)
+                            .TargetQuantization(VectorEmbeddingType.Int8), 
+                        factory => factory.ByText("fruit"))
+                    .ToList();
+                
+                Assert.Single(result);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void AlreadyQuantizedVectorShouldThrow(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var (configuration, _) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Int8);
+
+            using (var session = store.OpenSession())
+            {
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+                
+                session.Store(new Dto() { Name = "fruit" });
+                session.SaveChanges();
+                
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                _ = session.Query<Dto>()
+                    .Statistics(out var stats)
+                    .VectorSearch(x => 
+                            x.WithText("Name")
+                                .UsingTask(configuration.Identifier)
+                                .TargetQuantization(VectorEmbeddingType.Binary), 
+                        factory => factory.ByText("fruit"))
+                    .ToList();
+                
+                var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { stats.IndexName }));
+
+                Assert.Single(indexErrors);
+                Assert.Contains("Quantization cannot be performed on already quantized vector.", indexErrors[0].Errors.First().Error);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void Static(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            _ = AddEmbeddingsGenerationTask(store);
+
+            using (var session = store.OpenSession())
+            {
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+                
+                session.Store(new Dto() { Name = "fruit" });
+                session.SaveChanges();
+                
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
+                var index = new DummyIndex();
+                index.Execute(store);
+                Indexes.WaitForIndexing(store);
+                
+                var result = session.Query<DummyIndex.IndexEntry, DummyIndex>()
+                    .VectorSearch(x =>
+                            x.WithField(y => y.VectorFromTextEmbeddings),
+                        factory => factory.ByText("fruit"))
+                    .ProjectInto<Dto>()
+                    .ToList();
+                
+                Assert.Single(result);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void StaticJs(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            _ = AddEmbeddingsGenerationTask(store);
+
+            using (var session = store.OpenSession())
+            {
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+
+                session.Store(new Dto() { Name = "fruit" });
+                session.SaveChanges();
+
+                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                
+                var index = new DummyJsIndex();
+                index.Execute(store);
+                Indexes.WaitForIndexing(store);
+                
+                var result = session.Query<DummyJsIndex.IndexEntry, DummyJsIndex>()
+                    .VectorSearch(x =>
+                            x.WithField(y => y.VectorFromTextEmbeddings),
+                        factory => factory.ByText("fruit"))
+                    .ProjectInto<Dto>()
+                    .ToList();
+                
+                Assert.Single(result);
+            }
+        }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto, DummyIndex.IndexEntry>
+    {
+        public class IndexEntry
+        {
+            public object VectorFromTextEmbeddings { get; set; }
+        }
+        
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexEntry() { VectorFromTextEmbeddings = LoadVector("Name", "localaitask") };
+            
+            Vector("VectorFromTextEmbeddings", factory => factory.DestinationEmbedding(VectorEmbeddingType.Int8));
+        }
+    }
+    
+    private class DummyJsIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public class IndexEntry
+        {
+            public object VectorFromTextEmbeddings { get; set; }
+        }
+        
+        public DummyJsIndex()
+        {
+            Maps = new HashSet<string>()
+            {
+                @"map('Dtos', function (dto) {
+                   return {
+                       VectorFromTextEmbeddings: loadVector('Name', 'localaitask')
+                   };
+                })"
+            };
+            
+            Fields = new();
+            Fields.Add("VectorFromTextEmbeddings", new IndexFieldOptions()
+            {
+                Vector = new VectorOptions()
+                {
+                    SourceEmbeddingType = VectorEmbeddingType.Single, 
+                    DestinationEmbeddingType = VectorEmbeddingType.Int8
+                }
+            });
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23909.cs
+++ b/test/SlowTests/Issues/RavenDB-23909.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 
-public class RavenDB_23909(ITestOutputHelper output) : GenerateEmbeddingsTests(output)
+public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
@@ -141,6 +141,11 @@ public class RavenDB_23909(ITestOutputHelper output) : GenerateEmbeddingsTests(o
                 Assert.Single(result);
             }
         }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
     }
 
     private class DummyIndex : AbstractIndexCreationTask<Dto, DummyIndex.IndexEntry>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23909/Better-error-for-confusing-quantization

### Additional description

Auto index that uses embeddings generation from AI task should handle quantization correctly. 

1. Added support for quantization of raw embeddings taken from AI task (task generates F32 embeddings which are further quantized to Int8/Binary during indexing).
2. When quantization is not defined in the query that generates auto index, we take the desired quantization from AI task configuration. E.g. auto vector search query that uses task with Int8 quantization will index embeddings using Int8 quantization.
3. Attempt to quantize embeddings that were already quantized by the task will cause index errors

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
