### PR TITLE
RavenDB-24217 Reusable entryId for double deleted document.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.Testing.cs
+++ b/src/Corax/Indexing/IndexWriter.Testing.cs
@@ -1,0 +1,69 @@
+﻿using Corax.Utils;
+using Sparrow;
+using Sparrow.Compression;
+using Sparrow.Server;
+using Voron.Data.Containers;
+using Voron.Data.PostingLists;
+
+namespace Corax.Indexing;
+
+public partial class IndexWriter
+{
+    internal TestingInterface CreateTestingInterface() => new(this);
+    
+    internal class TestingInterface(IndexWriter writer)
+    {
+        public unsafe bool ValidateIdTreeToEntries(out long numberOfEntriesLocation, out long numberOfEntriesCompactTreeId)
+        {
+            numberOfEntriesLocation = writer._entryIdToLocation.NumberOfEntries;
+            numberOfEntriesCompactTreeId = 0;
+            
+            var idCompactTree = writer._fieldsTree.CompactTreeFor(
+                writer._fieldsMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName);
+
+
+            var keys = new long[1024];
+            var keysPtr = new long[1024];
+            using var _ = writer._transaction.Allocator.Allocate(1024 * sizeof(UnmanagedSpan), out ByteString containersPtrBs);
+            var containersPtr = (UnmanagedSpan*)(containersPtrBs.Ptr);
+            
+            var iterator = idCompactTree.Iterate();
+            iterator.Reset();
+            while (iterator.Fill(keys) is var read and > 0)
+            {
+                for (int i = 0; i < read; ++i)
+                {
+                    keysPtr[i] = keys[i];
+                    if ((keys[i] & (long)TermIdMask.EnsureIsSingleMask) != 0)
+                    {
+                        keysPtr[i] = EntryIdEncodings.GetContainerId(keys[i]);
+                        continue;
+                    }
+
+                    keysPtr[i] = -1;
+                }
+
+
+                Container.GetAll(writer._transaction.LowLevelTransaction, keysPtr[..read], containersPtr, -1, writer._transaction.LowLevelTransaction.PageLocator);
+                for (int i = 0; i < read; i++)
+                {
+                    var currentKey = keys[i];
+                    switch (currentKey & (long)TermIdMask.EnsureIsSingleMask)
+                    {
+                        case (long)TermIdMask.SmallPostingList:
+                            numberOfEntriesCompactTreeId += VariableSizeEncoding.Read<long>(containersPtr[i].Address, out var __);
+                            break;
+                        case (long)TermIdMask.PostingList:
+                            numberOfEntriesCompactTreeId += ((PostingListState*)containersPtr[i].Address)->NumberOfEntries;
+                            break;
+                        default:
+                            numberOfEntriesCompactTreeId += 1;
+                            break;
+                    }
+                }
+            }
+
+            return numberOfEntriesLocation == numberOfEntriesCompactTreeId;
+        }
+    }
+}

--- a/src/Corax/Indexing/IndexWriter.Testing.cs
+++ b/src/Corax/Indexing/IndexWriter.Testing.cs
@@ -9,9 +9,9 @@ namespace Corax.Indexing;
 
 public partial class IndexWriter
 {
-    internal TestingInterface CreateTestingInterface() => new(this);
+    internal TestingStuff ForTestingPurposes() => new(this);
     
-    internal class TestingInterface(IndexWriter writer)
+    internal class TestingStuff(IndexWriter writer)
     {
         public unsafe bool ValidateIdTreeToEntries(out long numberOfEntriesLocation, out long numberOfEntriesCompactTreeId)
         {

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -666,11 +666,13 @@ namespace Corax.Indexing
                     // note that the containerId may be a single value or many(!), if it is many items
                     // we'll delete them, but treat this as a _new_ entry, not an update to an existing
                     // one
-                    RecordAndPrepareDocumentsIdsForDeletion(containerId, out var setsAreDisjoint, out var isSingleDocument);
-                    entryId = isSingleDocument ? _entriesToDelete[0] : Constants.IndexSearcher.InvalidId;                        
-                    ProcessCurrentDeletes();
+                    RecordAndPrepareDocumentsIdsForDeletion(containerId, out var setsAreDisjoint, out var isSingleDocument, out var singleDocumentEntryId);
+                    entryId = isSingleDocument ? singleDocumentEntryId : Constants.IndexSearcher.InvalidId;
                     
-                    Debug.Assert(setsAreDisjoint, "The set scheduled for deletion shares common elements with the posting list. This should not be possible here.");
+                    Debug.Assert(isSingleDocument || setsAreDisjoint, $"A single document can be deleted twice (delete + update), however if it's not a single document, the sets are supposed to be disjoint.");
+
+                    
+                    ProcessCurrentDeletes();
                     return isSingleDocument;
                 }
                 entryId = Constants.IndexSearcher.InvalidId;
@@ -699,7 +701,7 @@ namespace Corax.Indexing
                     if (currentKey.Decoded().StartsWith(prefixSlice) == false)
                         break;
 
-                    RecordAndPrepareDocumentsIdsForDeletion(postingListId, out bool setsAreDisjoint, out _);
+                    RecordAndPrepareDocumentsIdsForDeletion(postingListId, out bool setsAreDisjoint, out _, out _);
                     ProcessCurrentDeletes();
                     requiresFlushingBatch = setsAreDisjoint == false;
                 }
@@ -789,7 +791,7 @@ namespace Corax.Indexing
                     return;
             }
 
-            RecordAndPrepareDocumentsIdsForDeletion(idInTree, out var setsAreDisjoint, out _);
+            RecordAndPrepareDocumentsIdsForDeletion(idInTree, out var setsAreDisjoint, out _, out _);
             ProcessCurrentDeletes();
             
             if (setsAreDisjoint == false)
@@ -805,7 +807,7 @@ namespace Corax.Indexing
         /// <param name="idInTree">With frequencies and container type.</param>
         /// <param name="setsAreDisjoint">Intersection between PostingList and _deletedEntries. We may use it as indicator for flushing batch.</param>
         [SkipLocalsInit]
-        private void RecordAndPrepareDocumentsIdsForDeletion(long postingListId, out bool setsAreDisjoint, out bool isSingleDocument)
+        private void RecordAndPrepareDocumentsIdsForDeletion(long postingListId, out bool setsAreDisjoint, out bool isSingleDocument, out long singleDocumentEntryId)
         {
             Debug.Assert(_entriesToDelete.Count == 0);
             
@@ -815,22 +817,23 @@ namespace Corax.Indexing
 
             if ((postingListId & (long)TermIdMask.EnsureIsSingleMask) == (long)TermIdMask.Single)
             {
-                var singleEntryId = containerId;
-                Debug.Assert(singleEntryId > 0);
+                singleDocumentEntryId = containerId;
+                Debug.Assert(singleDocumentEntryId > 0);
                 var isNewDocument = _deletedEntries.Add(containerId);
                 if (isNewDocument)
-                    _entriesToDelete.Add(singleEntryId);
+                    _entriesToDelete.Add(singleDocumentEntryId);
                 setsAreDisjoint &= isNewDocument;
                 _numberOfModifications -= _deletedEntries.Count - countOfAlreadyDeletedEntries;
                 isSingleDocument = true;
                 return;
             }
 
+            
             const int bufferSize = 1024;
             var bufferPtr = stackalloc long[bufferSize];
             var buffer = new Span<long>(bufferPtr, bufferSize);
             isSingleDocument = false;
-            
+            singleDocumentEntryId = Constants.IndexSearcher.InvalidId;
             if ((postingListId & (long)TermIdMask.PostingList) != 0)
             {
                 var setSpace = Container.GetMutable(_transaction.LowLevelTransaction, containerId);

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -38,7 +38,11 @@ public unsafe struct NativeList<T>
 
     public ref T this[int index]
     {
-        get => ref Unsafe.AsRef<T>((T*)_storage.Ptr + index);
+        get
+        {
+            Debug.Assert( index >= 0 && index < Count, "index >= 0 && index < Count");
+            return ref Unsafe.AsRef<T>((T*)_storage.Ptr + index);
+        }
     }
 
     public bool TryAdd(in T l)

--- a/test/FastTests/Corax/Bugs/RavenDB_24217.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_24217.cs
@@ -66,7 +66,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
 
             writer.Commit();
 
-            Assert.True(writer.CreateTestingInterface().ValidateIdTreeToEntries(out _, out _));
+            Assert.True(writer.ForTestingPurposes().ValidateIdTreeToEntries(out _, out _));
         }
 
         using (var searcher = new IndexSearcher(Env, mapping))
@@ -150,7 +150,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
 
             writer.Commit();
             
-            Assert.True(writer.CreateTestingInterface().ValidateIdTreeToEntries(out _, out _));
+            Assert.True(writer.ForTestingPurposes().ValidateIdTreeToEntries(out _, out _));
         }
 
         using (var searcher = new IndexSearcher(Env, mapping))
@@ -200,7 +200,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
 
         using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
         {
-            var testing = writer.CreateTestingInterface();
+            var testing = writer.ForTestingPurposes();
             var result = testing.ValidateIdTreeToEntries(out var numberOfEntriesLocation, out var numberOfEntriesCompactTreeId);
             Assert.Equal(numberOfEntriesCompactTreeId, numberOfEntriesLocation);
             Assert.True(result);
@@ -267,7 +267,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
 
             writer.Commit();
             
-            Assert.True(writer.CreateTestingInterface().ValidateIdTreeToEntries(out _, out _));
+            Assert.True(writer.ForTestingPurposes().ValidateIdTreeToEntries(out _, out _));
         }
 
 

--- a/test/FastTests/Corax/Bugs/RavenDB_24217.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_24217.cs
@@ -1,0 +1,324 @@
+﻿using System;
+using System.Linq;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using FastTests.Voron;
+using FastTests.Voron.FixedSize;
+using Sparrow;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanDeleteAndStillUpdateFanout()
+    {
+        using var mapping = GetMapping();
+        long[] entriesIds = [-1, -1, -1, -1];
+
+        var entries = new Entry[] { new("doc/0", "0"), new("doc/0", "1"), new("doc/1", "2"), new("doc/1", "3"), };
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            for (int i = 0; i < entries.Length; ++i)
+            {
+                var entry = entries[i];
+                using (var builder = writer.Index(entry.PrimaryKeyBytes))
+                {
+                    builder.Write(PrimaryKey, entry.PrimaryKeyBytes);
+                    builder.Write(SecondaryKey, entry.SecondaryKeyBytes);
+                    builder.EndWriting();
+                    entriesIds[i] = builder.EntryId;
+                }
+            }
+
+            writer.Commit();
+        }
+
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            writer.TryDeleteEntry("doc/1"u8);
+            writer.TryDeleteEntry("doc/0"u8);
+
+            for (int i = 3; i >= 0; --i)
+            {
+                var entry = entries[i];
+                using (var builder = writer.Index(entry.PrimaryKeyBytes))
+                {
+                    builder.Write(PrimaryKey, entry.PrimaryKeyBytes);
+                    builder.Write(SecondaryKey, entry.SecondaryKeyBytes);
+                    builder.EndWriting();
+                    entry.EntryId = builder.EntryId;
+                }
+            }
+
+            //Should not be reused
+            Assert.DoesNotContain(entries[0].EntryId, entriesIds);
+            Assert.DoesNotContain(entries[1].EntryId, entriesIds);
+            Assert.DoesNotContain(entries[2].EntryId, entriesIds);
+            Assert.DoesNotContain(entries[3].EntryId, entriesIds);
+            Assert.Distinct(entries.Select(x => x.EntryId));
+
+            writer.Commit();
+
+            Assert.True(writer.CreateTestingInterface().ValidateIdTreeToEntries(out _, out _));
+        }
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            var rootPages = searcher.GetIndexedFieldNamesByRootPage();
+            Page p = default;
+
+            foreach (var entry in entries)
+            {
+                var entryTermsReader = searcher.GetEntryTermsReader(entry.EntryId, ref p);
+                entryTermsReader.Reset();
+
+                while (entryTermsReader.MoveNext())
+                {
+                    Assert.True(rootPages.TryGetValue(entryTermsReader.FieldRootPage, out Slice fieldName));
+
+                    switch (fieldName.ToString())
+                    {
+                        case PrimaryKeyName:
+                            Assert.Equal(entry.PrimaryKeyBytes, entryTermsReader.Current.Decoded());
+                            break;
+                        case SecondaryKeyName:
+                            Assert.Equal(entry.SecondaryKeyBytes, entryTermsReader.Current.Decoded());
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException("Unknown field name: " + fieldName);
+                    }
+                }
+            }
+        }
+    }
+
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanDeleteAndStillUpdate()
+    {
+        using var mapping = GetMapping();
+
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            using (var builder = writer.Index("doc/0"u8))
+            {
+                builder.Write(PrimaryKey, "doc/0"u8);
+                builder.Write(SecondaryKey, "0"u8);
+                builder.EndWriting();
+            }
+
+            using (var builder = writer.Index("doc/1"u8))
+            {
+                builder.Write(PrimaryKey, "doc/1"u8);
+                builder.Write(SecondaryKey, "1"u8);
+                builder.EndWriting();
+            }
+
+            writer.Commit();
+        }
+
+        long doc1Id, doc0Id;
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            writer.TryDeleteEntry("doc/1"u8);
+            writer.TryDeleteEntry("doc/0"u8);
+
+            using (var builder = writer.Update("doc/1"u8))
+            {
+                builder.Write(PrimaryKey, "doc/1"u8);
+                builder.Write(SecondaryKey, "1"u8);
+                builder.EndWriting();
+
+                doc1Id = builder.EntryId;
+            }
+
+            using (var builder = writer.Update("doc/0"u8))
+            {
+                builder.Write(PrimaryKey, "doc/0"u8);
+                builder.Write(SecondaryKey, "0"u8);
+                builder.EndWriting();
+
+                doc0Id = builder.EntryId;
+            }
+
+            writer.Commit();
+            
+            Assert.True(writer.CreateTestingInterface().ValidateIdTreeToEntries(out _, out _));
+        }
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            var rootPages = searcher.GetIndexedFieldNamesByRootPage();
+            Page p = default;
+
+            var entryTermsReader = searcher.GetEntryTermsReader(doc0Id, ref p);
+            entryTermsReader.Reset();
+            while (entryTermsReader.MoveNext())
+            {
+                Assert.True(rootPages.TryGetValue(entryTermsReader.FieldRootPage, out Slice fieldName));
+
+                switch (fieldName.ToString())
+                {
+                    case PrimaryKeyName:
+                        Assert.Equal("doc/0"u8, entryTermsReader.Current.Decoded());
+                        break;
+                    case SecondaryKeyName:
+                        Assert.Equal("0"u8, entryTermsReader.Current.Decoded());
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Unknown field name: " + fieldName);
+                }
+            }
+
+            entryTermsReader = searcher.GetEntryTermsReader(doc1Id, ref p);
+            entryTermsReader.Reset();
+            while (entryTermsReader.MoveNext())
+            {
+                Assert.True(rootPages.TryGetValue(entryTermsReader.FieldRootPage, out Slice fieldName));
+
+                switch (fieldName.ToString())
+                {
+                    case PrimaryKeyName:
+                        Assert.Equal("doc/1"u8, entryTermsReader.Current.Decoded());
+                        break;
+                    case SecondaryKeyName:
+                        Assert.Equal("1"u8, entryTermsReader.Current.Decoded());
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Unknown field name: " + fieldName);
+                }
+            }
+        }
+
+
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            var testing = writer.CreateTestingInterface();
+            var result = testing.ValidateIdTreeToEntries(out var numberOfEntriesLocation, out var numberOfEntriesCompactTreeId);
+            Assert.Equal(numberOfEntriesCompactTreeId, numberOfEntriesLocation);
+            Assert.True(result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    public void CanDeleteAndStillUpdateFuzzy(int seed)
+    {
+        using var mapping = GetMapping();
+        var random = new Random(seed);
+        var docCount = random.Next(4, 512);
+
+        var entries = new Entry[docCount];
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            for (int docId = 0; docId < docCount; ++docId)
+            {
+                var newEntry = entries[docId] = new Entry($"doc/{docId}", docId.ToString());
+
+
+                using (var builder = writer.Index(newEntry.PrimaryKeyBytes))
+                {
+                    builder.Write(PrimaryKey, newEntry.PrimaryKeyBytes);
+                    builder.Write(SecondaryKey, Encodings.Utf8.GetBytes(docId.ToString()));
+                    builder.EndWriting();
+                    newEntry.EntryId = builder.EntryId;
+                }
+            }
+
+            writer.Commit();
+        }
+
+
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            // We want to test in removals in random order.
+            var toRemove = Enumerable.Range(0, docCount).ToArray();
+            random.Shuffle(toRemove.AsSpan());
+            foreach (var entryPosToRemove in toRemove)
+            {
+                var entry = entries[entryPosToRemove];
+                writer.TryDeleteEntry(entry.PrimaryKeyBytes);
+            }
+
+            var toAdd = Enumerable.Range(0, docCount).ToArray();
+            random.Shuffle(toAdd);
+
+            foreach (var entryIdToAdd in toAdd)
+            {
+                var entry = entries[entryIdToAdd];
+                entry.Reindex();
+
+                using (var builder = writer.Update(entry.PrimaryKeyBytes))
+                {
+                    builder.Write(PrimaryKey, entry.PrimaryKeyBytes);
+                    builder.Write(SecondaryKey, entry.SecondaryKeyBytes);
+                    builder.EndWriting();
+                }
+            }
+
+            writer.Commit();
+            
+            Assert.True(writer.CreateTestingInterface().ValidateIdTreeToEntries(out _, out _));
+        }
+
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            var rootPages = searcher.GetIndexedFieldNamesByRootPage();
+            Page p = default;
+
+            foreach (var entry in entries)
+            {
+                var entryTermsReader = searcher.GetEntryTermsReader(entry.EntryId, ref p);
+                entryTermsReader.Reset();
+
+                while (entryTermsReader.MoveNext())
+                {
+                    Assert.True(rootPages.TryGetValue(entryTermsReader.FieldRootPage, out Slice fieldName));
+
+                    switch (fieldName.ToString())
+                    {
+                        case PrimaryKeyName:
+                            Assert.Equal(entry.PrimaryKeyBytes, entryTermsReader.Current.Decoded());
+                            break;
+                        case SecondaryKeyName:
+                            Assert.Equal(entry.SecondaryKeyBytes, entryTermsReader.Current.Decoded());
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException("Unknown field name: " + fieldName);
+                    }
+                }
+            }
+        }
+    }
+
+    private const int PrimaryKey = 0;
+    private const string PrimaryKeyName = "id()";
+    private const int SecondaryKey = 1;
+    private const string SecondaryKeyName = "name";
+
+    private static IndexFieldsMapping GetMapping() => IndexFieldsMappingBuilder.CreateForWriter(false)
+        .AddBinding(PrimaryKey, PrimaryKeyName)
+        .AddBinding(SecondaryKey, SecondaryKeyName)
+        .Build();
+
+    private class Entry(string primaryKey, string secondaryKey)
+    {
+        private string _secondaryKey = secondaryKey;
+        public long EntryId { get; set; }
+
+        public ReadOnlySpan<byte> PrimaryKeyBytes => Encodings.Utf8.GetBytes(primaryKey);
+        public ReadOnlySpan<byte> SecondaryKeyBytes => Encodings.Utf8.GetBytes(_secondaryKey);
+
+        public void Reindex() => _secondaryKey = $"{SecondaryKey}/Updated";
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24217

### Additional description

Support for flow:
1) Delete(docId)
2) Update(docId)

The update calls Delete internally, so for cases when we have a single document (not a fanout index), we should reuse the previous entry id.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
