### PR TITLE
RavenDB-21226 [TESTING] Deleting all documents before document store dispose and checking indexes state 

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -669,8 +669,12 @@ namespace Corax.Indexing
                     RecordAndPrepareDocumentsIdsForDeletion(containerId, out var setsAreDisjoint, out var isSingleDocument);
                     entryId = isSingleDocument ? _entriesToDelete[0] : Constants.IndexSearcher.InvalidId;                        
                     ProcessCurrentDeletes();
-                    
-                    Debug.Assert(setsAreDisjoint, "The set scheduled for deletion shares common elements with the posting list. This should not be possible here.");
+
+                    if (setsAreDisjoint == false)
+                    {
+                        throw new InvalidOperationException("The set scheduled for deletion shares common elements with the posting list. This should not be possible here.");
+                    }
+   
                     return isSingleDocument;
                 }
                 entryId = Constants.IndexSearcher.InvalidId;

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -38,7 +38,13 @@ public unsafe struct NativeList<T>
 
     public ref T this[int index]
     {
-        get => ref Unsafe.AsRef<T>((T*)_storage.Ptr + index);
+        get
+        {
+            if (index < 0 || index >= Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+            
+            return ref Unsafe.AsRef<T>((T*)_storage.Ptr + index);
+        }
     }
 
     public bool TryAdd(in T l)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -16,7 +16,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
@@ -309,6 +311,36 @@ namespace FastTests
 
                     store.BeforeDispose += (sender, args) =>
                     {
+                        if (options.SearchEngineMode == RavenSearchEngineMode.Corax && options.DatabaseMode == RavenDatabaseMode.Single)
+                        {
+                            var database = GetDatabase(store.Database).Result;
+
+                            if (database.IndexStore.GetIndexes().All(x => x.State == IndexState.Normal))
+                            {
+                                var operation = store.Operations.Send(new DeleteByQueryOperation(new IndexQuery { Query = "from @all_docs" }));
+                                var result = operation.WaitForCompletion(TimeSpan.FromSeconds(30));
+
+                                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromSeconds(30), allowErrors: true);
+
+                                if (database.IndexStore.GetIndexes().Any(x => x.State == IndexState.Error))
+                                {
+                                    StringBuilder sb = new StringBuilder();
+                                    sb.AppendLine("---CORAX DEBUG---");
+                                    sb.AppendLine($"Database {store.Database}");
+
+                                    sb.Append("Errored indexes: ");
+
+                                    foreach (var erroredIndex in database.IndexStore.GetIndexes().Where(x => x.State == IndexState.Error))
+                                    {
+                                        sb.Append($"{erroredIndex.Name} ");
+                                    }
+
+                                    Output.WriteLine(sb.ToString());
+                                    Console.WriteLine(sb.ToString());
+                                }
+                            }
+                        }
+                        
                         var realException = Context.GetException();
                         try
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21226/Corax-testing-remove-all-documents-from-on-store-dispose-in-testing


https://github.com/ravendb/ravendb/pull/17289