### PR TITLE
RavenDB 24174

### DIFF
--- a/test/SlowTests/Issues/RavenDB_23103.cs
+++ b/test/SlowTests/Issues/RavenDB_23103.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
@@ -721,8 +722,19 @@ namespace SlowTests.Issues
                 ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MapBatchSize)] = 128.ToString()
             }))
             {
-                var index = new Companies_ByName();
-                index.Execute(store);
+                var indexDef = new Companies_ByName();
+                indexDef.Execute(store);
+                string indexName;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Query<Company>()
+                        .Statistics(out var stats)
+                        .Where(x => x.Name == "___")
+                        .ToList();
+
+                    indexName = stats.IndexName;
+                }
 
                 using (var bulk = store.BulkInsert())
                 {
@@ -732,13 +744,15 @@ namespace SlowTests.Issues
                     }
                 }
 
+                var database = Databases.GetDocumentDatabaseInstanceFor(store).Result;
+                database.IndexStore.GetIndex(indexName).ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() => Thread.Sleep(1));
                 Indexes.WaitForIndexing(store);
 
                 var iq = new IndexQuery { Query = $"from companies as c where c != null update {{ c.Name = 'Name2' }}" };
 
                 var waitForIndexingAfterPatchOptions = new IndexPatchOptions()
                 {
-                    WaitForIndexesTimeout = TimeSpan.FromMicroseconds(1)
+                    WaitForIndexesTimeout = TimeSpan.FromMilliseconds(1)
                 };
 
                 var operation = store.Operations.Send(new PatchByQueryOperation(iq,
@@ -749,7 +763,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     var count = session.Query<Company, Companies_ByName>().Count(x => x.Name == "Name2");
-                    Assert.NotEqual(NumberOfCompanies, count);
+                     Assert.NotEqual(NumberOfCompanies, count);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24174/Failing-Test-WaitForIndexesAfterPatchDynamicQueryWithTimeoutShouldntThrow

### Additional description
Introduce a small, test-only delay in the indexing pipeline to prevent it from completing prematurely and eliminate race conditions in our patch-by-query test.
This change should remove flakiness from our “patch then query” tests without altering any real-world indexing behavior.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
