### PR TITLE
RavenDB-23936 update BouncyCastle.Cryptography and disable Oracle Trusted Key Usage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.1" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.0" />
     <PackageVersion Include="CloudNative.CloudEvents" Version="2.8.0" />
     <PackageVersion Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
     <PackageVersion Include="CloudNative.CloudEvents.Kafka" Version="2.8.0" />

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -40,7 +40,7 @@ public sealed class LetsEncryptCertificateUtil
 
     public static async Task WriteCertificateAsPemToZipArchiveAsync(string name, byte[] rawBytes, string exportPassword, ZipArchive archive)
     {
-        var a = new Pkcs12StoreBuilder().Build();
+        var a = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
         a.Load(new MemoryStream(rawBytes), Array.Empty<char>());
 
         X509CertificateEntry entry = null;

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -40,7 +40,7 @@ public sealed class LetsEncryptCertificateUtil
 
     public static async Task WriteCertificateAsPemToZipArchiveAsync(string name, byte[] rawBytes, string exportPassword, ZipArchive archive)
     {
-        var a = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+        var a = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
         a.Load(new MemoryStream(rawBytes), Array.Empty<char>());
 
         X509CertificateEntry entry = null;

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -15,9 +15,9 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities;
-using Org.BouncyCastle.Utilities.Collections;
 using Org.BouncyCastle.Utilities.Encoders;
 using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Config.Categories;
@@ -933,7 +933,7 @@ namespace Raven.Server.ServerWide
                     byte[] data = ((Asn1OctetString)info.Content).GetOctets();
 
                     byte[] mac = CalculatePbeMac(algId.Algorithm, salt, itCount, password, false, data);
-                    byte[] dig = dInfo.GetDigest();
+                    byte[] dig = dInfo.Digest.GetOctets();
 
                     if (!Arrays.FixedTimeEquals(mac, dig))
                     {
@@ -1171,7 +1171,7 @@ namespace Raven.Server.ServerWide
             private static SubjectKeyIdentifier CreateSubjectKeyID(
                 AsymmetricKeyParameter pubKey)
             {
-                return new SubjectKeyIdentifier(
+                return X509ExtensionUtilities.CreateSubjectKeyIdentifier(
                     SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(pubKey));
             }
 

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -808,7 +808,7 @@ namespace Raven.Server.ServerWide
             {
                 try
                 {
-                    var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+                    var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
                     store.Load(new MemoryStream(rawData), certificatePassword?.ToCharArray() ?? Array.Empty<char>());
 
                     getKey = store.GetKey;

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -808,7 +808,7 @@ namespace Raven.Server.ServerWide
             {
                 try
                 {
-                    var store = new Pkcs12StoreBuilder().Build();
+                    var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
                     store.Load(new MemoryStream(rawData), certificatePassword?.ToCharArray() ?? Array.Empty<char>());
 
                     getKey = store.GetKey;

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -320,7 +320,7 @@ namespace Raven.Server.Utils
 
             // The Certificate Generator
             X509V3CertificateGenerator certificateGenerator = new X509V3CertificateGenerator();
-            var authorityKeyIdentifier = new AuthorityKeyIdentifierStructure(issuerKeyPair.PublicKey);
+            var authorityKeyIdentifier = X509ExtensionUtilities.CreateAuthorityKeyIdentifier(issuerKeyPair.PublicKey);
             certificateGenerator.AddExtension(X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
             certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, true, new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment));
             if (isClientCertificate)
@@ -437,15 +437,15 @@ namespace Raven.Server.Utils
             ISignatureFactory signatureFactory = new Asn1SignatureFactory("SHA512WITHRSA", issuerKeyPair.Private, random);
 
             var authorityKeyIdentifier =
-                new AuthorityKeyIdentifier(
-                    SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(issuerKeyPair.Public),
+                X509ExtensionUtilities.CreateAuthorityKeyIdentifier(
+                    issuerKeyPair.Public,
                     new GeneralNames(new GeneralName(issuerDN)),
                     serialNumber);
             certificateGenerator.AddExtension(
                 X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
 
             var subjectKeyIdentifier =
-                new SubjectKeyIdentifier(
+                X509ExtensionUtilities.CreateSubjectKeyIdentifier(
                     SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(subjectKeyPair.Public));
             certificateGenerator.AddExtension(
                 X509Extensions.SubjectKeyIdentifier.Id, false, subjectKeyIdentifier);

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Utils
 
             ValidateNoPrivateKeyInServerCert(serverCertBytes);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
             var serverCert = DotNetUtilities.FromX509Certificate(certificateHolder.Certificate);
 
             store.Load(new MemoryStream(certBytes), Array.Empty<char>());
@@ -369,7 +369,7 @@ namespace Raven.Server.Utils
             certificateGenerator.SetPublicKey(subjectKeyPair.Public);
 
             X509Certificate certificate = certificateGenerator.Generate(signatureFactory);
-            var store = new Pkcs12StoreBuilder().Build();
+            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -456,7 +456,7 @@ namespace Raven.Server.Utils
             ca = (issuerKeyPair.Private, issuerKeyPair.Public);
             name = certificate.SubjectDN;
 
-            var store = new Pkcs12StoreBuilder().Build();
+            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -635,7 +635,7 @@ namespace Raven.Server.Utils
         {
             var certWithKey = certificate.CopyWithPrivateKey(privateKey);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
 
             var chain = new X509Chain();
             chain.ChainPolicy.DisableCertificateDownloads = true;

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Utils
 
             ValidateNoPrivateKeyInServerCert(serverCertBytes);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
             var serverCert = DotNetUtilities.FromX509Certificate(certificateHolder.Certificate);
 
             store.Load(new MemoryStream(certBytes), Array.Empty<char>());
@@ -369,7 +369,7 @@ namespace Raven.Server.Utils
             certificateGenerator.SetPublicKey(subjectKeyPair.Public);
 
             X509Certificate certificate = certificateGenerator.Generate(signatureFactory);
-            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -456,7 +456,7 @@ namespace Raven.Server.Utils
             ca = (issuerKeyPair.Private, issuerKeyPair.Public);
             name = certificate.SubjectDN;
 
-            var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
             string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
@@ -635,7 +635,7 @@ namespace Raven.Server.Utils
         {
             var certWithKey = certificate.CopyWithPrivateKey(privateKey);
 
-            Pkcs12Store store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+            Pkcs12Store store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
 
             var chain = new X509Chain();
             chain.ChainPolicy.DisableCertificateDownloads = true;
@@ -795,6 +795,14 @@ namespace Raven.Server.Utils
             }
 
             return buffer;
+        }
+    }
+
+    public static class CertificateExtensions
+    {
+        public static Pkcs12Store BuildWithoutOracleOids(this Pkcs12StoreBuilder builder)
+        {
+            return builder.SetEnableOracleTrustedKeyUsage(false).Build();
         }
     }
 }

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -10,6 +10,7 @@ using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.X509;
+using Raven.Server.Utils;
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 namespace Tests.Infrastructure.Utils;
@@ -124,7 +125,7 @@ public static class CertificateGenerator
     private static X509Certificate2 IncludePrivateKeyWithTheCertificate(X509Certificate certificate, AsymmetricCipherKeyPair keyPair)
     {
         var random = new SecureRandom();
-        var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
+        var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
         string friendlyName = certificate.SubjectDN.ToString();
         var certificateEntry = new X509CertificateEntry(certificate);
         var keyEntry = new AsymmetricKeyEntry(keyPair.Private);

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -124,7 +124,7 @@ public static class CertificateGenerator
     private static X509Certificate2 IncludePrivateKeyWithTheCertificate(X509Certificate certificate, AsymmetricCipherKeyPair keyPair)
     {
         var random = new SecureRandom();
-        var store = new Pkcs12StoreBuilder().Build();
+        var store = new Pkcs12StoreBuilder().SetEnableOracleTrustedKeyUsage(false).Build();
         string friendlyName = certificate.SubjectDN.ToString();
         var certificateEntry = new X509CertificateEntry(certificate);
         var keyEntry = new AsymmetricKeyEntry(keyPair.Private);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-23936

### Additional description

Certificates generated by us are throwing exception when loading on .Net 9 due to Duplicates Limit. This disables the problematic key usages.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
