### PR TITLE
RavenDB-24233 Fix XML comments

### DIFF
--- a/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
@@ -18,7 +18,7 @@ public interface IVectorFieldFactory<T>
     /// <param name="fieldName">Name of the document field containing text data.</param>
     public IVectorEmbeddingTextField WithText(string fieldName);
     
-    /// <inheritdoc cref="WithText(string,Raven.Client.Documents.Indexes.Vector.VectorIndexingStrategy)"/>
+    /// <inheritdoc cref="WithText(string)"/>
     /// <param name="propertySelector">Path to the document field containing text data.</param>
     public IVectorEmbeddingTextField WithText(Expression<Func<T, object>> propertySelector);
     
@@ -29,7 +29,7 @@ public interface IVectorFieldFactory<T>
     /// <param name="storedEmbeddingQuantization">Quantization that was performed on stored embeddings.</param>
     public IVectorEmbeddingField WithEmbedding(string fieldName, VectorEmbeddingType storedEmbeddingQuantization = Constants.VectorSearch.DefaultEmbeddingType);
     
-    ///<inheritdoc cref="WithEmbedding(string,Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType,Raven.Client.Documents.Indexes.Vector.VectorIndexingStrategy)"/>
+    ///<inheritdoc cref="WithEmbedding(string,Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType)"/>
     /// <param name="propertySelector">Path to the document field containing embedding data.</param>
     public IVectorEmbeddingField WithEmbedding(Expression<Func<T, object>> propertySelector, VectorEmbeddingType storedEmbeddingQuantization = Constants.VectorSearch.DefaultEmbeddingType);
     
@@ -40,7 +40,7 @@ public interface IVectorFieldFactory<T>
     /// <param name="storedEmbeddingQuantization">Quantization of stored embeddings.</param>
     public IVectorEmbeddingField WithBase64(string fieldName, VectorEmbeddingType storedEmbeddingQuantization = Constants.VectorSearch.DefaultEmbeddingType);
     
-    /// <inheritdoc cref="WithBase64(string,Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType,Raven.Client.Documents.Indexes.Vector.VectorIndexingStrategy)"/>
+    /// <inheritdoc cref="WithBase64(string,Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType)"/>
     public IVectorEmbeddingField WithBase64(Expression<Func<T, object>> propertySelector, VectorEmbeddingType storedEmbeddingQuantization = Constants.VectorSearch.DefaultEmbeddingType);
 
     /// <summary>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24233/GH-Actions-warning-Invalid-type-for-VectorIndexingStrategy-in-XML-comment

### Additional description

Adjusted XML comments (we don't use `VectorIndexingStrategy` anymore).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
