### PR TITLE
RavenDB-23846

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -23,12 +23,21 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public virtual DynamicJsonValue ToAuditJson()
         {
-            return new DynamicJsonValue { [nameof(Disabled)] = Disabled, [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToAuditJson() };
+            return new DynamicJsonValue
+            {
+                [nameof(Disabled)] = Disabled,
+                [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToAuditJson()
+
+            };
         }
 
         public virtual DynamicJsonValue ToJson()
         {
-            return new DynamicJsonValue { [nameof(Disabled)] = Disabled, [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToJson() };
+            return new DynamicJsonValue
+            {
+                [nameof(Disabled)] = Disabled,
+                [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToJson()
+            };
         }
     }
 
@@ -59,12 +68,22 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public DynamicJsonValue ToAuditJson()
         {
-            return new DynamicJsonValue { [nameof(Exec)] = Exec, [nameof(TimeoutInMs)] = TimeoutInMs };
+
+            return new DynamicJsonValue
+            {
+                [nameof(Exec)] = Exec,
+                [nameof(TimeoutInMs)] = TimeoutInMs
+            };
         }
 
         public DynamicJsonValue ToJson()
         {
-            return new DynamicJsonValue { [nameof(Exec)] = Exec, [nameof(Arguments)] = Arguments, [nameof(TimeoutInMs)] = TimeoutInMs };
+            return new DynamicJsonValue
+            {
+                [nameof(Exec)] = Exec,
+                [nameof(Arguments)] = Arguments,
+                [nameof(TimeoutInMs)] = TimeoutInMs
+            };
         }
     }
 
@@ -158,6 +177,7 @@ namespace Raven.Client.Documents.Operations.Backups
 
             return djv;
         }
+
     }
 
     public sealed class S3Settings : AmazonSettings
@@ -274,6 +294,7 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public GlacierSettings()
         {
+
         }
 
         internal GlacierSettings(GlacierSettings settings)

--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -23,21 +23,12 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public virtual DynamicJsonValue ToAuditJson()
         {
-            return new DynamicJsonValue
-            {
-                [nameof(Disabled)] = Disabled,
-                [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToAuditJson()
-
-            };
+            return new DynamicJsonValue { [nameof(Disabled)] = Disabled, [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToAuditJson() };
         }
 
         public virtual DynamicJsonValue ToJson()
         {
-            return new DynamicJsonValue
-            {
-                [nameof(Disabled)] = Disabled,
-                [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToJson()
-            };
+            return new DynamicJsonValue { [nameof(Disabled)] = Disabled, [nameof(GetBackupConfigurationScript)] = GetBackupConfigurationScript?.ToJson() };
         }
     }
 
@@ -68,22 +59,12 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public DynamicJsonValue ToAuditJson()
         {
-
-            return new DynamicJsonValue
-            {
-                [nameof(Exec)] = Exec,
-                [nameof(TimeoutInMs)] = TimeoutInMs
-            };
+            return new DynamicJsonValue { [nameof(Exec)] = Exec, [nameof(TimeoutInMs)] = TimeoutInMs };
         }
 
         public DynamicJsonValue ToJson()
         {
-            return new DynamicJsonValue
-            {
-                [nameof(Exec)] = Exec,
-                [nameof(Arguments)] = Arguments,
-                [nameof(TimeoutInMs)] = TimeoutInMs
-            };
+            return new DynamicJsonValue { [nameof(Exec)] = Exec, [nameof(Arguments)] = Arguments, [nameof(TimeoutInMs)] = TimeoutInMs };
         }
     }
 
@@ -177,7 +158,6 @@ namespace Raven.Client.Documents.Operations.Backups
 
             return djv;
         }
-
     }
 
     public sealed class S3Settings : AmazonSettings
@@ -193,6 +173,8 @@ namespace Raven.Client.Documents.Operations.Backups
         public string CustomServerUrl { get; set; }
 
         public bool ForcePathStyle { get; set; }
+
+        public S3StorageClass? StorageClass { get; set; }
 
         public S3Settings()
         {
@@ -210,6 +192,7 @@ namespace Raven.Client.Documents.Operations.Backups
             AwsAccessKey = settings.AwsAccessKey;
             AwsSecretKey = settings.AwsSecretKey;
             AwsSessionToken = settings.AwsSessionToken;
+            StorageClass = settings.StorageClass;
 
             RemoteFolderName = settings.RemoteFolderName;
             Disabled = settings.Disabled;
@@ -249,6 +232,9 @@ namespace Raven.Client.Documents.Operations.Backups
             if (other.ForcePathStyle != ForcePathStyle)
                 return false;
 
+            if (other.StorageClass != StorageClass)
+                return false;
+
             return true;
         }
 
@@ -258,6 +244,10 @@ namespace Raven.Client.Documents.Operations.Backups
             djv[nameof(BucketName)] = BucketName;
             djv[nameof(CustomServerUrl)] = CustomServerUrl;
             djv[nameof(ForcePathStyle)] = ForcePathStyle;
+
+            if (StorageClass.HasValue)
+                djv[nameof(StorageClass)] = StorageClass.Value;
+            
             return djv;
         }
 
@@ -267,6 +257,10 @@ namespace Raven.Client.Documents.Operations.Backups
             djv[nameof(BucketName)] = BucketName;
             djv[nameof(CustomServerUrl)] = CustomServerUrl;
             djv[nameof(ForcePathStyle)] = ForcePathStyle;
+            
+            if (StorageClass.HasValue)
+                djv[nameof(StorageClass)] = StorageClass.Value;
+            
             return djv;
         }
     }
@@ -280,7 +274,6 @@ namespace Raven.Client.Documents.Operations.Backups
 
         public GlacierSettings()
         {
-
         }
 
         internal GlacierSettings(GlacierSettings settings)
@@ -335,7 +328,7 @@ namespace Raven.Client.Documents.Operations.Backups
             djv[nameof(VaultName)] = VaultName;
             return djv;
         }
-      
+
         public override DynamicJsonValue ToAuditJson()
         {
             var djv = base.ToAuditJson();
@@ -484,6 +477,7 @@ namespace Raven.Client.Documents.Operations.Backups
             return djv;
         }
     }
+
     public sealed class GoogleCloudSettings : BackupSettings, ICloudBackupSettings
     {
         /// <summary>
@@ -545,7 +539,7 @@ namespace Raven.Client.Documents.Operations.Backups
         public override DynamicJsonValue ToAuditJson()
         {
             var djv = base.ToAuditJson();
-            
+
             djv[nameof(BucketName)] = BucketName;
             djv[nameof(RemoteFolderName)] = RemoteFolderName;
 

--- a/src/Raven.Client/Documents/Operations/Backups/S3StorageClass.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/S3StorageClass.cs
@@ -1,0 +1,83 @@
+namespace Raven.Client.Documents.Operations.Backups;
+
+public enum S3StorageClass
+{
+    /// <summary>
+    /// S3 Glacier Deep Archive provides secure, durable object storage class for long term data archival.
+    /// It is the ideal storage class to make an archival, durable copy of data that rarely, if ever, needs to be accessed.
+    /// It can be used as an offline backup for their most important data assets and to meet long-term retention needs.
+    /// </summary>
+    DeepArchive,
+
+    /// <summary>
+    /// The GLACIER storage is for object that are stored in Amazon Glacier.
+    /// This storage class is for objects that are for archival purpose and 
+    /// get operations are rare.
+    /// <para></para>
+    /// Durability 99.999999999%
+    /// </summary>
+    Glacier,
+
+    /// <summary>
+    /// Constant GLACIER_IR for ObjectStorageClass
+    /// </summary>
+    GlacierInstantRetrieval,
+
+    /// <summary>
+    /// IntelligentTiering makes it easy to lower your overall cost of storage by automatically placing data in the storage
+    /// class that best matches the access patterns for the storage. With IntelligentTiering, you don’t need to define
+    /// and manage individual policies for lifecycle data management or write code to transition objects
+    /// between storage classes. Instead, you can use IntelligentTiering to manage transitions between Standard and
+    /// S-IA without writing any application code. IntelligentTiering also manages transitions automatically to
+    /// Glacier for long term archive in addition to S3 storage classes.
+    /// </summary>
+    IntelligentTiering,
+
+    /// <summary>
+    /// The ONEZONE_IA storage is for infrequently accessed objects. It is similiar to STANDARD_IA, but
+    /// only stores object data within one Availablity Zone in a given region.
+    /// <para></para>
+    /// Durability 99.999999999%; Availability 99% over a given year.
+    /// </summary>
+    OneZoneInfrequentAccess,
+
+    /// <summary>
+    /// The OUTPOSTS storage class for objects stored in a S3 Outpost
+    /// </summary>
+    Outposts,
+
+    /// <summary>
+    /// REDUCED_REDUNDANCY provides the same availability as standard, but at a lower durability.
+    /// <para></para>
+    /// Durability 99.99%; Availability 99.99% over a given year.
+    /// </summary>
+    ReducedRedundancy,
+
+    /// <summary>
+    /// The STANDARD storage class, which is the default
+    /// storage class for S3.
+    /// <para></para>
+    /// Durability 99.999999999%; Availability 99.99% over a given year.
+    /// </summary>
+    Standard,
+
+    /// <summary>
+    /// The STANDARD_IA storage is for infrequently accessed objects.
+    /// This storage class is for objects that are long-lived and less frequently accessed,
+    /// like backups and older data.
+    /// <para></para>
+    /// Durability 99.999999999%; Availability 99.9% over a given year.
+    /// </summary>
+    StandardInfrequentAccess,
+
+    /// <summary>
+    /// The SNOW storage is for objects stored in Amazon S3 compatible object storage
+    /// for Snow family devices.
+    /// </summary>
+    Snow,
+
+    /// <summary>
+    /// The EXPRESS_ONEZONE storage class for faster access to S3
+    /// </summary>
+    ExpressOneZone,
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -34,6 +34,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
         public readonly string RemoteFolderName;
 
         public readonly string Region;
+        private readonly Amazon.S3.S3StorageClass _storageClass;
 
         public RavenAwsS3Client(S3Settings s3Settings, Config.Categories.BackupConfiguration configuration, Progress progress = null, CancellationToken cancellationToken = default)
         {
@@ -95,6 +96,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             _bucketName = s3Settings.BucketName;
             RemoteFolderName = s3Settings.RemoteFolderName;
             Region = s3Settings.AwsRegionName == null ? string.Empty : s3Settings.AwsRegionName.ToLower();
+            _storageClass = s3Settings.StorageClass?.ToAmazonS3StorageClass() ?? Amazon.S3.S3StorageClass.Standard;;
             _progress = progress;
             _cancellationToken = cancellationToken;
         }
@@ -106,7 +108,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
 
         public IMultiPartUploader GetUploader(string key, Dictionary<string, string> metadata)
         {
-            return new AwsS3MultiPartUploader(_client, _bucketName, _progress, key, metadata, _cancellationToken);
+            return new AwsS3MultiPartUploader(_client, _bucketName, _storageClass, _progress, key, metadata, _cancellationToken);
         }
 
         public async Task PutObjectAsync(string key, Stream stream, Dictionary<string, string> metadata)
@@ -126,7 +128,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 {
                     _progress?.UploadProgress.ChangeType(UploadType.Chunked);
 
-                    var multiPartUploader = new AwsS3MultiPartUploader(_client, _bucketName, _progress, key, metadata, _cancellationToken);
+                    var multiPartUploader = new AwsS3MultiPartUploader(_client, _bucketName, _storageClass, _progress, key, metadata, _cancellationToken);
 
                     await multiPartUploader.InitializeAsync();
 
@@ -147,6 +149,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                     Key = key,
                     BucketName = _bucketName,
                     InputStream = stream,
+                    StorageClass = _storageClass,
                     StreamTransferProgress = (_, args) =>
                     {
                         _progress?.UploadProgress.ChangeState(UploadState.Uploading);

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupExtensions.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Raven.Client.Documents.Operations.Backups;
+
+public static class BackupExtensions
+{
+    public static Amazon.S3.S3StorageClass ToAmazonS3StorageClass(this S3StorageClass storageClass)
+    {
+        switch (storageClass)
+        {
+            case S3StorageClass.DeepArchive:
+                return Amazon.S3.S3StorageClass.DeepArchive;
+            case S3StorageClass.Glacier:
+                return Amazon.S3.S3StorageClass.Glacier;
+            case S3StorageClass.GlacierInstantRetrieval:
+                return Amazon.S3.S3StorageClass.GlacierInstantRetrieval;
+            case S3StorageClass.IntelligentTiering:
+                return Amazon.S3.S3StorageClass.IntelligentTiering;
+            case S3StorageClass.OneZoneInfrequentAccess:
+                return Amazon.S3.S3StorageClass.OneZoneInfrequentAccess;
+            case S3StorageClass.Outposts:
+                return Amazon.S3.S3StorageClass.Outposts;
+            case S3StorageClass.ReducedRedundancy:
+                return Amazon.S3.S3StorageClass.ReducedRedundancy;
+            case S3StorageClass.Standard:
+                return Amazon.S3.S3StorageClass.Standard;
+            case S3StorageClass.StandardInfrequentAccess:
+                return Amazon.S3.S3StorageClass.StandardInfrequentAccess;
+            case S3StorageClass.Snow:
+                return Amazon.S3.S3StorageClass.Snow;
+            case S3StorageClass.ExpressOneZone:
+                return Amazon.S3.S3StorageClass.ExpressOnezone;
+            default:
+                throw new NotSupportedException($"Could not convert '{storageClass}' to Amazon S3 Storage Class.");
+        }
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -8,6 +8,7 @@ using Amazon.S3.Model;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Util;
 using Raven.Server.Documents.PeriodicBackup.Aws;
+using S3StorageClass = Amazon.S3.S3StorageClass;
 
 namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
 
@@ -15,6 +16,7 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
 {
     private readonly AmazonS3Client _client;
     private readonly string _bucketName;
+    private readonly S3StorageClass _storageClass;
     private readonly Progress _progress;
     private readonly string _key;
     private readonly Dictionary<string, string> _metadata;
@@ -24,10 +26,12 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
     private int _partNumber;
     private List<PartETag> _partEtags;
 
-    public AwsS3MultiPartUploader(AmazonS3Client client, string bucketName, Progress progress, string key, Dictionary<string, string> metadata, CancellationToken cancellationToken)
+    public AwsS3MultiPartUploader(AmazonS3Client client, string bucketName, S3StorageClass storageClass, Progress progress, string key,
+        Dictionary<string, string> metadata, CancellationToken cancellationToken)
     {
         _client = client;
         _bucketName = bucketName;
+        _storageClass = storageClass;
         _progress = progress;
         _key = key;
         _metadata = metadata;
@@ -44,7 +48,8 @@ public class AwsS3MultiPartUploader : IMultiPartUploader
         var multipartRequest = new InitiateMultipartUploadRequest
         {
             Key = _key,
-            BucketName = _bucketName
+            BucketName = _bucketName,
+            StorageClass = _storageClass
         };
 
         RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);

--- a/test/SlowTests/Issues/RavenDB_23846.cs
+++ b/test/SlowTests/Issues/RavenDB_23846.cs
@@ -1,0 +1,493 @@
+﻿using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Raven.Server.ServerWide;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL.Olap;
+using SlowTests.Server.Documents.PeriodicBackup.Restore;
+using Sparrow.Backups;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using BackupConfiguration = Raven.Server.Config.Categories.BackupConfiguration;
+using S3StorageClass = Raven.Client.Documents.Operations.Backups.S3StorageClass;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23846 : RestoreFromS3
+{
+    private static readonly BackupConfiguration DefaultBackupConfiguration;
+
+    static RavenDB_23846()
+    {
+        var configuration = RavenConfiguration.CreateForTesting("foo", ResourceType.Database);
+        configuration.Initialize();
+
+        DefaultBackupConfiguration = configuration.Backup;
+    }
+
+    public RavenDB_23846(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task CanBackupAndRestoreWithDefault()
+    {
+        var s3Settings = GetS3Settings();
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.NotEmpty(list.S3Objects);
+
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+
+                Assert.Null(head.StorageClass);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}", delimiter: string.Empty);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
+    public async Task CanBackupAndRestoreWithIntelligentTieringSharding()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.IntelligentTiering;
+        try
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var waitHandles = await Sharding.Backup.WaitForBackupToComplete(store);
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Backup,
+                    s3Settings: s3Settings);
+                await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config);
+
+                Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+                var shardingCfg = await Sharding.GetShardingConfigurationAsync(store);
+
+                using var ravens3 = new RavenAwsS3Client(s3Settings, DefaultBackupConfiguration);
+                var prefix = s3Settings.RemoteFolderName + "/";
+                var cloudObjects = await ravens3.ListObjectsAsync(prefix, "/", listFolders: true);
+
+                Assert.Equal(3, cloudObjects.FileInfoDetails.Count);
+
+                using var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.Equal(3, list.S3Objects.Count);
+
+                foreach (var obj in list.S3Objects)
+                {
+                    var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, obj.Key);
+                    Assert.Equal("INTELLIGENT_TIERING", head.StorageClass?.Value);
+                }
+
+                var settings = Sharding.Backup.GenerateShardRestoreSettings(cloudObjects.FileInfoDetails.Select(f => f.FullPath).ToList(), shardingCfg);
+                var databaseName = $"{store.Database}_restored";
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = databaseName, ShardRestoreSettings = settings };
+                using (Backup.RestoreDatabaseFromCloud(store,
+                           restoreSettings,
+                           timeout: TimeSpan.FromSeconds(60)))
+                {
+                    using var restored = Sharding.GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                    using var restoredSession = restored.OpenSession();
+                    var user = restoredSession.Load<User>("users/1");
+                    Assert.Equal("Golan", user.Name);
+                }
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task CanBackupAndRestoreWithStandard()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.Standard;
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.NotEmpty(list.S3Objects);
+
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+
+                Assert.Null(head.StorageClass);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task CanBackupAndRestoreWithStandardInfrequentAccess()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.StandardInfrequentAccess;
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+                Assert.NotEmpty(list.S3Objects);
+
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+                Assert.Equal("STANDARD_IA", head.StorageClass?.Value);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task Can_backup_and_restore_with_intelligent_tiering()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.IntelligentTiering;
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.NotEmpty(list.S3Objects);
+
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+
+                Assert.Equal("INTELLIGENT_TIERING", head.StorageClass?.Value);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task Can_backup_and_restore_with_glacier_instant_retrieval()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.GlacierInstantRetrieval;
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.NotEmpty(list.S3Objects);
+
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+
+                Assert.Equal("GLACIER_IR", head.StorageClass?.Value);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}", delimiter: string.Empty);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task Can_backup_and_restore_with_one_zone_infrequent_access()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.OneZoneInfrequentAccess;
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.NotEmpty(list.S3Objects);
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+
+                Assert.Equal("ONEZONE_IA", head.StorageClass?.Value);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task Can_backup_and_restore_reduced_redundancy()
+    {
+        var s3Settings = GetS3Settings();
+        s3Settings.StorageClass = S3StorageClass.ReducedRedundancy;
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(
+                    backupType: BackupType.Snapshot,
+                    s3Settings: s3Settings);
+
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                };
+
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.WaitForBackupToComplete(store);
+
+                var s3Client = new AmazonS3Client(
+                    s3Settings.AwsAccessKey,
+                    s3Settings.AwsSecretKey,
+                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
+                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
+
+                Assert.NotEmpty(list.S3Objects);
+
+                var snapshotKey = list.S3Objects[0].Key;
+                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+
+                Assert.Equal("REDUCED_REDUNDANCY", head.StorageClass?.Value);
+
+                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
+                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                using var restoredSession = restored.OpenSession();
+                var user = restoredSession.Load<User>("users/1");
+                Assert.Equal("Golan", user.Name);
+            }
+        }
+        finally
+        {
+            await S3Tests.DeleteObjects(s3Settings);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_23846.cs
+++ b/test/SlowTests/Issues/RavenDB_23846.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
@@ -13,6 +16,7 @@ using Raven.Server.ServerWide;
 using SlowTests.Core.Utils.Entities;
 using SlowTests.Server.Documents.ETL.Olap;
 using SlowTests.Server.Documents.PeriodicBackup.Restore;
+using Sparrow;
 using Sparrow.Backups;
 using Tests.Infrastructure;
 using Xunit;
@@ -36,61 +40,6 @@ public class RavenDB_23846 : RestoreFromS3
 
     public RavenDB_23846(ITestOutputHelper output) : base(output)
     {
-    }
-
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task CanBackupAndRestoreWithDefault()
-    {
-        var s3Settings = GetS3Settings();
-        try
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
-                    await session.SaveChangesAsync();
-                }
-
-                var config = Backup.CreateBackupConfiguration(
-                    backupType: BackupType.Snapshot,
-                    s3Settings: s3Settings);
-
-                config.SnapshotSettings = new SnapshotSettings
-                {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
-                };
-                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                await Backup.WaitForBackupToComplete(store);
-
-                var s3Client = new AmazonS3Client(
-                    s3Settings.AwsAccessKey,
-                    s3Settings.AwsSecretKey,
-                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
-
-                Assert.NotEmpty(list.S3Objects);
-
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
-
-                Assert.Null(head.StorageClass);
-
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
-
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
-                using var restoredSession = restored.OpenSession();
-                var user = restoredSession.Load<User>("users/1");
-                Assert.Equal("Golan", user.Name);
-            }
-        }
-        finally
-        {
-            await S3Tests.DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}", delimiter: string.Empty);
-        }
     }
 
     [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
@@ -158,11 +107,94 @@ public class RavenDB_23846 : RestoreFromS3
         }
     }
 
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task CanBackupAndRestoreWithStandard()
+    [AmazonS3RetryTheory]
+    [InlineData(11, false, UploadType.Chunked, false)]
+    [InlineData(11, true, UploadType.Chunked, false)]
+    public async Task PutObjectAsync(int sizeInMB, bool testBlobKeyAsFolder, UploadType uploadType, bool noAsciiDbName)
+    {
+        var settings = GetS3Settings();
+        settings.StorageClass = S3StorageClass.IntelligentTiering;
+        var blobs = GenerateBlobNames(settings, 1, out _);
+        Assert.Equal(1, blobs.Count);
+        var key = "";
+
+        var progress = new Raven.Server.Documents.PeriodicBackup.Progress();
+        using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+        using (var client = new RavenAwsS3Client(settings, DefaultConfiguration, progress, cts.Token))
+        {
+            client.MaxUploadPutObject = new Sparrow.Size(10, SizeUnit.Megabytes);
+            client.MinOnePartUploadSizeLimit = new Sparrow.Size(7, SizeUnit.Megabytes);
+
+            var property1 = "property1";
+            var property2 = "property2";
+            var value1 = Guid.NewGuid().ToString();
+            var value2 = Guid.NewGuid().ToString();
+            if (noAsciiDbName)
+            {
+                string dateStr = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss-fff");
+                key = $"{dateStr}.ravendb-żżżרייבן-A-backup/{dateStr}.ravendb-full-backup";
+                property1 = "Description-żżרייבן";
+                value1 = "ravendb-żżżרייבן-A-backup";
+            }
+            else
+            {
+                key = $"{blobs[0]}";
+            }
+
+            if (testBlobKeyAsFolder)
+                key += "/";
+
+
+            var sb = new StringBuilder();
+            for (var i = 0; i < sizeInMB * 1024 * 1024; i++)
+            {
+                sb.Append("a");
+            }
+
+            long streamLength;
+            using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString())))
+            {
+                streamLength = memoryStream.Length;
+                await client.PutObjectAsync(key,
+                    memoryStream,
+                    new Dictionary<string, string> { { property1, value1 }, { property2, value2 } });
+            }
+
+            var @object = await client.GetObjectAsync(key);
+            Assert.NotNull(@object);
+
+            using (var reader = new StreamReader(@object.Data))
+                Assert.Equal(sb.ToString(), await reader.ReadToEndAsync(cts.Token));
+
+            var property1check = @object.Metadata.Keys.Single(x => x.Contains(Uri.EscapeDataString(property1).ToLower()));
+            var property2check = @object.Metadata.Keys.Single(x => x.Contains(property2));
+
+            Assert.Equal(Uri.EscapeDataString(value1), @object.Metadata[property1check]);
+            Assert.Equal(value2, @object.Metadata[property2check]);
+
+            Assert.Equal(UploadState.Done, progress.UploadProgress.UploadState);
+            Assert.Equal(uploadType, progress.UploadProgress.UploadType);
+            Assert.Equal(streamLength, progress.UploadProgress.TotalInBytes);
+            Assert.Equal(streamLength, progress.UploadProgress.UploadedInBytes);
+        }
+    }
+
+
+    [AmazonS3RetryTheory]
+    [InlineData(null)]
+    [InlineData(S3StorageClass.Standard)]
+    [InlineData(S3StorageClass.StandardInfrequentAccess)]
+    [InlineData(S3StorageClass.OneZoneInfrequentAccess)]
+    [InlineData(S3StorageClass.IntelligentTiering)]
+    [InlineData(S3StorageClass.GlacierInstantRetrieval)]
+    [InlineData(S3StorageClass.ReducedRedundancy)]
+
+    public async Task Can_backup_and_restore_with_various_storage_classes(S3StorageClass? storageClass)
     {
         var s3Settings = GetS3Settings();
-        s3Settings.StorageClass = S3StorageClass.Standard;
+        if (storageClass.HasValue)
+            s3Settings.StorageClass = storageClass.Value;
+
         try
         {
             using (var store = GetDocumentStore())
@@ -179,29 +211,47 @@ public class RavenDB_23846 : RestoreFromS3
 
                 config.SnapshotSettings = new SnapshotSettings
                 {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
+                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd,
+                    CompressionLevel = CompressionLevel.Fastest
                 };
+
                 await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
                 await Backup.WaitForBackupToComplete(store);
 
-                var s3Client = new AmazonS3Client(
+                using var s3 = new AmazonS3Client(
                     s3Settings.AwsAccessKey,
                     s3Settings.AwsSecretKey,
                     Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
 
+                var list = await s3.ListObjectsV2Async(
+                    new ListObjectsV2Request
+                    {
+                        BucketName = s3Settings.BucketName,
+                        Prefix = s3Settings.RemoteFolderName
+                    });
                 Assert.NotEmpty(list.S3Objects);
 
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
+                var objKey = list.S3Objects[0].Key;
+                var metadata = await s3.GetObjectMetadataAsync(s3Settings.BucketName, objKey);
 
-                Assert.Null(head.StorageClass);
+                var expected = GetExpectedStorageClassValue(storageClass);
+                if (expected == null)
+                    Assert.Null(metadata.StorageClass);
+                else
+                    Assert.Equal(expected, metadata.StorageClass?.Value);
 
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+                var restoreSettings = new RestoreFromS3Configuration
+                {
+                    Settings = s3Settings,
+                    DatabaseName = $"{store.Database}_restored"
+                };
 
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+                var op = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
+                await op.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+                using var restored = GetDocumentStore(
+                    new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
+
                 using var restoredSession = restored.OpenSession();
                 var user = restoredSession.Load<User>("users/1");
                 Assert.Equal("Golan", user.Name);
@@ -209,285 +259,21 @@ public class RavenDB_23846 : RestoreFromS3
         }
         finally
         {
-            await S3Tests.DeleteObjects(s3Settings);
+            await S3Tests.DeleteObjects(s3Settings);   
         }
     }
 
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task CanBackupAndRestoreWithStandardInfrequentAccess()
+    private string GetExpectedStorageClassValue(S3StorageClass? cls) => cls switch
     {
-        var s3Settings = GetS3Settings();
-        s3Settings.StorageClass = S3StorageClass.StandardInfrequentAccess;
-        try
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
-                    await session.SaveChangesAsync();
-                }
+        null => null,
+        S3StorageClass.Standard => null,
+        S3StorageClass.StandardInfrequentAccess => "STANDARD_IA",
+        S3StorageClass.OneZoneInfrequentAccess => "ONEZONE_IA",
+        S3StorageClass.IntelligentTiering => "INTELLIGENT_TIERING",
+        S3StorageClass.GlacierInstantRetrieval => "GLACIER_IR",
+        S3StorageClass.ReducedRedundancy => "REDUCED_REDUNDANCY",
+        _ => throw new ArgumentOutOfRangeException(nameof(cls), cls, $"Unknown S3 storage-class value: {cls}")
+    };
 
-                var config = Backup.CreateBackupConfiguration(
-                    backupType: BackupType.Snapshot,
-                    s3Settings: s3Settings);
-
-                config.SnapshotSettings = new SnapshotSettings
-                {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
-                };
-
-                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                await Backup.WaitForBackupToComplete(store);
-
-                var s3Client = new AmazonS3Client(
-                    s3Settings.AwsAccessKey,
-                    s3Settings.AwsSecretKey,
-                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
-                Assert.NotEmpty(list.S3Objects);
-
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
-                Assert.Equal("STANDARD_IA", head.StorageClass?.Value);
-
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
-
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
-                using var restoredSession = restored.OpenSession();
-                var user = restoredSession.Load<User>("users/1");
-                Assert.Equal("Golan", user.Name);
-            }
-        }
-        finally
-        {
-            await S3Tests.DeleteObjects(s3Settings);
-        }
-    }
-
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task Can_backup_and_restore_with_intelligent_tiering()
-    {
-        var s3Settings = GetS3Settings();
-        s3Settings.StorageClass = S3StorageClass.IntelligentTiering;
-        try
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
-                    await session.SaveChangesAsync();
-                }
-
-                var config = Backup.CreateBackupConfiguration(
-                    backupType: BackupType.Snapshot,
-                    s3Settings: s3Settings);
-
-                config.SnapshotSettings = new SnapshotSettings
-                {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
-                };
-
-                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                await Backup.WaitForBackupToComplete(store);
-
-                var s3Client = new AmazonS3Client(
-                    s3Settings.AwsAccessKey,
-                    s3Settings.AwsSecretKey,
-                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
-
-                Assert.NotEmpty(list.S3Objects);
-
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
-
-                Assert.Equal("INTELLIGENT_TIERING", head.StorageClass?.Value);
-
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
-
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
-                using var restoredSession = restored.OpenSession();
-                var user = restoredSession.Load<User>("users/1");
-                Assert.Equal("Golan", user.Name);
-            }
-        }
-        finally
-        {
-            await S3Tests.DeleteObjects(s3Settings);
-        }
-    }
-
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task Can_backup_and_restore_with_glacier_instant_retrieval()
-    {
-        var s3Settings = GetS3Settings();
-        s3Settings.StorageClass = S3StorageClass.GlacierInstantRetrieval;
-        try
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
-                    await session.SaveChangesAsync();
-                }
-
-                var config = Backup.CreateBackupConfiguration(
-                    backupType: BackupType.Snapshot,
-                    s3Settings: s3Settings);
-
-                config.SnapshotSettings = new SnapshotSettings
-                {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
-                };
-
-                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                await Backup.WaitForBackupToComplete(store);
-
-                var s3Client = new AmazonS3Client(
-                    s3Settings.AwsAccessKey,
-                    s3Settings.AwsSecretKey,
-                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
-
-                Assert.NotEmpty(list.S3Objects);
-
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
-
-                Assert.Equal("GLACIER_IR", head.StorageClass?.Value);
-
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
-                using var restoredSession = restored.OpenSession();
-                var user = restoredSession.Load<User>("users/1");
-                Assert.Equal("Golan", user.Name);
-            }
-        }
-        finally
-        {
-            await S3Tests.DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}", delimiter: string.Empty);
-        }
-    }
-
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task Can_backup_and_restore_with_one_zone_infrequent_access()
-    {
-        var s3Settings = GetS3Settings();
-        s3Settings.StorageClass = S3StorageClass.OneZoneInfrequentAccess;
-        try
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
-                    await session.SaveChangesAsync();
-                }
-
-                var config = Backup.CreateBackupConfiguration(
-                    backupType: BackupType.Snapshot,
-                    s3Settings: s3Settings);
-
-                config.SnapshotSettings = new SnapshotSettings
-                {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
-                };
-
-                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                await Backup.WaitForBackupToComplete(store);
-
-                var s3Client = new AmazonS3Client(
-                    s3Settings.AwsAccessKey,
-                    s3Settings.AwsSecretKey,
-                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
-
-                Assert.NotEmpty(list.S3Objects);
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
-
-                Assert.Equal("ONEZONE_IA", head.StorageClass?.Value);
-
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
-
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
-                using var restoredSession = restored.OpenSession();
-                var user = restoredSession.Load<User>("users/1");
-                Assert.Equal("Golan", user.Name);
-            }
-        }
-        finally
-        {
-            await S3Tests.DeleteObjects(s3Settings);
-        }
-    }
-
-    [RavenFact(RavenTestCategory.BackupExportImport)]
-    public async Task Can_backup_and_restore_reduced_redundancy()
-    {
-        var s3Settings = GetS3Settings();
-        s3Settings.StorageClass = S3StorageClass.ReducedRedundancy;
-        try
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "Golan" }, "users/1");
-                    await session.SaveChangesAsync();
-                }
-
-                var config = Backup.CreateBackupConfiguration(
-                    backupType: BackupType.Snapshot,
-                    s3Settings: s3Settings);
-
-                config.SnapshotSettings = new SnapshotSettings
-                {
-                    CompressionAlgorithm = SnapshotBackupCompressionAlgorithm.Zstd, CompressionLevel = CompressionLevel.Fastest
-                };
-
-                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
-                await Backup.WaitForBackupToComplete(store);
-
-                var s3Client = new AmazonS3Client(
-                    s3Settings.AwsAccessKey,
-                    s3Settings.AwsSecretKey,
-                    Amazon.RegionEndpoint.GetBySystemName(s3Settings.AwsRegionName));
-                var list = await s3Client.ListObjectsV2Async(new ListObjectsV2Request { BucketName = s3Settings.BucketName, Prefix = s3Settings.RemoteFolderName });
-
-                Assert.NotEmpty(list.S3Objects);
-
-                var snapshotKey = list.S3Objects[0].Key;
-                var head = await s3Client.GetObjectMetadataAsync(s3Settings.BucketName, snapshotKey);
-
-                Assert.Equal("REDUCED_REDUNDANCY", head.StorageClass?.Value);
-
-                var restoreSettings = new RestoreFromS3Configuration { Settings = s3Settings, DatabaseName = $"{store.Database}_restored" };
-                var restoreOp = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreSettings));
-                await restoreOp.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
-
-                using var restored = GetDocumentStore(new Options { CreateDatabase = false, ModifyDatabaseName = _ => restoreSettings.DatabaseName });
-                using var restoredSession = restored.OpenSession();
-                var user = restoredSession.Load<User>("users/1");
-                Assert.Equal("Golan", user.Name);
-            }
-        }
-        finally
-        {
-            await S3Tests.DeleteObjects(s3Settings);
-        }
-    }
 }
+

--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -1360,7 +1360,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
             await DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}/{additionalTable}", delimiter: string.Empty);
         }
 
-        private static async Task DeleteObjects(S3Settings s3Settings, string prefix, string delimiter, bool listFolder = false)
+        internal static async Task DeleteObjects(S3Settings s3Settings, string prefix, string delimiter, bool listFolder = false)
         {
             if (s3Settings == null)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23846/Add-S3StorageClass-for-Amazon-S3-backup

### Additional description

Users can now choose Standard-IA, Intelligent Tiering, Glacier tiers, etc., when configuring an S3 backup.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing - confirmed that a snapshot stored with Glacier Flexible Retrieval can be thawed (expedited restore) and restored successfully.
- [ ] Existing tests verify the correct behavior
- [x] Express One Zone, Snow family, and Outposts classes were **not** manually tested:
Express One Zone – requires a dedicated directory bucket that our account doesn’t have permission to create.
Snow classes – we don’t have Snowball/Snowcone devices in the dev environment.
Outposts – no S3 Outposts hardware is available in the lab.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
