### PR TITLE
RavenDB-22274 Audit log on license related operations

### DIFF
--- a/src/Raven.Server/Web/Studio/LicenseHandler.cs
+++ b/src/Raven.Server/Web/Studio/LicenseHandler.cs
@@ -10,6 +10,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 
 namespace Raven.Server.Web.Studio
 {
@@ -83,6 +84,9 @@ namespace Raven.Server.Web.Studio
                 license = JsonDeserializationServer.License(json);
             }
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+                LogAuditFor("Server", "ACTIVATE", $"License '{license.Id}'");
+            
             await ServerStore.EnsureNotPassiveAsync(skipLicenseActivation: true);
             await ServerStore.LicenseManager.ActivateAsync(license, GetRaftRequestIdFromQuery());
 
@@ -98,6 +102,9 @@ namespace Raven.Server.Web.Studio
                 return;
             }
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+                LogAuditFor("Server", "UPDATE", $"License");
+            
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {
@@ -126,6 +133,9 @@ namespace Raven.Server.Web.Studio
                 return;
             }
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+                LogAuditFor("Server", "RENEW", $"License");
+            
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22274

### Additional description
This PR adds audit log entries for the `POST` endpoints in the `LicenseHandler`:

- `Activate`
- `ForceUpdate`
- `RenewLicense`

Audit logs are written **before** executing the core operation to ensure that the action is captured even if an exception occurs later in the process.

Rejected requests are **not logged**.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
