### PR TITLE
RavenDB-23936 switch to BouncyCastle.Cryptography and disable Oracle Trusted Key Usage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.0" />
     <PackageVersion Include="CloudNative.CloudEvents" Version="2.8.0" />
     <PackageVersion Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
     <PackageVersion Include="CloudNative.CloudEvents.Kafka" Version="2.8.0" />
@@ -69,7 +70,6 @@
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.8.0" />
     <PackageVersion Include="Parquet.Net" Version="3.10.0" />
     <PackageVersion Include="Polly" Version="8.5.2" />
-    <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="Raven.CodeAnalysis" Version="1.0.11" />
     <PackageVersion Include="SourceLink.Create.CommandLine" Version="2.8.3" />

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -39,7 +39,7 @@ public class LetsEncryptCertificateUtil
 
     public static async Task WriteCertificateAsPemToZipArchiveAsync(string name, byte[] rawBytes, string exportPassword, ZipArchive archive)
     {
-        var a = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+        var a = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
         a.Load(new MemoryStream(rawBytes), Array.Empty<char>());
 
         X509CertificateEntry entry = null;

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -39,7 +39,7 @@ public class LetsEncryptCertificateUtil
 
     public static async Task WriteCertificateAsPemToZipArchiveAsync(string name, byte[] rawBytes, string exportPassword, ZipArchive archive)
     {
-        var a = new Pkcs12StoreBuilder().Build();
+        var a = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
         a.Load(new MemoryStream(rawBytes), Array.Empty<char>());
 
         X509CertificateEntry entry = null;

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -39,7 +39,7 @@ public class LetsEncryptCertificateUtil
 
     public static async Task WriteCertificateAsPemToZipArchiveAsync(string name, byte[] rawBytes, string exportPassword, ZipArchive archive)
     {
-        var a = new Pkcs12Store();
+        var a = new Pkcs12StoreBuilder().Build();
         a.Load(new MemoryStream(rawBytes), Array.Empty<char>());
 
         X509CertificateEntry entry = null;

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -156,6 +156,7 @@
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" />
     <PackageReference Include="CloudNative.CloudEvents" />
     <PackageReference Include="CloudNative.CloudEvents.Amqp" />
@@ -195,7 +196,6 @@
     <PackageReference Include="Oracle.ManagedDataAccess.Core" />
     <PackageReference Include="Parquet.Net" />
     <PackageReference Include="Polly" />
-    <PackageReference Include="Portable.BouncyCastle" />
     <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="Raven.CodeAnalysis">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -15,16 +15,15 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities;
-using Org.BouncyCastle.Utilities.Collections;
 using Org.BouncyCastle.Utilities.Encoders;
 using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
 using Raven.Client;
 using Raven.Server.Commercial;
 using Raven.Server.Config.Categories;
 using Raven.Server.Utils;
 using Sparrow.Logging;
 using Sparrow.Platform;
-using Sparrow.Server;
 using Sparrow.Server.Platform.Posix;
 
 namespace Raven.Server.ServerWide
@@ -927,14 +926,14 @@ namespace Raven.Server.ServerWide
                 {
                     MacData mData = bag.MacData;
                     DigestInfo dInfo = mData.Mac;
-                    AlgorithmIdentifier algId = dInfo.AlgorithmID;
+                    AlgorithmIdentifier algId = dInfo.DigestAlgorithm;
                     byte[] salt = mData.GetSalt();
                     int itCount = mData.IterationCount.IntValue;
 
                     byte[] data = ((Asn1OctetString)info.Content).GetOctets();
 
                     byte[] mac = CalculatePbeMac(algId.Algorithm, salt, itCount, password, false, data);
-                    byte[] dig = dInfo.GetDigest();
+                    byte[] dig = dInfo.Digest.GetOctets();
 
                     if (!Arrays.FixedTimeEquals(mac, dig))
                     {
@@ -1172,7 +1171,7 @@ namespace Raven.Server.ServerWide
             private static SubjectKeyIdentifier CreateSubjectKeyID(
                 AsymmetricKeyParameter pubKey)
             {
-                return new SubjectKeyIdentifier(
+                return X509ExtensionUtilities.CreateSubjectKeyIdentifier(
                     SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(pubKey));
             }
 

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -808,7 +808,7 @@ namespace Raven.Server.ServerWide
             {
                 try
                 {
-                    var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+                    var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
                     store.Load(new MemoryStream(rawData), certificatePassword?.ToCharArray() ?? Array.Empty<char>());
 
                     getKey = store.GetKey;

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -808,7 +809,7 @@ namespace Raven.Server.ServerWide
             {
                 try
                 {
-                    var store = new Pkcs12Store();
+                    var store = new Pkcs12StoreBuilder().Build();
                     store.Load(new MemoryStream(rawData), certificatePassword?.ToCharArray() ?? Array.Empty<char>());
 
                     getKey = store.GetKey;
@@ -935,7 +936,7 @@ namespace Raven.Server.ServerWide
                     byte[] mac = CalculatePbeMac(algId.Algorithm, salt, itCount, password, false, data);
                     byte[] dig = dInfo.GetDigest();
 
-                    if (!Arrays.ConstantTimeAreEqual(mac, dig))
+                    if (!Arrays.FixedTimeEquals(mac, dig))
                     {
                         if (password.Length > 0)
                             throw new IOException("PKCS12 key store MAC invalid - wrong password or corrupted file.");
@@ -943,7 +944,7 @@ namespace Raven.Server.ServerWide
                         // Try with incorrect zero length password
                         mac = CalculatePbeMac(algId.Algorithm, salt, itCount, password, true, data);
 
-                        if (!Arrays.ConstantTimeAreEqual(mac, dig))
+                        if (!Arrays.FixedTimeEquals(mac, dig))
                             throw new IOException("PKCS12 key store MAC invalid - wrong password or corrupted file.");
 
                         wrongPkcs12Zero = true;
@@ -1021,7 +1022,7 @@ namespace Raven.Server.ServerWide
                     //
                     // set the attributes
                     //
-                    IDictionary attributes = new Hashtable();
+                    IDictionary<DerObjectIdentifier, Asn1Encodable> attributes = new Dictionary<DerObjectIdentifier, Asn1Encodable>();
                     Asn1OctetString localId = null;
                     string alias = null;
 
@@ -1039,17 +1040,17 @@ namespace Raven.Server.ServerWide
 
                                 // TODO We might want to "merge" attribute sets with
                                 // the same OID - currently, differing values give an error
-                                if (attributes.Contains(aOid.Id))
+                                if (attributes.ContainsKey(aOid))
                                 {
                                     // OK, but the value has to be the same
-                                    if (!attributes[aOid.Id].Equals(attr))
+                                    if (!attributes[aOid].Equals(attr))
                                     {
                                         //throw new IOException("attempt to add existing attribute with different value");
                                     }
                                 }
                                 else
                                 {
-                                    attributes.Add(aOid.Id, attr);
+                                    attributes.Add(aOid, attr);
                                 }
 
                                 if (aOid.Equals(PkcsObjectIdentifiers.Pkcs9AtFriendlyName))
@@ -1108,12 +1109,12 @@ namespace Raven.Server.ServerWide
 
             public IEnumerable Aliases
             {
-                get { return new EnumerableProxy(GetAliasesTable().Keys); }
+                get { return GetAliasesTable().Keys; }
             }
 
-            private IDictionary GetAliasesTable()
+            private IDictionary<string, string> GetAliasesTable()
             {
-                IDictionary tab = new Hashtable();
+                IDictionary<string, string> tab = new Dictionary<string, string>();
 
                 foreach (string key in certs.Keys)
                 {
@@ -1262,7 +1263,7 @@ namespace Raven.Server.ServerWide
             {
                 AsymmetricKeyParameter privKey = PrivateKeyFactory.CreateKey(privKeyInfo);
 
-                IDictionary attributes = new Hashtable();
+                IDictionary<DerObjectIdentifier, Asn1Encodable> attributes = new Dictionary<DerObjectIdentifier, Asn1Encodable>();
                 AsymmetricKeyEntry keyEntry = new AsymmetricKeyEntry(privKey, attributes);
 
                 string alias = null;
@@ -1283,15 +1284,15 @@ namespace Raven.Server.ServerWide
 
                             // TODO We might want to "merge" attribute sets with
                             // the same OID - currently, differing values give an error
-                            if (attributes.Contains(aOid.Id))
+                            if (attributes.ContainsKey(aOid))
                             {
                                 // OK, but the value has to be the same
-                                if (!attributes[aOid.Id].Equals(attr))
+                                if (!attributes[aOid].Equals(attr))
                                     throw new IOException("attempt to add existing attribute with different value");
                             }
                             else
                             {
-                                attributes.Add(aOid.Id, attr);
+                                attributes.Add(aOid, attr);
                             }
 
                             if (aOid.Equals(PkcsObjectIdentifiers.Pkcs9AtFriendlyName))

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -809,7 +809,7 @@ namespace Raven.Server.ServerWide
             {
                 try
                 {
-                    var store = new Pkcs12StoreBuilder().Build();
+                    var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
                     store.Load(new MemoryStream(rawData), certificatePassword?.ToCharArray() ?? Array.Empty<char>());
 
                     getKey = store.GetKey;

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -337,7 +337,7 @@ namespace Raven.Server.Utils
 
             // The Certificate Generator
             X509V3CertificateGenerator certificateGenerator = new X509V3CertificateGenerator();
-            var authorityKeyIdentifier = new AuthorityKeyIdentifierStructure(issuerKeyPair.PublicKey);
+            var authorityKeyIdentifier = X509ExtensionUtilities.CreateAuthorityKeyIdentifier(issuerKeyPair.PublicKey);
             certificateGenerator.AddExtension(X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
             certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, true, new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment));
             if (isClientCertificate)
@@ -454,15 +454,15 @@ namespace Raven.Server.Utils
             ISignatureFactory signatureFactory = new Asn1SignatureFactory("SHA512WITHRSA", issuerKeyPair.Private, random);
 
             var authorityKeyIdentifier =
-                new AuthorityKeyIdentifier(
-                    SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(issuerKeyPair.Public),
+                X509ExtensionUtilities.CreateAuthorityKeyIdentifier(
+                    issuerKeyPair.Public,
                     new GeneralNames(new GeneralName(issuerDN)),
                     serialNumber);
             certificateGenerator.AddExtension(
                 X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
 
             var subjectKeyIdentifier =
-                new SubjectKeyIdentifier(
+                X509ExtensionUtilities.CreateSubjectKeyIdentifier(
                     SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(subjectKeyPair.Public));
             certificateGenerator.AddExtension(
                 X509Extensions.SubjectKeyIdentifier.Id, false, subjectKeyIdentifier);

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -342,12 +342,12 @@ namespace Raven.Server.Utils
             certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, true, new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment));
             if (isClientCertificate)
             {
-                certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true, new ExtendedKeyUsage(KeyPurposeID.IdKPClientAuth));
+                certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true, new ExtendedKeyUsage(KeyPurposeID.id_kp_clientAuth));
             }
             else
             {
                 certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true,
-                    new ExtendedKeyUsage(KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth));
+                    new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth));
             }
 
             if (isCaCertificate)
@@ -386,7 +386,7 @@ namespace Raven.Server.Utils
             certificateGenerator.SetPublicKey(subjectKeyPair.Public);
 
             X509Certificate certificate = certificateGenerator.Generate(signatureFactory);
-            var store = new Pkcs12Store();
+            var store = new Pkcs12StoreBuilder().Build();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -432,7 +432,7 @@ namespace Raven.Server.Utils
             certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, true,
                 new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.CrlSign | KeyUsage.KeyCertSign));
             certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true,
-                new ExtendedKeyUsage(KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth));
+                new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth));
 
             // Valid For
             DateTime notBefore = DateTime.UtcNow.Date.AddDays(-7);
@@ -473,7 +473,7 @@ namespace Raven.Server.Utils
             ca = (issuerKeyPair.Private, issuerKeyPair.Public);
             name = certificate.SubjectDN;
 
-            var store = new Pkcs12Store();
+            var store = new Pkcs12StoreBuilder().Build();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -279,7 +279,7 @@ namespace Raven.Server.Utils
 
             ValidateNoPrivateKeyInServerCert(serverCertBytes);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
             var serverCert = DotNetUtilities.FromX509Certificate(certificateHolder.Certificate);
 
             store.Load(new MemoryStream(certBytes), Array.Empty<char>());
@@ -386,7 +386,7 @@ namespace Raven.Server.Utils
             certificateGenerator.SetPublicKey(subjectKeyPair.Public);
 
             X509Certificate certificate = certificateGenerator.Generate(signatureFactory);
-            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -473,7 +473,7 @@ namespace Raven.Server.Utils
             ca = (issuerKeyPair.Private, issuerKeyPair.Public);
             name = certificate.SubjectDN;
 
-            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -652,7 +652,7 @@ namespace Raven.Server.Utils
         {
             var certWithKey = certificate.CopyWithPrivateKey(privateKey);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
 
             var chain = new X509Chain();
             chain.ChainPolicy.DisableCertificateDownloads = true;
@@ -812,6 +812,14 @@ namespace Raven.Server.Utils
             }
 
             return buffer;
+        }
+    }
+
+    public static class CertificateExtensions
+    {
+        public static Pkcs12Store BuildWithoutOracleOids(this Pkcs12StoreBuilder builder)
+        {
+            return builder.SetEnableOracleTrustedKeyUsage(false).Build();
         }
     }
 }

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -279,7 +279,7 @@ namespace Raven.Server.Utils
 
             ValidateNoPrivateKeyInServerCert(serverCertBytes);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
             var serverCert = DotNetUtilities.FromX509Certificate(certificateHolder.Certificate);
 
             store.Load(new MemoryStream(certBytes), Array.Empty<char>());
@@ -386,7 +386,7 @@ namespace Raven.Server.Utils
             certificateGenerator.SetPublicKey(subjectKeyPair.Public);
 
             X509Certificate certificate = certificateGenerator.Generate(signatureFactory);
-            var store = new Pkcs12StoreBuilder().Build();
+            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -473,7 +473,7 @@ namespace Raven.Server.Utils
             ca = (issuerKeyPair.Private, issuerKeyPair.Public);
             name = certificate.SubjectDN;
 
-            var store = new Pkcs12StoreBuilder().Build();
+            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -652,7 +652,7 @@ namespace Raven.Server.Utils
         {
             var certWithKey = certificate.CopyWithPrivateKey(privateKey);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
 
             var chain = new X509Chain();
             chain.ChainPolicy.DisableCertificateDownloads = true;

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -38,7 +38,7 @@ public static class CertificateGenerator
         int yearsValid, AsymmetricCipherKeyPair clientKeyPair, string[] sans = null)
     {
         var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
-        var extendedKeyUsage = new ExtendedKeyUsage(new[] { KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth });
+        var extendedKeyUsage = new ExtendedKeyUsage(new[] { KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth });
         GeneralNames subjectAlternativeNames;
         if (sans == null)
         {
@@ -65,7 +65,7 @@ public static class CertificateGenerator
     public static X509Certificate2 GenerateSelfSignedClientCertificate(string subjectName, int yearsValid, AsymmetricCipherKeyPair keyPair)
     {
         var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
-        var extendedKeyUsage = new ExtendedKeyUsage(KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth);
+        var extendedKeyUsage = new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth);
         var subjectAlternativeName = new GeneralNames(new GeneralName(GeneralName.DnsName, "localhost"));
 
         return GenerateCertificate(subjectName, yearsValid, keyPair, keyUsage, extendedKeyUsage, subjectAlternativeName, isCa: true);
@@ -124,7 +124,7 @@ public static class CertificateGenerator
     private static X509Certificate2 IncludePrivateKeyWithTheCertificate(X509Certificate certificate, AsymmetricCipherKeyPair keyPair)
     {
         var random = new SecureRandom();
-        var store = new Pkcs12Store();
+        var store = new Pkcs12StoreBuilder().Build();
         string friendlyName = certificate.SubjectDN.ToString();
         var certificateEntry = new X509CertificateEntry(certificate);
         var keyEntry = new AsymmetricKeyEntry(keyPair.Private);

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -10,6 +10,7 @@ using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.X509;
+using Raven.Server.Utils;
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 namespace Tests.Infrastructure.Utils;
@@ -124,7 +125,7 @@ public static class CertificateGenerator
     private static X509Certificate2 IncludePrivateKeyWithTheCertificate(X509Certificate certificate, AsymmetricCipherKeyPair keyPair)
     {
         var random = new SecureRandom();
-        var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+        var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
         string friendlyName = certificate.SubjectDN.ToString();
         var certificateEntry = new X509CertificateEntry(certificate);
         var keyEntry = new AsymmetricKeyEntry(keyPair.Private);

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -124,7 +124,7 @@ public static class CertificateGenerator
     private static X509Certificate2 IncludePrivateKeyWithTheCertificate(X509Certificate certificate, AsymmetricCipherKeyPair keyPair)
     {
         var random = new SecureRandom();
-        var store = new Pkcs12StoreBuilder().Build();
+        var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
         string friendlyName = certificate.SubjectDN.ToString();
         var certificateEntry = new X509CertificateEntry(certificate);
         var keyEntry = new AsymmetricKeyEntry(keyPair.Private);

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -154,12 +154,12 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="DasMulli.Win32.ServiceUtils.Signed" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Polly" />
-    <PackageReference Include="Portable.BouncyCastle" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
     <PackageReference Include="System.ServiceProcess.ServiceController" />
     <PackageReference Include="YamlDotNet" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23936 

### Additional description

Certificates generated by us are throwing exception when loading on .Net 9 due to Duplicates Limit. This disables the problematic key usages.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
