### PR TITLE
RavenDB-22270 Add Audit Logging for Memory Dump Endpoints

### DIFF
--- a/src/Raven.Server/Web/System/AdminDumpHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDumpHandler.cs
@@ -9,6 +9,7 @@ using Raven.Client.Properties;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.Utils;
+using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Utils;
 
@@ -27,6 +28,9 @@ namespace Raven.Server.Web.System
             if (string.IsNullOrWhiteSpace(path))
                 path = Path.GetTempPath();
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+                LogAuditFor("Server", "CREATE",  $"{typeAsString} Memory Dump");
+            
             using (var process = Process.GetCurrentProcess())
             {
                 var fileNames = GetFileNames(".dmp");
@@ -54,6 +58,9 @@ namespace Raven.Server.Web.System
             if (string.IsNullOrWhiteSpace(path))
                 path = Path.GetTempPath();
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+                LogAuditFor("Server", "CREATE",  "GC Memory Dump");
+            
             using (var process = Process.GetCurrentProcess())
             {
                 var fileNames = GetFileNames(".gcdump");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22270

### Additional description
This PR adds audit log entries to the following debug endpoints in `AdminDumpHandler`:

- `/admin/debug/dump` – Standard memory dump (Mini, Heap, Full, Triage)
- `/admin/debug/gcdump` – GC memory dump

The audit log is written **before** executing the dump to ensure that the action is captured even if an exception occurs during the operation.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
