### PR TITLE
RavenDB-23754 : Add `/databases/*/collections/stats/detailed` to debug package

### DIFF
--- a/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
+++ b/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
@@ -105,7 +105,6 @@ namespace Raven.Client.Documents.Operations
         public long CountOfTombstones { get; set; }
         public long CountOfRevisions { get; set; }
         public long CountOfTimeSeriesDeletedRanges { get; set; }
-        public long CountOfAttachments { get; set; }
         public long CountOfCounterEntries { get; set; }
         public long CountOfTimeSeriesSegments { get; set; }
         public Size TimeSeriesSegmentsSize { get; set; }

--- a/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
+++ b/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
@@ -102,15 +102,19 @@ namespace Raven.Client.Documents.Operations
     {
         public string Name { get; set; }
         public long CountOfDocuments { get; set; }
+        public long CountOfTombstones { get; set; }
+        public long CountOfRevisions { get; set; }
+        public long CountOfTimeSeriesDeletedRanges { get; set; }
+        public long CountOfAttachments { get; set; }
+        public long CountOfCounterEntries { get; set; }
+        public long CountOfTimeSeriesSegments { get; set; }
+        public Size TimeSeriesSegmentsSize { get; set; }
         public Size Size { get; set; }
         public Size DocumentsSize { get; set; }
         public Size TombstonesSize { get; set; }
         public Size RevisionsSize { get; set; }
         public Size TimeSeriesDeletedRangesSize { get; set; }
-        public Size DocumentsConflictsSize { get; set; }
-        public Size AttachmentsSize { get; set; }
         public Size CounterEntriesSize { get; set; }
-        public Size TimeSeriesSegmentsSize { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -128,26 +132,31 @@ namespace Raven.Client.Documents.Operations
                     [nameof(DocumentsSize.HumaneSize)] = DocumentsSize.HumaneSize,
                     [nameof(DocumentsSize.SizeInBytes)] = DocumentsSize.SizeInBytes
                 },
+                [nameof(CountOfTombstones)] = CountOfTombstones,
                 [nameof(TombstonesSize)] = new DynamicJsonValue
                 {
                     [nameof(TombstonesSize.HumaneSize)] = TombstonesSize.HumaneSize,
                     [nameof(TombstonesSize.SizeInBytes)] = TombstonesSize.SizeInBytes
                 },
+                [nameof(CountOfRevisions)] = CountOfRevisions,
                 [nameof(RevisionsSize)] = new DynamicJsonValue
                 {
                     [nameof(RevisionsSize.HumaneSize)] = RevisionsSize.HumaneSize,
                     [nameof(RevisionsSize.SizeInBytes)] = RevisionsSize.SizeInBytes
                 },
+                [nameof(CountOfTimeSeriesDeletedRanges)] = CountOfTimeSeriesDeletedRanges,
                 [nameof(TimeSeriesDeletedRangesSize)] = new DynamicJsonValue
                 {
                     [nameof(TimeSeriesDeletedRangesSize.HumaneSize)] = TimeSeriesDeletedRangesSize.HumaneSize,
                     [nameof(TimeSeriesDeletedRangesSize.SizeInBytes)] = TimeSeriesDeletedRangesSize.SizeInBytes
                 },
+                [nameof(CountOfCounterEntries)] = CountOfCounterEntries,
                 [nameof(CounterEntriesSize)] = new DynamicJsonValue
                 {
                     [nameof(CounterEntriesSize.HumaneSize)] = CounterEntriesSize.HumaneSize,
                     [nameof(CounterEntriesSize.SizeInBytes)] = CounterEntriesSize.SizeInBytes
                 },
+                [nameof(CountOfTimeSeriesSegments)] = CountOfTimeSeriesSegments,
                 [nameof(TimeSeriesSegmentsSize)] = new DynamicJsonValue
                 {
                     [nameof(TimeSeriesSegmentsSize.HumaneSize)] = TimeSeriesSegmentsSize.HumaneSize,

--- a/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
+++ b/src/Raven.Client/Documents/Operations/CollectionStatistics.cs
@@ -14,6 +14,13 @@ namespace Raven.Client.Documents.Operations
 
         public long CountOfDocuments { get; set; }
         public long CountOfConflicts { get; set; }
+        public long CountOfRevisionDocuments { get; set; }
+        public long CountOfTombstones { get; set; }
+        public long CountOfTimeSeriesDeletedRanges { get; set; }
+        public long CountOfDocumentsConflicts { get; set; }
+        public long CountOfAttachments { get; set; }
+        public long CountOfCounterEntries { get; set; }
+        public long CountOfTimeSeriesSegments { get; set; }
 
         public Dictionary<string, long> Collections { get; set; }
 
@@ -25,6 +32,13 @@ namespace Raven.Client.Documents.Operations
             {
                 [nameof(CollectionStatistics.CountOfDocuments)] = CountOfDocuments,
                 [nameof(CollectionStatistics.CountOfConflicts)] = CountOfConflicts,
+                [nameof(CollectionStatistics.CountOfRevisionDocuments)] = CountOfRevisionDocuments,
+                [nameof(CollectionStatistics.CountOfTombstones)] = CountOfTombstones,
+                [nameof(CollectionStatistics.CountOfTimeSeriesDeletedRanges)] = CountOfTimeSeriesDeletedRanges,
+                [nameof(CollectionStatistics.CountOfDocumentsConflicts)] = CountOfDocumentsConflicts,
+                [nameof(CollectionStatistics.CountOfAttachments)] = CountOfAttachments,
+                [nameof(CollectionStatistics.CountOfCounterEntries)] = CountOfCounterEntries,
+                [nameof(CollectionStatistics.CountOfTimeSeriesSegments)] = CountOfTimeSeriesSegments,
                 [nameof(CollectionStatistics.Collections)] = collections
             };
 
@@ -46,6 +60,13 @@ namespace Raven.Client.Documents.Operations
 
         public long CountOfDocuments { get; set; }
         public long CountOfConflicts { get; set; }
+        public long CountOfRevisionDocuments { get; set; }
+        public long CountOfTombstones { get; set; }
+        public long CountOfTimeSeriesDeletedRanges { get; set; }
+        public long CountOfDocumentsConflicts { get; set; }
+        public long CountOfAttachments { get; set; }
+        public long CountOfCounterEntries { get; set; }
+        public long CountOfTimeSeriesSegments { get; set; }
 
         public Dictionary<string, CollectionDetails> Collections { get; set; }
 
@@ -57,6 +78,13 @@ namespace Raven.Client.Documents.Operations
             {
                 [nameof(CollectionStatistics.CountOfDocuments)] = CountOfDocuments,
                 [nameof(CollectionStatistics.CountOfConflicts)] = CountOfConflicts,
+                [nameof(CollectionStatistics.CountOfRevisionDocuments)] = CountOfRevisionDocuments,
+                [nameof(CollectionStatistics.CountOfTombstones)] = CountOfTombstones,
+                [nameof(CollectionStatistics.CountOfTimeSeriesDeletedRanges)] = CountOfTimeSeriesDeletedRanges,
+                [nameof(CollectionStatistics.CountOfDocumentsConflicts)] = CountOfDocumentsConflicts,
+                [nameof(CollectionStatistics.CountOfAttachments)] = CountOfAttachments,
+                [nameof(CollectionStatistics.CountOfCounterEntries)] = CountOfCounterEntries,
+                [nameof(CollectionStatistics.CountOfTimeSeriesSegments)] = CountOfTimeSeriesSegments,
                 [nameof(CollectionStatistics.Collections)] = collections
             };
 
@@ -78,6 +106,11 @@ namespace Raven.Client.Documents.Operations
         public Size DocumentsSize { get; set; }
         public Size TombstonesSize { get; set; }
         public Size RevisionsSize { get; set; }
+        public Size TimeSeriesDeletedRangesSize { get; set; }
+        public Size DocumentsConflictsSize { get; set; }
+        public Size AttachmentsSize { get; set; }
+        public Size CounterEntriesSize { get; set; }
+        public Size TimeSeriesSegmentsSize { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -104,6 +137,21 @@ namespace Raven.Client.Documents.Operations
                 {
                     [nameof(RevisionsSize.HumaneSize)] = RevisionsSize.HumaneSize,
                     [nameof(RevisionsSize.SizeInBytes)] = RevisionsSize.SizeInBytes
+                },
+                [nameof(TimeSeriesDeletedRangesSize)] = new DynamicJsonValue
+                {
+                    [nameof(TimeSeriesDeletedRangesSize.HumaneSize)] = TimeSeriesDeletedRangesSize.HumaneSize,
+                    [nameof(TimeSeriesDeletedRangesSize.SizeInBytes)] = TimeSeriesDeletedRangesSize.SizeInBytes
+                },
+                [nameof(CounterEntriesSize)] = new DynamicJsonValue
+                {
+                    [nameof(CounterEntriesSize.HumaneSize)] = CounterEntriesSize.HumaneSize,
+                    [nameof(CounterEntriesSize.SizeInBytes)] = CounterEntriesSize.SizeInBytes
+                },
+                [nameof(TimeSeriesSegmentsSize)] = new DynamicJsonValue
+                {
+                    [nameof(TimeSeriesSegmentsSize.HumaneSize)] = TimeSeriesSegmentsSize.HumaneSize,
+                    [nameof(TimeSeriesSegmentsSize.SizeInBytes)] = TimeSeriesSegmentsSize.SizeInBytes
                 }
             };
         }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1442,19 +1442,5 @@ namespace Raven.Server.Documents
                 return key.Length;
             }
         }
-
-        public long GetNumberOfAttachmentsDocumentsForCollection(DocumentsOperationContext context, string collection)
-        {
-            var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection));
-            if (table == null)
-                return 0;
-            return table.GetNumberOfEntriesFor(AttachmentsSchema.FixedSizeIndexes[AttachmentsEtagSlice]);
-        }
-
-        private Table GetExistingTable(Transaction tx, CollectionName collection)
-        {
-            string tableName = collection.GetTableName(CollectionTableType.CounterGroups);
-            return tx.OpenTable(AttachmentsSchema, tableName);
-        }
     }
 }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1442,5 +1442,19 @@ namespace Raven.Server.Documents
                 return key.Length;
             }
         }
+
+        public long GetNumberOfAttachmentsDocumentsForCollection(DocumentsOperationContext context, string collection)
+        {
+            var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection));
+            if (table == null)
+                return 0;
+            return table.GetNumberOfEntriesFor(AttachmentsSchema.FixedSizeIndexes[AttachmentsEtagSlice]);
+        }
+
+        private Table GetExistingTable(Transaction tx, CollectionName collection)
+        {
+            string tableName = collection.GetTableName(CollectionTableType.CounterGroups);
+            return tx.OpenTable(AttachmentsSchema, tableName);
+        }
     }
 }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -254,7 +254,7 @@ namespace Raven.Server.Documents
             var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection));
             if (table == null)
                 return 0;
-            return table.GetNumberOfEntriesFor(CountersSchema.FixedSizeIndexes[CollectionCountersEtagsSlice]);
+            return table.NumberOfEntries;
         }
 
         private Table GetExistingTable(Transaction tx, CollectionName collection)

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -249,6 +249,20 @@ namespace Raven.Server.Documents
             };
         }
 
+        public long GetNumberOfCountersDocumentsForCollection(DocumentsOperationContext context, string collection)
+        {
+            var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection));
+            if (table == null)
+                return 0;
+            return table.GetNumberOfEntriesFor(CountersSchema.FixedSizeIndexes[CollectionCountersEtagsSlice]);
+        }
+
+        private Table GetExistingTable(Transaction tx, CollectionName collection)
+        {
+            string tableName = collection.GetTableName(CollectionTableType.CounterGroups);
+            return tx.OpenTable(CountersSchema, tableName);
+        }
+
         internal static CounterReplicationItem CreateReplicationBatchItem(DocumentsOperationContext context, ref TableValueReader reader)
         {
             var data = GetCounterValuesData(context, ref reader);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2381,6 +2381,11 @@ namespace Raven.Server.Documents
                 TableReport collectionTableReport = GetReportForTable(context, DocsSchema, collectionName.GetTableName(CollectionTableType.Documents));
 
                 collectionDetails.CountOfDocuments = collectionTableReport.NumberOfEntries;
+                collectionDetails.CountOfRevisions = RevisionsStorage.GetNumberOfRevisionDocumentsForCollection(context, collection);
+                collectionDetails.CountOfTombstones = TombstonesCountForCollection(context, collection);
+                collectionDetails.CountOfCounterEntries = CountersStorage.GetNumberOfCountersDocumentsForCollection(context, collection);
+                collectionDetails.CountOfTimeSeriesDeletedRanges = TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesForCollection(context, collection);
+                collectionDetails.CountOfTimeSeriesSegments = TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsForCollection(context, collection);
 
                 var documentsSize = collectionTableReport.DataSizeInBytes;
                 var revisionsSize = GetReportForTable(context, RevisionsStorage.RevisionsSchema, collectionName.GetTableName(CollectionTableType.Revisions))

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2369,7 +2369,10 @@ namespace Raven.Server.Documents
                 Size = new Client.Util.Size(),
                 DocumentsSize = new Client.Util.Size(),
                 RevisionsSize = new Client.Util.Size(),
-                TombstonesSize = new Client.Util.Size()
+                TombstonesSize = new Client.Util.Size(),
+                TimeSeriesDeletedRangesSize = new Client.Util.Size(),
+                CounterEntriesSize = new Client.Util.Size(),
+                TimeSeriesSegmentsSize = new Client.Util.Size()
             };
             CollectionName collectionName = GetCollection(collection, throwIfDoesNotExist: false);
 
@@ -2383,12 +2386,20 @@ namespace Raven.Server.Documents
                 var revisionsSize = GetReportForTable(context, RevisionsStorage.RevisionsSchema, collectionName.GetTableName(CollectionTableType.Revisions))
                     .DataSizeInBytes;
                 var tombstonesSize = GetReportForTable(context, TombstonesSchema, collectionName.GetTableName(CollectionTableType.Tombstones)).DataSizeInBytes;
+                var timeSeriesDeletedRangesSize = GetReportForTable(context, TimeSeriesDeleteRangesSchema, collectionName.GetTableName(CollectionTableType.TimeSeriesDeletedRanges)).DataSizeInBytes;
+
+                var counterEntriesSize = GetReportForTable(context, CountersSchema, collectionName.GetTableName(CollectionTableType.CounterGroups)).DataSizeInBytes;
+                var timeSeriesSegmentsSize = GetReportForTable(context, TimeSeriesSchema, collectionName.GetTableName(CollectionTableType.TimeSeries)).DataSizeInBytes;
 
                 collectionDetails.DocumentsSize.SizeInBytes = documentsSize;
                 collectionDetails.RevisionsSize.SizeInBytes = revisionsSize;
                 collectionDetails.TombstonesSize.SizeInBytes = tombstonesSize;
+                collectionDetails.TimeSeriesDeletedRangesSize.SizeInBytes = timeSeriesDeletedRangesSize;
 
-                collectionDetails.Size.SizeInBytes = documentsSize + revisionsSize + tombstonesSize;
+                collectionDetails.CounterEntriesSize.SizeInBytes = counterEntriesSize;
+                collectionDetails.TimeSeriesSegmentsSize.SizeInBytes = timeSeriesSegmentsSize;
+
+                collectionDetails.Size.SizeInBytes = documentsSize + revisionsSize + tombstonesSize + timeSeriesDeletedRangesSize + counterEntriesSize + timeSeriesSegmentsSize;
             }
 
             return collectionDetails;

--- a/src/Raven.Server/Documents/Handlers/CollectionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CollectionsHandler.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Handlers
                 await processor.ExecuteAsync();
         }
 
-        [RavenAction("/databases/*/collections/stats/detailed", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        [RavenAction("/databases/*/collections/stats/detailed", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task GetDetailedCollectionStats()
         {
             using (var processor = new CollectionsHandlerProcessorForGetCollectionStats(this, detailed: true))

--- a/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionStats.cs
@@ -28,7 +28,14 @@ namespace Raven.Server.Documents.Handlers.Processors.Collections
             {
                 [nameof(CollectionStatistics.CountOfDocuments)] = RequestHandler.Database.DocumentsStorage.GetNumberOfDocuments(context),
                 [nameof(CollectionStatistics.CountOfConflicts)] = RequestHandler.Database.DocumentsStorage.ConflictsStorage.GetNumberOfDocumentsConflicts(context),
-                [nameof(CollectionStatistics.Collections)] = collections
+                [nameof(CollectionStatistics.CountOfRevisionDocuments)] = RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context),
+                [nameof(CollectionStatistics.CountOfTombstones)] = RequestHandler.Database.DocumentsStorage.GetNumberOfTombstones(context),
+                [nameof(CollectionStatistics.CountOfTimeSeriesDeletedRanges)] = RequestHandler.Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRanges(context),
+                [nameof(CollectionStatistics.CountOfDocumentsConflicts)] = RequestHandler.Database.DocumentsStorage.ConflictsStorage.GetNumberOfDocumentsConflicts(context),
+                [nameof(CollectionStatistics.CountOfAttachments)] = RequestHandler.Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachments(context).AttachmentCount,
+                [nameof(CollectionStatistics.CountOfCounterEntries)] = RequestHandler.Database.DocumentsStorage.CountersStorage.GetNumberOfCounterEntries(context),
+                [nameof(CollectionStatistics.CountOfTimeSeriesSegments)] = RequestHandler.Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegments(context),
+                [nameof(CollectionStatistics.Collections)] = collections,
             };
 
             foreach (var collection in RequestHandler.Database.DocumentsStorage.GetCollections(context))

--- a/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionStats.cs
@@ -27,11 +27,11 @@ namespace Raven.Server.Documents.Handlers.Processors.Collections
             DynamicJsonValue stats = new DynamicJsonValue()
             {
                 [nameof(CollectionStatistics.CountOfDocuments)] = RequestHandler.Database.DocumentsStorage.GetNumberOfDocuments(context),
-                [nameof(CollectionStatistics.CountOfConflicts)] = RequestHandler.Database.DocumentsStorage.ConflictsStorage.GetNumberOfDocumentsConflicts(context),
+                [nameof(CollectionStatistics.CountOfDocumentsConflicts)] = RequestHandler.Database.DocumentsStorage.ConflictsStorage.GetNumberOfDocumentsConflicts(context),
+                [nameof(CollectionStatistics.CountOfConflicts)] = RequestHandler.Database.DocumentsStorage.ConflictsStorage.ConflictsCount,
                 [nameof(CollectionStatistics.CountOfRevisionDocuments)] = RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context),
                 [nameof(CollectionStatistics.CountOfTombstones)] = RequestHandler.Database.DocumentsStorage.GetNumberOfTombstones(context),
                 [nameof(CollectionStatistics.CountOfTimeSeriesDeletedRanges)] = RequestHandler.Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRanges(context),
-                [nameof(CollectionStatistics.CountOfDocumentsConflicts)] = RequestHandler.Database.DocumentsStorage.ConflictsStorage.GetNumberOfDocumentsConflicts(context),
                 [nameof(CollectionStatistics.CountOfAttachments)] = RequestHandler.Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachments(context).AttachmentCount,
                 [nameof(CollectionStatistics.CountOfCounterEntries)] = RequestHandler.Database.DocumentsStorage.CountersStorage.GetNumberOfCounterEntries(context),
                 [nameof(CollectionStatistics.CountOfTimeSeriesSegments)] = RequestHandler.Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegments(context),

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2949,7 +2949,7 @@ namespace Raven.Server.Documents.Revisions
             var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection));
             if (table == null)
                 return 0;
-            return table.GetNumberOfEntriesFor(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice]);
+            return table.NumberOfEntries;
         }
 
         private Table GetExistingTable(Transaction tx, CollectionName collection)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2943,5 +2943,19 @@ namespace Raven.Server.Documents.Revisions
             var table = context.Transaction.InnerTransaction.OpenTable(_documentsStorage.TombstonesSchema, RevisionsTombstones);
             return table?.NumberOfEntries ?? 0;
         }
+
+        public long GetNumberOfRevisionDocumentsForCollection(DocumentsOperationContext context, string collection)
+        {
+            var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection));
+            if (table == null)
+                return 0;
+            return table.GetNumberOfEntriesFor(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice]);
+        }
+
+        private Table GetExistingTable(Transaction tx, CollectionName collection)
+        {
+            string tableName = collection.GetTableName(CollectionTableType.Revisions);
+            return tx.OpenTable(RevisionsSchema, tableName);
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
@@ -112,7 +112,6 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
                         stats.Collections[collectionInfo.Key].CountOfCounterEntries += collectionInfo.Value.CountOfCounterEntries;
                         stats.Collections[collectionInfo.Key].TimeSeriesSegmentsSize.SizeInBytes += collectionInfo.Value.TimeSeriesSegmentsSize.SizeInBytes;
                         stats.Collections[collectionInfo.Key].CountOfTimeSeriesSegments += collectionInfo.Value.CountOfTimeSeriesSegments;
-                        stats.Collections[collectionInfo.Key].CountOfAttachments += collectionInfo.Value.CountOfAttachments;
                     }
                     else
                     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
@@ -88,6 +88,14 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
             {
                 stats.CountOfDocuments += result.Result.CountOfDocuments;
                 stats.CountOfConflicts += result.Result.CountOfConflicts;
+                stats.CountOfRevisionDocuments += result.Result.CountOfRevisionDocuments;
+                stats.CountOfTombstones += result.Result.CountOfTombstones;
+                stats.CountOfTimeSeriesDeletedRanges += result.Result.CountOfTimeSeriesDeletedRanges;
+                stats.CountOfDocumentsConflicts += result.Result.CountOfDocumentsConflicts;
+                stats.CountOfAttachments += result.Result.CountOfAttachments;
+                stats.CountOfCounterEntries += result.Result.CountOfCounterEntries;
+                stats.CountOfTimeSeriesSegments += result.Result.CountOfTimeSeriesSegments;
+
                 foreach (var collectionInfo in result.Result.Collections)
                 {
                     if (stats.Collections.ContainsKey(collectionInfo.Key))
@@ -96,6 +104,9 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
                         stats.Collections[collectionInfo.Key].DocumentsSize.SizeInBytes += collectionInfo.Value.DocumentsSize.SizeInBytes;
                         stats.Collections[collectionInfo.Key].RevisionsSize.SizeInBytes += collectionInfo.Value.RevisionsSize.SizeInBytes;
                         stats.Collections[collectionInfo.Key].TombstonesSize.SizeInBytes += collectionInfo.Value.TombstonesSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].TimeSeriesDeletedRangesSize.SizeInBytes += collectionInfo.Value.TimeSeriesDeletedRangesSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].CounterEntriesSize.SizeInBytes += collectionInfo.Value.CounterEntriesSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].TimeSeriesSegmentsSize.SizeInBytes += collectionInfo.Value.TimeSeriesSegmentsSize.SizeInBytes;
                     }
                     else
                     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Collections/ShardedCollectionsHandlerProcessorForGetCollectionStats.cs
@@ -103,10 +103,16 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Collections
                         stats.Collections[collectionInfo.Key].CountOfDocuments += collectionInfo.Value.CountOfDocuments;
                         stats.Collections[collectionInfo.Key].DocumentsSize.SizeInBytes += collectionInfo.Value.DocumentsSize.SizeInBytes;
                         stats.Collections[collectionInfo.Key].RevisionsSize.SizeInBytes += collectionInfo.Value.RevisionsSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].CountOfRevisions += collectionInfo.Value.CountOfRevisions;
                         stats.Collections[collectionInfo.Key].TombstonesSize.SizeInBytes += collectionInfo.Value.TombstonesSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].CountOfTombstones += collectionInfo.Value.CountOfTombstones;
                         stats.Collections[collectionInfo.Key].TimeSeriesDeletedRangesSize.SizeInBytes += collectionInfo.Value.TimeSeriesDeletedRangesSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].CountOfTimeSeriesDeletedRanges += collectionInfo.Value.CountOfTimeSeriesDeletedRanges;
                         stats.Collections[collectionInfo.Key].CounterEntriesSize.SizeInBytes += collectionInfo.Value.CounterEntriesSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].CountOfCounterEntries += collectionInfo.Value.CountOfCounterEntries;
                         stats.Collections[collectionInfo.Key].TimeSeriesSegmentsSize.SizeInBytes += collectionInfo.Value.TimeSeriesSegmentsSize.SizeInBytes;
+                        stats.Collections[collectionInfo.Key].CountOfTimeSeriesSegments += collectionInfo.Value.CountOfTimeSeriesSegments;
+                        stats.Collections[collectionInfo.Key].CountOfAttachments += collectionInfo.Value.CountOfAttachments;
                     }
                     else
                     {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -3013,30 +3013,24 @@ namespace Raven.Server.Documents.TimeSeries
 
         public long GetNumberOfTimeSeriesDeletedRangesForCollection(DocumentsOperationContext context, string collection)
         {
-            var table = GetExistingTable1(context.Transaction.InnerTransaction, new CollectionName(collection));
+            var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection), CollectionTableType.TimeSeriesDeletedRanges, DeleteRangesSchema);
             if (table == null)
                 return 0;
-            return table.GetNumberOfEntriesFor(DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice]);
+            return table.NumberOfEntries;
         }
 
         public long GetNumberOfTimeSeriesSegmentsForCollection(DocumentsOperationContext context, string collection)
         {
-            var table = GetExistingTable2(context.Transaction.InnerTransaction, new CollectionName(collection));
+            var table = GetExistingTable(context.Transaction.InnerTransaction, new CollectionName(collection), CollectionTableType.TimeSeries, TimeSeriesSchema);
             if (table == null)
                 return 0;
-            return table.GetNumberOfEntriesFor(TimeSeriesSchema.FixedSizeIndexes[CollectionTimeSeriesEtagsSlice]);
+            return table.NumberOfEntries;
         }
 
-        private Table GetExistingTable1(Transaction tx, CollectionName collection)
+        private Table GetExistingTable(Transaction tx, CollectionName collection, CollectionTableType type, TableSchema tableSchema)
         {
-            string tableName = collection.GetTableName(CollectionTableType.TimeSeriesDeletedRanges);
-            return tx.OpenTable(DeleteRangesSchema, tableName);
-        }
-
-        private Table GetExistingTable2(Transaction tx, CollectionName collection)
-        {
-            string tableName = collection.GetTableName(CollectionTableType.TimeSeries);
-            return tx.OpenTable(TimeSeriesSchema, tableName);
+            string tableName = collection.GetTableName(type);
+            return tx.OpenTable(tableSchema, tableName);
         }
     }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -3010,6 +3010,34 @@ namespace Raven.Server.Documents.TimeSeries
                 }
             }
         }
+
+        public long GetNumberOfTimeSeriesDeletedRangesForCollection(DocumentsOperationContext context, string collection)
+        {
+            var table = GetExistingTable1(context.Transaction.InnerTransaction, new CollectionName(collection));
+            if (table == null)
+                return 0;
+            return table.GetNumberOfEntriesFor(DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice]);
+        }
+
+        public long GetNumberOfTimeSeriesSegmentsForCollection(DocumentsOperationContext context, string collection)
+        {
+            var table = GetExistingTable2(context.Transaction.InnerTransaction, new CollectionName(collection));
+            if (table == null)
+                return 0;
+            return table.GetNumberOfEntriesFor(TimeSeriesSchema.FixedSizeIndexes[CollectionTimeSeriesEtagsSlice]);
+        }
+
+        private Table GetExistingTable1(Transaction tx, CollectionName collection)
+        {
+            string tableName = collection.GetTableName(CollectionTableType.TimeSeriesDeletedRanges);
+            return tx.OpenTable(DeleteRangesSchema, tableName);
+        }
+
+        private Table GetExistingTable2(Transaction tx, CollectionName collection)
+        {
+            string tableName = collection.GetTableName(CollectionTableType.TimeSeries);
+            return tx.OpenTable(TimeSeriesSchema, tableName);
+        }
     }
 
     public sealed class NanValueException : Exception

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -63,7 +63,8 @@ namespace SlowTests.Authentication
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json",
                 "admin.txinfo.json", "admin.cluster.txinfo.json", "admin.configuration.settings.json", "etl.stats.json", "etl.progress.json",
-                "admin.tombstones.state.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json"
+                "admin.tombstones.state.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json", 
+                "collections.stats.detailed.json"
             };
 
             var dbName = GetDatabaseName();
@@ -81,7 +82,8 @@ namespace SlowTests.Authentication
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json",
                 "admin.txinfo.json", "admin.cluster.txinfo.json", "admin.configuration.settings.json", "etl.stats.json", "etl.progress.json",
-                "admin.tombstones.state.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json"
+                "admin.tombstones.state.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json",
+                "collections.stats.detailed.json"
             };
 
             var dbName = GetDatabaseName();
@@ -99,7 +101,8 @@ namespace SlowTests.Authentication
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json",
                 "admin.txinfo.json", "admin.cluster.txinfo.json", "admin.configuration.settings.json", "etl.stats.json", "etl.progress.json",
-                "admin.tombstones.state.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json"
+                "admin.tombstones.state.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json",
+                "collections.stats.detailed.json"
             };
 
             var dbName = GetDatabaseName();
@@ -117,7 +120,8 @@ namespace SlowTests.Authentication
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json",
-                "etl.stats.json", "etl.progress.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json"
+                "etl.stats.json", "etl.progress.json", "indexes.performance.json", "replication.progress.json", "replication.internal.outgoing.progress.json",
+                "collections.stats.detailed.json"
             };
 
             var dbName = GetDatabaseName();

--- a/test/SlowTests/Issues/RavenDB_14881.cs
+++ b/test/SlowTests/Issues/RavenDB_14881.cs
@@ -75,6 +75,7 @@ namespace SlowTests.Issues
                 // get detailed collection statistics before we are going to change some data
                 // right now there shouldn't be any revisions
                 var detailedCollectionStats_beforeDataChanged = await store.Maintenance.SendAsync(new GetDetailedCollectionStatisticsOperation());
+                Assert.Equal(20, detailedCollectionStats_beforeDataChanged.CountOfRevisionDocuments);
                 Assert.Equal(strCollectionName, detailedCollectionStats_beforeDataChanged.Collections[strCollectionName].Name);
                 long sizeInBytesWithoutRevisions = detailedCollectionStats_beforeDataChanged.Collections[strCollectionName].Size.SizeInBytes;
                 Assert.True(sizeInBytesWithoutRevisions > 0);

--- a/test/SlowTests/Issues/RavenDB_23754.cs
+++ b/test/SlowTests/Issues/RavenDB_23754.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -13,7 +10,6 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using SlowTests.Core.Utils.Entities;
-using SlowTests.Core.Utils.Entities.Faceted;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,9 +23,9 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public async Task Test()
+        public async Task GetDetailedCollectionStats_ShouldReturnCorrectConflictCounts()
         {
-            var (nodes, leader) = await CreateRaftCluster(2);
+            var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
             using var store = GetDocumentStore(new Options()
             {
                 ReplicationFactor = 2,
@@ -87,7 +83,6 @@ namespace SlowTests.Issues
                 timeout: 5000,
                 interval: 500);
         }
-
         private IDocumentStore GetStoreForServer(RavenServer server, string database)
         {
             return new DocumentStore
@@ -99,38 +94,6 @@ namespace SlowTests.Issues
         }
 
         private const string UsersId = "Users/1";
-        private const string OrdersId = "Orders/1";
-
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void DebugPackage_Should_Contain_Collections_Stats_Detailed()
-        {
-            using var store = GetDocumentStore();
-            var dbName = store.Database;
-
-            using (var s = store.OpenSession())
-            {
-                s.Store(new User(), UsersId);
-                s.Store(new Order(), OrdersId);
-                s.SaveChanges();
-            }
-
-            var baseUrl = $"{store.Urls.Single().TrimEnd('/')}";
-            using var http = new HttpClient();
-            var resp = http.GetAsync($"{baseUrl}/admin/debug/info-package").Result;
-            resp.EnsureSuccessStatusCode();
-
-            using var zipStream = resp.Content.ReadAsStreamAsync().Result;
-            using var zip = new ZipArchive(zipStream);
-
-            var entryName = $"{dbName}/collections.stats.detailed.json";
-            var detailedEntry = zip.Entries.SingleOrDefault(e => e.FullName == entryName);
-            Assert.NotNull(detailedEntry);
-
-            using var reader = new StreamReader(detailedEntry.Open());
-            var json = reader.ReadToEnd();
-            Assert.Contains("\"Users\"", json);
-            Assert.Contains("\"Orders\"", json);
-        }
 
         [RavenFact(RavenTestCategory.ClientApi)]
         public void GetCollectionStatsTests()

--- a/test/SlowTests/Issues/RavenDB_23754.cs
+++ b/test/SlowTests/Issues/RavenDB_23754.cs
@@ -1,11 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
-using FastTests;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
 using SlowTests.Core.Utils.Entities;
 using SlowTests.Core.Utils.Entities.Faceted;
 using Tests.Infrastructure;
@@ -14,10 +20,82 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_23754 : RavenTestBase
+    public class RavenDB_23754 : ReplicationTestBase
     {
         public RavenDB_23754(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task Test()
+        {
+            var (nodes, leader) = await CreateRaftCluster(2);
+            using var store = GetDocumentStore(new Options()
+            {
+                ReplicationFactor = 2,
+                Server = leader
+            });
+
+            var usersCollection = store.Conventions.FindCollectionName(typeof(User));
+            var scriptResolver = new ScriptResolver
+            {
+                Script = "return doc[10];"
+            };
+            var op = new ModifyConflictSolverOperation(
+                database: store.Database,
+                collectionByScript: new Dictionary<string, ScriptResolver>
+                {
+                    [usersCollection] = scriptResolver
+                },
+                resolveToLatest: false
+            );
+            store.Maintenance.Server.Send(op);
+
+            using var store1 = GetStoreForServer(nodes[0], store.Database);
+            using var store2 = GetStoreForServer(nodes[1], store.Database);
+
+            var r1 = BreakReplication(nodes[0].ServerStore, store.Database);
+            var r2 = BreakReplication(nodes[1].ServerStore, store.Database);
+
+            using (var session = store1.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User()
+                {
+                    Name = "Golan1"
+                }, UsersId);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store2.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User()
+                {
+                    Name = "Golan2"
+                }, UsersId);
+                await session.SaveChangesAsync();
+            }
+
+            r1.Result.Mend();
+            r2.Result.Mend();
+
+            await WaitAndAssertForValueAsync(() =>
+                {
+                    var detailedCollectionStats = store1.Maintenance.Send(new GetDetailedCollectionStatisticsOperation());
+                    return (detailedCollectionStats.CountOfConflicts, detailedCollectionStats.CountOfDocumentsConflicts);
+                }, 
+                expectedVal: (2, 1),
+                timeout: 5000,
+                interval: 500);
+        }
+
+        private IDocumentStore GetStoreForServer(RavenServer server, string database)
+        {
+            return new DocumentStore
+            {
+                Database = database,
+                Urls = new[] { server.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true }
+            }.Initialize();
         }
 
         private const string UsersId = "Users/1";

--- a/test/SlowTests/Issues/RavenDB_23754.cs
+++ b/test/SlowTests/Issues/RavenDB_23754.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using FastTests;
+using Raven.Client.Documents.Operations;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Core.Utils.Entities.Faceted;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23754 : RavenTestBase
+    {
+        public RavenDB_23754(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const string UsersId = "Users/1";
+        private const string OrdersId = "Orders/1";
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void DebugPackage_Should_Contain_Collections_Stats_Detailed()
+        {
+            using var store = GetDocumentStore();
+            var dbName = store.Database;
+
+            using (var s = store.OpenSession())
+            {
+                s.Store(new User(), UsersId);
+                s.Store(new Order(), OrdersId);
+                s.SaveChanges();
+            }
+
+            var baseUrl = $"{store.Urls.Single().TrimEnd('/')}";
+            using var http = new HttpClient();
+            var resp = http.GetAsync($"{baseUrl}/admin/debug/info-package").Result;
+            resp.EnsureSuccessStatusCode();
+
+            using var zipStream = resp.Content.ReadAsStreamAsync().Result;
+            using var zip = new ZipArchive(zipStream);
+
+            var entryName = $"{dbName}/collections.stats.detailed.json";
+            var detailedEntry = zip.Entries.SingleOrDefault(e => e.FullName == entryName);
+            Assert.NotNull(detailedEntry);
+
+            using var reader = new StreamReader(detailedEntry.Open());
+            var json = reader.ReadToEnd();
+            Assert.Contains("\"Users\"", json);
+            Assert.Contains("\"Orders\"", json);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void GetCollectionStatsTests()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User() { Name = "user1" }, "users/1");
+                    session.Store(new User() { Name = "user2" }, "users/2");
+                    session.Store(new User() { Name = "user3" }, "users/3");
+                    session.Store(new Company() { Name = "com1" }, "com/1");
+                    session.Store(new Company() { Name = "com2" }, "com/2");
+                    session.Store(new Address() { City = "city1" }, "add/1");
+
+                    session.SaveChanges();
+
+                    session.Advanced.Revisions.ForceRevisionCreationFor("users/1");
+                    session.Advanced.Revisions.ForceRevisionCreationFor("com/1");
+
+                    session.Delete("users/3");
+
+                    session.Advanced.Attachments.Store(
+                        "users/1", "hello.txt",
+                        new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+                    session.CountersFor("users/1").Increment("likes", 5);
+                    session.CountersFor("com/1").Increment("views", 10);
+
+                    var tsTime = DateTime.UtcNow;
+                    var ts = session.TimeSeriesFor("users/1", "heartrate");
+                    ts.Append(tsTime, 72, "wrist");
+
+                    ts.Delete(tsTime.AddMinutes(-5), tsTime.AddMinutes(-1));
+
+                    session.SaveChanges();
+                }
+
+                var collectionStats = store.Maintenance.Send(new GetCollectionStatisticsOperation());
+
+                Assert.Equal(3, collectionStats.Collections.Count);
+                Assert.Equal(5, collectionStats.CountOfDocuments);
+                Assert.Equal(0, collectionStats.CountOfConflicts);
+
+                var detailedCollectionStats = store.Maintenance.Send(new GetDetailedCollectionStatisticsOperation());
+
+                Assert.Equal(3, detailedCollectionStats.Collections.Count);
+                Assert.Equal(5, detailedCollectionStats.CountOfDocuments);
+                Assert.Equal(0, detailedCollectionStats.CountOfConflicts);
+                Assert.Equal(2, detailedCollectionStats.CountOfRevisionDocuments);
+                Assert.Equal(1, detailedCollectionStats.CountOfTombstones);
+                Assert.Equal(1, detailedCollectionStats.CountOfAttachments);
+                Assert.Equal(2, detailedCollectionStats.CountOfCounterEntries);
+                Assert.Equal(1, detailedCollectionStats.CountOfTimeSeriesSegments);
+                Assert.Equal(1, detailedCollectionStats.CountOfTimeSeriesDeletedRanges);
+                Assert.Equal(0, detailedCollectionStats.CountOfDocumentsConflicts);
+                Assert.Equal(2, detailedCollectionStats.Collections["Users"].CountOfDocuments);
+                Assert.Equal(2, detailedCollectionStats.Collections["Companies"].CountOfDocuments);
+                Assert.Equal(1, detailedCollectionStats.Collections["Addresses"].CountOfDocuments);
+            }
+        }
+    }
+}
+
+

--- a/test/SlowTests/Sharding/Client/Operations/GetCollectionStatisticsOperationTests.cs
+++ b/test/SlowTests/Sharding/Client/Operations/GetCollectionStatisticsOperationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -39,23 +40,50 @@ namespace SlowTests.Sharding.Client.Operations
                     session.Store(new Address() { City = "city1" }, "add/1");
 
                     session.SaveChanges();
+
+                    session.Advanced.Revisions.ForceRevisionCreationFor("users/1");
+                    session.Advanced.Revisions.ForceRevisionCreationFor("com/1");
+
+                    session.Delete("users/3");
+
+                    session.Advanced.Attachments.Store(
+                        "users/1", "hello.txt",
+                        new MemoryStream(Encoding.UTF8.GetBytes("hello")));
+
+                    session.CountersFor("users/1").Increment("likes", 5);
+                    session.CountersFor("com/1").Increment("views", 10);
+
+                    var tsTime = DateTime.UtcNow;
+                    var ts = session.TimeSeriesFor("users/1", "heartrate");
+                    ts.Append(tsTime, 72, "wrist");
+
+                    ts.Delete(tsTime.AddMinutes(-5), tsTime.AddMinutes(-1));
+
+
+                    session.SaveChanges();
                 }
 
                 var collectionStats = store.Maintenance.Send(new GetCollectionStatisticsOperation());
 
                 Assert.Equal(3, collectionStats.Collections.Count);
-                Assert.Equal(6, collectionStats.CountOfDocuments);
+                Assert.Equal(5, collectionStats.CountOfDocuments);
                 Assert.Equal(0, collectionStats.CountOfConflicts);
 
                 var detailedCollectionStats = store.Maintenance.Send(new GetDetailedCollectionStatisticsOperation());
 
                 Assert.Equal(3, detailedCollectionStats.Collections.Count);
-                Assert.Equal(6, detailedCollectionStats.CountOfDocuments);
+                Assert.Equal(5, detailedCollectionStats.CountOfDocuments);
                 Assert.Equal(0, detailedCollectionStats.CountOfConflicts);
-                Assert.Equal(3, detailedCollectionStats.Collections["Users"].CountOfDocuments);
+                Assert.Equal(2, detailedCollectionStats.CountOfRevisionDocuments);
+                Assert.Equal(1, detailedCollectionStats.CountOfTombstones);
+                Assert.Equal(1, detailedCollectionStats.CountOfAttachments);
+                Assert.Equal(2, detailedCollectionStats.CountOfCounterEntries);
+                Assert.Equal(1, detailedCollectionStats.CountOfTimeSeriesSegments);
+                Assert.Equal(1, detailedCollectionStats.CountOfTimeSeriesDeletedRanges);
+                Assert.Equal(0, detailedCollectionStats.CountOfDocumentsConflicts);
+                Assert.Equal(2, detailedCollectionStats.Collections["Users"].CountOfDocuments);
                 Assert.Equal(2, detailedCollectionStats.Collections["Companies"].CountOfDocuments);
                 Assert.Equal(1, detailedCollectionStats.Collections["Addresses"].CountOfDocuments);
-
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23754/Add-databases-collections-stats-detailed-to-debug-package

### Additional description

- Debug-package now includes collections.stats.detailed.json.

- Detailed collection stats now expose the full set of counters:
`CountOfDocuments`, `CountOfRevisionDocuments`, `CountOfTombstones`,
`CountOfDocumentsConflicts`, `CountOfConflicts`, `CountOfAttachments`,
`CountOfCounterEntries`, `CountOfTimeSeriesSegments`, `CountOfTimeSeriesDeletedRanges`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
