### PR TITLE
RavenDB-24155 - Add logs & SNMP monitoring to Missing Attachments

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Exceptions;
@@ -96,6 +97,8 @@ namespace Raven.Server.Documents
             });
         }
 
+        private long _missingAttachmentsCount;
+
         public AttachmentsStorage(DocumentDatabase documentDatabase, Transaction tx)
         {
             _documentDatabase = documentDatabase;
@@ -105,6 +108,8 @@ namespace Raven.Server.Documents
             tx.CreateTree(AttachmentsSlice);
             AttachmentsSchema.Create(tx, AttachmentsMetadataSlice, 44);
             TombstonesSchema.Create(tx, AttachmentsTombstonesSlice, 16);
+
+            _missingAttachmentsCount = 0;
         }
 
         public static long ReadLastEtag(Transaction tx)
@@ -1215,7 +1220,16 @@ namespace Raven.Server.Documents
                 }
             }
         }
-        
+
+        public void IncrementMissingAttachmentsCount() =>
+            Interlocked.Increment(ref _missingAttachmentsCount);
+
+        public void ResetMissingAttachmentsCount() =>
+            Interlocked.Exchange(ref _missingAttachmentsCount, 0);
+
+        public long GetMissingAttachmentsCount() => 
+            Interlocked.Read(ref _missingAttachmentsCount);
+
         public static class AttachmentKey
         {
             /*

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1327,12 +1327,9 @@ namespace Raven.Server.Documents.Replication
                                     {
                                         AssertAttachmentsFromReplication(context, doc);
                                     }
-                                    catch (MissingAttachmentException)
+                                    catch (MissingAttachmentException mea)
                                     {
-                                        if (_replicationInfo.SupportedFeatures.Replication.MissingAttachments)
-                                        {
-                                            throw;
-                                        }
+                                        context.DocumentDatabase.DocumentsStorage.AttachmentsStorage.IncrementMissingAttachmentsCount();
 
                                         database.NotificationCenter.Add(AlertRaised.Create(
                                             database.Name,
@@ -1341,6 +1338,14 @@ namespace Raven.Server.Documents.Replication
                                             $" ({string.Join(',', GetAttachmentsNameAndHash(document).Select(x => $"name: {x.Name}, hash: {x.Hash}"))}).",
                                             AlertType.ReplicationMissingAttachments,
                                             NotificationSeverity.Warning));
+
+                                        if (_replicationInfo.Logger.IsInfoEnabled)
+                                            _replicationInfo.Logger.Info("Detected missing attachment while processing incoming document.", mea);
+
+                                        if (_replicationInfo.SupportedFeatures.Replication.MissingAttachments)
+                                        {
+                                            throw;
+                                        }
                                     }
                                 }
 

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -1318,6 +1318,7 @@ namespace Raven.Server.Documents.Replication
             {
                 _parent.Database.NotificationCenter.Dismiss(_missingAttachmentsAlert.Id);
                 _missingAttachmentsAlert = null;
+                _parent.Database.DocumentsStorage.AttachmentsStorage.ResetMissingAttachmentsCount();
             }
          
             MissingAttachmentsRetries = 0;

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -303,6 +303,7 @@ public class MetricsProvider
             var attachments = documentsStorage.AttachmentsStorage.GetNumberOfAttachments(context.Documents);
             result.Attachments = attachments.AttachmentCount;
             result.UniqueAttachments = attachments.StreamsCount;
+            result.MissingAttachments = documentsStorage.AttachmentsStorage.GetMissingAttachmentsCount();
         }
 
         result.Alerts = database.NotificationCenter.GetAlertCount();

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/1/DatabaseCountOfMissingAttachments.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/1/DatabaseCountOfMissingAttachments.cs
@@ -1,0 +1,23 @@
+﻿using Lextm.SharpSnmpLib;
+using Raven.Server.Documents;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Database
+{
+    public class DatabaseCountOfMissingAttachments : DatabaseScalarObjectBase<Gauge32>
+    {
+        public DatabaseCountOfMissingAttachments(string databaseName, DatabasesLandlord landlord, int index)
+            : base(databaseName, landlord, SnmpOids.Databases.CountOfMissingAttachments, index)
+        {
+        }
+
+        protected override Gauge32 GetData(DocumentDatabase database)
+        {
+            return new Gauge32(GetCount(database));
+        }
+
+        private static long GetCount(DocumentDatabase database)
+        {
+            return database.DocumentsStorage.AttachmentsStorage.GetMissingAttachmentsCount();
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpDatabase.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Monitoring.Snmp
             _objectStore.Add(new DatabaseCountOfRevisionDocuments(_databaseName, _databaseLandlord, _databaseIndex));
             _objectStore.Add(new DatabaseCountOfAttachments(_databaseName, _databaseLandlord, _databaseIndex));
             _objectStore.Add(new DatabaseCountOfUniqueAttachments(_databaseName, _databaseLandlord, _databaseIndex));
+            _objectStore.Add(new DatabaseCountOfMissingAttachments(_databaseName, _databaseLandlord, _databaseIndex));
             _objectStore.Add(new DatabaseAlerts(_databaseName, _databaseLandlord, _databaseIndex));
             _objectStore.Add(new DatabaseId(_databaseName, _databaseLandlord, _databaseIndex));
             _objectStore.Add(new DatabaseUpTime(_databaseName, _databaseLandlord, _databaseIndex));

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -434,6 +434,9 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("Number of indexing errors")]
             public const string IndexingErrors = "5.2.{0}.1.16";
 
+            [Description("Number of missing attachments")]
+            public const string CountOfMissingAttachments = "5.2.{0}.1.17";
+
             [Description("Documents storage allocated size in MB")]
             public const string DocumentsStorageAllocatedSize = "5.2.{0}.2.1";
 
@@ -514,9 +517,6 @@ namespace Raven.Server.Monitoring.Snmp
 
             [Description("Number of bytes written (documents, attachments, counters, timeseries)")]
             public const string DataWrittenPerSecond = "5.2.{0}.6.2";
-
-            [Description("Number of missing attachments")]
-            public const string CountOfMissingAttachments = "5.2.{0}.6.3";
 
             public class Indexes
             {

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -515,6 +515,9 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("Number of bytes written (documents, attachments, counters, timeseries)")]
             public const string DataWrittenPerSecond = "5.2.{0}.6.2";
 
+            [Description("Number of missing attachments")]
+            public const string CountOfMissingAttachments = "5.2.{0}.6.3";
+
             public class Indexes
             {
                 private Indexes()

--- a/src/Raven.Server/Utils/Monitoring/DatabaseMetrics.cs
+++ b/src/Raven.Server/Utils/Monitoring/DatabaseMetrics.cs
@@ -73,6 +73,7 @@ namespace Raven.Server.Utils.Monitoring
         public int Rehabs { get; set; }
         public long PerformanceHints { get; set; }
         public int ReplicationFactor { get; set; }
+        public long MissingAttachments { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -85,7 +86,8 @@ namespace Raven.Server.Utils.Monitoring
                 [nameof(Alerts)] = Alerts,
                 [nameof(Rehabs)] = Rehabs,
                 [nameof(PerformanceHints)] = PerformanceHints,
-                [nameof(ReplicationFactor)] = ReplicationFactor
+                [nameof(ReplicationFactor)] = ReplicationFactor,
+                [nameof(MissingAttachments)] = MissingAttachments
             };
         }
     }

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -230,6 +230,7 @@ namespace Raven.Server.Web.System
                     WriteGauges(writer, "Number of performance hints", "database_performance_hints_count", metrics, x => x.Counts.PerformanceHints, cachedTags);
                     WriteGauges(writer, "Database replication factor", "database_replication_factor", metrics, x => x.Counts.ReplicationFactor,
                         cachedTags);
+                    WriteGauges(writer, "Number of missing attachments", "database_missing_attachments_count", metrics, x => x.Counts.MissingAttachments, cachedTags);
 
                     // statistics 
                     


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24155/Add-logs-SNMP-monitoring-to-Missing-Attachments

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
