### PR TITLE
RavenDB-23635 Missing handling for license attributes

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -57,10 +57,12 @@ public sealed partial class ClusterStateMachine
         nameof(EditTimeSeriesConfigurationCommand),
         nameof(EditDocumentsCompressionCommand),
         nameof(AddElasticSearchEtlCommand),
-        nameof(PutServerWideExternalReplicationCommand),
+        nameof(AddQueueSinkCommand),
+        nameof(UpdateQueueSinkCommand),
+        nameof(EditDataArchivalCommand)
     };
 
-    private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context)
+    private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
     {
         switch (type)
         {
@@ -69,7 +71,7 @@ public sealed partial class ClusterStateMachine
                 AssertMultiNodeSharding(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(PutIndexCommand):
-                AssertAdditionalAssembliesFromNuGetLicenseLimits(serverStore, databaseRecord, context);
+                AssertAdditionalAssembliesFromNuGetLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 AssertStaticIndexesCount(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, items, type);
                 break;
 
@@ -78,7 +80,7 @@ public sealed partial class ClusterStateMachine
                 break;
 
             case nameof(PutIndexesCommand):
-                AssertAdditionalAssembliesFromNuGetLicenseLimits(serverStore, databaseRecord, context);
+                AssertAdditionalAssembliesFromNuGetLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 AssertStaticIndexesCount(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, items, type);
                 AssertAutoIndexesCount(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, items, type);
                 break;
@@ -104,17 +106,12 @@ public sealed partial class ClusterStateMachine
                 break;
 
             case nameof(UpdatePeriodicBackupCommand):
-                AssertPeriodicBackupLicenseLimits(serverStore, databaseRecord, context);
+                AssertPeriodicBackupLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
 
             case nameof(PutDatabaseClientConfigurationCommand):
             case nameof(EditDatabaseClientConfigurationCommand):
                 AssertDatabaseClientConfiguration(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
-                break;
-
-            case nameof(PutClientConfigurationCommand):
-                if (AssertClientConfiguration(serverStore.LicenseManager.LicenseStatus, context) == false)
-                    throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding the client configuration.");
                 break;
 
             case nameof(PutDatabaseStudioConfigurationCommand):
@@ -128,44 +125,42 @@ public sealed partial class ClusterStateMachine
 
             case nameof(AddQueueSinkCommand):
             case nameof(UpdateQueueSinkCommand):
-                if (AssertQueueSink(serverStore.LicenseManager.LicenseStatus, context) == false)
-                    throw new LicenseLimitException(LimitType.QueueSink, "Your license doesn't support using the queue sink feature.");
+                AssertQueueSink(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
 
             case nameof(EditDataArchivalCommand):
-                if (AssertDataArchival(serverStore.LicenseManager.LicenseStatus, context) == false)
-                    throw new LicenseLimitException(LimitType.DataArchival, "Your license doesn't support using the data archival feature.");
+                AssertDataArchival(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
 
             case nameof(UpdatePullReplicationAsSinkCommand):
-                AssertPullReplicationAsSinkLicenseLimits(serverStore, databaseRecord, context);
+                AssertPullReplicationAsSinkLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(UpdatePullReplicationAsHubCommand):
-                AssertPullReplicationAsHubLicenseLimits(serverStore, databaseRecord, context);
+                AssertPullReplicationAsHubLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(UpdateExternalReplicationCommand):
-                AssertExternalReplicationLicenseLimits(serverStore, databaseRecord, context);
+                AssertExternalReplicationLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, updateDatabaseCommand);
                 break;
             case nameof(AddRavenEtlCommand):
-                AssertRavenEtlLicenseLimits(serverStore, databaseRecord, context);
+                AssertRavenEtlLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(AddSqlEtlCommand):
-                AssertSqlEtlLicenseLimits(serverStore, databaseRecord, context);
+                AssertSqlEtlLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(AddOlapEtlCommand):
-                AssertOlapEtlLicenseLimits(serverStore, databaseRecord, context);
+                AssertOlapEtlLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(AddQueueEtlCommand):
-                AssertQueueEtlLicenseLimits(serverStore, databaseRecord, context);
+                AssertQueueEtlLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(AddElasticSearchEtlCommand):
-                AssertElasticSearchEtlLicenseLimits(serverStore, databaseRecord, context);
+                AssertElasticSearchEtlLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(EditTimeSeriesConfigurationCommand):
-                AssertTimeSeriesConfigurationLicenseLimits(serverStore, databaseRecord, context);
+                AssertTimeSeriesConfigurationLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(EditDocumentsCompressionCommand):
-                AssertDocumentsCompressionLicenseLimits(serverStore, databaseRecord, context);
+                AssertDocumentsCompressionLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
         }
     }
@@ -191,6 +186,7 @@ public sealed partial class ClusterStateMachine
 
         var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
 
+        AssertClusterSizeAndCores(serverStore, newLicenseLimits);
         foreach (var database in serverStore.DatabasesLandlord.DatabasesCache.Values.GetEnumerator())
         {
             DatabaseRecord databaseRecord = serverStore.Cluster.ReadDatabase(context, ShardHelper.ToDatabaseName(database.Result.Name));
@@ -203,18 +199,29 @@ public sealed partial class ClusterStateMachine
             AssertRefreshFrequency(databaseRecord, newLicenseLimits, context);
             AssertSorters(databaseRecord, newLicenseLimits, context, items, type);
             AssertAnalyzers(databaseRecord, newLicenseLimits, context, items, type);
-            if (AssertPeriodicBackup(newLicenseLimits, context) == false && databaseRecord.PeriodicBackups.Count > 0)
-                throw new LicenseLimitException(LimitType.PeriodicBackup, $"Your license doesn't support periodic backup.");
             AssertDatabaseClientConfiguration(databaseRecord, newLicenseLimits, context);
             if (AssertClientConfiguration(newLicenseLimits, context) == false && databaseRecord.Client is { Disabled: false })
                 throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding the client configuration.");
             AssertDatabaseStudioConfiguration(databaseRecord, newLicenseLimits, context);
             if (AssertServerWideStudioConfiguration(newLicenseLimits, context) == false && databaseRecord.Studio is { Disabled: false })
                 throw new LicenseLimitException(LimitType.StudioConfiguration, "Your license doesn't support adding the studio configuration.");
-            if (AssertQueueSink(newLicenseLimits, context) == false && databaseRecord.QueueSinks.Count > 0)
-                throw new LicenseLimitException(LimitType.QueueSink, "Your license doesn't support using the queue sink feature.");
-            if (AssertDataArchival(newLicenseLimits, context) == false && databaseRecord.DataArchival is { Disabled: false })
-                throw new LicenseLimitException(LimitType.DataArchival, "Your license doesn't support using the data archival feature.");
+            AssertQueueSink(databaseRecord, newLicenseLimits, context);
+            AssertDataArchival(databaseRecord, newLicenseLimits, context);
+            AssertEncryptionLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertDynamicNodesDistribution(databaseRecord, newLicenseLimits, context);
+            AssertSnmp(serverStore, newLicenseLimits);
+            AssertRavenEtlLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertSqlEtlLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertElasticSearchEtlLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertQueueEtlLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertExternalReplicationLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertPullReplicationAsHubLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertTimeSeriesConfigurationLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertPeriodicBackupLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertPullReplicationAsSinkLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertAdditionalAssembliesFromNuGetLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertOlapEtlLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertDocumentsCompressionLicenseLimits(databaseRecord, newLicenseLimits, context);
         }
     }
 
@@ -445,11 +452,9 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.CustomAnalyzers, $"The maximum number of analyzers per cluster cannot exceed the limit of: {maxAnalyzersPerCluster}");
     }
 
-    private bool AssertPeriodicBackup(LicenseStatus licenseStatus, ClusterOperationContext context)
+    private bool AssertPeriodicBackup(LicenseStatus licenseStatus)
     {
-        if (licenseStatus.HasPeriodicBackup)
-            return true;
-        return false;
+        return licenseStatus.HasPeriodicBackup;
     }
 
     private void AssertDatabaseClientConfiguration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
@@ -496,20 +501,32 @@ public sealed partial class ClusterStateMachine
         return CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false;
     }
 
-    private bool AssertQueueSink(LicenseStatus licenseStatus, ClusterOperationContext context)
+    private void AssertQueueSink(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (licenseStatus.HasQueueSink)
-            return true;
+            return;
 
-        return CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false;
+        if (databaseRecord.QueueSinks == null || databaseRecord.QueueSinks.Count == 0)
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
+            return;
+
+        throw new LicenseLimitException(LimitType.QueueSink, "Your license doesn't support using the queue sink feature.");
     }
 
-    private bool AssertDataArchival(LicenseStatus licenseStatus, ClusterOperationContext context)
+    private void AssertDataArchival(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (licenseStatus.HasDataArchival)
-            return true;
+            return;
 
-        return CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false;
+        if (databaseRecord.DataArchival == null || databaseRecord.DataArchival.Disabled)
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
+            return;
+
+        throw new LicenseLimitException(LimitType.DataArchival, "Your license doesn't support using the data archival feature.");
     }
 
     private static long GetTotal(DatabaseRecordElementType resultType, string exceptDb, ClusterOperationContext context, Table items, string type)
@@ -675,7 +692,7 @@ public sealed partial class ClusterStateMachine
 
             foreach (string subscriptionName in subscriptionNamesToExclude)
             {
-                var subscriptionItemName = Raven.Client.Documents.Subscriptions.SubscriptionState.GenerateSubscriptionItemKeyName(databaseName, subscriptionName);
+                var subscriptionItemName = Client.Documents.Subscriptions.SubscriptionState.GenerateSubscriptionItemKeyName(databaseName, subscriptionName);
                 using (Slice.From(allocator, subscriptionItemName.ToLowerInvariant(), out Slice valueNameLowered))
                 {
                     if (items.ReadByKey(valueNameLowered, out _))
@@ -752,16 +769,31 @@ public sealed partial class ClusterStateMachine
                 break;
         }
     }
-    private void AssertPeriodicBackupLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+
+    private void AssertPeriodicBackupLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
         {
-            if (AssertPeriodicBackup(serverStore.LicenseManager.LicenseStatus, context) == false)
+            if (AssertPeriodicBackup(licenseStatus) == false)
                 throw new LicenseLimitException(LimitType.PeriodicBackup, "Your license doesn't support adding periodic backups.");
         }
+
+        var backupTypes = LicenseManager.GetBackupTypes(databaseRecord.PeriodicBackups);
+
+        if (backupTypes.HasSnapshotBackup)
+            if (licenseStatus.HasSnapshotBackups == false)
+                throw new LicenseLimitException(LimitType.SnapshotBackup, "Your license doesn't support adding Snapshot backups feature.");
+
+        if (backupTypes.HasCloudBackup)
+            if (licenseStatus.HasCloudBackups == false)
+                throw new LicenseLimitException(LimitType.CloudBackup, "Your license doesn't support adding Cloud backups feature.");
+
+        if (backupTypes.HasEncryptedBackup)
+            if (licenseStatus.HasEncryptedBackups == false)
+                throw new LicenseLimitException(LimitType.EncryptedBackup, "Your license doesn't support adding Encrypted backups feature.");
 
         foreach (var configuration in databaseRecord.PeriodicBackups)
         {
@@ -770,31 +802,20 @@ public sealed partial class ClusterStateMachine
                 if (configuration.BackupType == BackupType.Backup &&
                     configuration.HasCloudBackup() == false &&
                     configuration.BackupEncryptionSettings?.Key == null)
-                    return;
+                {
+                    if (AssertPeriodicBackup(licenseStatus) == false)
+                        throw new LicenseLimitException(LimitType.PeriodicBackup, "Your license doesn't support adding periodic backups.");
+                }
             }
         }
-
-        var backupTypes = LicenseManager.GetBackupTypes(databaseRecord.PeriodicBackups);
-
-        if (backupTypes.HasSnapshotBackup)
-            if (serverStore.LicenseManager.LicenseStatus.HasSnapshotBackups == false)
-                throw new LicenseLimitException(LimitType.SnapshotBackup, "Your license doesn't support adding Snapshot backups feature.");
-
-        if (backupTypes.HasCloudBackup)
-            if (serverStore.LicenseManager.LicenseStatus.HasCloudBackups == false)
-                throw new LicenseLimitException(LimitType.CloudBackup, "Your license doesn't support adding Cloud backups feature.");
-
-        if (backupTypes.HasEncryptedBackup)
-            if (serverStore.LicenseManager.LicenseStatus.HasEncryptedBackups == false)
-                throw new LicenseLimitException(LimitType.EncryptedBackup, "Your license doesn't support adding Encrypted backups feature.");
     }
 
-    private void AssertPullReplicationAsSinkLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertPullReplicationAsSinkLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasPullReplicationAsSink)
+        if (licenseStatus.HasPullReplicationAsSink)
             return;
 
         if (databaseRecord.SinkPullReplications.Count == 0)
@@ -803,12 +824,12 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.PullReplicationAsSink, "Your license doesn't support adding Sink Replication feature.");
     }
 
-    private void AssertPullReplicationAsHubLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertPullReplicationAsHubLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasPullReplicationAsHub)
+        if (licenseStatus.HasPullReplicationAsHub)
             return;
 
         if (databaseRecord.HubPullReplications.Count == 0)
@@ -817,35 +838,50 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.PullReplicationAsHub, "Your license doesn't support adding Hub Replication feature.");
     }
 
-    private void AssertExternalReplicationLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertExternalReplicationLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasDelayedExternalReplication)
+        if (licenseStatus.HasDelayedExternalReplication)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasExternalReplication == false && databaseRecord.ExternalReplications.Count > 0)
+        if (licenseStatus.HasExternalReplication == false)
         {
-            if (databaseRecord.ExternalReplications.All(exRep => exRep.DelayReplicationFor == TimeSpan.Zero))
-                throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding External Replication.");
+            if (databaseRecord.ExternalReplications.Count > 0)
+            {
+                if (databaseRecord.ExternalReplications.All(exRep => exRep.DelayReplicationFor == TimeSpan.Zero))
+                    throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding External Replication.");
 
-            throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+                throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+            }
+
+            if (updateDatabaseCommand != null && updateDatabaseCommand is UpdateExternalReplicationCommand uerc)
+            {
+                if (uerc.Watcher.DelayReplicationFor == TimeSpan.Zero)
+                    throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding External Replication.");
+                throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+            }
         }
-
-        if (serverStore.LicenseManager.LicenseStatus.HasDelayedExternalReplication)
-            return;
 
         if (databaseRecord.ExternalReplications.Any(exRep => exRep.DelayReplicationFor != TimeSpan.Zero))
             throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding External Replication.");
+
+        if (updateDatabaseCommand != null && updateDatabaseCommand is UpdateExternalReplicationCommand uerc2)
+        {
+            if (uerc2.Watcher.DelayReplicationFor == TimeSpan.Zero)
+                return;
+
+            throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+        }
     }
 
-    private void AssertRavenEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertRavenEtlLicenseLimits( DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasRavenEtl)
+        if (licenseStatus.HasRavenEtl)
             return;
 
         if (databaseRecord.RavenEtls.Count == 0)
@@ -854,12 +890,12 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.RavenEtl, "Your license doesn't support adding Raven ETL feature.");
     }
 
-    private void AssertSqlEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertSqlEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasSqlEtl)
+        if (licenseStatus.HasSqlEtl)
             return;
 
         if (databaseRecord.SqlEtls.Count == 0)
@@ -868,12 +904,12 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.SqlEtl, "Your license doesn't support adding SQL ETL feature.");
     }
 
-    private void AssertOlapEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertOlapEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasOlapEtl)
+        if (licenseStatus.HasOlapEtl)
             return;
 
         if (databaseRecord.OlapEtls.Count == 0)
@@ -882,12 +918,12 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.OlapEtl, "Your license doesn't support adding Olap ETL feature.");
     }
 
-    private void AssertQueueEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertQueueEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasQueueEtl)
+        if (licenseStatus.HasQueueEtl)
             return;
 
         if (databaseRecord.QueueEtls.Count == 0)
@@ -896,26 +932,26 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Queue ETL feature.");
     }
 
-    private void AssertElasticSearchEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertElasticSearchEtlLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasElasticSearchEtl)
+        if (licenseStatus.HasElasticSearchEtl)
             return;
 
         if (databaseRecord.ElasticSearchEtls.Count == 0)
             return;
 
-        throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Elastic Search ETL feature.");
+        throw new LicenseLimitException(LimitType.ElasticSearchEtl, "Your license doesn't support adding Elastic Search ETL feature.");
     }
 
-    private void AssertTimeSeriesConfigurationLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertTimeSeriesConfigurationLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasTimeSeriesRollupsAndRetention)
+        if (licenseStatus.HasTimeSeriesRollupsAndRetention)
             return;
 
         if (databaseRecord.TimeSeries == null)
@@ -927,9 +963,12 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.TimeSeriesRollupsAndRetention, "Your license doesn't support adding Time Series Rollups And Retention feature.");
     }
 
-    private void AssertDocumentsCompressionLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertDocumentsCompressionLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (AssertDocumentsCompression(serverStore, context)) 
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (licenseStatus.HasDocumentsCompression)
             return;
 
         if (databaseRecord.DocumentsCompression == null)
@@ -941,26 +980,42 @@ public sealed partial class ClusterStateMachine
         throw new LicenseLimitException(LimitType.DocumentsCompression, "Your license doesn't support adding Documents Compression feature.");
     }
 
-    private bool AssertDocumentsCompression(ServerStore serverStore, ClusterOperationContext context)
-    {
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return true;
-
-        return serverStore.LicenseManager.LicenseStatus.HasDocumentsCompression;
-    }
-
-    private void AssertAdditionalAssembliesFromNuGetLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    private void AssertAdditionalAssembliesFromNuGetLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
             return;
 
-        if (serverStore.LicenseManager.LicenseStatus.HasAdditionalAssembliesFromNuGet)
+        if (licenseStatus.HasAdditionalAssembliesFromNuGet)
             return;
 
         if (LicenseManager.HasAdditionalAssembliesFromNuGet(databaseRecord.Indexes) == false)
             return;
 
         throw new LicenseLimitException(LimitType.AdditionalAssembliesFromNuGet, "Your license doesn't support Additional Assemblies From NuGet feature.");
+    }
+
+    private void AssertEncryptionLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
+    {
+        if (databaseRecord.Encrypted == false)
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
+            return;
+
+        if (licenseStatus.HasEncryption == false)
+            throw new LicenseLimitException(LimitType.Encryption, "Your license does not support encrypted databases.");
+    }
+
+    private void AssertDynamicNodesDistribution(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
+    {
+        if (databaseRecord.Topology.DynamicNodesDistribution == false)
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
+            return;
+
+        if (licenseStatus.HasDynamicNodesDistribution == false)
+            throw new LicenseLimitException(LimitType.DynamicNodeDistribution, "Your license does not support Dynamic Nodes Distribution.");
     }
 
     internal void AssertAllLicenseLimitsOnRestore(ServerStore serverStore, DatabaseRecord databaseRecord)
@@ -976,6 +1031,32 @@ public sealed partial class ClusterStateMachine
             }
         }
     }
+    internal void AssertClusterSizeAndCores(ServerStore serverStore, LicenseStatus licenseStatus)
+    {
+        if (serverStore.IsPassive())
+            return;
+        var clusterSize = serverStore.GetClusterTopology().AllNodes.Count;
+        if (clusterSize > licenseStatus.MaxClusterSize)
+            throw new LicenseLimitException(LimitType.ClusterSize, $"Your license support {licenseStatus.MaxClusterSize} cluster Size, while your cluster size is : {clusterSize}.");
+
+        var maxCores = licenseStatus.MaxCores;
+        if (clusterSize > maxCores)
+            throw new LicenseLimitException(LimitType.Cores, $"Your license support {maxCores} limit, while the current cluster size is: {clusterSize}!");
+    }
+
+    private void AssertSnmp(ServerStore serverStore, LicenseStatus licenseStatus)
+    {
+        if (serverStore.Configuration.Monitoring.Snmp.Enabled == false)
+            return;
+
+        const string message = "SNMP Monitoring is currently enabled. " +
+                               "The provided license cannot be activated as it doesn't contain this feature. " +
+                               "In order to use this license please disable SNMP Monitoring in the server configuration";
+
+        if (licenseStatus.HasSnmpMonitoring == false)
+            throw new LicenseLimitException(LimitType.Snmp, message);
+    }
+
     private enum DatabaseRecordElementType
     {
         StaticIndex,

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2732,7 +2732,7 @@ namespace Raven.Server.ServerWide
                         return;
                     }
 
-                    AssertLicenseLimits(type, serverStore, databaseRecord, items, context);
+                    AssertLicenseLimits(type, serverStore, databaseRecord, items, context, updateCommand);
 
                     UpdateIndexForBackup(databaseRecord, type, index);
                     var updatedDatabaseBlittable = DocumentConventions.DefaultForServer.Serialization.DefaultConverter.ToBlittable(databaseRecord, context);

--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
@@ -96,7 +96,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -137,7 +137,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_PRO);
+                    await ChangeLicense(Server, RL_PRO, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -186,7 +186,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -228,7 +228,7 @@ namespace SlowTests.Issues
                         var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
-                        await ChangeLicense(server, RL_COMM);
+                        await ChangeLicense(server, RL_COMM, store2);
 
                         var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                         {
@@ -276,7 +276,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -312,7 +312,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -348,7 +348,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_PRO);
+                    await ChangeLicense(Server, RL_PRO, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -387,7 +387,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -422,7 +422,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -457,7 +457,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_PRO);
+                    await ChangeLicense(Server, RL_PRO, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -508,7 +508,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM);
+                    await ChangeLicense(Server, RL_COMM, store);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -526,11 +526,11 @@ namespace SlowTests.Issues
         }
 
 
-        private static async Task ChangeLicense(RavenServer server, string licenseType)
+        private static async Task ChangeLicense(RavenServer server, string licenseType, DocumentStore store)
         {
             var license = Environment.GetEnvironmentVariable(licenseType);
             LicenseHelper.TryDeserializeLicense(license, out License li);
-
+            await RavenDB_21427.DisableRevisionCompression(server, store);
             await server.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
         }
     }

--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -5,31 +5,49 @@ using System.Linq;
 using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Analysis;
+using Raven.Client.Documents.Operations.Analyzers;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.DataArchival;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.ElasticSearch;
+using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Operations.QueueSink;
 using Raven.Client.Documents.Operations.Refresh;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Operations.Sorters;
+using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Exceptions.Commercial;
+using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Http;
 using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands.Cluster;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Commercial;
+using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.ServerWide.Commands;
+using SlowTests.Core.Utils.Entities;
+using Sparrow;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using Transformation = Raven.Client.Documents.Operations.ETL.Transformation;
 
 namespace SlowTests.Issues
 {
@@ -43,108 +61,57 @@ namespace SlowTests.Issues
         private const string RL_DEV = "RAVEN_LICENSE_DEVELOPER";
         private const string RL_PRO = "RAVEN_LICENSE_PROFESSIONAL";
 
+        // ----------------------------------------
+        // Tests for Sharding License Limits
+        // ----------------------------------------
+
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Sharding)]
         public async Task Prevent_License_Downgrade_Multi_Node_Sharding()
         {
             DoNotReuseServer();
 
-            var (_, leader) = await CreateRaftCluster(3, false, watcherCluster: true);
+            var (_, leader) = await CreateRaftCluster(2, false, watcherCluster: true);
             var options = Options.ForMode(RavenDatabaseMode.Sharded);
             options.Server = leader;
-            options.ReplicationFactor = 3;
+            options.ReplicationFactor = 2;
             options.ModifyDatabaseRecord = r =>
             {
                 r.Sharding ??= new ShardingConfiguration();
                 r.Sharding.Shards = Enumerable.Range(0, 5)
                     .Select((shardNumber) => new KeyValuePair<int, DatabaseTopology>(shardNumber, new DatabaseTopology())).ToDictionary(x => x.Key, x => x.Value);
             };
-            using (var store = GetDocumentStore(options))
+
+            using (GetDocumentStore(options))
             {
-                await TryToChangeLicense(leader, RL_COMM, LimitType.Sharding);
-                await TryToChangeLicense(leader, RL_DEV, LimitType.Sharding);
-                await TryToChangeLicense(leader, RL_PRO, LimitType.Sharding);
+                await FailToChangeLicense(leader, RL_COMM, LimitType.Sharding);
+                await FailToChangeLicense(leader, RL_DEV, LimitType.Sharding);
+                await FailToChangeLicense(leader, RL_PRO, LimitType.Sharding);
             }
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
-        public async Task Prevent_License_Downgrade_QueueSink()
-        {
-            DoNotReuseServer();
-            using var store = GetDocumentStore();
-            var res = store.Maintenance.Send(
-                new PutConnectionStringOperation<QueueConnectionString>(
-                    new QueueConnectionString
-                    {
-                        Name = "KafkaConStr",
-                        BrokerType = QueueBrokerType.Kafka,
-                        KafkaConnectionSettings = new KafkaConnectionSettings()
-                            { BootstrapServers = "localhost:9092" }
-                    }));
-
-            // Define a Sink script
-            QueueSinkScript queueSinkScript = new QueueSinkScript
-            {
-                // Script name
-                Name = "orders",
-                // A list of Kafka topics to connect
-                Queues = new List<string>() { "orders" },
-                // Apply this script
-                Script = @"this['@metadata']['@collection'] = 'Orders';
-               put(this.Id.toString(), this)"
-            };
-
-            // Define a Kafka configuration
-            var config = new QueueSinkConfiguration()
-            {
-                // Sink name
-                Name = "KafkaSinkTaskName",
-                // The connection string to connect the broker with
-                ConnectionStringName = "KafkaConStr",
-                // What queue broker is this task using
-                BrokerType = QueueBrokerType.Kafka,
-                // The list of scripts to run
-                Scripts = { queueSinkScript }
-            };
-
-            AddQueueSinkOperationResult addQueueSinkOperationResult =
-                store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
-
-            await TryToChangeLicense(Server, RL_COMM, LimitType.QueueSink);
-            await TryToChangeLicense(Server, RL_PRO, LimitType.QueueSink);
-
-            config = new QueueSinkConfiguration()
-            {
-                // Sink name
-                Name = "KafkaSinkTaskName2",
-                // The connection string to connect the broker with
-                ConnectionStringName = "KafkaConStr",
-                // What queue broker is this task using
-                BrokerType = QueueBrokerType.RabbitMq,
-                // The list of scripts to run
-                Scripts = { queueSinkScript }
-            };
-
-            addQueueSinkOperationResult =
-                store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
-
-            await TryToChangeLicense(Server, RL_COMM, LimitType.QueueSink);
-            await TryToChangeLicense(Server, RL_PRO, LimitType.QueueSink);
-        }
-
+        // ----------------------------------------
+        // Tests for Data Archival License Limits
+        // ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ExpirationRefresh)]
         public async Task Prevent_License_Downgrade_DataArchival()
         {
             DoNotReuseServer();
 
-            using var store = GetDocumentStore();
-            var config = new DataArchivalConfiguration { Disabled = false, ArchiveFrequencyInSec = 100 };
+            using (var store = GetDocumentStore())
+            {
+                var config = new DataArchivalConfiguration { Disabled = false, ArchiveFrequencyInSec = 100 };
 
-            await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config);
-            await TryToChangeLicense(Server, RL_COMM, LimitType.DataArchival);
-            await TryToChangeLicense(Server, RL_PRO, LimitType.DataArchival);
+                await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.DataArchival);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.DataArchival);
+                await ChangeLicense(Server, RL_DEV);
+            }
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        // ----------------------------------------
+        // Tests for Indexes License Limits
+        // ----------------------------------------
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
         public async Task Prevent_License_Downgrade_Static_Index_Count_Per_Database()
         {
             DoNotReuseServer();
@@ -158,38 +125,89 @@ namespace SlowTests.Issues
                         new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + i }
                     }));
                 }
-
-                await TryToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
             }
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
+        public async Task Prevent_Put_Static_Index_Max_Per_Database()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                for (int i = 0; i < 12; i++)
+                {
+                    store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + i }));
+                }
+                Assert.Throws<IndexCreationException>(() => store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test12" })));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
         public async Task Prevent_License_Downgrade_Static_Index_Count_Per_Cluster()
         {
             DoNotReuseServer();
-            var (_, leader) = await CreateRaftCluster(3, false, watcherCluster: true);
+            await CreateRaftCluster(3, false, watcherCluster: true);
             var storeList = new List<DocumentStore>();
-            for (int i = 0; i < 7; i++)
+            try
             {
-                var store = GetDocumentStore();
-                storeList.Add(store);
-                for (int j = 0; j < 10; j++)
+                for (int i = 0; i < 7; i++)
                 {
-                    store.Maintenance.Send(new PutIndexesOperation(new[]
+                    var store = GetDocumentStore();
+                    storeList.Add(store);
+                    for (int j = 0; j < 10; j++)
                     {
-                        new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + j }
-                    }));
+                        store.Maintenance.Send(new PutIndexesOperation(new[]
+                        {
+                            new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + j }
+                        }));
+                    }
                 }
-            }
 
-            await TryToChangeLicense(Server, RL_COMM, LimitType.Indexes);
-            foreach (var store in storeList)
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+            }
+            finally
             {
-                store.Dispose();
+                foreach (var store in storeList)
+                {
+                    store.Dispose();
+                }
             }
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
+        public async Task Prevent_Put_Static_Index_Max_Per_Cluster()
+        {
+            DoNotReuseServer();
+            await CreateRaftCluster(3, false, watcherCluster: true);
+            var storeList = new List<DocumentStore>();
+            try
+            {
+                for (int i = 0; i < 6; i++)
+                {
+                    DocumentStore store = GetDocumentStore();
+                    await DisableRevisionCompression(Server, store);
+                    await PutLicense(Server, RL_COMM);
+                    storeList.Add(store);
+                    for (int j = 0; j < 10; j++)
+                    {
+                        store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + j }));
+                    }
+                }
+                Assert.Throws<IndexCreationException>(() => storeList[0].Maintenance.Send(new PutIndexesOperation(new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test44" })));
+            }
+            finally
+            {
+                foreach (var store in storeList)
+                {
+                    store.Dispose();
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
         public async Task Prevent_License_Downgrade_Auto_Index_Count_Per_Database()
         {
             DoNotReuseServer();
@@ -199,74 +217,234 @@ namespace SlowTests.Issues
                 for (int j = 0; j < 28; j++)
                 {
                     var database = await Databases.GetDocumentDatabaseInstanceFor(store);
-                    var index = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + j } }),
+                    await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + j } }),
                         Guid.NewGuid().ToString());
+                }
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+            }
+        }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
+        public async Task Prevent_Put_Auto_Index_Max_Per_Database()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                DocumentDatabase database;
+                for (int j = 0; j < 24; j++)
+                {
+                    database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                    await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + j } }),
+                        Guid.NewGuid().ToString());
+                }
+                database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                await Assert.ThrowsAsync<IndexCreationException>(async () => await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" } }),
+                    Guid.NewGuid().ToString()));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
+        public async Task Prevent_License_Downgrade_Auto_Index_Count_Per_Cluster()
+        {
+            DoNotReuseServer();
+            await CreateRaftCluster(3, false, watcherCluster: true);
+            var storeList = new List<DocumentStore>();
+            try
+            {
+                for (int i = 0; i < 7; i++)
+                {
+                    var store = GetDocumentStore();
+                    storeList.Add(store);
+                    for (int j = 0; j < 20; j++)
+                    {
+                        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                        await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + j } }),
+                            Guid.NewGuid().ToString());
+                    }
                 }
 
-                await TryToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+            }
+            finally
+            {
+                foreach (var store in storeList)
+                {
+                    store.Dispose();
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Skip = "No count restriction at the moment")]
+        public async Task Prevent_Put_Auto_Index_Max_Per_Cluster()
+        {
+            DoNotReuseServer();
+            await CreateRaftCluster(3, false, watcherCluster: true);
+            var storeList = new List<DocumentStore>();
+            DocumentDatabase database;
+            try
+            {
+                for (int i = 0; i < 6; i++)
+                {
+                    var store = GetDocumentStore();
+                    await DisableRevisionCompression(Server, store);
+                    await PutLicense(Server, RL_COMM);
+                    storeList.Add(store);
+                    for (int j = 0; j < 20; j++)
+                    {
+                        database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                        await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + i + j } }),
+                            Guid.NewGuid().ToString());
+                    }
+                }
+                database = await Databases.GetDocumentDatabaseInstanceFor(storeList[0]);
+                await Assert.ThrowsAsync<LicenseLimitException>(async () => await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" } }),
+                    Guid.NewGuid().ToString()));
+            }
+            finally
+            {
+                foreach (var store in storeList)
+                {
+                    store.Dispose();
+                }
             }
         }
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
-        public async Task Prevent_License_Downgrade_Auto_Index_Count_Per_Cluster()
+        public async Task Prevent_License_Downgrade_Index_Additional_Assemblies()
         {
             DoNotReuseServer();
-            var (_, leader) = await CreateRaftCluster(3, false, watcherCluster: true);
-            var storeList = new List<DocumentStore>();
-            for (int i = 0; i < 7; i++)
+            using (var store = GetDocumentStore())
             {
-                var store = GetDocumentStore();
-                storeList.Add(store);
-                for (int j = 0; j < 20; j++)
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
                 {
-                    var database = await Databases.GetDocumentDatabaseInstanceFor(store);
-                    var index = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + j } }),
-                        Guid.NewGuid().ToString());
+                    Maps = { "from doc in docs.Images select new { doc.Tags }" },
+                    Name = "test",
+                    AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") }
+                }));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.AdditionalAssembliesFromNuGet);
 
-                }
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
             }
-
-            await TryToChangeLicense(Server, RL_COMM, LimitType.Indexes);
-            foreach (var store in storeList)
-            {
-                store.Dispose();
-            }
-
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        public async Task Prevent_Put_Index_Additional_Assemblies()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var exception = Assert.Throws<LicenseLimitException>(() => store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags }" },
+                    Name = "test",
+                    AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") }
+                })));
+                Assert.Equal(LimitType.AdditionalAssembliesFromNuGet, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Images select new { doc.Tags }" },
+                    Name = "test",
+                    AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") }
+                }));
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Revision License Limits
+        // ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
         public async Task Prevent_License_Downgrade_Revision_Default_Configuration()
         {
             DoNotReuseServer();
-
             using (var store = GetDocumentStore())
             {
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
-                var result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
-                await TryToChangeLicense(Server, RL_COMM, LimitType.RevisionsConfiguration);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.RevisionsConfiguration);
 
-                configuration = new RevisionsConfiguration
-                {
-                    Collections = new Dictionary<string, RevisionsCollectionConfiguration>
-                    {
-                        {
-                            "Companies", new RevisionsCollectionConfiguration()
-                            {
-                                Disabled = false,
-                                MinimumRevisionsToKeep = 5
-                            }
-                        }
-                    }
-                };
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.RevisionsConfiguration);
 
-                result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
-
-                await TryToChangeLicense(Server, RL_COMM, LimitType.RevisionsConfiguration);
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_PRO);
+                await ChangeLicense(Server, RL_DEV);
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task Prevent_Put_Revision()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration)));
+                Assert.Equal(LimitType.RevisionsConfiguration, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+
+                await PutLicense(Server, RL_DEV);
+                configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task Prevent_License_Downgrade_Revision_Compression()
+        {
+            DoNotReuseServer();
+            using (GetDocumentStore())
+            {
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_COMM));
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+
+                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_PRO));
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task Prevent_Enable_Revision_Compression()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var configuration = new DocumentsCompressionConfiguration { CompressRevisions = true, Collections = new string[] { } };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await Server.ServerStore.SendToLeaderAsync(new EditDocumentsCompressionCommand(configuration, store.Database, RaftIdGenerator.DontCareId)));
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await Server.ServerStore.SendToLeaderAsync(new EditDocumentsCompressionCommand(configuration, store.Database, RaftIdGenerator.DontCareId)));
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                await Server.ServerStore.SendToLeaderAsync(new EditDocumentsCompressionCommand(configuration, store.Database, RaftIdGenerator.DontCareId));
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Backup License Limits
+        // ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
         public async Task Prevent_License_Downgrade_PeriodicBackup()
         {
@@ -276,17 +454,204 @@ namespace SlowTests.Issues
             {
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.PeriodicBackup);
 
-                await TryToChangeLicense(Server, RL_COMM, LimitType.PeriodicBackup);
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_PRO);
+                await ChangeLicense(Server, RL_DEV);
             }
         }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_Put_PeriodicBackup()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
+                Assert.Equal(LimitType.PeriodicBackup, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_License_Downgrade_Encrypted_Backup()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                var config = Backup.CreateBackupConfiguration(backupPath,
+                    fullBackupFrequency: "* */1 * * *",
+                    incrementalBackupFrequency: "* */2 * * *",
+                    backupEncryptionSettings: new BackupEncryptionSettings()
+                    {
+                        EncryptionMode = EncryptionMode.UseProvidedKey,
+                        Key = "OI7Vll7DroXdUORtc6Uo64wdAk1W0Db9ExXXgcg5IUs="
+                    });
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.EncryptedBackup);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_License_Downgrade_Snapshot()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                var config = Backup.CreateBackupConfiguration(backupPath,
+                    fullBackupFrequency: "* */1 * * *",
+                    incrementalBackupFrequency: "* */2 * * *",
+                    backupType: BackupType.Snapshot);
+
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.SnapshotBackup);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.SnapshotBackup);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_Put_Snapshot_Backup()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var config = new PeriodicBackupConfiguration
+                {
+                    BackupType = BackupType.Snapshot,
+                    FullBackupFrequency = "* */1 * * *",
+                    IncrementalBackupFrequency = "* */2 * * *",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = NewDataPath("SnapshotBackup")
+                    }
+                };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
+                Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
+                Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_License_Downgrade_Snapshot_Backup()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                var config = new PeriodicBackupConfiguration
+                {
+                    BackupType = BackupType.Snapshot,
+                    FullBackupFrequency = "* */1 * * *",
+                    IncrementalBackupFrequency = "* */2 * * *",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = NewDataPath("SnapshotBackup")
+                    }
+                };
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.SnapshotBackup);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.SnapshotBackup);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_Put_Cloud_Backup()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = new PeriodicBackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    FullBackupFrequency = "* */1 * * *",
+                    IncrementalBackupFrequency = "* */2 * * *",
+                    GoogleCloudSettings = new GoogleCloudSettings
+                    {
+                        BucketName = "dummy-bucket",
+                        GoogleCredentialsJson = "{}", // placeholder
+                        RemoteFolderName = "backups"
+                    }
+                };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
+                Assert.Equal(LimitType.CloudBackup, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Prevent_License_Downgrade_Cloud_Backup()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var config = new PeriodicBackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    FullBackupFrequency = "* */1 * * *",
+                    IncrementalBackupFrequency = "* */2 * * *",
+                    GoogleCloudSettings = new GoogleCloudSettings
+                    {
+                        BucketName = "dummy-bucket",
+                        GoogleCredentialsJson = "{}", // placeholder
+                        RemoteFolderName = "backups"
+                    }
+                };
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.CloudBackup);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Sorters License Limits
+        // ----------------------------------------
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
         public async Task Prevent_License_Downgrade_Sorters_Per_Database()
         {
             DoNotReuseServer();
             var sorterName = GetDatabaseName();
-
             using (var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => sorterName,
@@ -303,7 +668,34 @@ namespace SlowTests.Issues
                        }
             }))
             {
-                await TryToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_Sorters_Per_Database()
+        {
+            DoNotReuseServer();
+            var sorterName = GetDatabaseName();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var sorterCode1 = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName);
+                var sorterCode2 = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName + "2");
+
+                await store.Maintenance.SendAsync(new PutSortersOperation(new SorterDefinition { Name = sorterName, Code = sorterCode1 }));
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new PutSortersOperation(new SorterDefinition { Name = sorterName + "2", Code = sorterCode2 })));
+                Assert.Equal(LimitType.CustomSorters, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new PutSortersOperation(new SorterDefinition { Name = sorterName + "2", Code = sorterCode2 }));
             }
         }
 
@@ -311,55 +703,89 @@ namespace SlowTests.Issues
         public async Task Prevent_License_Downgrade_Sorters_Per_Cluster()
         {
             DoNotReuseServer();
-            var (_, leader) = await CreateRaftCluster(3, false, watcherCluster: true);
+            await CreateRaftCluster(3, false, watcherCluster: true);
             var sorterName = GetDatabaseName();
-
             var storeList = new List<DocumentStore>();
-            for (int i = 0; i < 6; i++)
+            try
             {
-                var store = GetDocumentStore(new Options
+                for (int i = 0; i < 6; i++)
                 {
-                    ModifyDatabaseRecord = record => record.Sorters = new Dictionary<string, SorterDefinition>
+                    var store = GetDocumentStore(new Options
                     {
+                        ModifyDatabaseRecord = record => record.Sorters = new Dictionary<string, SorterDefinition>
                         {
-                            "MySorter", new SorterDefinition { Name = sorterName + "1", Code = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName + "1") }
+                            {
+                                "MySorter", new SorterDefinition { Name = sorterName + "1", Code = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName + "1") }
+                            }
                         }
-                    }
-                });
-
-                storeList.Add(store);
+                    });
+                    storeList.Add(store);
+                }
+                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
             }
-
-            await TryToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
-            foreach (var store in storeList)
+            finally
             {
-                store.Dispose();
+                foreach (var store in storeList)
+                {
+                    store.Dispose();
+                }
             }
         }
+
+        // ----------------------------------------
+        // Tests for Analyzer License Limits
+        //  ----------------------------------------
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
         public async Task Prevent_License_Downgrade_Analyzer_Per_Database()
         {
             DoNotReuseServer();
             var sorterName = GetDatabaseName();
-
             using (var store = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => sorterName,
-                ModifyDatabaseRecord = record => record.Sorters = new Dictionary<string, SorterDefinition>
-                       {
-                           {
-                               "MySorter",
-                               new SorterDefinition { Name = sorterName + "1", Code = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName + "1") }
-                           },
-                           {
-                               "MySorter2",
-                               new SorterDefinition { Name = sorterName + "2", Code = GetSorter("RavenDB_8355.MySorter.cs", "MySorter2", sorterName + "2") }
-                           }
-                       }
+                ModifyDatabaseRecord = record => record.Analyzers = record.Analyzers = new Dictionary<string, AnalyzerDefinition>
+                {
+                    ["MyAnalyzer"] = new AnalyzerDefinition
+                    {
+                        Name = "MyAnalyzer",
+                        Code = @"
+            using Lucene.Net.Analysis;
+            using Lucene.Net.Analysis.Standard;
+            using System.IO;
+
+            public class MyAnalyzer : Analyzer
+            {
+                public override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+                {
+                    return new TokenStreamComponents(new StandardTokenizer(Lucene.Net.Util.LuceneVersion.LUCENE_48, reader));
+                }
+            }"
+                    },
+                    ["MyAnalyzer2"] = new AnalyzerDefinition
+                    {
+                        Name = "MyAnalyzer2",
+                        Code = @"
+using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Core;
+using System.IO;
+
+public class MyAnalyzer2 : Analyzer
+{
+    public override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+    {
+        return new TokenStreamComponents(new WhitespaceTokenizer(Lucene.Net.Util.LuceneVersion.LUCENE_48, reader));
+    }
+}"
+                    }
+                }
             }))
             {
-                await TryToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomAnalyzers);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
             }
         }
 
@@ -367,56 +793,176 @@ namespace SlowTests.Issues
         public async Task Prevent_License_Downgrade_Analyzer_Per_Cluster()
         {
             DoNotReuseServer();
-            var (_, leader) = await CreateRaftCluster(3, false, watcherCluster: true);
-            var sorterName = GetDatabaseName();
-
+            await CreateRaftCluster(3, false, watcherCluster: true);
             var storeList = new List<DocumentStore>();
-            for (int i = 0; i < 6; i++)
+            try
             {
-                var store = GetDocumentStore(new Options
+                for (int i = 0; i < 6; i++)
                 {
-                    ModifyDatabaseRecord = record => record.Sorters = new Dictionary<string, SorterDefinition>
+                    var store = GetDocumentStore(new Options
                     {
+                        ModifyDatabaseRecord = record => record.Analyzers = record.Analyzers = new Dictionary<string, AnalyzerDefinition>
                         {
-                            "MySorter", new SorterDefinition { Name = sorterName + "1", Code = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName + "1") }
-                        }
-                    }
-                });
+                            ["MyAnalyzer"] = new AnalyzerDefinition
+                            {
+                                Name = "MyAnalyzer",
+                                Code = @"
+            using Lucene.Net.Analysis;
+            using Lucene.Net.Analysis.Standard;
+            using System.IO;
 
-                storeList.Add(store);
-            }
-
-            await TryToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
-            foreach (var store in storeList)
+            public class MyAnalyzer : Analyzer
             {
-                store.Dispose();
-            }
+                public override TokenStreamComponents CreateComponents(string fieldName, TextReader reader)
+                {
+                    return new TokenStreamComponents(new StandardTokenizer(Lucene.Net.Util.LuceneVersion.LUCENE_48, reader));
+                }
+            }"
+                            }
+                        }
+                    });
 
+                    storeList.Add(store);
+                }
+                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomAnalyzers);
+            }
+            finally
+            {
+                foreach (var store in storeList)
+                {
+                    store.Dispose();
+                }
+            }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_Analyzer_Per_Database()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
+                {
+                    Name = "MyAnalyzer2",
+                    Code = GetAnalyzer("RavenDB_14939.MyAnalyzer.cs", "MyAnalyzer", "MyAnalyzer2")
+                }));
+                var exception = Assert.Throws<LicenseLimitException>(() =>
+                    store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
+                    {
+                        Name = "MyAnalyzer",
+                        Code = GetAnalyzer("RavenDB_14939.MyAnalyzer.cs", "MyAnalyzer", "MyAnalyzer")
+                    })));
+
+                Assert.Equal(LimitType.CustomAnalyzers, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
+                {
+                    Name = "MyAnalyzer",
+                    Code = GetAnalyzer("RavenDB_14939.MyAnalyzer.cs", "MyAnalyzer", "MyAnalyzer")
+                }));
+            }
+        }
+        private static string GetAnalyzer(string resourceName, string originalAnalyzerName, string analyzerName)
+        {
+            using (var stream = GetDump(resourceName))
+            using (var reader = new StreamReader(stream))
+            {
+                var analyzerCode = reader.ReadToEnd();
+                analyzerCode = analyzerCode.Replace(originalAnalyzerName, analyzerName);
+
+                return analyzerCode;
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Client Api License Limits
+        //  ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ClientApi)]
         public async Task Prevent_License_Downgrade_ClientConfiguration()
         {
             DoNotReuseServer();
             using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = r => r.Client = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50 } }))
             {
-                await TryToChangeLicense(Server, RL_COMM, LimitType.ClientConfiguration);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.ClientConfiguration);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_ClientConfiguration()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var config = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50 };
+
+                var command = new PutDatabaseClientConfigurationCommand(config, store.Database, RaftIdGenerator.NewId());
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await Server.ServerStore.SendToLeaderAsync(command));
+                Assert.Equal(LimitType.ClientConfiguration, exception.LimitType);
+
+                command = new PutDatabaseClientConfigurationCommand(config, store.Database, RaftIdGenerator.NewId());
+                await PutLicense(Server, RL_PRO);
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Studio Configuration License Limits
+        //  ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
         public async Task Prevent_License_Downgrade_StudioConfiguration()
         {
             DoNotReuseServer();
 
-            using var store = GetDocumentStore();
-            var command = new PutDatabaseStudioConfigurationCommand(new ServerWideStudioConfiguration() { DisableAutoIndexCreation = true, }, store.Database,
-                RaftIdGenerator.NewId());
-            await Server.ServerStore.SendToLeaderAsync(command);
+            using (var store = GetDocumentStore())
+            {
+                var command = new PutDatabaseStudioConfigurationCommand(new ServerWideStudioConfiguration() { DisableAutoIndexCreation = true, }, store.Database,
+                    RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
 
-            await TryToChangeLicense(Server, RL_COMM, LimitType.StudioConfiguration);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.StudioConfiguration);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
+            }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_StudioConfiguration()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var command = new PutDatabaseStudioConfigurationCommand(
+                    new ServerWideStudioConfiguration { DisableAutoIndexCreation = true },
+                    store.Database, RaftIdGenerator.NewId());
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await Server.ServerStore.SendToLeaderAsync(command));
+                Assert.Equal(LimitType.StudioConfiguration, exception.LimitType);
+
+                command = new PutDatabaseStudioConfigurationCommand(
+                    new ServerWideStudioConfiguration { DisableAutoIndexCreation = true },
+                    store.Database, RaftIdGenerator.NewId());
+                await PutLicense(Server, RL_PRO);
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Expiration License Limits
+        //  ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ExpirationRefresh)]
         public async Task Prevent_License_Downgrade_Expiration_Configuration()
         {
@@ -427,7 +973,28 @@ namespace SlowTests.Issues
                 var config = new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 100, };
 
                 await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
-                await TryToChangeLicense(Server, RL_COMM, LimitType.Expiration);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Expiration);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_ExpirationConfiguration()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 60 };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config));
+                Assert.Equal(LimitType.Expiration, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
             }
         }
 
@@ -435,16 +1002,1072 @@ namespace SlowTests.Issues
         public async Task Prevent_License_Downgrade_Refresh_Configuration()
         {
             DoNotReuseServer();
-
             using (var store = GetDocumentStore())
             {
                 var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = false };
                 await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
-                await TryToChangeLicense(Server, RL_COMM, LimitType.Refresh);
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Refresh);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
             }
         }
 
-        private static async Task TryToChangeLicense(RavenServer leader, string licenseType, LimitType limitType)
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ExpirationRefresh)]
+        public async Task Prevent_Put_Refresh_Configuration()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = false };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig)));
+
+                Assert.Equal(LimitType.Refresh, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Encryption License Limits
+        //  ----------------------------------------
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Encryption)]
+        public async Task Prevent_License_Downgrade_Encryption()
+        {
+            DoNotReuseServer();
+            string dbName = Encryption.SetupEncryptedDatabase(out var certificates, out var _);
+            using (var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = certificates.ServerCertificate.Value,
+                ClientCertificate = certificates.ServerCertificate.Value,
+                ModifyDatabaseName = _ => dbName,
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Encrypted = true;
+                },
+                Path = NewDataPath()
+            }))
+            {
+                await FailToChangeLicense(Server, RL_COMM, LimitType.Encryption);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.Encryption);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Dynamic Nodes Distribution License Limits
+        //  ----------------------------------------
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Sharding)]
+        public async Task Prevent_Put_Dynamic_Node_Distribution()
+        {
+            DoNotReuseServer();
+            var (_, leader) = await CreateRaftCluster(3);
+            var options = Options.ForMode(RavenDatabaseMode.Sharded);
+            options.Server = leader;
+            options.ModifyDatabaseRecord = record =>
+            {
+                record.Topology = new DatabaseTopology
+                {
+                    DynamicNodesDistribution = true,
+                    Members = new List<string> { "A", "B", "C" },
+                    ReplicationFactor = 3
+                };
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await PutLicense(leader, RL_COMM);
+                });
+
+                Assert.Equal(LimitType.DynamicNodeDistribution, exception.LimitType);
+
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await PutLicense(leader, RL_PRO);
+                });
+
+                Assert.Equal(LimitType.DynamicNodeDistribution, exception.LimitType);
+
+                await DisableRevisionCompression(leader, store);
+                await ChangeLicense(leader, RL_DEV);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Documents Compression License Limits
+        //  ----------------------------------------
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task Prevent_Put_Revision_Compression()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = new DocumentsCompressionConfiguration
+                {
+                    CompressRevisions = true,
+                    Collections = new[] { "Users" }
+                };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await Server.ServerStore.SendToLeaderAsync(
+                        new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()))
+                );
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await Server.ServerStore.SendToLeaderAsync(
+                        new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()))
+                );
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_Document_Compression()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var config = new DocumentsCompressionConfiguration
+                {
+                    CompressAllCollections = true,
+                    Collections = new string[] { }
+                };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await Server.ServerStore.SendToLeaderAsync(
+                        new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()))
+                );
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await Server.ServerStore.SendToLeaderAsync(
+                        new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()))
+                );
+                Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_License_Downgrade_Document_Compression()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                var config = new DocumentsCompressionConfiguration
+                {
+                    CompressAllCollections = true,
+                    Collections = new string[]{}
+                };
+                await Server.ServerStore.SendToLeaderAsync(
+                    new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.DocumentsCompression);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.DocumentsCompression);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for ETL License Limits
+        //  ---------------------------------------
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_Put_Raven_ETL()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var connectionString = new RavenConnectionString
+                {
+                    Name = "RavenConnStr",
+                    Database = store.Database,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                };
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                var config = new RavenEtlConfiguration
+                {
+                    Name = "RavenEtlTask",
+                    ConnectionStringName = "RavenConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = null
+                        }
+                    }
+                };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config)));
+                Assert.Equal(LimitType.RavenEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_License_Downgrade_Raven_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var connectionString = new RavenConnectionString
+                {
+                    Name = "RavenConnStr",
+                    Database = store.Database,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+
+                var config = new RavenEtlConfiguration
+                {
+                    Name = "RavenEtlTask",
+                    ConnectionStringName = "RavenConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = null
+                        }
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.RavenEtl);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_PRO);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_Put_Sql_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new SqlConnectionString
+                {
+                    Name = "SqlConnStr",
+                    FactoryName = "System.Data.SqlClient",
+                    ConnectionString = "Server=localhost;Database=Test;User Id=sa;Password=123456;"
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(connectionString));
+
+                var config = new SqlEtlConfiguration
+                {
+                    Name = "SqlEtlTask",
+                    ConnectionStringName = "SqlConnStr",
+                    SqlTables = { new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false } },
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config)));
+                Assert.Equal(LimitType.SqlEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_License_Downgrade_Sql_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var connectionString = new SqlConnectionString
+                {
+                    Name = "SqlConnStr",
+                    FactoryName = "System.Data.SqlClient",
+                    ConnectionString = "Server=localhost;Database=Test;User Id=sa;Password=123456;"
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(connectionString));
+
+                var config = new SqlEtlConfiguration
+                {
+                    Name = "SqlEtlTask",
+                    ConnectionStringName = "SqlConnStr",
+                    SqlTables = { new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false } },
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.SqlEtl);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_PRO);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_Put_Olap_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new OlapConnectionString
+                {
+                    Name = "OlapConnStr",
+                    LocalSettings = new LocalSettings
+                        {
+                            FolderPath = NewDataPath(suffix: "OlapOutput")
+                        }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<OlapConnectionString>(connectionString));
+
+                var config = new OlapEtlConfiguration
+                {
+                    Name = "OlapEtlTask",
+                    ConnectionStringName = "OlapConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "OlapTransform",
+                            Collections = new List<string> { "Orders" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config)));
+
+                Assert.Equal(LimitType.OlapEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config)));
+
+                Assert.Equal(LimitType.OlapEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_License_Downgrade_Olap_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var connectionString = new OlapConnectionString
+                {
+                    Name = "OlapConnStr",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = NewDataPath(suffix: "OlapOutput")
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<OlapConnectionString>(connectionString));
+
+                var config = new OlapEtlConfiguration
+                {
+                    Name = "OlapEtlTask",
+                    ConnectionStringName = "OlapConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "OlapTransform",
+                            Collections = new List<string> { "Orders" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.OlapEtl);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.OlapEtl);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_Put_Elasticsearch_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new ElasticSearchConnectionString
+                {
+                    Name = "ElasticConnStr",
+                    Nodes = new[] { "http://localhost:9200" }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<ElasticSearchConnectionString>(connectionString));
+
+                var config = new ElasticSearchEtlConfiguration
+                {
+                    Name = "ElasticEtlTask",
+                    ConnectionStringName = "ElasticConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Products" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config)));
+
+                Assert.Equal(LimitType.ElasticSearchEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config)));
+
+                Assert.Equal(LimitType.ElasticSearchEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_License_Downgrade_Elasticsearch_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var connectionString = new ElasticSearchConnectionString
+                {
+                    Name = "ElasticConnStr",
+                    Nodes = new[] { "http://localhost:9200" }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<ElasticSearchConnectionString>(connectionString));
+
+                var config = new ElasticSearchEtlConfiguration
+                {
+                    Name = "ElasticEtlTask",
+                    ConnectionStringName = "ElasticConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Products" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.ElasticSearchEtl);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.ElasticSearchEtl);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_Put_Queue_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new QueueConnectionString
+                {
+                    Name = "QueueConnStr",
+                    BrokerType = QueueBrokerType.Kafka,
+                    KafkaConnectionSettings = new KafkaConnectionSettings
+                    {
+                        BootstrapServers = "localhost:9092"
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(connectionString));
+
+                var config = new QueueEtlConfiguration
+                {
+                    Name = "QueueEtlTask",
+                    ConnectionStringName = "QueueConnStr",
+                    BrokerType = QueueBrokerType.Kafka,
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "QueueScript",
+                            Collections = new List<string> { "Orders" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config)));
+
+                Assert.Equal(LimitType.QueueEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config)));
+                Assert.Equal(LimitType.QueueEtl, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_License_Downgrade_Queue_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var connectionString = new QueueConnectionString
+                {
+                    Name = "QueueConnStr",
+                    BrokerType = QueueBrokerType.Kafka,
+                    KafkaConnectionSettings = new KafkaConnectionSettings
+                    {
+                        BootstrapServers = "localhost:9092"
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(connectionString));
+
+                var config = new QueueEtlConfiguration
+                {
+                    Name = "QueueEtlTask",
+                    ConnectionStringName = "QueueConnStr",
+                    BrokerType = QueueBrokerType.Kafka,
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "QueueScript",
+                            Collections = new List<string> { "Orders" },
+                            Script = "loadToUsers(this)"
+                        }
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.QueueEtl);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.QueueEtl);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_License_Downgrade_QueueSink()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(
+                    new PutConnectionStringOperation<QueueConnectionString>(
+                        new QueueConnectionString
+                        {
+                            Name = "KafkaConStr",
+                            BrokerType = QueueBrokerType.Kafka,
+                            KafkaConnectionSettings = new KafkaConnectionSettings() { BootstrapServers = "localhost:9092" }
+                        }));
+
+                QueueSinkScript queueSinkScript = new()
+                {
+                    Name = "orders",
+                    Queues = new List<string>() { "orders" },
+                    Script = @"this['@metadata']['@collection'] = 'Orders';
+               put(this.Id.toString(), this)"
+                };
+
+                var config = new QueueSinkConfiguration() { ConnectionStringName = "KafkaConStr", BrokerType = QueueBrokerType.Kafka, Scripts = { queueSinkScript } };
+
+                store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.QueueSink);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.QueueSink);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Prevent_Put_QueueSink()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                store.Maintenance.Send(
+                    new PutConnectionStringOperation<QueueConnectionString>(
+                        new QueueConnectionString
+                        {
+                            Name = "KafkaConStr",
+                            BrokerType = QueueBrokerType.Kafka,
+                            KafkaConnectionSettings = new KafkaConnectionSettings() { BootstrapServers = "localhost:9092" }
+                        }));
+
+                QueueSinkScript queueSinkScript = new QueueSinkScript
+                {
+                    Name = "orders",
+                    Queues = new List<string>() { "orders" },
+                    Script = @"this['@metadata']['@collection'] = 'Orders';
+               put(this.Id.toString(), this)"
+                };
+
+                var config = new QueueSinkConfiguration()
+                {
+                    Name = "KafkaSinkTaskName", ConnectionStringName = "KafkaConStr", BrokerType = QueueBrokerType.Kafka, Scripts = { queueSinkScript }
+                };
+
+                var exception = Assert.Throws<LicenseLimitException>(() => store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config)));
+                Assert.Equal(LimitType.QueueSink, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = Assert.Throws<LicenseLimitException>(() => store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config)));
+
+                Assert.Equal(LimitType.QueueSink, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Replication License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_License_Downgrade_External_Replication()
+        {
+            DoNotReuseServer();
+            using (var server1 = GetNewServer())
+            {
+                var options = new Options() { Server = server1 };
+                using (var store1 = GetDocumentStore(options))
+                using (var store2 = GetDocumentStore())
+                {
+                    await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                    {
+                        Name = "ToTargetDb",
+                        Database = store2.Database,
+                        TopologyDiscoveryUrls = store2.Urls
+                    }));
+
+                    var replicationTask = new ExternalReplication { Name = "ReplicateToTargetDb", ConnectionStringName = "ToTargetDb", MentorNode = null };
+
+                    await store1.Maintenance.SendAsync(
+                        new UpdateExternalReplicationOperation(replicationTask));
+
+                    using (var session = store1.OpenSession())
+                    {
+                        session.Store(new User { Name = "John Dow" }, "users/1");
+
+
+                        session.SaveChanges();
+                    }
+
+                    var replicated1 = WaitForDocumentToReplicate<User>(store2, "users/1", 15000);
+                    Assert.NotNull(replicated1);
+
+                    await FailToChangeLicense(server1, RL_COMM, LimitType.ExternalReplication);
+
+                    await DisableRevisionCompression(server1, store1);
+                    await ChangeLicense(server1, RL_DEV);
+                    await ChangeLicense(server1, RL_PRO);
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_Put_External_Replication()
+        {
+            DoNotReuseServer();
+            using (var server1 = GetNewServer())
+            {
+                var options = new Options() { Server = server1 };
+                using (var store1 = GetDocumentStore(options))
+                using (var store2 = GetDocumentStore())
+                {
+                    await DisableRevisionCompression(server1, store1);
+                    await DisableRevisionCompression(Server, store2);
+                    await PutLicense(server1, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await SetupReplicationAsync(store1, store2));
+                    Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
+
+                    await PutLicense(server1, RL_PRO);
+                    await SetupReplicationAsync(store1, store2);
+
+                    await PutLicense(server1, RL_DEV);
+                    await SetupReplicationAsync(store1, store2);
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_License_Downgrade_Pull_Replication_As_Hub()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutPullReplicationAsHubOperation("test"));
+                await FailToChangeLicense(Server, RL_COMM, LimitType.PullReplicationAsHub);
+
+                await FailToChangeLicense(Server, RL_PRO, LimitType.PullReplicationAsHub);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication) ]
+        public async Task Prevent_Put_Pull_Replication_As_Hub_Replication()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutPullReplicationAsHubOperation("test")));
+                Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutPullReplicationAsHubOperation("test")));
+                Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
+            }
+        }
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_Put_PullReplicationAsSink()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new RavenConnectionString
+                {
+                    Name = "HubConnStr",
+                    Database = store.Database,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                };
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                var sink = new PullReplicationAsSink
+                {
+                    HubName = "aa",
+                    ConnectionString = connectionString,
+                    ConnectionStringName = connectionString.Name
+                };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sink)));
+
+                Assert.Equal(LimitType.PullReplicationAsSink, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await PutLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_License_Downgrade_Pull_Replication_As_Sink()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var config = new PullReplicationAsSink
+                {
+                    Name = "test-sink",
+                    HubName = "hub1",
+                    ConnectionStringName = "HubConnStr"
+                };
+
+                var connectionString = new RavenConnectionString
+                {
+                    Name = "HubConnStr",
+                    Database = store.Database,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                };
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(config));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.PullReplicationAsSink);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_PRO);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_Put_Delayed_Replication()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var delayed = new ExternalReplication("otherDb", "DelayedReplication")
+                {
+                    DelayReplicationFor = TimeSpan.FromMinutes(5)
+                };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed)));
+                Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed)));
+                Assert.Equal(LimitType.DelayedExternalReplication, exception.LimitType);
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task Prevent_License_Downgrade_Delayed_Replication()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var delayed = new ExternalReplication("otherDb", "DelayedReplication")
+                {
+                    DelayReplicationFor = TimeSpan.FromMinutes(5)
+                };
+
+                await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.DelayedExternalReplication);
+                await FailToChangeLicense(Server, RL_PRO, LimitType.DelayedExternalReplication);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for cluster size License Limits
+        //  ----------------------------------------
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster)]
+        public async Task Prevent_License_Downgrade_Cluster_Size()
+        {
+            DoNotReuseServer();
+
+            var (_, leader) = await CreateRaftCluster(6, false, watcherCluster: true);
+
+            using (GetDocumentStore())
+            {
+                await FailToChangeLicense(leader, RL_COMM, LimitType.ClusterSize);
+                await FailToChangeLicense(leader, RL_DEV, LimitType.ClusterSize);
+                await FailToChangeLicense(leader, RL_PRO, LimitType.ClusterSize);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Cluster)]
+        public async Task Prevent_Add_Node_To_Cluster()
+        {
+            DoNotReuseServer();
+
+            var (_, leader) = await CreateRaftCluster(3, false, watcherCluster: true);
+
+            using (GetDocumentStore())
+            {
+                await PutLicense(leader, RL_COMM);
+                using (var server = GetNewServer(new ServerCreationOptions()))
+                using (var server2 = GetNewServer(new ServerCreationOptions()))
+                using (var server3 = GetNewServer(new ServerCreationOptions()))
+                {
+                    var command = new AddClusterNodeCommand(server.WebUrl);
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.WebUrl, null, DocumentConventions.DefaultForServer))
+                    using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                    {
+                        var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await requestExecutor.ExecuteAsync(command, context));
+                        Assert.Equal(LimitType.ClusterSize, exception.LimitType);
+
+                        await PutLicense(leader, RL_DEV);
+                        exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await requestExecutor.ExecuteAsync(command, context));
+                        Assert.Equal(LimitType.ClusterSize, exception.LimitType);
+
+                        await PutLicense(leader, RL_PRO);
+                        await requestExecutor.ExecuteAsync(command, context); // cluster size = 4, which is allowed by PRO license
+                        command = new AddClusterNodeCommand(server2.WebUrl);
+                        await requestExecutor.ExecuteAsync(command, context); // cluster size = 5, which is allowed by PRO license
+                        command = new AddClusterNodeCommand(server3.WebUrl);
+                        exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await requestExecutor.ExecuteAsync(command, context));
+                        Assert.Equal(LimitType.ClusterSize, exception.LimitType);
+                    }
+                }
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Time Series Configuration License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.TimeSeries)]
+        public async Task Prevent_Put_TimeSeries_Configuration()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var timeSeriesConfig = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        {
+                            "Users", new TimeSeriesCollectionConfiguration
+                            {
+                                Policies = new List<TimeSeriesPolicy>
+                                {
+                                    new TimeSeriesPolicy("30Seconds", TimeValue.FromSeconds(30)),
+                                    new TimeSeriesPolicy("1Hour", TimeValue.FromHours(1))
+                                },
+                                RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromMinutes(1))
+                            }
+                        }
+                    }
+                };
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig)));
+
+                Assert.Equal(LimitType.TimeSeriesRollupsAndRetention, exception.LimitType);
+
+                await PutLicense(Server, RL_PRO);
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
+
+                await PutLicense(Server, RL_DEV);
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.TimeSeries)]
+        public async Task Prevent_License_Downgrade_TimeSeries_Configuration()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var timeSeriesConfig = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        {
+                            "Users", new TimeSeriesCollectionConfiguration
+                            {
+                                Policies = new List<TimeSeriesPolicy>
+                                {
+                                    new TimeSeriesPolicy("30Seconds", TimeValue.FromSeconds(30)),
+                                    new TimeSeriesPolicy("1Hour", TimeValue.FromHours(1))
+                                },
+                                RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromMinutes(1))
+                            }
+                        }
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
+
+                await FailToChangeLicense(Server, RL_COMM, LimitType.TimeSeriesRollupsAndRetention);
+
+                await DisableRevisionCompression(Server, store);
+                await ChangeLicense(Server, RL_DEV);
+                await ChangeLicense(Server, RL_PRO);
+            }
+        }
+
+        private static async Task FailToChangeLicense(RavenServer leader, string licenseType, LimitType limitType)
         {
             var license = Environment.GetEnvironmentVariable(licenseType);
             LicenseHelper.TryDeserializeLicense(license, out License li);
@@ -454,6 +2077,28 @@ namespace SlowTests.Issues
             Assert.Equal(limitType, exception.LimitType);
         }
 
+        private static async Task ChangeLicense(RavenServer leader, string licenseType)
+        {
+            var license = Environment.GetEnvironmentVariable(licenseType);
+            LicenseHelper.TryDeserializeLicense(license, out License li);
+
+            await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+        }
+
+        private static async Task PutLicense(RavenServer leader, string licenseType)
+        {
+            var license = Environment.GetEnvironmentVariable(licenseType);
+            LicenseHelper.TryDeserializeLicense(license, out License li);
+
+             await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+        }
+
+        internal static async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
+        {
+            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
+                RaftIdGenerator.NewId());
+            await leader.ServerStore.SendToLeaderAsync(command);
+        }
 
         private static string GetSorter(string resourceName, string originalSorterName, string sorterName)
         {

--- a/test/Tests.Infrastructure/RavenMultiLicenseRequiredFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiLicenseRequiredFactAttribute.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Xunit;
 
 namespace Tests.Infrastructure
 {
@@ -11,7 +10,7 @@ namespace Tests.Infrastructure
         private static readonly bool RavenLicenseProfessional;
 
         internal static readonly bool HasLicense;
-
+        private string _skip;
         internal static string SkipMessage = $"Requires Licenses to be set via environment variable. : " +
                                              $"'RAVEN_LICENSE' - {IsSet(RavenLicense)} . " +
                                              $"'RAVEN_LICENSE_DEVELOPER' - {IsSet(RavenLicenseDeveloper)} . " +
@@ -40,11 +39,17 @@ namespace Tests.Infrastructure
         {
             get
             {
+                // Added support for the Skip option to allow temporarily skipping tests.
+                // Currently used for tests affected by RavenDB-24118 until the issue is resolved.
+                if (_skip != null)
+                    return _skip;
+
                 if (ShouldSkip(licenseRequired: true))
                     return SkipMessage;
 
                 return null;
             }
+            set => _skip = value;
         }
 
         internal static bool ShouldSkip(bool licenseRequired)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23635

### Additional description
Added missing handling of several license-related attributes in AssertLicense within ClusterStateMachine.
Extended the RavenDB_21427 test class with:
* Additional tests for the newly handled license attributes
* Expanded coverage for attributes previously introduced as part of RavenDB-21427

Also added support for the Skip option in RavenMultiLicenseRequiredFactAttribute, to allow skipping specific tests — currently used to temporarily skip tests affected by RavenDB-24118.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
