### PR TITLE
RavenDB-24065 fix AVE on 32-bits when we try to unmap an already closed pager

### DIFF
--- a/src/Voron/Impl/Paging/Pager.32.cs
+++ b/src/Voron/Impl/Paging/Pager.32.cs
@@ -99,12 +99,15 @@ public unsafe partial class Pager
                     {
                         pager32BitsState.MemoryMapping.TryRemove(addr.StartPage, out set);
                     }
-                    
+
                     NativeMemory.UnregisterFileMapping(addr.File, addr.Address, addr.Size);
-                    var rc = Pal.rvn_unmap_memory(txState.Handle, (void*)addr.Address, addr.Size, out var errorCode);
-                    if (rc != PalFlags.FailCodes.Success)
+                    if (addr.State.Disposed is false) // we may closed the entire file during rollback
                     {
-                        PalHelper.ThrowLastError(rc, errorCode, $"Failed to unmap memory in 32 bits mode for {pager.FileName}");
+                        var rc = Pal.rvn_unmap_memory(txState.Handle, (void*)addr.Address, addr.Size, out var errorCode);
+                        if (rc != PalFlags.FailCodes.Success)
+                        {
+                            PalHelper.ThrowLastError(rc, errorCode, $"Failed to unmap memory in 32 bits mode for {pager.FileName}");
+                        }
                     }
                 }
             }
@@ -168,7 +171,7 @@ public unsafe partial class Pager
             try
             {
                 var addresses = pager._32BitsState.MemoryMapping.GetOrAdd(startPage,
-                    _ => new ConcurrentSet<MappedAddresses>());
+                    static _ => []);
 
                 foreach (var addr in addresses)
                 {
@@ -203,7 +206,7 @@ public unsafe partial class Pager
                 }
 
                 NativeMemory.RegisterFileMapping(pager.FileName, new IntPtr(result), size, null);
-                var mappedAddresses = new MappedAddresses(pager.FileName, (IntPtr)result, startPage, size);
+                var mappedAddresses = new MappedAddresses(pager.FileName, state, (IntPtr)result, startPage, size);
                 addresses.Add(mappedAddresses);
                 return AddMappingToTransaction(pagerTxState, startPage, size, mappedAddresses);
             }

--- a/src/Voron/Impl/Paging/Pager.StateFor32Bits.cs
+++ b/src/Voron/Impl/Paging/Pager.StateFor32Bits.cs
@@ -16,12 +16,13 @@ public partial class Pager
         public long TotalLoadedSize;
     }
 
-    public sealed class MappedAddresses(string file, IntPtr address, long startPage, long size)
+    public sealed class MappedAddresses(string file, Pager.State state, IntPtr address, long startPage, long size)
     {
-        public string File = file;
-        public IntPtr Address = address;
-        public long StartPage = startPage;
-        public long Size = size;
+        public readonly Pager.State State = state;
+        public readonly string File = file;
+        public readonly IntPtr Address = address;
+        public readonly long StartPage = startPage;
+        public readonly long Size = size;
         public int Usages = 1;
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24065

### Additional description

It might happened that during a rollback we decide to close the pagers for the unused scratches.
On 32bits during the tx dispose we also unmap the views and might unmap an already closed pager, which can cause an AVE. 

The test `MustNotThrowObjectDisposedExceptionWhenFreeingPagesOnTxRollback` was used to reproduce the issue.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms. - only 32 bits (was also manually tested for crypto pagers and seems to work)
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
