### PR TITLE
RavenDB-23034 - Implements rate limiting for backup/restore and import/export operations

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
@@ -31,6 +31,11 @@ namespace Raven.Client.Documents.Operations.Backups
         public BackupEncryptionSettings BackupEncryptionSettings { get; set; }
 
         /// <summary>
+        /// The maximum number of read operations per second allowed during backup.
+        /// </summary>
+        public int? MaxReadOpsPerSecond { get; set; }
+
+        /// <summary>
         /// Settings for local storage backup.
         /// </summary>
         public LocalSettings LocalSettings { get; set; }
@@ -147,6 +152,7 @@ namespace Raven.Client.Documents.Operations.Backups
                 [nameof(BackupUploadMode)] = BackupUploadMode,
                 [nameof(SnapshotSettings)] = SnapshotSettings?.ToJson(),
                 [nameof(BackupEncryptionSettings)] = BackupEncryptionSettings?.ToJson(),
+                [nameof(MaxReadOpsPerSecond)] = MaxReadOpsPerSecond,
                 [nameof(LocalSettings)] = LocalSettings?.ToJson(),
                 [nameof(S3Settings)] = S3Settings?.ToJson(),
                 [nameof(GlacierSettings)] = GlacierSettings?.ToJson(),
@@ -162,13 +168,13 @@ namespace Raven.Client.Documents.Operations.Backups
                 [nameof(BackupType)] = BackupType,
                 [nameof(SnapshotSettings)] = SnapshotSettings?.ToAuditJson(),
                 [nameof(BackupEncryptionSettings)] = BackupEncryptionSettings?.ToAuditJson(),
+                [nameof(MaxReadOpsPerSecond)] = MaxReadOpsPerSecond,
                 [nameof(LocalSettings)] = LocalSettings?.ToAuditJson(),
                 [nameof(S3Settings)] = S3Settings?.ToAuditJson(),
                 [nameof(GlacierSettings)] = GlacierSettings?.ToAuditJson(),
                 [nameof(AzureSettings)] = AzureSettings?.ToAuditJson(),
                 [nameof(GoogleCloudSettings)] = GoogleCloudSettings?.ToAuditJson(),
                 [nameof(FtpSettings)] = FtpSettings?.ToAuditJson()
-
             };
         }
 

--- a/src/Raven.Client/Documents/Operations/Backups/RestoreBackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/RestoreBackupConfiguration.cs
@@ -24,6 +24,8 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public BackupEncryptionSettings BackupEncryptionSettings { get; set; }
 
+        public int? MaxReadOpsPerSecond { get; set; }
+
         protected RestoreBackupConfigurationBase(RestoreBackupConfigurationBase other)
         {
             if (other == null)
@@ -35,6 +37,7 @@ namespace Raven.Client.Documents.Operations.Backups
             EncryptionKey = other.EncryptionKey;
             DisableOngoingTasks = other.DisableOngoingTasks;
             SkipIndexes = other.SkipIndexes;
+            MaxReadOpsPerSecond = other.MaxReadOpsPerSecond;
             if (other.ShardRestoreSettings != null)
                 ShardRestoreSettings = new ShardedRestoreSettings(other.ShardRestoreSettings);
             if (other.BackupEncryptionSettings != null)
@@ -59,7 +62,8 @@ namespace Raven.Client.Documents.Operations.Backups
                 [nameof(SkipIndexes)] = SkipIndexes,
                 [nameof(BackupEncryptionSettings)] = BackupEncryptionSettings,
                 [nameof(Type)] = Type,
-                [nameof(ShardRestoreSettings)] = ShardRestoreSettings?.ToJson()
+                [nameof(ShardRestoreSettings)] = ShardRestoreSettings?.ToJson(),
+                [nameof(MaxReadOpsPerSecond)] = MaxReadOpsPerSecond
             };
         }
 
@@ -72,7 +76,8 @@ namespace Raven.Client.Documents.Operations.Backups
                 [nameof(DisableOngoingTasks)] = DisableOngoingTasks,
                 [nameof(SkipIndexes)] = SkipIndexes,
                 [nameof(BackupEncryptionSettings)] = BackupEncryptionSettings,
-                [nameof(Type)] = Type
+                [nameof(Type)] = Type,
+                [nameof(MaxReadOpsPerSecond)] = MaxReadOpsPerSecond
             };
     }
 

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -1,5 +1,5 @@
 ﻿using Sparrow.Json;
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Smuggler
@@ -94,6 +94,8 @@ namespace Raven.Client.Documents.Smuggler
 
         public List<string> Collections { get; set; }
 
+        public int? MaxReadOpsPerSecond { get; set; }
+
         /// <summary>
         /// In case the database is corrupted (for example, Compression Dictionaries are lost), it is possible to export all the remaining data.
         /// If '<c>true</c>', the process will continue in the presence of corrupted data, with an entry of error data into the export result report.
@@ -116,7 +118,8 @@ namespace Raven.Client.Documents.Smuggler
                 [nameof(TransformScript)] = TransformScript,
                 [nameof(MaxStepsForTransformScript)] = MaxStepsForTransformScript,
                 [nameof(Collections)] = Collections,
-                [nameof(SkipCorruptedData)] = SkipCorruptedData
+                [nameof(SkipCorruptedData)] = SkipCorruptedData,
+                [nameof(MaxReadOpsPerSecond)] = MaxReadOpsPerSecond
             };
     }
 
@@ -131,6 +134,7 @@ namespace Raven.Client.Documents.Smuggler
         string TransformScript { get; set; }
         int MaxStepsForTransformScript { get; set; }
         List<string> Collections { get; set; }
+        int? MaxReadOpsPerSecond { get; set; }
         DynamicJsonValue ToAuditJson();
     }
 

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -41,6 +41,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.MaxNumberOfConcurrentBackups", ConfigurationEntryScope.ServerWideOnly)]
         public int? MaxNumberOfConcurrentBackups { get; set; }
 
+        [Description("Maximum number of Read operations per second allowed during backup. This setting is used to limit the impact of backup operations on the database performance.")]
+        [DefaultValue(null)]
+        [ConfigurationEntry("Backup.MaxReadOpsPerSecond", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int? MaxReadOpsPerSecond { get; set; }
+
         [Description("Number of seconds to delay the backup after hitting the maximum number of concurrent backups limit")]
         [DefaultValue(30)]
         [TimeUnit(TimeUnit.Seconds)]

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -6,8 +6,6 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
-using Raven.Client.Util.RateLimiting;
-using Raven.Server.Commercial;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Handlers.Processors.Batches;
 using Raven.Server.Documents.Patch;
@@ -17,6 +15,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
+using Voron.Util.RateLimiting;
 using Constants = Raven.Client.Constants;
 using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1472,8 +1472,13 @@ namespace Raven.Server.Documents
             }
         }
 
-        public SmugglerResult FullBackupTo(Stream stream, SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel = CompressionLevel.Optimal,
-            bool excludeIndexes = false, Action<(string Message, int FilesCount)> infoNotify = null, CancellationToken cancellationToken = default)
+        public SmugglerResult FullBackupTo(Stream stream,
+            SnapshotBackupCompressionAlgorithm compressionAlgorithm,
+            CompressionLevel compressionLevel = CompressionLevel.Optimal,
+            bool excludeIndexes = false,
+            int? maxReadOpsPerSecond = null,
+            Action<(string Message, int FilesCount)> infoNotify = null,
+            CancellationToken cancellationToken = default)
         {
             SmugglerResult smugglerResult;
 
@@ -1500,7 +1505,8 @@ namespace Raven.Server.Documents
                             var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, compressionAlgorithm.ToExportCompressionAlgorithm(), compressionLevel);
                             var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
                             {
-                                OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities
+                                OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities,
+                                MaxReadOpsPerSecond = maxReadOpsPerSecond
                             };
 
                             var smuggler = Smuggler.Create(
@@ -1572,7 +1578,7 @@ namespace Raven.Server.Documents
 
                 infoNotify?.Invoke(("Backed up database values", 1));
 
-                BackupMethods.Full.ToFile(GetAllStoragesForBackup(excludeIndexes), zipArchive, compressionAlgorithm, compressionLevel, infoNotify: infoNotify, cancellationToken: cancellationToken);
+                BackupMethods.Full.ToFile(GetAllStoragesForBackup(excludeIndexes), zipArchive, compressionAlgorithm, compressionLevel, maxReadOpsPerSecond, infoNotify, cancellationToken);
             }
 
             return smugglerResult;

--- a/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
+++ b/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using Raven.Client.Util.RateLimiting;
 using Raven.Server.Documents.TransactionMerger;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Voron.Util.RateLimiting;
 
 namespace Raven.Server.Documents
 {

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -577,7 +577,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                         var options = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
                         {
                             IncludeArtificial = true, // we want to include artificial in backup
-                            IncludeArchived = true // wa want also to include archived documents in backup
+                            IncludeArchived = true, // we want also to include archived documents in the backup
+                            MaxReadOpsPerSecond = Configuration.MaxReadOpsPerSecond ?? Database.Configuration.Backup.MaxReadOpsPerSecond,
                         };
 
                         options.OperateOnTypes |= DatabaseItemType.Tombstones;
@@ -619,12 +620,13 @@ namespace Raven.Server.Documents.PeriodicBackup
                         var compressionAlgorithm = Configuration.SnapshotSettings?.CompressionAlgorithm ?? Database.Configuration.Backup.SnapshotCompressionAlgorithm;
                         var compressionLevel = Configuration.SnapshotSettings?.CompressionLevel ?? Database.Configuration.Backup.SnapshotCompressionLevel;
                         var excludeIndexes = Configuration.SnapshotSettings?.ExcludeIndexes ?? false;
+                        var maxReadOpsPerSecond = Configuration.MaxReadOpsPerSecond ?? Database.Configuration.Backup.MaxReadOpsPerSecond;
 
                         using (var stream = GetStreamForBackupDestination(tempBackupFilePath, folderName, fileName))
                         {
                             try
                             {
-                                var smugglerResult = Database.FullBackupTo(stream, compressionAlgorithm, compressionLevel, excludeIndexes,
+                                var smugglerResult = Database.FullBackupTo(stream, compressionAlgorithm, compressionLevel, excludeIndexes, maxReadOpsPerSecond,
                                     info =>
                                     {
                                         AddInfo(info.Message);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -316,7 +316,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             var options = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
             {
                 SkipRevisionCreation = true,
-                IncludeArchived = true
+                IncludeArchived = true,
+                MaxReadOpsPerSecond = RestoreConfiguration.MaxReadOpsPerSecond
             };
 
             options.OperateOnTypes |= DatabaseItemType.LegacyDocumentDeletions;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         protected override async Task RestoreAsync()
         {
-            await RestoreFromSmugglerFileAsync(Progress, Database, _firstFile, Context);
+            await RestoreFromSmugglerFileAsync(Progress, Database, _firstFile, Context, RestoreConfiguration.MaxReadOpsPerSecond);
             await HandleSubscriptionFromSnapshot(FilesToRestore, RestoreSettings.Subscriptions, DatabaseName, Database);
             await SmugglerRestoreAsync(Database, Context, Database.Smuggler.CreateDestinationForSnapshotRestore(RestoreSettings.Subscriptions));
 
@@ -266,6 +266,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         restoreResult.SnapshotRestore.ReadCount++;
                         onProgress.Invoke(restoreResult.Progress);
                     },
+                    RestoreConfiguration.MaxReadOpsPerSecond,
                     cancellationToken: OperationCancelToken.Token);
             }
 
@@ -275,14 +276,15 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return restoreSettings;
         }
 
-        private async Task RestoreFromSmugglerFileAsync(Action<IOperationProgress> onProgress, DocumentDatabase database, string smugglerFile, JsonOperationContext context)
+        private async Task RestoreFromSmugglerFileAsync(Action<IOperationProgress> onProgress, DocumentDatabase database, string smugglerFile, JsonOperationContext context, int? maxReadOpsPerSecond)
         {
             var destination = database.Smuggler.CreateDestination();
 
             var smugglerOptions = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
             {
                 OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities | DatabaseItemType.Subscriptions,
-                SkipRevisionCreation = true
+                SkipRevisionCreation = true,
+                MaxReadOpsPerSecond = maxReadOpsPerSecond,
             };
 
             Result.Files.CurrentFileName = smugglerFile; 

--- a/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Indexes;
-using Raven.Client.Util.RateLimiting;
 using Raven.Server.Documents.Handlers.Processors.Batches;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
@@ -15,6 +14,7 @@ using Raven.Server.Documents.Queries.Suggestions;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
+using Voron.Util.RateLimiting;
 using Index = Raven.Server.Documents.Indexes.Index;
 using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
 

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -98,7 +98,8 @@ namespace Raven.Server.Smuggler.Documents.Data
                 OperateOnTypes = OperateOnTypes,
                 RemoveAnalyzers = RemoveAnalyzers,
                 TransformScript = TransformScript,
-                IsShard = IsShard
+                IsShard = IsShard,
+                MaxReadOpsPerSecond = MaxReadOpsPerSecond
             };
         }
         

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -76,6 +76,10 @@ namespace Raven.Server.Smuggler.Documents
             ICompareExchangeActions actions)
         {
             _token.ThrowIfCancellationRequested();
+
+            if (_rateGate != null)
+                await _rateGate.WaitToProceedAsync();
+
             result.CompareExchange.ReadCount++;
             if (result.CompareExchange.ReadCount != 0 && result.CompareExchange.ReadCount % 1000 == 0)
                 AddInfoToSmugglerResult(result, $"Read {result.CompareExchange.ReadCount:#,#;;0} compare exchange values.");
@@ -101,6 +105,10 @@ namespace Raven.Server.Smuggler.Documents
         protected virtual async Task InternalProcessCompareExchangeTombstonesAsync(SmugglerResult result, (CompareExchangeKey Key, long Index) key, ICompareExchangeActions actions)
         {
             _token.ThrowIfCancellationRequested();
+
+            if (_rateGate != null)
+                await _rateGate.WaitToProceedAsync();
+
             result.CompareExchangeTombstones.ReadCount++;
 
             if (key.Equals(default))

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -205,6 +205,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var kvp in _source.GetCompareExchangeValuesAsync())
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.CompareExchange.ReadCount++;
                     if (result.CompareExchange.ReadCount != 0 && result.CompareExchange.ReadCount % 1000 == 0)
                         AddInfoToSmugglerResult(result, $"Read {result.CompareExchange.ReadCount:#,#;;0} compare exchange values.");
@@ -248,6 +252,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var kvp in _source.GetCompareExchangeTombstonesAsync())
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.CompareExchangeTombstones.ReadCount++;
 
                     if (kvp.Equals(default))

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -22,6 +22,7 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Processors;
 using Sparrow.Json;
+using Voron.Util.RateLimiting;
 using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Smuggler.Documents
@@ -41,6 +42,7 @@ namespace Raven.Server.Smuggler.Documents
         public BackupKind BackupKind = BackupKind.None;
         internal readonly ISmugglerDestination _destination;
         private SmugglerPatcher _patcher;
+        internal RateGate _rateGate;
 
         protected SmugglerBase(
             [NotNull] string databaseName,
@@ -78,6 +80,7 @@ namespace Raven.Server.Smuggler.Documents
                 _patcher = CreatePatcher();
 
             var result = _result ?? new SmugglerResult();
+            using (_rateGate = _options.MaxReadOpsPerSecond.HasValue ? new RateGate(_options.MaxReadOpsPerSecond.Value, TimeSpan.FromSeconds(1)) : null)
             using (var initializeResult = await _source.InitializeAsync(_options, result))
             using (_patcher?.Initialize())
             await using (await _destination.InitializeAsync(_options, result, _onProgress, initializeResult.BuildNumber))
@@ -409,6 +412,9 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     _token.ThrowIfCancellationRequested();
 
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     var isPreV4Revision = DatabaseSmuggler.IsPreV4Revision(buildType, item.Document.Id, item.Document);
                     if (isPreV4Revision)
                     {
@@ -475,13 +481,13 @@ namespace Raven.Server.Smuggler.Documents
                             continue;
                         }
                     }
-                    
+
                     if (_options.IncludeArtificial == false && item.Document.Flags.HasFlag(DocumentFlags.Artificial))
                     {
                         SkipDocument(item, result.Documents);
                         continue;
                     }
-                    
+
                     if (_options.IncludeArchived == false && item.Document.Flags.HasFlag(DocumentFlags.Archived))
                     {
                         SkipDocument(item, result.Documents);
@@ -541,6 +547,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var item in _source.GetRevisionDocumentsAsync(_options.Collections, actions))
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.RevisionDocuments.ReadCount++;
 
                     if (item.Document != null)
@@ -602,6 +612,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var tombstone in _source.GetTombstonesAsync(_options.Collections, actions))
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Tombstones.ReadCount++;
 
                     if (result.Tombstones.ReadCount % 1000 == 0)
@@ -672,6 +686,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var conflict in _source.GetConflictsAsync(_options.Collections, actions))
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Conflicts.ReadCount++;
 
                     if (result.Conflicts.ReadCount % 1000 == 0)
@@ -704,6 +722,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var index in _source.GetIndexesAsync())
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Indexes.ReadCount++;
 
                     if (index == null)
@@ -814,6 +836,9 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     _token.ThrowIfCancellationRequested();
 
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Documents.ReadCount++;
                     result.Documents.Attachments.ReadCount++;
                     if (result.Documents.Attachments.ReadCount % 1000 == 0)
@@ -896,6 +921,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var counterGroup in _source.GetCounterValuesAsync(_options.Collections, actions))
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Counters.ReadCount++;
 
                     if (result.Counters.ReadCount % 1000 == 0)
@@ -938,6 +967,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var ts in _source.GetTimeSeriesAsync(actions, _options.Collections))
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.TimeSeries.ReadCount += ts.Segment.NumberOfEntries;
                     result.TimeSeries.SizeInBytes += ts.Segment.NumberOfBytes;
 
@@ -977,6 +1010,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var deletedRange in _source.GetTimeSeriesDeletedRangesAsync(actions, _options.Collections))
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.TimeSeriesDeletedRanges.ReadCount++;
 
                     if (result.TimeSeriesDeletedRanges.ReadCount % 1000 == 0)
@@ -1008,6 +1045,9 @@ namespace Raven.Server.Smuggler.Documents
                 var databaseRecord = await _source.GetDatabaseRecordAsync();
 
                 _token.ThrowIfCancellationRequested();
+
+                if (_rateGate != null)
+                    await _rateGate.WaitToProceedAsync();
 
                 if (OnDatabaseRecordAction != null)
                 {
@@ -1050,6 +1090,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var identity in _source.GetIdentitiesAsync())
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Identities.ReadCount++;
 
                     if (identity.Equals(default))
@@ -1090,6 +1134,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var subscription in _source.GetSubscriptionsAsync())
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.Subscriptions.ReadCount++;
 
                     if (result.Subscriptions.ReadCount % 1000 == 0)
@@ -1111,6 +1159,10 @@ namespace Raven.Server.Smuggler.Documents
                 await foreach (var (hub, access) in _source.GetReplicationHubCertificatesAsync())
                 {
                     _token.ThrowIfCancellationRequested();
+
+                    if (_rateGate != null)
+                        await _rateGate.WaitToProceedAsync();
+
                     result.ReplicationHubCertificates.ReadCount++;
 
                     if (result.ReplicationHubCertificates.ReadCount % 1000 == 0)

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -22,6 +22,7 @@ using Voron.Impl.FileHeaders;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
 using Voron.Util;
+using Voron.Util.RateLimiting;
 using Voron.Util.Settings;
 
 namespace Voron.Impl.Backup
@@ -68,12 +69,14 @@ namespace Voron.Impl.Backup
             ZipArchive archive,
             SnapshotBackupCompressionAlgorithm compressionAlgorithm,
             CompressionLevel compressionLevel,
+            int? maxReadOpsPerSecond = null,
             Action<(string Message, int FilesCount)> infoNotify = null,
             CancellationToken cancellationToken = default)
         {
             infoNotify ??= (_ => { });
             infoNotify(("Voron backup db started", 0));
 
+            using var rateGate = maxReadOpsPerSecond.HasValue ? new RateGate(maxReadOpsPerSecond.Value, TimeSpan.FromSeconds(1)) : null;
             foreach (var e in envs)
             {
                 infoNotify(($"Voron backup {e.Name} started", 0));
@@ -81,7 +84,7 @@ namespace Voron.Impl.Backup
 
                 var env = e.Env;
                 var dataPager = env.Options.DataPager;
-                var copier = new DataCopier(Constants.Storage.PageSize * 16);
+                var copier = new DataCopier(Constants.Storage.PageSize * 16, rateGate);
                 Backup(env, compressionAlgorithm, compressionLevel, dataPager, archive, basePath, copier, infoNotify, cancellationToken);
             }
 
@@ -280,19 +283,22 @@ namespace Voron.Impl.Backup
             VoronPathSetting voronDataDir,
             VoronPathSetting journalDir = null,
             Action<string> onProgress = null,
+            int? maxReadOpsPerSecond = null,
             CancellationToken cancellationToken = default)
         {
             using (var zip = ZipFile.Open(backupPath.FullPath, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
-                Restore(zip.Entries, voronDataDir, journalDir, onProgress, cancellationToken);
+                Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, cancellationToken);
         }
 
         public void Restore(IEnumerable<ZipArchiveEntry> entries,
             VoronPathSetting voronDataDir,
             VoronPathSetting journalDir = null,
             Action<string> onProgress = null,
+            int? maxReadOpsPerSecond = null,
             CancellationToken cancellationToken = default)
         {
             journalDir ??= voronDataDir.Combine("Journals");
+            var rateGate = maxReadOpsPerSecond.HasValue ? new RateGate(maxReadOpsPerSecond.Value, TimeSpan.FromSeconds(1)) : null;
 
             if (Directory.Exists(voronDataDir.FullPath) == false)
                 Directory.CreateDirectory(voronDataDir.FullPath);
@@ -323,6 +329,8 @@ namespace Voron.Impl.Backup
                     var isZstd = decompressionStream is ZstdStream;
                     decompressionStream.CopyTo(output, readCount =>
                     {
+                        rateGate?.WaitToProceed();
+
                         totalRead += readCount;
                         if (swForProgress.ElapsedMilliseconds > 5000)
                         {

--- a/src/Voron/Util/DataCopier.cs
+++ b/src/Voron/Util/DataCopier.cs
@@ -12,16 +12,19 @@ using Sparrow;
 using Voron.Global;
 using Voron.Impl.Journal;
 using Voron.Impl.Paging;
+using Voron.Util.RateLimiting;
 
 namespace Voron.Util
 {
     public sealed unsafe class DataCopier
     {
         private readonly byte[] _buffer;
+        private readonly RateGate _rateGate;
 
-        public DataCopier(int bufferSize)
+        public DataCopier(int bufferSize, RateGate rateGate = null)
         {
             _buffer = new byte[bufferSize];
+            _rateGate = rateGate;
         }
 
         public void ToStream(byte* ptr, long count, Stream output)
@@ -57,6 +60,8 @@ namespace Voron.Util
                 for (var i = startPage; i < startPage + numberOfPages; i += steps)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    _rateGate?.WaitToProceed();
 
                     var pagesToCopy = (int) (i + steps > numberOfPages ? numberOfPages - i : steps);
                     src.EnsureMapped(tempTx, i, pagesToCopy);

--- a/src/Voron/Util/RateLimiting/RateGate.cs
+++ b/src/Voron/Util/RateLimiting/RateGate.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 
-namespace Raven.Client.Util.RateLimiting
+namespace Voron.Util.RateLimiting
 {
     /// <summary>
     /// http://www.jackleitch.net/2010/10/better-rate-limiting-with-dot-net/
@@ -22,7 +23,7 @@ namespace Raven.Client.Util.RateLimiting
     ///     threads.
     ///     </para>
     /// </remarks>
-    internal sealed class RateGate : IDisposable
+    public sealed class RateGate : IDisposable
     {
         // Semaphore used to count and limit the number of occurrences per
         // unit time.
@@ -167,6 +168,53 @@ namespace Raven.Client.Util.RateLimiting
         public void WaitToProceed()
         {
             WaitToProceed(Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Blocks the current thread until allowed to proceed or until the
+        /// specified timeout elapses.
+        /// </summary>
+        /// <param name="millisecondsTimeout">Number of milliseconds to wait, or -1 to wait indefinitely.</param>
+        /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
+        public async Task<bool> WaitToProceedAsync(int millisecondsTimeout)
+        {
+            // Check the arguments.
+            if (millisecondsTimeout < -1)
+                throw new ArgumentOutOfRangeException(nameof(millisecondsTimeout));
+
+            CheckDisposed();
+
+            // Block until we can enter the semaphore or until the timeout expires.
+            var entered = await _semaphore.WaitAsync(millisecondsTimeout).ConfigureAwait(false);
+
+            // If we entered the semaphore, compute the corresponding exit time 
+            // and add it to the queue.
+            if (entered)
+            {
+                var timeToExit = unchecked(Environment.TickCount + TimeUnitMilliseconds);
+                _exitTimes.Enqueue(timeToExit);
+            }
+
+            return entered;
+        }
+
+        /// <summary>
+        /// Blocks the current thread until allowed to proceed or until the
+        /// specified timeout elapses.
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns>true if the thread is allowed to proceed, or false if timed out</returns>
+        public Task<bool> WaitToProceedAsync(TimeSpan timeout)
+        {
+            return WaitToProceedAsync((int)timeout.TotalMilliseconds);
+        }
+
+        /// <summary>
+        /// Blocks the current thread indefinitely until allowed to proceed.
+        /// </summary>
+        public Task WaitToProceedAsync()
+        {
+            return WaitToProceedAsync(Timeout.Infinite);
         }
 
         // Throws an ObjectDisposedException if this object is disposed.

--- a/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
@@ -1,0 +1,578 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.PeriodicBackup;
+
+public class MaxReadOpsPerSecOptionTests : ClusterTestBase
+{
+    private readonly ITestOutputHelper _output;
+
+    public MaxReadOpsPerSecOptionTests(ITestOutputHelper output) : base(output)
+    {
+        _output = output;
+    }
+
+    [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.Periodic, BackupKind.Full, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.Periodic, BackupKind.Full, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.Periodic, BackupKind.Incremental, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.Periodic, BackupKind.Incremental, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.ServerWide, BackupKind.Full, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.ServerWide, BackupKind.Full, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.ServerWide, BackupKind.Incremental, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup, BackupScope.ServerWide, BackupKind.Incremental, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Full, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Full, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Incremental, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Incremental, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Full, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Full, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Incremental, ConfigurationSource.BackupConfiguration])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Incremental, ConfigurationSource.DatabaseSettings])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Full, ConfigurationSource.BackupConfiguration], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Full, ConfigurationSource.DatabaseSettings], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Incremental, ConfigurationSource.BackupConfiguration], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.Periodic, BackupKind.Incremental, ConfigurationSource.DatabaseSettings], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Full, ConfigurationSource.BackupConfiguration], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Full, ConfigurationSource.DatabaseSettings], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Incremental, ConfigurationSource.BackupConfiguration], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot, BackupScope.ServerWide, BackupKind.Incremental, ConfigurationSource.DatabaseSettings], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    public async Task ShouldRespect_Option_MaxReadOpsPerSec_OnPeriodicBackup(Options options, BackupType backupType, BackupScope backupScope, BackupKind backupKind, ConfigurationSource configurationSource)
+    {
+        DoNotReuseServer();
+
+        using var scenario = new MaxReadOpsPerSecOptionBackupTestScenario(this, options)
+        {
+            BackupType = backupType,
+            BackupScope = backupScope,
+            BackupKind = backupKind,
+            ConfigurationSource = configurationSource
+        };
+
+        await scenario.ConfigurePeriodicBackupSettingsBasedOnScopeAsync();
+        await scenario.CreateInitialDocumentsAsync();
+
+        var backupDurationWithDefaults = await scenario.MeasurePeriodicBackupDurationAsync();
+        await scenario.SetMaxReadOpsPerSecondAsync();
+        var backupDurationWithMaxReadOps = await scenario.MeasurePeriodicBackupDurationAsync();
+
+        scenario.AssertResults(backupDurationWithDefaults, backupDurationWithMaxReadOps);
+        _output.WriteLine($"Backup duration with defaults: {backupDurationWithDefaults}, Backup duration with MaxReadOpsPerSec: {backupDurationWithMaxReadOps}");
+    }
+
+    [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot], Skip = "Backups of the type 'Snapshot' are not supported in sharding.")]
+    public async Task ShouldRespect_Option_MaxReadOpsPerSec_OnOneTimeBackup(Options options, BackupType backupType)
+    {
+        DoNotReuseServer();
+
+        using var scenario = new MaxReadOpsPerSecOptionBackupTestScenario(this, options)
+        {
+            BackupType = backupType,
+        };
+
+        scenario.ConfigureOneTimeBackupSettings();
+        await scenario.CreateInitialDocumentsAsync();
+
+        var backupDurationWithDefaults = await scenario.MeasureOneTimeBackupDurationAsync();
+        scenario.OneTimeBackupConfiguration.MaxReadOpsPerSecond = scenario.MaxReadOpsPerSecToTest;
+        var backupDurationWithMaxReadOps = await scenario.MeasureOneTimeBackupDurationAsync();
+
+        scenario.AssertResults(backupDurationWithDefaults, backupDurationWithMaxReadOps);
+        _output.WriteLine($"Backup duration with defaults: {backupDurationWithDefaults}, Backup duration with MaxReadOpsPerSec: {backupDurationWithMaxReadOps}");
+    }
+
+    [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = [BackupType.Backup])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [BackupType.Snapshot])]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Data = [BackupType.Snapshot], Skip = "Backups of type 'Snapshot' are not supported in sharding.")]
+    public async Task ShouldRespect_Option_MaxReadOpsPerSec_OnRestore(Options options, BackupType backupType)
+    {
+        DoNotReuseServer();
+
+        using var scenario = new MaxReadOpsPerSecOptionRestoreTestScenario(this, options) { BackupType = backupType };
+
+        await scenario.CreateInitialDocumentsAsync();
+        await scenario.PrepareBackupFileToRestore();
+
+        var restoreDurationWithDefaults = scenario.MeasureShardedDatabaseRestoreDuration();
+        scenario.SetMaxReadOpsPerSecond();
+        var restoreDurationWithMaxReadOps = scenario.MeasureShardedDatabaseRestoreDuration();
+
+        scenario.AssertResults(restoreDurationWithDefaults, restoreDurationWithMaxReadOps);
+        _output.WriteLine($"Restore duration with defaults: {restoreDurationWithDefaults}, Restore duration with MaxReadOpsPerSec: {restoreDurationWithMaxReadOps}");
+    }
+
+    public enum BackupScope
+    {
+        Periodic,
+        ServerWide
+    }
+
+    public enum ConfigurationSource
+    {
+        BackupConfiguration,
+        DatabaseSettings
+    }
+
+    private abstract class MaxReadOpsPerSecOptionTestScenarioBase : IDisposable
+    {
+        protected const string InitialDocumentId = "foo/bar";
+        protected readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
+
+        protected readonly ClusterTestBase ClusterTestBase;
+        protected readonly string BackupPath;
+        protected readonly DocumentStore Store;
+
+        private readonly Options _options;
+        private int? _expectedMinimumOperationDurationInSeconds;
+
+        public RavenDatabaseMode DatabaseMode => _options.DatabaseMode;
+
+        protected MaxReadOpsPerSecOptionTestScenarioBase(ClusterTestBase clusterTestBase, Options options, [CallerMemberName] string testName = null)
+        {
+            ClusterTestBase = clusterTestBase;
+            _options = options;
+
+            BackupPath = ClusterTestBase.NewDataPath(prefix: testName, suffix: "BackupFolder");
+            Store = ClusterTestBase.GetDocumentStore(options, caller: testName);
+        }
+
+        protected internal BackupType BackupType { get; init; }
+        protected abstract int DocumentsToCreate { get; }
+        protected internal abstract int MaxReadOpsPerSecToTest { get; }
+
+        private int ExpectedMinimumOperationDurationInSeconds
+        {
+            get
+            {
+                _expectedMinimumOperationDurationInSeconds ??= CalculateExpectedMinimumOperationDurationInSeconds();
+                return _expectedMinimumOperationDurationInSeconds.Value;
+            }
+        }
+
+        protected abstract int CalculateExpectedMinimumOperationDurationInSeconds();
+
+        protected abstract string OperationName { get; }
+
+        protected async Task CreateDocumentsForNonShardedDatabaseAsync()
+        {
+            for (int i = 0; i < DocumentsToCreate; i++)
+                using (var session = Store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = $"Name{i}" });
+                    await session.SaveChangesAsync();
+                }
+        }
+
+        internal async Task CreateInitialSingleDocumentAsync()
+        {
+            using var session = Store.OpenAsyncSession();
+            await session.StoreAsync(new User { Name = "InitialDocument" }, InitialDocumentId);
+            await session.SaveChangesAsync();
+        }
+
+        public void AssertResults(TimeSpan defaultDuration, TimeSpan rateControlledDuration)
+        {
+            Assert.True(rateControlledDuration > defaultDuration,
+                $"{OperationName} with MaxReadOpsPerSecond = {MaxReadOpsPerSecToTest} should take more time than {OperationName} with default value, " +
+                $"but it took '{rateControlledDuration}', while with default value took '{defaultDuration}'");
+
+            Assert.True(defaultDuration.TotalSeconds < ExpectedMinimumOperationDurationInSeconds,
+                $"{OperationName} with default options should take less than '{ExpectedMinimumOperationDurationInSeconds}' seconds, but it took " +
+                $"'{defaultDuration}' despite MaxReadOpsPerSecond was not set");
+
+            Assert.True(rateControlledDuration.TotalSeconds > ExpectedMinimumOperationDurationInSeconds,
+                $"{OperationName} with MaxReadOpsPerSecond = {MaxReadOpsPerSecToTest} should take more than " +
+                $"'{ExpectedMinimumOperationDurationInSeconds}' seconds, but it took '{rateControlledDuration}'");
+        }
+
+        public void Dispose()
+        {
+            Store?.Dispose();
+        }
+    }
+
+    private class MaxReadOpsPerSecOptionBackupTestScenario : MaxReadOpsPerSecOptionTestScenarioBase
+    {
+        private long _taskId;
+
+        public MaxReadOpsPerSecOptionBackupTestScenario(ClusterTestBase clusterTestBase, Options options, [CallerMemberName] string testName = null)
+            : base(clusterTestBase, options, testName) { }
+
+        public BackupScope BackupScope { get; init; }
+        public BackupKind BackupKind { get; init; } = BackupKind.Full;
+        public ConfigurationSource ConfigurationSource { get; init; }
+
+        private PeriodicBackupConfiguration PeriodicBackupConfiguration { get; set; }
+        private ServerWideBackupConfiguration ServerWideBackupConfiguration { get; set; }
+        internal BackupConfiguration OneTimeBackupConfiguration { get; private set; }
+
+        protected override int DocumentsToCreate => BackupType == BackupType.Snapshot ? 200 : 150;
+        protected internal override int MaxReadOpsPerSecToTest => BackupType == BackupType.Snapshot ? 16 : 10;
+
+        protected override string OperationName => $"{BackupKind} {(BackupType == BackupType.Backup ? "Logical" : nameof(BackupType.Snapshot))} backup of {DatabaseMode} database";
+
+        protected override int CalculateExpectedMinimumOperationDurationInSeconds()
+        {
+            switch (BackupType)
+            {
+                case BackupType.Snapshot when BackupKind == BackupKind.Full:
+                    // Snapshots are created by copying data page by page, rather than one document at a time. Due to specific data storage characteristics,
+                    // creating 200 documents results in 257 pages for the document data. (value obtained experimentally)
+                    // And minus `MaxReadOpsPerSecToTest` because rateGate will not wait after the last operation
+                    return (257 - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
+
+                case BackupType.Snapshot when BackupKind == BackupKind.Incremental: // Incremental for snapshot is a logical backup
+                case BackupType.Backup:
+                    // Minus `MaxReadOpsPerSecToTest` because rateGate will not wait after the last operation
+                    return (DocumentsToCreate - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(BackupType), BackupType, null);
+            }
+        }
+
+        public async Task CreateInitialDocumentsAsync()
+        {
+            switch (DatabaseMode)
+            {
+                case RavenDatabaseMode.Single when BackupKind == BackupKind.Full:
+                    await CreateDocumentsForNonShardedDatabaseAsync();
+                    break;
+
+                case RavenDatabaseMode.Sharded when BackupKind == BackupKind.Full:
+                    // We want to store all documents in the same shard to get clear understanding the number of documents per shard to do clear measurements
+                    await CreateInitialSingleDocumentAsync();
+                    await CreateDocumentsOnTheSameShardAsInitialDocumentAsync();
+                    break;
+
+                case RavenDatabaseMode.Single  when BackupKind == BackupKind.Incremental:
+                    await CreateInitialSingleDocumentAsync();
+                    _ = await MeasureNonShardedBackupDurationAsync();
+                    break;
+
+                case RavenDatabaseMode.Sharded when BackupKind == BackupKind.Incremental:
+                    await CreateInitialSingleDocumentAsync();
+                    _ = await MeasureShardedBackupDurationAsync();
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private async Task CreateDocumentsOnTheSameShardAsInitialDocumentAsync()
+        {
+            var docsToCreate = DocumentsToCreate;
+            if (BackupKind == BackupKind.Full)
+                docsToCreate -= 1; // We already created the initial document and didn't back it up yet
+
+            for (int i = 1; i < docsToCreate; i++)
+                using (var session = Store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = $"Name{i}" }, $"{nameof(User)}s/{i}${InitialDocumentId}");
+                    await session.SaveChangesAsync();
+                }
+        }
+
+        public async Task ConfigurePeriodicBackupSettingsBasedOnScopeAsync()
+        {
+            switch (BackupScope)
+            {
+                case BackupScope.Periodic:
+                    PeriodicBackupConfiguration = ClusterTestBase.Backup.CreateBackupConfiguration(BackupPath, BackupType);
+
+                    switch (DatabaseMode)
+                    {
+                        case RavenDatabaseMode.Single:
+                            _taskId = PeriodicBackupConfiguration.TaskId = await ClusterTestBase.Backup.UpdateConfigAsync(ClusterTestBase.Server, PeriodicBackupConfiguration, Store);
+                            break;
+                        case RavenDatabaseMode.Sharded:
+                            _taskId = PeriodicBackupConfiguration.TaskId = await ClusterTestBase.Sharding.Backup.UpdateConfigAsync(ClusterTestBase.Server, PeriodicBackupConfiguration, Store);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+                    }
+
+                    Assert.Null(ServerWideBackupConfiguration);
+                    Assert.NotNull(PeriodicBackupConfiguration);
+                    break;
+
+                case BackupScope.ServerWide:
+                    ServerWideBackupConfiguration = new ServerWideBackupConfiguration { BackupType = BackupType, FullBackupFrequency = "0 0 1 1 *", Disabled = false, LocalSettings = new LocalSettings { FolderPath = BackupPath } };
+
+                    switch (DatabaseMode)
+                    {
+                        case RavenDatabaseMode.Single:
+                            _taskId = ServerWideBackupConfiguration.TaskId = await ClusterTestBase.Backup.UpdateServerWideConfigAsync(ClusterTestBase.Server, ServerWideBackupConfiguration, Store);
+                            break;
+                        case RavenDatabaseMode.Sharded:
+                            _taskId = ServerWideBackupConfiguration.TaskId = await ClusterTestBase.Sharding.Backup.UpdateServerWideConfigAsync(ClusterTestBase.Server, ServerWideBackupConfiguration, Store);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+                    }
+
+                    Assert.Null(PeriodicBackupConfiguration);
+                    Assert.NotNull(ServerWideBackupConfiguration);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(BackupScope), BackupScope, null);
+            }
+        }
+
+        public void ConfigureOneTimeBackupSettings()
+        {
+            OneTimeBackupConfiguration = new BackupConfiguration
+            {
+                BackupType = BackupType,
+                LocalSettings = new LocalSettings { FolderPath = BackupPath },
+            };
+        }
+
+        public async Task SetMaxReadOpsPerSecondAsync()
+        {
+            if (ConfigurationSource == ConfigurationSource.DatabaseSettings)
+            {
+                switch (DatabaseMode)
+                {
+                    case RavenDatabaseMode.Single:
+                        var database = await ClusterTestBase.Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(Store.Database);
+                        database.Configuration.Backup.MaxReadOpsPerSecond = MaxReadOpsPerSecToTest;
+
+
+                        break;
+
+                    case RavenDatabaseMode.Sharded:
+                        await foreach (var shardedDocumentDatabase in ClusterTestBase.Sharding.GetShardsDocumentDatabaseInstancesFor(Store.Database,[ClusterTestBase.Server]))
+                            shardedDocumentDatabase.Configuration.Backup.MaxReadOpsPerSecond = MaxReadOpsPerSecToTest;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+                }
+
+                Assert.Null(PeriodicBackupConfiguration?.MaxReadOpsPerSecond);
+                Assert.Null(ServerWideBackupConfiguration?.MaxReadOpsPerSecond);
+                return;
+            }
+
+            switch (BackupScope)
+            {
+                case BackupScope.Periodic:
+                    Assert.NotNull(PeriodicBackupConfiguration);
+                    Assert.Null(ServerWideBackupConfiguration);
+
+                    PeriodicBackupConfiguration.MaxReadOpsPerSecond = MaxReadOpsPerSecToTest;
+                    switch (DatabaseMode)
+                    {
+                        case RavenDatabaseMode.Single:
+                            await ClusterTestBase.Backup.UpdateConfigAsync(ClusterTestBase.Server, PeriodicBackupConfiguration, Store);
+                            break;
+
+                        case RavenDatabaseMode.Sharded:
+                            await ClusterTestBase.Sharding.Backup.UpdateConfigAsync(ClusterTestBase.Server, PeriodicBackupConfiguration, Store);
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+                    }
+                    break;
+
+                case BackupScope.ServerWide:
+                    Assert.NotNull(ServerWideBackupConfiguration);
+                    Assert.Null(PeriodicBackupConfiguration);
+
+                    ServerWideBackupConfiguration.MaxReadOpsPerSecond = MaxReadOpsPerSecToTest;
+                    switch (DatabaseMode)
+                    {
+                        case RavenDatabaseMode.Single:
+                            await ClusterTestBase.Backup.UpdateServerWideConfigAsync(ClusterTestBase.Server, ServerWideBackupConfiguration, Store);
+                            break;
+
+                        case RavenDatabaseMode.Sharded:
+                            await ClusterTestBase.Sharding.Backup.UpdateServerWideConfigAsync(ClusterTestBase.Server, ServerWideBackupConfiguration, Store);
+                            break;
+
+                        case RavenDatabaseMode.All:
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+                    }
+                    break;
+            }
+        }
+
+        public async Task<TimeSpan> MeasurePeriodicBackupDurationAsync()
+        {
+            switch (DatabaseMode)
+            {
+                case RavenDatabaseMode.Single when BackupKind == BackupKind.Full:
+                    return await MeasureNonShardedBackupDurationAsync();
+
+                case RavenDatabaseMode.Single when BackupKind == BackupKind.Incremental:
+                    await CreateDocumentsForNonShardedDatabaseAsync();
+                    return await MeasureNonShardedBackupDurationAsync();
+
+                case RavenDatabaseMode.Sharded when BackupKind == BackupKind.Full:
+                    return await MeasureShardedBackupDurationAsync();
+
+                case RavenDatabaseMode.Sharded when BackupKind == BackupKind.Incremental:
+                    await CreateDocumentsOnTheSameShardAsInitialDocumentAsync();
+                    return await MeasureShardedBackupDurationAsync();
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public async Task<TimeSpan> MeasureOneTimeBackupDurationAsync()
+        {
+            var sw = Stopwatch.StartNew();
+            var operation = await Store.Maintenance.SendAsync(new BackupOperation(OneTimeBackupConfiguration));
+            await operation.WaitForCompletionAsync(DefaultTimeout);
+            return sw.Elapsed;
+        }
+
+        private async Task<TimeSpan> MeasureNonShardedBackupDurationAsync()
+        {
+            var sw = Stopwatch.StartNew();
+            await ClusterTestBase.Backup.RunBackupAsync(ClusterTestBase.Server, _taskId, Store, isFullBackup: BackupKind == BackupKind.Full);
+            return sw.Elapsed;
+        }
+
+        private async Task<TimeSpan> MeasureShardedBackupDurationAsync()
+        {
+            var sw = Stopwatch.StartNew();
+            var waitHandles = await ClusterTestBase.Sharding.Backup.WaitForBackupsToComplete([ClusterTestBase.Server], Store.Database);
+            await ClusterTestBase.Sharding.Backup.RunBackupAsync(Store, _taskId, isFullBackup: BackupKind == BackupKind.Full);
+            WaitHandle.WaitAll(waitHandles, DefaultTimeout);
+            return sw.Elapsed;
+        }
+    }
+
+    private class MaxReadOpsPerSecOptionRestoreTestScenario : MaxReadOpsPerSecOptionTestScenarioBase
+    {
+        public MaxReadOpsPerSecOptionRestoreTestScenario(ClusterTestBase clusterTestBase, Options options, [CallerMemberName] string testName = null)
+            : base(clusterTestBase, options, testName) { }
+
+        protected override int DocumentsToCreate => BackupType == BackupType.Backup ? 150 : 5;
+        protected internal override int MaxReadOpsPerSecToTest => BackupType == BackupType.Backup ? 10 : 1;
+        protected override int CalculateExpectedMinimumOperationDurationInSeconds()
+        {
+            switch (BackupType)
+            {
+                case BackupType.Backup:
+                    // Minus `MaxReadOpsPerSecToTest` because rateGate will not wait after the last operation
+                    return (DocumentsToCreate - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
+
+                case BackupType.Snapshot:
+                    // snapshot data requires 11 buffer iterations for db with 5 docs (value obtained experimentally)
+                    return 11;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        protected override string OperationName => "Restore";
+
+        private RestoreBackupConfiguration RestoreBackupConfiguration { get; set; }
+
+        public async Task CreateInitialDocumentsAsync()
+        {
+            switch (DatabaseMode)
+            {
+                case RavenDatabaseMode.Single:
+                    await CreateDocumentsForNonShardedDatabaseAsync();
+                    break;
+                case RavenDatabaseMode.Sharded:
+                    // We want to store all documents in the same shard to get clear understanding the number of documents per shard to do clear measurements
+                    await CreateInitialSingleDocumentAsync();
+                    await CreateDocumentsOnTheSameShardAsInitialDocumentAsync();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+            }
+        }
+
+        private async Task CreateDocumentsOnTheSameShardAsInitialDocumentAsync()
+        {
+            for (int i = 1; i < DocumentsToCreate; i++)
+                using (var session = Store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = $"Name{i}" }, $"{nameof(User)}s/{i}${InitialDocumentId}");
+                    await session.SaveChangesAsync();
+                }
+        }
+
+        public async Task PrepareBackupFileToRestore()
+        {
+            var backupConfig = ClusterTestBase.Backup.CreateBackupConfiguration(BackupPath, BackupType);
+
+            switch (DatabaseMode)
+            {
+                case RavenDatabaseMode.Single:
+                    await ClusterTestBase.Backup.UpdateConfigAndRunBackupAsync(ClusterTestBase.Server, backupConfig, Store);
+
+                    RestoreBackupConfiguration = new RestoreBackupConfiguration
+                    {
+                        BackupLocation = Directory.GetDirectories(BackupPath).First(),
+                        DatabaseName = $"restored_with_defaults_database-{Guid.NewGuid()}"
+                    };
+                    break;
+
+                case RavenDatabaseMode.Sharded:
+                    var waitHandles = await ClusterTestBase.Sharding.Backup.WaitForBackupsToComplete([ClusterTestBase.Server], Store.Database);
+                    await ClusterTestBase.Sharding.Backup.UpdateConfigurationAndRunBackupAsync([ClusterTestBase.Server], Store, backupConfig);
+                    Assert.True(WaitHandle.WaitAll(waitHandles, DefaultTimeout));
+
+                    var dirs = Directory.GetDirectories(BackupPath);
+                    var sharding = await ClusterTestBase.Sharding.GetShardingConfigurationAsync(Store);
+                    var settings = ClusterTestBase.Sharding.Backup.GenerateShardRestoreSettings(dirs, sharding);
+
+                    RestoreBackupConfiguration = new RestoreBackupConfiguration
+                    {
+                        DatabaseName = $"restored_with_defaults_database-{Guid.NewGuid()}",
+                        ShardRestoreSettings = settings
+                    };
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(DatabaseMode), DatabaseMode, null);
+            }
+        }
+
+        public TimeSpan MeasureShardedDatabaseRestoreDuration()
+        {
+            var cw = Stopwatch.StartNew();
+
+            using (ClusterTestBase.Sharding.Backup.ReadOnly(BackupPath))
+            using (ClusterTestBase.Backup.RestoreDatabase(Store, RestoreBackupConfiguration));
+
+            return cw.Elapsed;
+        }
+
+        public void SetMaxReadOpsPerSecond()
+        {
+            RestoreBackupConfiguration.MaxReadOpsPerSecond = MaxReadOpsPerSecToTest;
+            RestoreBackupConfiguration.DatabaseName = $"restored_with_maxReadOps_database-{Guid.NewGuid()}";
+        }
+    }
+}

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -2197,6 +2198,112 @@ namespace SlowTests.Smuggler
             finally
             {
                 File.Delete(file);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Smuggler)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldRespect_Option_MaxReadOpsPerSec_OnExport(Options options)
+        {
+            const int documentsToCreate = 150;
+            const int maxReadOpsPerSecToTest = 10;
+            const int expectedMinimumExportDurationInSeconds = (documentsToCreate - maxReadOpsPerSecToTest) / maxReadOpsPerSecToTest;
+
+            var file = GetTempFileName();
+
+            using (var store = GetDocumentStore(options))
+            {
+                // We want to store all documents in the same shard to get clear understanding the number of documents per shard to do clear measurements
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "InitialDocument" }, "foo/bar");
+                    await session.SaveChangesAsync();
+                }
+
+                for (int i = 1; i < documentsToCreate - 1; i++)
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = $"Name{i}" }, $"{nameof(User)}s/{i}$foo/bar");
+                        await session.SaveChangesAsync();
+                    }
+
+                var exportOptions = new DatabaseSmugglerExportOptions();
+
+                var sw = Stopwatch.StartNew();
+                var operation = await store.Smuggler.ExportAsync(exportOptions, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                var exportDurationDefaultOptions = sw.Elapsed;
+                File.Delete(file);
+
+                exportOptions.MaxReadOpsPerSecond = maxReadOpsPerSecToTest;
+
+                sw.Restart();
+                operation = await store.Smuggler.ExportAsync(exportOptions, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                var exportDurationWithMaxReadOps = sw.Elapsed;
+
+                Assert.True(exportDurationWithMaxReadOps > exportDurationDefaultOptions,
+                    $"Export with {nameof(exportOptions.MaxReadOpsPerSecond)} with value '{maxReadOpsPerSecToTest}' should take more time than default export, " +
+                    $"but it took '{exportDurationWithMaxReadOps}' seconds, while with default value took '{exportDurationDefaultOptions}' seconds");
+                Assert.True(exportDurationDefaultOptions.TotalSeconds < expectedMinimumExportDurationInSeconds,
+                    $"Export with default options should take less than '{expectedMinimumExportDurationInSeconds}' seconds, but it took " +
+                    $"'{exportDurationDefaultOptions}' seconds despite {nameof(exportOptions.MaxReadOpsPerSecond)} was not set");
+                Assert.True(exportDurationWithMaxReadOps.TotalSeconds > expectedMinimumExportDurationInSeconds,
+                    $"Export with {nameof(exportOptions.MaxReadOpsPerSecond)} with value '{maxReadOpsPerSecToTest}' should take more than " +
+                    $"'{expectedMinimumExportDurationInSeconds}' seconds, but it took '{exportDurationWithMaxReadOps}' seconds");
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Smuggler)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldRespect_Option_MaxReadOpsPerSec_OnImport(Options dstOptions)
+        {
+            const int documentsToCreate = 150;
+            const int maxReadOpsPerSecToTest = 10;
+            const int expectedMinimumImportDurationInSeconds = (documentsToCreate - maxReadOpsPerSecToTest) / maxReadOpsPerSecToTest;
+
+            var file = GetTempFileName();
+
+            using (var srcStore = GetDocumentStore())
+            using (var destStoreForDefaultValue = GetDocumentStore(dstOptions))
+            using (var destStoreForMaxReadOpsPerSec = GetDocumentStore(dstOptions))
+            {
+                using (var session = srcStore.OpenAsyncSession())
+                {
+                    for (int i = 0; i < documentsToCreate; i++)
+                        await session.StoreAsync(new User { Name = $"Name{i}" });
+
+                    await session.SaveChangesAsync();
+                }
+
+                var exportOptions = new DatabaseSmugglerExportOptions();
+
+                var operation = await srcStore.Smuggler.ExportAsync(exportOptions, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                var importOptions = new DatabaseSmugglerImportOptions();
+
+                var sw = Stopwatch.StartNew();
+                operation = await destStoreForDefaultValue.Smuggler.ImportAsync(importOptions, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                var importDurationDefaultOptions = sw.Elapsed;
+
+                importOptions.MaxReadOpsPerSecond = maxReadOpsPerSecToTest;
+
+                sw.Restart();
+                operation = await destStoreForMaxReadOpsPerSec.Smuggler.ImportAsync(importOptions, file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                var importDurationWithMaxReadOps = sw.Elapsed;
+
+                Assert.True(importDurationWithMaxReadOps > importDurationDefaultOptions,
+                    $"Import with {nameof(importOptions.MaxReadOpsPerSecond)} with value '{maxReadOpsPerSecToTest}' should take more time than default import, " +
+                    $"but it took '{importDurationWithMaxReadOps}' seconds, while with default value took '{importDurationDefaultOptions}' seconds");
+                Assert.True(importDurationDefaultOptions.TotalSeconds < expectedMinimumImportDurationInSeconds,
+                    $"Import with default options should take less than '{expectedMinimumImportDurationInSeconds}' seconds, but it took " +
+                    $"'{importDurationDefaultOptions}' seconds despite {nameof(importOptions.MaxReadOpsPerSecond)} was not set");
+                Assert.True(importDurationWithMaxReadOps.TotalSeconds > expectedMinimumImportDurationInSeconds,
+                    $"Import with {nameof(importOptions.MaxReadOpsPerSecond)} with value '{maxReadOpsPerSecToTest}' should take more than " +
+                    $"'{expectedMinimumImportDurationInSeconds}' seconds, but it took '{importDurationWithMaxReadOps}' seconds");
             }
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -17,7 +17,8 @@ using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Subscriptions;
-using Raven.Client.Exceptions.Database;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server;
@@ -374,6 +375,19 @@ public partial class RavenTestBase
             WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, result.TaskId);
 
             return result.TaskId;
+        }
+
+        public async Task<long> UpdateServerWideConfigAsync(RavenServer server, ServerWideBackupConfiguration config, DocumentStore store)
+        {
+            await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(config));
+
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var backup = record.PeriodicBackups.First();
+            var backupTaskId = backup.TaskId;
+
+            WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId);
+
+            return backupTaskId;
         }
 
         public void WaitForResponsibleNodeUpdate(ServerStore serverStore, string databaseName, long taskId, string differentThan = null)

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -711,7 +711,7 @@ namespace FastTests
             Process.Start("xdg-open", url);
         }
 
-        protected string NewDataPath([CallerMemberName] string prefix = null, string suffix = null, bool forceCreateDir = false)
+        protected internal string NewDataPath([CallerMemberName] string prefix = null, string suffix = null, bool forceCreateDir = false)
         {
             if (suffix != null)
                 prefix += suffix;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23034

### Additional description

Add a `MaxReadOpsPerSec` option to backup/restore and import/export a database in "slow mode" to minimize the performance impact on other databases. This mode should throttle resource consumption (CPU, disk, I/O) during the operation, ensuring smooth performance for existing databases.

Configuration of `MaxReadOpsPerSec` is available by defining the corresponding operation/task configurations, and for backups, also through Server/Database configuration.

The values are nullable everywhere; when `MaxReadOpsPerSec` == null, "slow mode" is disabled, and the operation is performed without speed limits.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
