### PR TITLE
RavenDB-24179 - move log to be debug and add subscription name to log

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
@@ -54,8 +54,8 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
         {
             AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info, "Finished processing sharded subscription."));
 
-            if (_logger.IsInfoEnabled)
-                _logger.Info($"Finished processing sharded subscription '{SubscriptionId}' / from client '{ClientUri}'.");
+            if (_logger.IsDebugEnabled)
+                _logger.Debug($"Finished processing sharded subscription '{SubscriptionId}' / from client '{ClientUri}'.");
         }
 
         protected override StatusMessageDetails GetStatusMessageDetails()

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -167,9 +167,9 @@ public sealed class SubscriptionConnectionsStateOrchestrator : AbstractSubscript
             catch (Exception ex)
             {
                 // connection is disposed
-                if (connection._logger.IsInfoEnabled)
+                if (connection._logger.IsDebugEnabled)
                 {
-                    connection._logger.Info("Got exception while disposing sharded subscription workers", ex);
+                    connection._logger.Debug("Got exception while disposing sharded subscription workers", ex);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
@@ -258,9 +258,9 @@ public abstract class AbstractSubscriptionConnectionsState<TSubscriptionConnecti
             }
             catch (TimeoutException)
             {
-                if (connection._logger.IsInfoEnabled)
+                if (connection._logger.IsDebugEnabled)
                 {
-                    connection._logger.Info(
+                    connection._logger.Debug(
                         $"A connection from IP {connection.ClientUri} is starting to wait until previous connection from " +
                         $"{GetConnectionsAsString()} is released");
                 }

--- a/src/Raven.Server/Documents/Subscriptions/Processor/DatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DatabaseSubscriptionProcessor.cs
@@ -88,8 +88,8 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                 return batchItem;
             }
 
-            if (Logger.IsInfoEnabled)
-                Logger.Info(reason, batchItem.Exception);
+            if (Logger.IsDebugEnabled)
+                Logger.Debug($"Subscription '{Connection.Options.SubscriptionName}' skipped a document, the reason is: {reason}", batchItem.Exception);
 
             if (batchItem.Status  == SubscriptionBatchItemStatus.Exception)
             {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -148,9 +148,9 @@ namespace Raven.Server.Documents.Subscriptions
             where TConnection : SubscriptionConnectionBase<TIncludesCommand>
         {
             AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info, "Starting to process subscription"));
-            if (_logger.IsInfoEnabled)
+            if (_logger.IsDebugEnabled)
             {
-                _logger.Info($"Starting processing documents for subscription {SubscriptionId} received from {ClientUri}");
+                _logger.Debug($"Starting processing documents for subscription {SubscriptionId} received from {ClientUri}");
             }
 
             using (Processor = CreateProcessor(this))
@@ -258,9 +258,9 @@ namespace Raven.Server.Documents.Subscriptions
             }
             else
             {
-                if (_logger.IsInfoEnabled)
+                if (_logger.IsDebugEnabled)
                 {
-                    _logger.Info($"Expected to get '{SubscriptionConnectionClientMessage.MessageType.DisposedNotification}' from client, but there was no reply.");
+                    _logger.Debug($"Expected to get '{SubscriptionConnectionClientMessage.MessageType.DisposedNotification}' from client, but there was no reply.");
                 }
             }
 
@@ -269,8 +269,8 @@ namespace Raven.Server.Documents.Subscriptions
 
         protected async Task LogBatchStatusAndUpdateStatsAsync(Stopwatch sendingCurrentBatchStopwatch, string logMessage)
         {
-            if (_logger.IsInfoEnabled)
-                _logger.Info(logMessage);
+            if (_logger.IsDebugEnabled)
+                _logger.Debug(logMessage);
 
             Stats.UpdateBatchPerformanceStats(0, false);
 
@@ -755,9 +755,9 @@ namespace Raven.Server.Documents.Subscriptions
                             }
 
                             AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info, "Redirecting subscription client to different server"));
-                            if (_logger.IsInfoEnabled)
+                            if (_logger.IsDebugEnabled)
                             {
-                                _logger.Info("Subscription does not belong to current node", ex);
+                                _logger.Debug("Subscription does not belong to current node", ex);
                             }
 
                             await WriteJsonAsync(new DynamicJsonValue
@@ -782,9 +782,9 @@ namespace Raven.Server.Documents.Subscriptions
                         {
                             AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info,
                                 $"Subscription change vector update concurrency error, reporting to '{ClientUri}'"));
-                            if (_logger.IsInfoEnabled)
+                            if (_logger.IsDebugEnabled)
                             {
-                                _logger.Info("Subscription change vector update concurrency error", ex);
+                                _logger.Debug("Subscription change vector update concurrency error", ex);
                             }
 
                             await WriteJsonAsync(new DynamicJsonValue
@@ -1066,8 +1066,8 @@ namespace Raven.Server.Documents.Subscriptions
         {
             token.ThrowIfCancellationRequested();
 
-            if (logger is { IsInfoEnabled: true })
-                logger.Info($"Flushing {flushedDocs} documents for subscription {subscriptionId} sending to {tcpConnection.TcpClient.Client.RemoteEndPoint} {(endOfBatch ? ", ending batch" : string.Empty)}");
+            if (logger is { IsDebugEnabled: true })
+                logger.Debug($"Flushing {flushedDocs} documents for subscription {subscriptionId} sending to {tcpConnection.TcpClient.Client.RemoteEndPoint} {(endOfBatch ? ", ending batch" : string.Empty)}");
 
             await writer.FlushAsync(token);
             var bufferSize = buffer.Length;

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
@@ -122,9 +122,9 @@ public sealed class SubscriptionConnectionForShard : SubscriptionConnection
             AddToStatusDescription(CreateStatusMessage(ConnectionStatus.Info,
                 $"Skipped '{_processor.Skipped.Count}' docs after apply '{nameof(RecordBatchSubscriptionDocumentsCommand)}' command."));
 
-            if (_logger.IsInfoEnabled)
+            if (_logger.IsDebugEnabled)
             {
-                _logger.Info($"Skipped '{_processor.Skipped.Count}' docs after apply '{nameof(RecordBatchSubscriptionDocumentsCommand)}' command. Skipped docs:{Environment.NewLine}{string.Join(",", _processor.Skipped)}");
+                _logger.Debug($"Skipped '{_processor.Skipped.Count}' docs after apply '{nameof(RecordBatchSubscriptionDocumentsCommand)}' command. Skipped docs:{Environment.NewLine}{string.Join(",", _processor.Skipped)}");
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24179/Subscription-name-is-missing-in-the-subscription-logs

### Additional description

- [ ] Add subscription name to the log
- [ ] Move the subscription logs to be debug, since it was `Information` previously.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
