### PR TITLE
RavenDB-23717 Show postgres calls on Traffic Watch

### DIFF
--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -464,10 +464,14 @@ namespace Raven.Client.Documents.Changes
     {
         public override TrafficWatchType TrafficWatchType => TrafficWatchType.Postgres;
         public string Source { get; set; }
+        public string Username { get; set; }
+        public string Query { get; set; }
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
             json[nameof(Source)] = Source;
+            json[nameof(Username)] = Username;
+            json[nameof(Query)] = Query;
             return json;
         }
     }

--- a/src/Raven.Client/Documents/Changes/ChangeNotification.cs
+++ b/src/Raven.Client/Documents/Changes/ChangeNotification.cs
@@ -405,7 +405,8 @@ namespace Raven.Client.Documents.Changes
     public enum TrafficWatchType
     {
         Http,
-        Tcp
+        Tcp,
+        Postgres
     }
 
     internal sealed class TrafficWatchHttpChange : TrafficWatchChangeBase
@@ -458,6 +459,19 @@ namespace Raven.Client.Documents.Changes
             return json;
         }
     }
+    
+    internal sealed class TrafficWatchPostgresChange : TrafficWatchChangeBase
+    {
+        public override TrafficWatchType TrafficWatchType => TrafficWatchType.Postgres;
+        public string Source { get; set; }
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(Source)] = Source;
+            return json;
+        }
+    }
+    
 
     public enum TrafficWatchChangeType
     {

--- a/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgServer.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                     _server.Certificate,
                     identifier,
                     _processId,
-                    _server.ServerStore.DatabasesLandlord,
+                    _server.ServerStore,
                     _cts.Token);
 
                 await session.Run();

--- a/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
@@ -196,12 +196,14 @@ namespace Raven.Server.Integrations.PostgreSQL
                     try
                     {
                         await message.Init(transaction.MessageReader, reader, _token);
+                        await message.Handle(transaction, messageBuilder, reader, writer, _token);
                         if (TrafficWatchManager.HasRegisteredClients && message is Query queryMessage)
                             DispatchPostgresQueryMessageToTrafficWatch(queryMessage, nodeTag);
-                        await message.Handle(transaction, messageBuilder, reader, writer, _token);
                     }
                     catch (PgErrorException e)
                     {
+                        if (TrafficWatchManager.HasRegisteredClients && message is Query queryMessage)
+                            DispatchPostgresQueryMessageToTrafficWatch(queryMessage, nodeTag, e);
                         await message.HandleError(e, transaction, messageBuilder, writer, _token);
                     }
                 }
@@ -279,19 +281,22 @@ namespace Raven.Server.Integrations.PostgreSQL
             return details;
         }
         
-        private void DispatchPostgresQueryMessageToTrafficWatch(Query message, string nodeTag)
+        private void DispatchPostgresQueryMessageToTrafficWatch(Query message, string nodeTag, PgErrorException e = null)
         {
             var clientIp = _client.Client.LocalEndPoint?.ToString();
             string databaseName = _clientOptions.GetValueOrDefault("database", "N/A");
+            string username = _clientOptions.GetValueOrDefault("username", "N/A");
 
             var twn = new TrafficWatchPostgresChange()
             {
                 TimeStamp = DateTime.UtcNow,
                 DatabaseName = databaseName,  
-                CertificateThumbprint = _serverCertificateHolder.Certificate?.Thumbprint,
-                CustomInfo = message.QueryString,
+                CertificateThumbprint = null,
+                CustomInfo = e is null ? null : $"{e.ErrorCode} - {e.Message}",
                 ClientIP = clientIp,
                 Source = nodeTag,
+                Username = username,
+                Query = message.QueryString
             };
             TrafficWatchManager.DispatchMessage(twn);
         }

--- a/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
@@ -12,6 +12,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Queries.Parser;
 using Raven.Server.Integrations.PostgreSQL.Exceptions;
 using Raven.Server.Integrations.PostgreSQL.Messages;
+using Raven.Server.ServerWide;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
 using Sparrow.Logging;
@@ -26,7 +27,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         private readonly CertificateUtils.CertificateHolder _serverCertificateHolder;
         private readonly int _identifier;
         private readonly int _processId;
-        private readonly DatabasesLandlord _databasesLandlord;
+        private readonly ServerStore _serverStore;
         private readonly CancellationToken _token;
         private Dictionary<string, string> _clientOptions;
 
@@ -35,14 +36,14 @@ namespace Raven.Server.Integrations.PostgreSQL
             CertificateUtils.CertificateHolder serverCertificateHolder,
             int identifier,
             int processId,
-            DatabasesLandlord databasesLandlord,
+            ServerStore serverStore,
             CancellationToken token)
         {
             _client = client;
             _serverCertificateHolder = serverCertificateHolder;
             _identifier = identifier;
             _processId = processId;
-            _databasesLandlord = databasesLandlord;
+            _serverStore = serverStore;
             _token = token;
             _clientOptions = null;
             NamedStatements = new ConcurrentDictionary<string, PgQuery>();
@@ -138,8 +139,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 return;
             }
 
-            var result = _databasesLandlord.TryGetOrCreateDatabase(databaseName);
-            var nodeTag = result.DatabaseTask.Result.ServerStore.NodeTag;
+            var result = _serverStore.DatabasesLandlord.TryGetOrCreateDatabase(databaseName);
 
             if (result.DatabaseStatus == DatabasesLandlord.DatabaseSearchResult.Status.Missing)
             {
@@ -198,12 +198,12 @@ namespace Raven.Server.Integrations.PostgreSQL
                         await message.Init(transaction.MessageReader, reader, _token);
                         await message.Handle(transaction, messageBuilder, reader, writer, _token);
                         if (TrafficWatchManager.HasRegisteredClients && message is Query queryMessage)
-                            DispatchPostgresQueryMessageToTrafficWatch(queryMessage, nodeTag);
+                            DispatchPostgresQueryMessageToTrafficWatch(queryMessage);
                     }
                     catch (PgErrorException e)
                     {
                         if (TrafficWatchManager.HasRegisteredClients && message is Query queryMessage)
-                            DispatchPostgresQueryMessageToTrafficWatch(queryMessage, nodeTag, e);
+                            DispatchPostgresQueryMessageToTrafficWatch(queryMessage, e);
                         await message.HandleError(e, transaction, messageBuilder, writer, _token);
                     }
                 }
@@ -281,7 +281,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             return details;
         }
         
-        private void DispatchPostgresQueryMessageToTrafficWatch(Query message, string nodeTag, PgErrorException e = null)
+        private void DispatchPostgresQueryMessageToTrafficWatch(Query message, PgErrorException e = null)
         {
             var clientIp = _client.Client.LocalEndPoint?.ToString();
             string databaseName = _clientOptions.GetValueOrDefault("database", "N/A");
@@ -294,7 +294,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 CertificateThumbprint = null,
                 CustomInfo = e is null ? null : $"{e.ErrorCode} - {e.Message}",
                 ClientIP = clientIp,
-                Source = nodeTag,
+                Source = _serverStore.NodeTag,
                 Username = username,
                 Query = message.QueryString
             };

--- a/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
@@ -7,10 +7,12 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Changes;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Queries.Parser;
 using Raven.Server.Integrations.PostgreSQL.Exceptions;
 using Raven.Server.Integrations.PostgreSQL.Messages;
+using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
 using Sparrow.Logging;
 
@@ -137,6 +139,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             }
 
             var result = _databasesLandlord.TryGetOrCreateDatabase(databaseName);
+            var nodeTag = result.DatabaseTask.Result.ServerStore.NodeTag;
 
             if (result.DatabaseStatus == DatabasesLandlord.DatabaseSearchResult.Status.Missing)
             {
@@ -193,6 +196,8 @@ namespace Raven.Server.Integrations.PostgreSQL
                     try
                     {
                         await message.Init(transaction.MessageReader, reader, _token);
+                        if (TrafficWatchManager.HasRegisteredClients && message is Query queryMessage)
+                            DispatchPostgresQueryMessageToTrafficWatch(queryMessage, nodeTag);
                         await message.Handle(transaction, messageBuilder, reader, writer, _token);
                     }
                     catch (PgErrorException e)
@@ -272,6 +277,23 @@ namespace Raven.Server.Integrations.PostgreSQL
                 details += $" - Username: {userName}";
 
             return details;
+        }
+        
+        private void DispatchPostgresQueryMessageToTrafficWatch(Query message, string nodeTag)
+        {
+            var clientIp = _client.Client.LocalEndPoint?.ToString();
+            string databaseName = _clientOptions.GetValueOrDefault("database", "N/A");
+
+            var twn = new TrafficWatchPostgresChange()
+            {
+                TimeStamp = DateTime.UtcNow,
+                DatabaseName = databaseName,  
+                CertificateThumbprint = _serverCertificateHolder.Certificate?.Thumbprint,
+                CustomInfo = message.QueryString,
+                ClientIP = clientIp,
+                Source = nodeTag,
+            };
+            TrafficWatchManager.DispatchMessage(twn);
         }
     }
 }

--- a/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
@@ -125,12 +125,13 @@ internal sealed class TrafficWatchToLog : IDynamicJson
         else if (trafficWatchData is TrafficWatchPostgresChange twpsc)
         {
             stringBuilder
-                .Append("POSTGRE, ")
+                .Append("POSTGRES, ")
+                .Append(twpsc.Username).Append(", ")
+                .Append(twpsc.Query).Append(", ")
                 .Append(twpsc.DatabaseName).Append(", ")
                 .Append(twpsc.Source).Append(", ")
                 .Append(twpsc.CustomInfo).Append(", ")
-                .Append(twpsc.ClientIP).Append(", ")
-                .Append(twpsc.CertificateThumbprint);
+                .Append(twpsc.ClientIP);
         }
 
         Logger.Operations(stringBuilder.ToString());

--- a/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchToLog.cs
@@ -122,6 +122,16 @@ internal sealed class TrafficWatchToLog : IDynamicJson
                 .Append(twtc.ClientIP).Append(", ")
                 .Append(twtc.CertificateThumbprint);
         }
+        else if (trafficWatchData is TrafficWatchPostgresChange twpsc)
+        {
+            stringBuilder
+                .Append("POSTGRE, ")
+                .Append(twpsc.DatabaseName).Append(", ")
+                .Append(twpsc.Source).Append(", ")
+                .Append(twpsc.CustomInfo).Append(", ")
+                .Append(twpsc.ClientIP).Append(", ")
+                .Append(twpsc.CertificateThumbprint);
+        }
 
         Logger.Operations(stringBuilder.ToString());
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23717/Show-postgres-calls-on-Traffic-Watch

### Additional description
The main goal here is to answer the "I have 30% CPU Usage but I don't see no calls on Traffic Watch" problem, that happens for Postgre integration users. To cover that, we decided to spawn Traffic Watch entries on every query Message from Postgre, as the rest of the protocol doesn't really matter for us down there (agreed with @gregolsky).

When implementing, at first I started opening it up to scale for different types messages in the future, but then went back and discarded most of it - if we only care about registering Queries in the context of the Traffic Watch (the rest is in the logs), and the postrgre protocol is a standard without high chance to mutate soon, there's no need to do pattern matching on Message etc. 

Instead, I've focused on handling queries, shrinking the logic here to clean and minimal code solution. 
If we'll change our mind for some reason, it's super easy to extend for different kind of messages anyway.

Things to be done yet:
- [x] Ensure we don't want any more details in the message. (Added username, error message and query)
- [x] Ensure that the feature works

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
