### PR TITLE
RavenDB-24218 updated SECURITY.md - 6.0 is no longer supported

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 | ------- | ------------------ |
 | 7.0.x   | :white_check_mark: |
 | 6.2.x   | :white_check_mark: |
-| 6.0.x   | :white_check_mark: |
+| 6.0.x   | :x:                |
 | 5.4.x   | :white_check_mark: |
 | 5.3.x   | :x:                |
 | 5.2.x   | :x:                |

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Resources;
 
-[assembly: AssemblyCopyright("© Hibernating Rhinos 2009 - 2024 All rights reserved.")]
+[assembly: AssemblyCopyright("© Hibernating Rhinos 2009 - 2025 All rights reserved.")]
 
 [assembly: AssemblyVersion("7.0.3")]
 [assembly: AssemblyFileVersion("7.0.3.70")]

--- a/src/Raven.Server/Smuggler/Migration/MajorVersion.cs
+++ b/src/Raven.Server/Smuggler/Migration/MajorVersion.cs
@@ -17,6 +17,8 @@ namespace Raven.Server.Smuggler.Migration
         V5,
         [Description("v6.x")]
         V6,
+        [Description("v7.x")]
+        V7,
         [Description("Greater than current")]
         GreaterThanCurrent
     }

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -112,9 +112,13 @@ namespace Raven.Server.Smuggler.Migration
                 buildInfo.TryGet(nameof(BuildInfo.FullVersion), out string fullVersion);
 
                 MajorVersion version;
-                if ((buildVersion >= 70 && buildVersion <= 1000) || buildVersion >= 70000)
+                if ((buildVersion >= 80 && buildVersion <= 1000) || buildVersion >= 80000)
                 {
                     version = MajorVersion.GreaterThanCurrent;
+                }
+                else if ((buildVersion >= 70 && buildVersion <= 79) || buildVersion >= 70000)
+                {
+                    version = MajorVersion.V7;
                 }
                 else if ((buildVersion >= 60 && buildVersion <= 69) || buildVersion >= 60000)
                 {
@@ -184,7 +188,7 @@ namespace Raven.Server.Smuggler.Migration
                     databases = new List<DatabaseMigrationSettings>();
 
                 var operateOnTypes = DatabaseSmugglerOptions.DefaultOperateOnTypes;
-                if (_buildMajorVersion != MajorVersion.V4 && _buildMajorVersion != MajorVersion.V5 && _buildMajorVersion != MajorVersion.V6 && _buildMajorVersion != MajorVersion.GreaterThanCurrent)
+                if (_buildMajorVersion != MajorVersion.V4 && _buildMajorVersion != MajorVersion.V5 && _buildMajorVersion != MajorVersion.V6 && _buildMajorVersion != MajorVersion.V7 && _buildMajorVersion != MajorVersion.GreaterThanCurrent)
                 {
                     operateOnTypes |= DatabaseItemType.LegacyAttachments;
                 }
@@ -242,7 +246,7 @@ namespace Raven.Server.Smuggler.Migration
 
             try
             {
-                return (buildMajorVersion == MajorVersion.V4 || buildMajorVersion == MajorVersion.V5 || buildMajorVersion == MajorVersion.V6 || buildMajorVersion == MajorVersion.GreaterThanCurrent)
+                return buildMajorVersion is MajorVersion.V4 or MajorVersion.V5 or MajorVersion.V6 or MajorVersion.V7 or MajorVersion.GreaterThanCurrent
                     ? await Importer.GetDatabasesToMigrate(_serverUrl, _httpClient, _serverStore.ServerShutdown)
                     : await AbstractLegacyMigrator.GetResourcesToMigrate(_serverUrl, _httpClient, false, _apiKey, _enableBasicAuthenticationOverUnsecuredHttp, _skipServerCertificateValidation, isLegacyOAuthToken, _serverStore.ServerShutdown);
             }
@@ -319,6 +323,7 @@ namespace Raven.Server.Smuggler.Migration
                                 case MajorVersion.V4:
                                 case MajorVersion.V5:
                                 case MajorVersion.V6:
+                                case MajorVersion.V7:
                                 case MajorVersion.GreaterThanCurrent:
                                     migrator = new Importer(options, parameters, _buildVersion, authorizationStatus);
                                     break;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24218

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
