### PR TITLE
RavenDB-24219 AI views: Add links to docs in "About this view"

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiConnectionStrings/AiConnectionStringsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiConnectionStrings/AiConnectionStringsInfoHub.tsx
@@ -5,10 +5,14 @@ import FeatureAvailabilitySummaryWrapper, {
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppUrls } from "hooks/useAppUrls";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export function AiConnectionStringsInfoHub() {
     const { appUrl } = useAppUrls();
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+
+    const aiConnectionStringsDocsLink = useRavenLink({ hash: "EAIKIA" });
 
     return (
         <AboutViewAnchored>
@@ -47,6 +51,11 @@ export function AiConnectionStringsInfoHub() {
                         </li>
                     </ul>
                 </div>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={aiConnectionStringsDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - AI Connection Strings
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={true} data={defaultFeatureAvailability} />
         </AboutViewAnchored>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditEmbeddingsGenerationInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditEmbeddingsGenerationInfoHub.tsx
@@ -6,12 +6,17 @@ import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUti
 import { useAppUrls } from "hooks/useAppUrls";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { allAiExternalProviders } from "components/utils/common";
+import { Icon } from "components/common/Icon";
+import { useRavenLink } from "hooks/useRavenLink";
 
 export function EditEmbeddingsGenerationInfoHub() {
     const hasEmbeddingsGeneration = useAppSelector(licenseSelectors.statusValue("HasEmbeddingsGeneration"));
 
     const { appUrl } = useAppUrls();
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+
+    const generatingEmbeddingsOverviewDocsLink = useRavenLink({ hash: "H6GDNY" });
+    const embeddingsGenerationTaskDocsLink = useRavenLink({ hash: "MKXRLR" });
     
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
@@ -82,6 +87,15 @@ export function EditEmbeddingsGenerationInfoHub() {
                     Whenever a document in the selected collection is modified, the task is triggered to extract the
                     updated text and regenerate its embeddings.
                 </div>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={generatingEmbeddingsOverviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Generating Embeddings Overview
+                </a>
+                <br />
+                <a href={embeddingsGenerationTaskDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - The Embeddings Generation Task
+                </a>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper
                 isUnlimited={hasEmbeddingsGeneration}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24219/AI-views-Add-links-to-docs-in-About-this-view

### Additional description
Added links to documentation in the following views:
* Embeddings Generation Task
* AI Connection Strings

### Type of change
- [x] Bug fix - Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
