### PR TITLE
RavenDB-24239 Lucene: return an empty query when an analyzer removed all terms in the search method.

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -209,6 +209,17 @@ namespace Raven.Server.Documents.Queries
                 terms.Add(attribute.Term);
             }
 
+            if (terms.Count == 0)
+            {
+                // Backward compatibility for proximity search
+                query = new PhraseQuery
+                {
+                    Boost = boost.Value
+                };
+                
+                return false;
+            }
+            
             switch (type)
             {
                 case LuceneTermType.Prefix:
@@ -226,17 +237,7 @@ namespace Raven.Server.Documents.Queries
                     };
                     return true;
             }
-
-            if (terms.Count == 0)
-            {
-                // Backward compatibility for proximity search
-                query = new PhraseQuery
-                {
-                    Boost = boost.Value
-                };
-                return false;
-            }
-
+            
             if (terms.Count == 1)
             {
                 query = new TermQuery(new Term(fieldName, terms[0]))

--- a/test/SlowTests/Issues/RavenDB_14939.cs
+++ b/test/SlowTests/Issues/RavenDB_14939.cs
@@ -199,6 +199,54 @@ namespace SlowTests.Issues
                 AssertCount<MyIndex_WithoutAnalyzer>(store);
             }
         }
+        
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void PrefixQueryWithOnlyStopWordWillNotThrowException(Options options)
+        {
+            string analyzerName = GetDatabaseName();
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDatabaseName = _ => analyzerName,
+                       ModifyDatabaseRecord = record =>
+                       {
+                           options.ModifyDatabaseRecord(record);
+                           record.Analyzers = new Dictionary<string, AnalyzerDefinition>
+                           {
+                               {
+                                   analyzerName,
+                                   new AnalyzerDefinition { Name = analyzerName, Code = GetAnalyzer("RavenDB_14939.MyAnalyzer.cs", "MyAnalyzer", analyzerName) }
+                               }
+                           };
+
+                           record.Settings[RavenConfiguration.GetKey(x => x.Indexing.DefaultSearchAnalyzer)] = analyzerName;
+                       }
+                   }))
+            {
+                store.ExecuteIndex(new MyIndex(analyzerName));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Customer() { Name = "Theodore" });
+                    session.SaveChanges();
+                }
+                Indexes.WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var results = session.Query<Customer, MyIndex>()
+                        .Customize(x => x.NoCaching())
+                        .Search(x => x.Name, "The*");
+                    Assert.Equal(results.Count(), 0);
+                    
+                    results = session.Query<Customer, MyIndex>()
+                        .Customize(x => x.NoCaching())
+                        .Search(x => x.Name, "Theo*");
+                    Assert.Equal(results.Count(), 1);
+                }
+            }
+        }
 
         private static void Fill(IDocumentStore store)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24239

### Additional description

Return an empty query when an analyzer removed all terms in the search method instead throwing OutOfRangeException.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
