### PR TITLE
RavenDB-24224 - disable certificate reset in test

### DIFF
--- a/test/StressTests/Authentication/AuthenticationStressTests.cs
+++ b/test/StressTests/Authentication/AuthenticationStressTests.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using FastTests;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
@@ -92,7 +93,11 @@ namespace StressTests.Authentication
                 {
                     Urls = new[] { server.WebUrl },
                     Database = databaseName2,
-                    Certificate = adminCert
+                    Certificate = adminCert,
+                    Conventions =
+                    {
+                        DisposeCertificate = false
+                    }
                 }.Initialize())
                 {
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
@@ -224,7 +229,11 @@ namespace StressTests.Authentication
                 {
                     Urls = new[] { server.WebUrl },
                     Database = databaseName2,
-                    Certificate = adminCert
+                    Certificate = adminCert,
+                    Conventions =
+                    {
+                        DisposeCertificate = false
+                    }
                 }.Initialize())
                 {
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
@@ -349,7 +358,11 @@ namespace StressTests.Authentication
                 {
                     Urls = new[] { server.WebUrl },
                     Database = databaseName2,
-                    Certificate = adminCert
+                    Certificate = adminCert,
+                    Conventions =
+                    {
+                        DisposeCertificate = false
+                    }
                 }.Initialize())
                 {
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
@@ -473,7 +486,11 @@ namespace StressTests.Authentication
                 {
                     Urls = new[] { server.WebUrl },
                     Database = databaseName2,
-                    Certificate = adminCert
+                    Certificate = adminCert,
+                    Conventions =
+                    {
+                        DisposeCertificate = false
+                    }
                 }.Initialize())
                 {
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
@@ -591,7 +608,11 @@ namespace StressTests.Authentication
                 {
                     Urls = new[] { server.WebUrl },
                     Database = databaseName2,
-                    Certificate = adminCert
+                    Certificate = adminCert,
+                    Conventions =
+                    {
+                        DisposeCertificate = false
+                    }
                 }.Initialize())
                 {
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24224/StressTests.Authentication.AuthenticationStressTests.RoutesDatabaseRead

### Additional description

Fix cert was disposed or reset in test

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
