### PR TITLE
RavenDB-24231

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Queue/AmazonSqsConnectionSettings.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/AmazonSqsConnectionSettings.cs
@@ -72,6 +72,21 @@ public sealed class AmazonSqsConnectionSettings
         // this is just static part of the url, dynamic parts are not accessible
         return UseEmulator ? Environment.GetEnvironmentVariable(EmulatorUrlEnvironmentVariable) : "https://queue.amazonaws.com/"; 
     }
+    
+    private bool Equals(AmazonSqsConnectionSettings other)
+    {
+        return Equals(Basic, other.Basic) && Passwordless == other.Passwordless && UseEmulator == other.UseEmulator;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj) || obj is AmazonSqsConnectionSettings other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Basic, Passwordless, UseEmulator);
+    }
 }
 
 public class AmazonSqsCredentials
@@ -87,5 +102,23 @@ public class AmazonSqsCredentials
         return string.IsNullOrWhiteSpace(AccessKey) == false &&
                string.IsNullOrWhiteSpace(SecretKey) == false &&
                string.IsNullOrWhiteSpace(RegionName) == false;
+    }
+    
+    protected bool Equals(AmazonSqsCredentials other)
+    {
+        return AccessKey == other.AccessKey && SecretKey == other.SecretKey && RegionName == other.RegionName;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((AmazonSqsCredentials)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(AccessKey, SecretKey, RegionName);
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
@@ -144,7 +144,16 @@ public sealed class QueueConnectionString : ConnectionString
                         return false;
             
                     return AzureQueueStorageConnectionSettings.Equals(queueConnectionString.AzureQueueStorageConnectionSettings);
-            
+                
+                case QueueBrokerType.AmazonSqs:
+                    if (AmazonSqsConnectionSettings == null && queueConnectionString.AmazonSqsConnectionSettings == null)
+                        return true;
+
+                    if (AmazonSqsConnectionSettings == null || queueConnectionString.AmazonSqsConnectionSettings == null)
+                        return false;
+
+                    return AmazonSqsConnectionSettings.Equals(queueConnectionString.AmazonSqsConnectionSettings);
+
                 default:
                     throw new NotSupportedException($"'{BrokerType}' broker is not supported");
             }


### PR DESCRIPTION
- implemented IsEqual for the AmazonSqs
- fixes SlowTests.Server.Documents.ETL.EtlTimeSeriesTests.RavenEtlWithTimeSeries_WhenStoreDocumentAndMultipleSegmentOfTimeSeriesInAnotherSession_ShouldDestBeAsSrc test

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24231

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
