### PR TITLE
RavenDB-24270: Optimization of Tensor Primitives on CPU

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/Tensors/CosineSimilarity.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Tensors/CosineSimilarity.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics.Tensors;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+using Sparrow;
+using Sparrow.Server.Tensors;
+
+namespace Micro.Benchmark.Benchmarks.Tensors
+{
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 3, exportHtml: true)]
+    [Config(typeof(Config))]
+    public class CosineSimilarityBench
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(new Job { Environment = { Runtime = CoreRuntime.Core80, Platform = Platform.X64, Jit = Jit.RyuJit, }, });
+
+                // Exporters for data
+                AddExporter(GetExporters().ToArray());
+
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        [Params(
+            384,  // Mini-LM,
+            1536, // OpenAI
+            3072, // text-embedding-3-large, Gemini
+            4096, // Llama 3 
+            8192 // Llama 2 70B
+            )]
+        public int EmbeddingSize { get; set; }
+
+        private static (float[], float[], double[], double[]) Generator(int size)
+        {
+            var gen = new Random(size);
+
+            var resultF1 = new float[size];
+            var resultF2 = new float[size];
+            var resultD1 = new double[size];
+            var resultD2 = new double[size];
+            for (int i = 0; i < size; i++)
+            {
+                double value = gen.NextDouble();
+                resultF1[i] = (float)value;
+                resultD1[i] = value;
+                value = gen.NextDouble();
+                resultF2[i] = (float)value;
+                resultD2[i] = value;
+            }
+
+            return (resultF1, resultF2, resultD1, resultD2);
+        }
+
+        private float[] _floatValuesA;
+        private float[] _floatValuesB;
+        private double[] _doubleValuesA;
+        private double[] _doubleValuesB;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            (_floatValuesA, _floatValuesB, _doubleValuesA, _doubleValuesB) = Generator(EmbeddingSize);
+        }
+
+        [Benchmark(Baseline = true)]
+        public float Microsoft_TensorPrimitives_Float()
+        {
+            return TensorPrimitives.CosineSimilarity(_floatValuesA, _floatValuesB);
+        }
+
+        [Benchmark]
+        public float Serial_Float()
+        {
+            return Functions.Serial.CosineSimilarity<float, float>(_floatValuesA, _floatValuesB);
+        }
+
+        [Benchmark]
+        public double Serial_Double()
+        {
+            return Functions.Serial.CosineSimilarity<double, double>(_doubleValuesA, _doubleValuesB);
+        }
+
+        [Benchmark]
+        public float Fma_SingleLane_Float()
+        {
+            return Functions.Vectorized256.CosineSimilarity<float, float>(_floatValuesA, _floatValuesB);
+        }
+
+        [Benchmark]
+        public float Fma_DoubleLane_Float()
+        {
+            return Functions.Vectorized512.CosineSimilarity<float, float>(_floatValuesA, _floatValuesB);
+        }
+
+        [Benchmark]
+        public double Fma_DoubleLane_Double()
+        {
+            return Functions.Vectorized512.CosineSimilarity<double, double>(_doubleValuesA, _doubleValuesB);
+        }
+    }
+}

--- a/bench/Micro.Benchmark/Benchmarks/Tensors/HammingBitDistance.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Tensors/HammingBitDistance.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics.Tensors;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+using Sparrow.Server.Tensors;
+
+
+
+namespace Micro.Benchmark.Benchmarks.Tensors
+{
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 3, exportHtml: true)]
+    [Config(typeof(Config))]
+    public class HammingBitDistanceBench
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(new Job { Environment = { Runtime = CoreRuntime.Core80, Platform = Platform.X64, Jit = Jit.RyuJit, }, });
+
+                // Exporters for data
+                AddExporter(GetExporters().ToArray());
+
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        [Params(
+            384,  // Mini-LM,
+            1536, // OpenAI
+            3072, // text-embedding-3-large, Gemini
+            4096, // Llama 3 
+            8192 // Llama 2 70B
+        )]
+        public int EmbeddingSize { get; set; }
+
+        private static (byte[], byte[], long[], long[]) Generator(int size)
+        {
+            var gen = new Random(size);
+
+            var resultF1 = new byte[size * sizeof(long)];
+            var resultF2 = new byte[size * sizeof(long)];
+            var resultD1 = new long[size];
+            var resultD2 = new long[size];
+            for (int i = 0; i < size; i++)
+            {
+                byte value = (byte)gen.Next(byte.MaxValue);
+                resultF1[i * sizeof(long)] = value;
+                resultD1[i] = value;
+
+                value = (byte)gen.Next(byte.MaxValue);
+                resultF2[i * sizeof(long)] = value;
+                resultD2[i] = value;
+            }
+
+            return (resultF1, resultF2, resultD1, resultD2);
+        }
+
+        private byte[] _byteValuesA;
+        private byte[] _byteValuesB;
+        private long[] _longValuesA;
+        private long[] _longValuesB;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            (_byteValuesA, _byteValuesB, _longValuesA, _longValuesB) = Generator(EmbeddingSize);
+        }
+
+        [Benchmark(Baseline = true)]
+        public long Microsoft_TensorPrimitives_Byte()
+        {
+            return TensorPrimitives.HammingBitDistance<byte>(_byteValuesA, _byteValuesB);
+        }
+
+        [Benchmark]
+        public long Microsoft_TensorPrimitives_Long()
+        {
+            return TensorPrimitives.HammingBitDistance<long>(_longValuesA, _longValuesB);
+        }
+
+        [Benchmark]
+        public long Ours_Byte()
+        {
+            return Functions.HammingBitDistance<byte>(_byteValuesA, _byteValuesB);
+        }
+
+        [Benchmark]
+        public double Ours_Long()
+        {
+            return Functions.HammingBitDistance<long>(_longValuesA, _longValuesB);
+        }
+    }
+}

--- a/bench/Micro.Benchmark/Benchmarks/Tensors/QuantizedCosineSimilarity.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Tensors/QuantizedCosineSimilarity.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics.Tensors;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+using Sparrow;
+using Sparrow.Server.Tensors;
+
+namespace Micro.Benchmark.Benchmarks.Tensors
+{
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 3, exportHtml: true)]
+    [Config(typeof(Config))]
+    public class QuantizedCosineSimilarityBench
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(new Job { Environment = { Runtime = CoreRuntime.Core80, Platform = Platform.X64, Jit = Jit.RyuJit, }, });
+
+                // Exporters for data
+                AddExporter(GetExporters().ToArray());
+
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        [Params(
+            384,  // Mini-LM,
+            1536, // OpenAI
+            3072, // text-embedding-3-large, Gemini
+            4096, // Llama 3 
+            8192 // Llama 2 70B
+        )]
+        //[Params(
+        //    384  // Mini-LM
+        //)]
+        public int EmbeddingSize { get; set; }
+
+        private static (sbyte[], sbyte[], short[], short[], int[], int[], float[], float[]) Generator(int size)
+        {
+            var gen = new Random(size);
+
+            var resultSB1 = new sbyte[size];
+            var resultSB2 = new sbyte[size];
+            var resultS1 = new short[size];
+            var resultS2 = new short[size];
+            var resultI1 = new int[size];
+            var resultI2 = new int[size];
+            var resultF1 = new float[size];
+            var resultF2 = new float[size];
+            for (int i = 0; i < size; i++)
+            {
+                int value = gen.Next(4096);
+                resultSB1[i] = (sbyte)(value % byte.MaxValue);
+                resultS1[i] = (short)(value % ushort.MaxValue);
+                resultI1[i] = value;
+                resultF1[i] = value;
+
+                value = gen.Next(4096);
+                resultSB2[i] = (sbyte)(value % byte.MaxValue);
+                resultS2[i] = (short)(value % ushort.MaxValue);
+                resultI2[i] = value;
+                resultF2[i] = value;
+            }
+
+            return (resultSB1, resultSB2, resultS1, resultS2, resultI1, resultI2, resultF1, resultF2);
+        }
+
+        private sbyte[] _sbyteValuesA;
+        private sbyte[] _sbyteValuesB;
+        private short[] _shortValuesA;
+        private short[] _shortValuesB;
+        private int[] _intValuesA;
+        private int[] _intValuesB;
+        private float[] _floatValuesA;
+        private float[] _floatValuesB;
+        private float _magnitudeA;
+        private float _magnitudeB;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            (_sbyteValuesA, _sbyteValuesB, _shortValuesA, _shortValuesB, _intValuesA, _intValuesB, _floatValuesA, _floatValuesB) = Generator(EmbeddingSize);
+            _magnitudeA = Random.Shared.NextSingle();
+            _magnitudeB = Random.Shared.NextSingle();
+        }
+
+        [Benchmark(Baseline = true)]
+        public float Unquantized_Float()
+        {
+            return Functions.CosineSimilarity<float, float>(_floatValuesA, _magnitudeA, _floatValuesB, _magnitudeB);
+        }
+
+        [Benchmark]
+        public float Serial_SByte()
+        {
+            return Functions.Serial.CosineSimilarity<sbyte, float>(_sbyteValuesA, _magnitudeA, _sbyteValuesB, _magnitudeB);
+        }
+
+        [Benchmark]
+        public float Avx2_SByteSerial()
+        {
+            return Functions.Vectorized256.CosineSimilarityIntegersAvx2(_sbyteValuesA, _magnitudeA, _sbyteValuesB, _magnitudeB);
+        }
+
+        [Benchmark]
+        public float Avx512_SByteSerial()
+        {
+            return Functions.Vectorized512.CosineSimilarityIntegersAvx512(_sbyteValuesA, _magnitudeA, _sbyteValuesB, _magnitudeB);
+        }
+    }
+}

--- a/bench/Micro.Benchmark/Micro.Benchmark.csproj
+++ b/bench/Micro.Benchmark/Micro.Benchmark.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Sparrow.Server\Sparrow.Server.csproj" />
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsWindows64)' == 'true'">

--- a/bench/Micro.Benchmark/Program.cs
+++ b/bench/Micro.Benchmark/Program.cs
@@ -16,6 +16,12 @@ namespace Micro.Benchmark
 
             Console.WriteLine($"{nameof(Avx)} support: {Avx.IsSupported}");
             Console.WriteLine($"{nameof(Avx2)} support: {Avx2.IsSupported}");
+            Console.WriteLine($"{nameof(Avx512F)} support: {Avx512F.IsSupported}");
+            Console.WriteLine($"{nameof(Avx512BW)} support: {Avx512BW.IsSupported}");
+            Console.WriteLine($"{nameof(Avx512CD)} support: {Avx512CD.IsSupported}");
+            Console.WriteLine($"{nameof(Avx512DQ)} support: {Avx512DQ.IsSupported}");
+            Console.WriteLine($"{nameof(Avx512Vbmi)} support: {Avx512Vbmi.IsSupported}");
+            Console.WriteLine($"{nameof(AvxVnni)} support: {AvxVnni.IsSupported}");
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }

--- a/src/Sparrow.Server/Sparrow.Server.csproj
+++ b/src/Sparrow.Server/Sparrow.Server.csproj
@@ -49,6 +49,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+    <PackageReference Include="System.Numerics.Tensors" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sparrow\Sparrow.csproj" />

--- a/src/Sparrow.Server/Tensors/Arithmetics.cs
+++ b/src/Sparrow.Server/Tensors/Arithmetics.cs
@@ -54,7 +54,7 @@ namespace Sparrow.Server.Tensors
                 return Vector512.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
             }
 #else
-            if (Avx512F.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx512Basic)
             {
                 if (typeof(T) == typeof(float))
                     return Avx512F.FusedMultiplyAdd(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
@@ -62,7 +62,7 @@ namespace Sparrow.Server.Tensors
                     return Avx512F.FusedMultiplyAdd(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
             }
 
-            if (Fma.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
                 // PERF: we do the FMA on the upper and lower lanes separately
                 if (typeof(T) == typeof(float))

--- a/src/Sparrow.Server/Tensors/Arithmetics.cs
+++ b/src/Sparrow.Server/Tensors/Arithmetics.cs
@@ -27,6 +27,7 @@ namespace Sparrow.Server.Tensors
                 return Vector256.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
             }
 #else
+
             if (Fma.IsSupported)
             {
                 if (typeof(T) == typeof(float))
@@ -53,29 +54,36 @@ namespace Sparrow.Server.Tensors
                 return Vector512.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
             }
 #else
+            if (Avx512F.IsSupported)
+            {
+                if (typeof(T) == typeof(float))
+                    return Avx512F.FusedMultiplyAdd(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
+                if (typeof(T) == typeof(double))
+                    return Avx512F.FusedMultiplyAdd(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
+            }
 
             if (Fma.IsSupported)
             {
                 // PERF: we do the FMA on the upper and lower lanes separately
-                Vector256<T> upperX = x.GetUpper();
-                Vector256<T> upperY = y.GetUpper();
-                Vector256<T> upperZ = z.GetUpper();
-
-                Vector256<T> lowerX = x.GetLower();
-                Vector256<T> lowerY = y.GetLower();
-                Vector256<T> lowerZ = z.GetLower();
-
                 if (typeof(T) == typeof(float))
                 {
-                    var upperS = Fma.MultiplyAdd(upperX.AsSingle(), upperY.AsSingle(), upperZ.AsSingle());
-                    var lowerS = Fma.MultiplyAdd(lowerX.AsSingle(), lowerY.AsSingle(), lowerZ.AsSingle());
+                    Vector512<float> fx = x.AsSingle();
+                    Vector512<float> fy = y.AsSingle();
+                    Vector512<float> fz = z.AsSingle();
+
+                    var upperS = Fma.MultiplyAdd(fx.GetUpper(), fy.GetUpper(), fz.GetUpper());
+                    var lowerS = Fma.MultiplyAdd(fx.GetLower(), fy.GetLower(), fz.GetLower());
                     return Vector512.Create(upperS, lowerS).As<float, T>();
                 }
 
                 if (typeof(T) == typeof(double))
                 {
-                    var upperS = Fma.MultiplyAdd(upperX.AsDouble(), upperY.AsDouble(), upperZ.AsDouble());
-                    var lowerS = Fma.MultiplyAdd(lowerX.AsDouble(), lowerY.AsDouble(), lowerZ.AsDouble());
+                    Vector512<double> dx = x.AsDouble();
+                    Vector512<double> dy = y.AsDouble();
+                    Vector512<double> dz = z.AsDouble();
+
+                    var upperS = Fma.MultiplyAdd(dx.GetUpper(), dy.GetUpper(), dz.GetUpper());
+                    var lowerS = Fma.MultiplyAdd(dx.GetLower(), dy.GetLower(), dz.GetLower());
                     return Vector512.Create(upperS, lowerS).As<double, T>();
                 }
             }

--- a/src/Sparrow.Server/Tensors/Arithmetics.cs
+++ b/src/Sparrow.Server/Tensors/Arithmetics.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sparrow.Server.Tensors
+{
+    public static class Arithmetics
+    {
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<T> MultiplyAddEstimate<T>(Vector256<T> x, Vector256<T> y, Vector256<T> z)
+            where T : unmanaged
+        {
+#if NET9_0_OR_GREATER
+            if (typeof(T) == typeof(double))
+            {
+                return Vector256.MultiplyAddEstimate(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                return Vector256.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
+            }
+#else
+            if (Fma.IsSupported)
+            {
+                if (typeof(T) == typeof(float))
+                    return Fma.MultiplyAdd(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
+                if (typeof(T) == typeof(double))
+                    return Fma.MultiplyAdd(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
+            }
+#endif
+            // This version is less accurate numerically.
+            return (x * y) + z;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<T> MultiplyAddEstimate<T>(Vector512<T> x, Vector512<T> y, Vector512<T> z)
+            where T : unmanaged
+        {
+#if NET9_0_OR_GREATER
+            if (typeof(T) == typeof(double))
+            {
+                return Vector512.MultiplyAddEstimate(x.AsDouble(), y.AsDouble(), z.AsDouble()).As<double, T>();
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                return Vector512.MultiplyAddEstimate(x.AsSingle(), y.AsSingle(), z.AsSingle()).As<float, T>();
+            }
+#else
+
+            if (Fma.IsSupported)
+            {
+                // PERF: we do the FMA on the upper and lower lanes separately
+                Vector256<T> upperX = x.GetUpper();
+                Vector256<T> upperY = y.GetUpper();
+                Vector256<T> upperZ = z.GetUpper();
+
+                Vector256<T> lowerX = x.GetLower();
+                Vector256<T> lowerY = y.GetLower();
+                Vector256<T> lowerZ = z.GetLower();
+
+                if (typeof(T) == typeof(float))
+                {
+                    var upperS = Fma.MultiplyAdd(upperX.AsSingle(), upperY.AsSingle(), upperZ.AsSingle());
+                    var lowerS = Fma.MultiplyAdd(lowerX.AsSingle(), lowerY.AsSingle(), lowerZ.AsSingle());
+                    return Vector512.Create(upperS, lowerS).As<float, T>();
+                }
+
+                if (typeof(T) == typeof(double))
+                {
+                    var upperS = Fma.MultiplyAdd(upperX.AsDouble(), upperY.AsDouble(), upperZ.AsDouble());
+                    var lowerS = Fma.MultiplyAdd(lowerX.AsDouble(), lowerY.AsDouble(), lowerZ.AsDouble());
+                    return Vector512.Create(upperS, lowerS).As<double, T>();
+                }
+            }
+#endif
+
+            // This version is less accurate numerically.
+            return (x * y) + z;
+        }
+    }
+}

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -884,5 +884,61 @@ namespace Sparrow.Server.Tensors
                 return CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
             }
         }
+
+        /// <summary>Computes the bitwise Hamming distance between two equal-length tensors of values.</summary>
+        /// <param name="x">The first tensor, represented as a span.</param>
+        /// <param name="y">The second tensor, represented as a span.</param>
+        /// <returns>The number of bits that differ between the two spans.</returns>
+        /// <exception cref="ArgumentException">Length of <paramref name="x" /> must be same as length of <paramref name="y" />.</exception>
+        /// <exception cref="ArgumentException"><paramref name="x" /> and <paramref name="y" /> must not be empty.</exception>
+        public static long HammingBitDistance<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y) where T : unmanaged, IBinaryInteger<T>
+        {
+            var xAsByte = MemoryMarshal.Cast<T, byte>(x);
+            var yAsByte = MemoryMarshal.Cast<T, byte>(y);
+
+            ref byte xRef = ref MemoryMarshal.GetReference(xAsByte);
+            ref byte yRef = ref MemoryMarshal.GetReference(yAsByte);
+
+            const int Word = sizeof(ulong);
+            const int N = Word * 3;     
+
+            ulong count1 = 0;
+            ulong count2 = 0;
+            ulong count3 = 0;
+
+            int offset = 0;
+            int length = xAsByte.Length;
+
+            // Process all full 24-byte blocks
+            while (offset + N <= length)
+            {
+                int byteOffset = offset;
+                ulong xBits1 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref xRef, byteOffset));
+                ulong yBits1 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref yRef, byteOffset));
+                count1 += ulong.PopCount(xBits1 ^ yBits1);
+
+                byteOffset = (offset + Word);
+                ulong xBits2 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref xRef, byteOffset));
+                ulong yBits2 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref yRef, byteOffset));
+                count2 += ulong.PopCount(xBits2 ^ yBits2);
+
+                byteOffset = (offset + 2 * Word);
+                ulong xBits3 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref xRef, byteOffset));
+                ulong yBits3 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref yRef, byteOffset));
+                count3 += ulong.PopCount(xBits3 ^ yBits3);
+
+                offset += N;
+            }
+
+            ulong count = count1 + count2 + count3;
+
+            for (int i = offset; i < length; i++)
+            {
+                var xor = Unsafe.Add(ref xRef, i) ^ Unsafe.Add(ref yRef, i);
+                count += (ulong)int.PopCount(xor);
+            }
+
+            return (long)count;
+        }
     }
 }

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -302,7 +302,7 @@ namespace Sparrow.Server.Tensors
             ];
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal static double CosineSimilarityInternal(ref float aRef, float aMagnitude, ref float bRef, float bMagnitude, nuint size)
+            internal static double CosineSimilarityInternalX64(ref float aRef, float aMagnitude, ref float bRef, float bMagnitude, nuint size)
             {
                 Vector512<float> abVec = Vector512<float>.Zero;
                 Vector512<float> a2Vec = Vector512<float>.Zero;
@@ -388,11 +388,86 @@ namespace Sparrow.Server.Tensors
                 double b2Reciprocal = rsqrts.ToScalar(); // lane 0
                 double a2Reciprocal = Sse2.UnpackHigh(rsqrts, rsqrts).ToScalar(); // lane 1
                 return  ab * a2Reciprocal * b2Reciprocal;
-           }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double CosineSimilarityInternalNeon(ref float aRef, float aMagnitude, ref float bRef, float bMagnitude, nuint size)
+            {
+                Vector512<float> abVec = Vector512<float>.Zero;
+                Vector512<float> a2Vec = Vector512<float>.Zero;
+                Vector512<float> b2Vec = Vector512<float>.Zero;
+
+                nuint i = 0;
+                nuint oneVectorFromEnd = size - (nuint)Vector512<float>.Count;
+
+            Loop:
+
+                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
+                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
+                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
+                // of the instructions themselves.
+                Vector512<float> aVec = Vector512.LoadUnsafe(ref aRef, i);
+                Vector512<float> bVec = Vector512.LoadUnsafe(ref bRef, i);
+
+                i += (nuint)Vector512<float>.Count;
+
+            LoopWithoutLoad:
+
+                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+
+                if (i <= oneVectorFromEnd)
+                    goto Loop;
+
+                if (i != (nuint)size)
+                {
+                    nuint offset = size - i;
+                    Debug.Assert((int)offset * sizeof(float) + Vector512<byte>.Count <= MoveMaskTable.Length);
+
+                    var mask = Vector512.LoadUnsafe<float>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(MoveMaskTable)), (nuint)offset);
+
+                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+
+                    i = (nuint)size;
+                    goto LoopWithoutLoad;
+                }
+
+                float ab = aMagnitude * bMagnitude * Vector512.Sum(abVec);
+                float a2 = aMagnitude * aMagnitude * Vector512.Sum(a2Vec);
+                float b2 = bMagnitude * bMagnitude * Vector512.Sum(b2Vec);
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return double.NaN; // Both zero vectors: nan
+                if (ab == 0)
+                    return 0; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Create vector with the squared magnitudes
+                var squares = Vector64.Create(float.CreateTruncating(b2), float.CreateTruncating(a2));
+
+                // Compute reciprocal square root approximation
+                Vector64<float> rsqrts = AdvSimd.ReciprocalSquareRootEstimate(squares);
+
+                // Perform two rounds of Newton-Raphson refinement for better accuracy
+                // Formula: rsqrt_new = rsqrt * (1.5 - 0.5 * x * rsqrt^2)
+                // Which can be rewritten as: rsqrt * vrsqrts(x * rsqrt, rsqrt)
+                rsqrts = AdvSimd.Multiply(rsqrts, AdvSimd.ReciprocalSquareRootStep(AdvSimd.Multiply(squares, rsqrts), rsqrts));
+                rsqrts = AdvSimd.Multiply(rsqrts, AdvSimd.ReciprocalSquareRootStep(AdvSimd.Multiply(squares, rsqrts), rsqrts));
+
+                // Extract the refined reciprocal square roots
+                float rsqrtA = rsqrts.GetElement(0);
+                float rsqrtB = rsqrts.GetElement(1);
+
+                // Compute the cosine similarity
+                return ab * rsqrtA * rsqrtB;
+            }
 
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal static double CosineSimilarityInternal(ref double aRef, double aMagnitude, ref double bRef, double bMagnitude, nuint size)
+            internal static double CosineSimilarityInternalX64(ref double aRef, double aMagnitude, ref double bRef, double bMagnitude, nuint size)
             {
                 Vector512<double> abVec = Vector512<double>.Zero;
                 Vector512<double> a2Vec = Vector512<double>.Zero;
@@ -480,6 +555,81 @@ namespace Sparrow.Server.Tensors
                 return ab * a2Reciprocal * b2Reciprocal;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double CosineSimilarityInternalNeon(ref double aRef, double aMagnitude, ref double bRef, double bMagnitude, nuint size)
+            {
+                Vector512<double> abVec = Vector512<double>.Zero;
+                Vector512<double> a2Vec = Vector512<double>.Zero;
+                Vector512<double> b2Vec = Vector512<double>.Zero;
+
+                nuint i = 0;
+                nuint oneVectorFromEnd = size - (nuint)Vector512<double>.Count;
+
+            Loop:
+
+                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
+                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
+                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
+                // of the instructions themselves.
+                Vector512<double> aVec = Vector512.LoadUnsafe(ref aRef, i);
+                Vector512<double> bVec = Vector512.LoadUnsafe(ref bRef, i);
+
+                i += (nuint)Vector512<double>.Count;
+
+            LoopWithoutLoad:
+
+                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+
+                if (i <= oneVectorFromEnd)
+                    goto Loop;
+
+                if (i != (nuint)size)
+                {
+                    nuint offset = (nuint)size - i;
+                    Debug.Assert((int)offset * sizeof(double) + Vector512<byte>.Count <= MoveMaskTable.Length);
+
+                    var mask = Vector512.LoadUnsafe<double>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, double>(MoveMaskTable)), (nuint)offset);
+
+                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+
+                    i = (nuint)size;
+                    goto LoopWithoutLoad;
+                }
+
+                double ab = aMagnitude * bMagnitude * Vector512.Sum(abVec);
+                double a2 = aMagnitude * aMagnitude * Vector512.Sum(a2Vec);
+                double b2 = bMagnitude * bMagnitude * Vector512.Sum(b2Vec);
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return double.NaN; // Both zero vectors: nan
+                if (ab == 0)
+                    return 0; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Create vector with the squared magnitudes
+                var squares = Vector64.Create(float.CreateTruncating(b2), float.CreateTruncating(a2));
+
+                // Compute reciprocal square root approximation
+                Vector64<float> rsqrts = AdvSimd.ReciprocalSquareRootEstimate(squares);
+
+                // Perform two rounds of Newton-Raphson refinement for better accuracy
+                // Formula: rsqrt_new = rsqrt * (1.5 - 0.5 * x * rsqrt^2)
+                // Which can be rewritten as: rsqrt * vrsqrts(x * rsqrt, rsqrt)
+                rsqrts = AdvSimd.Multiply(rsqrts, AdvSimd.ReciprocalSquareRootStep(AdvSimd.Multiply(squares, rsqrts), rsqrts));
+                rsqrts = AdvSimd.Multiply(rsqrts, AdvSimd.ReciprocalSquareRootStep(AdvSimd.Multiply(squares, rsqrts), rsqrts));
+
+                // Extract the refined reciprocal square roots
+                float rsqrtA = rsqrts.GetElement(0);
+                float rsqrtB = rsqrts.GetElement(1);
+
+                // Compute the cosine similarity
+                return ab * rsqrtA * rsqrtB;
+            }
+
 
             [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
             public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
@@ -492,17 +642,33 @@ namespace Sparrow.Server.Tensors
                 double similarity;
                 if (typeof(T) == typeof(float))
                 {
-                    similarity = CosineSimilarityInternal(
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a)), 1.0f,
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b)), 1.0f,
-                        (nuint)a.Length);
+                    ref var afRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a));
+                    ref var bfRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b));
+
+                    if (Sse2.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalX64(ref afRef, 1.0f, ref bfRef, 1.0f, (nuint)a.Length);
+                    }
+                    else if (AdvInstructionSet.Arm.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalNeon(ref afRef, 1.0f, ref bfRef, 1.0f, (nuint)a.Length);
+                    }
+                    else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
                 } 
                 else if (typeof(T) == typeof(double))
                 {
-                    similarity = CosineSimilarityInternal(
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(a)), 1.0d,
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(b)), 1.0d,
-                        (nuint)a.Length);
+                    ref var adRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(a));
+                    ref var bdRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(b));
+
+                    if (Sse2.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalX64(ref adRef, 1.0d, ref bdRef, 1.0d, (nuint)a.Length);
+                    }
+                    else if (AdvInstructionSet.Arm.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalNeon(ref adRef, 1.0d, ref bdRef, 1.0d, (nuint)a.Length);
+                    }
+                    else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
                 }
                 else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
 
@@ -536,13 +702,20 @@ namespace Sparrow.Server.Tensors
                         aMag = (float)(double)(object)aMagnitude;
                         bMag = (float)(double)(object)bMagnitude;
                     }
-                    else
-                        throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+                    else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
 
-                    similarity = CosineSimilarityInternal(
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a)), aMag,
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b)), bMag,
-                        (nuint)a.Length);
+                    ref var adRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a));
+                    ref var bdRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b));
+
+                    if (Sse2.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalX64(ref adRef, aMag, ref bdRef, bMag, (nuint)a.Length);
+                    }
+                    else if (AdvInstructionSet.Arm.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalNeon(ref adRef, aMag, ref bdRef, bMag, (nuint)a.Length);
+                    }
+                    else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
                 }
                 else if (typeof(T) == typeof(double))
                 {
@@ -557,16 +730,22 @@ namespace Sparrow.Server.Tensors
                         aMag = (double)(object)aMagnitude;
                         bMag = (double)(object)bMagnitude;
                     }
-                    else
-                        throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+                    else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
 
-                    similarity = CosineSimilarityInternal(
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(a)), aMag,
-                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(b)), bMag,
-                        (nuint)a.Length);
+                    ref var adRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(a));
+                    ref var bdRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(b));
+
+                    if (Sse2.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalX64(ref adRef, aMag, ref bdRef, bMag, (nuint)a.Length);
+                    }
+                    else if (AdvInstructionSet.Arm.IsSupported)
+                    {
+                        similarity = CosineSimilarityInternalNeon(ref adRef, aMag, ref bdRef, bMag, (nuint)a.Length);
+                    }
+                    else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
                 }
-                else
-                    throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+                else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
 
                 if (typeof(TResult) == typeof(float))
                 {
@@ -645,17 +824,12 @@ namespace Sparrow.Server.Tensors
 
         public static class Vectorized256
         {
+
             [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
-            internal static TResult CosineSimilarityNormalize<T, TResult>(T ab, T a2, T b2)
+            internal static TResult CosineSimilarityNormalizeSse<T, TResult>(T ab, T a2, T b2)
                 where T : unmanaged, IRootFunctions<T>, INumber<T>
                 where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
             {
-                if (!Sse.IsSupported || !Sse2.IsSupported)
-                {
-                    // Fallback to the serial implementation if SIMD is not supported
-                    return Serial.CosineSimilarityNormalize<T, TResult>(ab, a2, b2);
-                }
-
                 // Create a 128-bit vector with a2 in the high lane and b2 in the low lane.
                 // Note: _mm_set_pd(a2, b2) in C sets lane1=a2 and lane0=b2.
                 // In .NET, Vector128.Create(x, y) sets lane0 = x and lane1 = y.
@@ -689,6 +863,46 @@ namespace Sparrow.Server.Tensors
 
                 return TResult.CreateTruncating(double.CreateTruncating(ab) * a2Reciprocal * b2Reciprocal);
             }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityNormalizeNeon<T, TResult>(T ab, T a2, T b2)
+                where T : unmanaged, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                // Create vector with the squared magnitudes
+                var squares = Vector64.Create(float.CreateTruncating(b2), float.CreateTruncating(a2));
+
+                // Compute reciprocal square root approximation
+                Vector64<float> rsqrts = AdvSimd.ReciprocalSquareRootEstimate(squares);
+
+                // Perform two rounds of Newton-Raphson refinement for better accuracy
+                // Formula: rsqrt_new = rsqrt * (1.5 - 0.5 * x * rsqrt^2)
+                // Which can be rewritten as: rsqrt * vrsqrts(x * rsqrt, rsqrt)
+                rsqrts = AdvSimd.Multiply(rsqrts, AdvSimd.ReciprocalSquareRootStep(AdvSimd.Multiply(squares, rsqrts), rsqrts));
+                rsqrts = AdvSimd.Multiply(rsqrts, AdvSimd.ReciprocalSquareRootStep(AdvSimd.Multiply(squares, rsqrts), rsqrts));
+
+                // Extract the refined reciprocal square roots
+                float a2Reciprocal = rsqrts.GetElement(0);
+                float b2Reciprocal = rsqrts.GetElement(1);
+
+                return TResult.CreateTruncating(float.CreateTruncating(ab) * a2Reciprocal * b2Reciprocal);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityNormalize<T, TResult>(T ab, T a2, T b2)
+                where T : unmanaged, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                if (Sse2.IsSupported)
+                    return CosineSimilarityNormalizeSse<T, TResult>(ab, a2, b2);
+
+                if (AdvInstructionSet.Arm.IsSupported)
+                    return CosineSimilarityNormalizeNeon<T, TResult>(ab, a2, b2);
+
+                // Fallback to the serial implementation if SIMD is not supported
+                return Serial.CosineSimilarityNormalize<T, TResult>(ab, a2, b2);
+            }
+
 
             [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
             public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -111,7 +111,7 @@ namespace Sparrow.Server.Tensors
             {
                 if (a.Length >= Vector256<sbyte>.Count && AdvInstructionSet.X86.IsSupportedAvx256)
                 {
-                    if (Avx512BW.IsSupported && Avx512F.IsSupported)
+                    if (AdvInstructionSet.X86.IsSupportedAvx512Basic)
                     {
                         return Vectorized512.CosineSimilarityIntegersAvx512(
                             MemoryMarshal.Cast<T, sbyte>(a), aMagnitude,
@@ -135,20 +135,20 @@ namespace Sparrow.Server.Tensors
             {
                 if (typeof(T) == typeof(float))
                 {
-                    return Vectorized512.CosineSimilarity(
+                    return Vectorized512.CosineSimilarity<float, TResult>(
                         MemoryMarshal.Cast<T, float>(a), aMagnitude,
                         MemoryMarshal.Cast<T, float>(b), bMagnitude);
                 }
 
                 if (typeof(T) == typeof(double))
                 {
-                    return Vectorized512.CosineSimilarity(
+                    return Vectorized512.CosineSimilarity<double, TResult>(
                         MemoryMarshal.Cast<T, double>(a), aMagnitude,
                         MemoryMarshal.Cast<T, double>(b), bMagnitude);
                 }
             }
 
-            return Serial.CosineSimilarity(a, aMagnitude, b, bMagnitude);
+            return Serial.CosineSimilarity<T, TResult>(a, aMagnitude, b, bMagnitude);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -645,7 +645,7 @@ namespace Sparrow.Server.Tensors
                     ref var afRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a));
                     ref var bfRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b));
 
-                    if (Sse2.IsSupported)
+                    if (AdvInstructionSet.X86.IsSupportedSse)
                     {
                         similarity = CosineSimilarityInternalX64(ref afRef, 1.0f, ref bfRef, 1.0f, (nuint)a.Length);
                     }

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -1,0 +1,732 @@
+﻿using System;
+using System.Numerics;
+using System.Numerics.Tensors;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
+
+namespace Sparrow.Server.Tensors
+{
+    public static class Functions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T CosineDistance<T>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+            where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
+        {
+            return T.One - CosineSimilarity(a, b);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TResult CosineDistance<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+            where T : unmanaged, IRootFunctions<T>, INumber<T>
+            where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+        {
+            return TResult.One - CosineSimilarity<T, TResult>(a, b);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T CosineSimilarity<T>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+            where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
+        {
+            if (a.Length >= Vector512<T>.Count)
+            {
+                if (typeof(T) == typeof(float))
+                {
+                    if (AdvInstructionSet.IsAcceleratedVector256)
+                    {
+                        return Vectorized512.CosineSimilarity<T, T>(a, b);
+                    }
+
+                    return TensorPrimitives.CosineSimilarity(a, b);
+                }
+
+                if (typeof(T) == typeof(double) && AdvInstructionSet.IsAcceleratedVector256)
+                {
+                    return Vectorized512.CosineSimilarity<T, T>(a, b);
+                }
+            }
+
+            return Serial.CosineSimilarity<T,T>(a, b);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+            where T : unmanaged, INumber<T>
+            where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+        {
+            if (typeof(T) == typeof(sbyte))
+            {
+                if (a.Length >= Vector256<sbyte>.Count && AdvInstructionSet.X86.IsSupportedAvx256)
+                {
+                    if (Avx512BW.IsSupported && Avx512F.IsSupported)
+                    {
+                        return Vectorized512.CosineSimilarityIntegersAvx512(
+                            MemoryMarshal.Cast<T, sbyte>(a), TResult.One,
+                            MemoryMarshal.Cast<T, sbyte>(b), TResult.One);
+                    }
+
+                    return Vectorized256.CosineSimilarityIntegersAvx2(
+                        MemoryMarshal.Cast<T, sbyte>(a), TResult.One,
+                        MemoryMarshal.Cast<T, sbyte>(b), TResult.One);
+                }
+
+                if (a.Length >= Vector256<sbyte>.Count && AdvInstructionSet.Arm.IsSupported && Dp.IsSupported)
+                {
+                    return Vectorized256.CosineSimilarityIntegersNeon(
+                        MemoryMarshal.Cast<T, sbyte>(a), TResult.One,
+                        MemoryMarshal.Cast<T, sbyte>(b), TResult.One);
+                }
+            }
+
+            if (a.Length >= Vector512<T>.Count && AdvInstructionSet.IsAcceleratedVector256)
+            {
+                if (typeof(T) == typeof(float))
+                {
+                    return Vectorized512.CosineSimilarity<float, TResult>(
+                        MemoryMarshal.Cast<T, float>(a),
+                        MemoryMarshal.Cast<T, float>(b));
+                }
+
+                if (typeof(T) == typeof(double))
+                {
+                    return Vectorized512.CosineSimilarity<double, TResult>(
+                        MemoryMarshal.Cast<T, double>(a),
+                        MemoryMarshal.Cast<T, double>(b));
+                }
+            }
+
+            return Serial.CosineSimilarity<T, TResult>(a, b);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+            where T : unmanaged, INumber<T>
+            where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+        {
+            if (typeof(T) == typeof(sbyte))
+            {
+                if (a.Length >= Vector256<sbyte>.Count && AdvInstructionSet.X86.IsSupportedAvx256)
+                {
+                    if (Avx512BW.IsSupported && Avx512F.IsSupported)
+                    {
+                        return Vectorized512.CosineSimilarityIntegersAvx512(
+                            MemoryMarshal.Cast<T, sbyte>(a), aMagnitude,
+                            MemoryMarshal.Cast<T, sbyte>(b), bMagnitude);
+                    }
+
+                    return Vectorized256.CosineSimilarityIntegersAvx2(
+                        MemoryMarshal.Cast<T, sbyte>(a), aMagnitude,
+                        MemoryMarshal.Cast<T, sbyte>(b), bMagnitude);
+                }
+
+                if (a.Length >= Vector256<sbyte>.Count && AdvInstructionSet.Arm.IsSupported && Dp.IsSupported)
+                {
+                    return Vectorized256.CosineSimilarityIntegersNeon(
+                        MemoryMarshal.Cast<T, sbyte>(a), aMagnitude,
+                        MemoryMarshal.Cast<T, sbyte>(b), bMagnitude);
+                }
+            }
+
+            if (a.Length >= Vector512<T>.Count && AdvInstructionSet.IsAcceleratedVector256)
+            {
+                if (typeof(T) == typeof(float))
+                {
+                    return Vectorized512.CosineSimilarityFloatingPoint(
+                        MemoryMarshal.Cast<T, float>(a), aMagnitude,
+                        MemoryMarshal.Cast<T, float>(b), bMagnitude);
+                }
+
+                if (typeof(T) == typeof(double))
+                {
+                    return Vectorized512.CosineSimilarityFloatingPoint(
+                        MemoryMarshal.Cast<T, double>(a), aMagnitude,
+                        MemoryMarshal.Cast<T, double>(b), bMagnitude);
+                }
+            }
+
+            return Serial.CosineSimilarity(a, aMagnitude, b, bMagnitude);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TResult CosineDistance<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+            where T : unmanaged, INumber<T>
+            where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+        {
+            return TResult.One - CosineSimilarity(a, aMagnitude, b, bMagnitude);
+        }
+
+        public static class Serial
+        {
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityNormalize<T, TResult>(T ab, T a2, T b2)
+                where T : unmanaged, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                // Convert the accumulation values from T to TResult.
+                // This assumes that converting from T to TResult is lossless or acceptable in your context.
+                TResult a2Conv = TResult.CreateTruncating(a2);
+                TResult b2Conv = TResult.CreateTruncating(b2);
+                TResult abConv = TResult.CreateTruncating(ab);
+
+                // Compute the reciprocal of the magnitudes:
+                // invSqrtA2 = 1 / sqrt(a2) and invSqrtB2 = 1 / sqrt(b2)
+                TResult invSqrtA2B2 = TResult.Sqrt(a2Conv) * TResult.Sqrt(b2Conv);
+
+                // Calculate the cosine similarity (note that cos(theta) = ab / (sqrt(a2)*sqrt(b2)))
+                TResult cosineSimilarity = abConv / invSqrtA2B2;
+                return cosineSimilarity;
+            }
+
+            /// <summary>
+            /// Serial implementation of Cosine distance.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+                where T : unmanaged, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                TResult ab = TResult.Zero, a2 = TResult.Zero, b2 = TResult.Zero;
+                for (int i = 0; i < a.Length; i++)
+                {
+                    var rai = TResult.CreateTruncating(a[i]);
+                    var rbi = TResult.CreateTruncating(b[i]);
+                    ab += rai * rbi;
+                    a2 += rai * rai;
+                    b2 += rbi * rbi;
+                }
+
+                // Special cases
+                if (TResult.IsZero(a2) && TResult.IsZero(b2))
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (TResult.IsZero(ab))
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                return CosineSimilarityNormalize<TResult, TResult>(ab, a2, b2);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+                where T : unmanaged, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                if (typeof(T) == typeof(float) || typeof(T) == typeof(double))
+                {
+                    return CosineSimilarityFloatingPoint(a, aMagnitude, b, bMagnitude);
+                }
+
+                return CosineSimilarityIntegers(a, aMagnitude, b, bMagnitude);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            private static TResult CosineSimilarityIntegers<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+                where T : unmanaged, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                long ab = 0, a2 = 0, b2 = 0;
+                for (int i = 0; i < a.Length; i++)
+                {
+                    long rai = long.CreateTruncating(a[i]);
+                    long rbi = long.CreateTruncating(b[i]);
+
+                    ab += rai * rbi;
+                    a2 += rai * rai;
+                    b2 += rbi * rbi;
+                }
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (ab == 0)
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                TResult fab = aMagnitude * bMagnitude * TResult.CreateTruncating(ab);
+                TResult fa2 = aMagnitude * aMagnitude * TResult.CreateTruncating(a2);
+                TResult fb2 = bMagnitude * bMagnitude * TResult.CreateTruncating(b2);
+                return CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarityFloatingPoint<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+                where T : unmanaged, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                TResult ab = TResult.Zero, a2 = TResult.Zero, b2 = TResult.Zero;
+                for (int i = 0; i < a.Length; i++)
+                {
+                    ab += TResult.CreateTruncating(a[i] * b[i]);
+                    a2 += TResult.CreateTruncating(a[i] * a[i]);
+                    b2 += TResult.CreateTruncating(b[i] * b[i]);
+                }
+
+                // Special cases
+                if (a2 == TResult.Zero && b2 == TResult.Zero)
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (ab == TResult.Zero)
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                TResult fab = aMagnitude * bMagnitude * TResult.CreateTruncating(ab);
+                TResult fa2 = aMagnitude * aMagnitude * TResult.CreateTruncating(a2);
+                TResult fb2 = bMagnitude * bMagnitude * TResult.CreateTruncating(b2);
+                return CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+            }
+        }
+
+        public static class Vectorized512
+        {
+            private static ReadOnlySpan<byte> MoveMaskTable =>
+            [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 64 bits
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 128 bits
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 256 bits
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 512 bits
+                // Now comes the part were we are having 0xFF
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 64 bits
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 128 bits
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 256 bits
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 512 bits
+            ];
+
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+                where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                Vector512<T> abVec = Vector512<T>.Zero;
+                Vector512<T> a2Vec = Vector512<T>.Zero;
+                Vector512<T> b2Vec = Vector512<T>.Zero;
+
+                int i = a.Length;
+                ref T aRef = ref MemoryMarshal.GetReference(a);
+                ref T bRef = ref MemoryMarshal.GetReference(b);
+
+                Loop:
+
+                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
+                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
+                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
+                // of the instructions themselves.
+                Vector512<T> aVec = Vector512.LoadUnsafe(ref aRef);
+                Vector512<T> bVec = Vector512.LoadUnsafe(ref bRef);
+
+                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+
+                i -= Vector512<T>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector512<T>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector512<T>.Count);
+                if (i >= Vector512<T>.Count)
+                    goto Loop;
+
+                if (i > 0)
+                {
+                    int offset = Vector512<T>.Count - i;
+                    aRef = ref Unsafe.Subtract(ref aRef, offset);
+                    bRef = ref Unsafe.Subtract(ref bRef, offset);
+
+                    ref var moveMaskTable = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, T>(MoveMaskTable));
+                    var mask = Vector512.LoadUnsafe<T>(ref moveMaskTable, (nuint)i);
+
+                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef), mask);
+                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef), mask);
+
+                    abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                    a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                    b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+                }
+
+                T ab = Vector512.Sum(abVec);
+                T a2 = Vector512.Sum(a2Vec);
+                T b2 = Vector512.Sum(b2Vec);
+
+                // Special cases
+                if (T.IsZero(a2) && T.IsZero(b2))
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (T.IsZero(ab))
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                return Vectorized256.CosineSimilarityNormalize<T, TResult>(ab, a2, b2);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityFloatingPoint<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+                where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                Vector512<T> abVec = Vector512<T>.Zero;
+                Vector512<T> a2Vec = Vector512<T>.Zero;
+                Vector512<T> b2Vec = Vector512<T>.Zero;
+
+                int i = a.Length;
+                ref T aRef = ref MemoryMarshal.GetReference(a);
+                ref T bRef = ref MemoryMarshal.GetReference(b);
+
+            Loop:
+
+                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
+                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
+                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
+                // of the instructions themselves.
+                Vector512<T> aVec = Vector512.LoadUnsafe(ref aRef);
+                Vector512<T> bVec = Vector512.LoadUnsafe(ref bRef);
+
+                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+
+                i -= Vector512<T>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector512<T>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector512<T>.Count);
+                if (i >= Vector512<T>.Count)
+                    goto Loop;
+
+                if (i > 0)
+                {
+                    int offset = Vector512<T>.Count - i;
+                    aRef = ref Unsafe.Subtract(ref aRef, offset);
+                    bRef = ref Unsafe.Subtract(ref bRef, offset);
+
+                    ref var moveMaskTable = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, T>(MoveMaskTable));
+                    var mask = Vector512.LoadUnsafe<T>(ref moveMaskTable, (nuint)i);
+
+                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef), mask);
+                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef), mask);
+
+                    abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                    a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                    b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+                }
+
+                T ab = Vector512.Sum(abVec);
+                T a2 = Vector512.Sum(a2Vec);
+                T b2 = Vector512.Sum(b2Vec);
+
+                // Special cases
+                if (T.IsZero(a2) && T.IsZero(b2))
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (T.IsZero(ab))
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                TResult fab = aMagnitude * bMagnitude * TResult.CreateTruncating(ab);
+                TResult fa2 = aMagnitude * aMagnitude * TResult.CreateTruncating(a2);
+                TResult fb2 = bMagnitude * bMagnitude * TResult.CreateTruncating(b2);
+                return Vectorized256.CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityIntegersAvx512<TResult>(ReadOnlySpan<sbyte> a, TResult aMagnitude, ReadOnlySpan<sbyte> b, TResult bMagnitude)
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                // 1) 512-bit accumulators for ab, a2, b2
+                var abVec = Vector512<int>.Zero;
+                var a2Vec = Vector512<int>.Zero;
+                var b2Vec = Vector512<int>.Zero;
+
+                int i = a.Length;
+
+                ref sbyte aRef = ref MemoryMarshal.GetReference(a);
+                ref sbyte bRef = ref MemoryMarshal.GetReference(b);
+
+            Loop:
+
+                // 2) load full 32-byte block
+                Vector512<short> aVec = Avx512BW.ConvertToVector512Int16(Vector256.LoadUnsafe(ref aRef));
+                Vector512<short> bVec = Avx512BW.ConvertToVector512Int16(Vector256.LoadUnsafe(ref bRef));
+
+                i -= Vector256<sbyte>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector256<sbyte>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector256<sbyte>.Count);
+
+                // 3) multiply-add pairs: i16×i16→i32
+                abVec = Avx512F.Add(abVec, Avx512BW.MultiplyAddAdjacent(aVec, bVec));
+                a2Vec = Avx512F.Add(a2Vec, Avx512BW.MultiplyAddAdjacent(aVec, aVec));
+                b2Vec = Avx512F.Add(b2Vec, Avx512BW.MultiplyAddAdjacent(bVec, bVec));
+
+                if (i > 0)
+                    goto Loop;
+
+                // 4) horizontal reductions
+                int ab = Vector512.Sum(abVec);
+                int a2 = Vector512.Sum(a2Vec);
+                int b2 = Vector512.Sum(b2Vec);
+
+                // Tail loop for remaining elements
+                while (i >= 0)
+                {
+                    ab += aRef * bRef;
+                    a2 += aRef * aRef;
+                    b2 += bRef * bRef;
+
+                    i--;
+                    aRef = ref Unsafe.Add(ref aRef, 1);
+                    bRef = ref Unsafe.Add(ref bRef, 1);
+                }
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (ab == 0)
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Apply magnitudes and normalise
+                TResult fab = TResult.CreateTruncating(ab) * aMagnitude * bMagnitude;
+                TResult fa2 = TResult.CreateTruncating(a2) * aMagnitude * aMagnitude;
+                TResult fb2 = TResult.CreateTruncating(b2) * bMagnitude * bMagnitude;
+
+                return Vectorized256.CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+            }
+        }
+
+        public static class Vectorized256
+        {
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityNormalize<T, TResult>(T ab, T a2, T b2)
+                where T : unmanaged, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                if (!Sse.IsSupported || !Sse2.IsSupported)
+                {
+                    // Fallback to the serial implementation if SIMD is not supported
+                    return Serial.CosineSimilarityNormalize<T, TResult>(ab, a2, b2);
+                }
+
+                // Create a 128-bit vector with a2 in the high lane and b2 in the low lane.
+                // Note: _mm_set_pd(a2, b2) in C sets lane1=a2 and lane0=b2.
+                // In .NET, Vector128.Create(x, y) sets lane0 = x and lane1 = y.
+                // So we swap the order.
+                var squares = Vector128.Create(double.CreateTruncating(b2), double.CreateTruncating(a2));
+
+                // Compute approximate reciprocal square root (single precision).
+                var rsqrts = Sse2.ConvertToVector128Double(
+                    Sse.ReciprocalSqrt(
+                        Sse2.ConvertToVector128Single(squares))
+                );
+
+                // Newton-Raphson iteration for reciprocal square root:
+                // https://en.wikipedia.org/wiki/Newton%27s_method
+                rsqrts = Sse2.Add(
+                    Sse2.Multiply(Vector128.Create(1.5d), rsqrts),
+                    Sse2.Multiply(
+                        Sse2.Multiply(
+                            Sse2.Multiply(squares, Vector128.Create(-0.5d)),
+                            rsqrts),
+                        Sse2.Multiply(rsqrts, rsqrts)
+                    )
+                );
+
+                // Extract the results.
+                // According to our lane ordering:
+                //   - Lane 0 contains b2 reciprocal.
+                //   - Lane 1 contains a2 reciprocal.
+                double b2Reciprocal = rsqrts.ToScalar(); // lane 0
+                double a2Reciprocal = Sse2.UnpackHigh(rsqrts, rsqrts).ToScalar(); // lane 1
+
+                return TResult.CreateTruncating(double.CreateTruncating(ab) * a2Reciprocal * b2Reciprocal);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+                where T : unmanaged, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                Vector256<T> abVec = Vector256<T>.Zero;
+                Vector256<T> a2Vec = Vector256<T>.Zero;
+                Vector256<T> b2Vec = Vector256<T>.Zero;
+
+                int i = a.Length;
+                ref T aRef = ref MemoryMarshal.GetReference(a);
+                ref T bRef = ref MemoryMarshal.GetReference(b);
+
+                Loop:
+                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
+                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
+                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
+                // of the instructions themselves.
+                Vector256<T> aVec = Vector256.LoadUnsafe(ref aRef);
+                Vector256<T> bVec = Vector256.LoadUnsafe(ref bRef);
+
+                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+
+                i -= Vector256<T>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector256<T>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector256<T>.Count);
+                if (i >= Vector256<T>.Count)
+                    goto Loop;
+
+                T ab = Vector256.Sum(abVec);
+                T a2 = Vector256.Sum(a2Vec);
+                T b2 = Vector256.Sum(b2Vec);
+                while (i >= 0)
+                {
+                    ab += aRef * bRef;
+                    a2 += aRef * aRef;
+                    b2 += bRef * bRef;
+
+                    i--;
+                    aRef = ref Unsafe.Add(ref aRef, 1);
+                    bRef = ref Unsafe.Add(ref bRef, 1);
+                }
+
+                // Special cases
+                if (T.IsZero(a2) && T.IsZero(b2))
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (T.IsZero(ab))
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                return CosineSimilarityNormalize<T, TResult>(ab, a2, b2);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityIntegersAvx2<TResult>(ReadOnlySpan<sbyte> a, TResult aMagnitude, ReadOnlySpan<sbyte> b, TResult bMagnitude)
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                //  Prepare six 256-bit accumulators: low/high lanes for ab, a2, b2
+                Vector256<int> abLo = Vector256<int>.Zero, abHi = Vector256<int>.Zero;
+                Vector256<int> a2Lo = Vector256<int>.Zero, a2Hi = Vector256<int>.Zero;
+                Vector256<int> b2Lo = Vector256<int>.Zero, b2Hi = Vector256<int>.Zero;
+
+                int i = a.Length;
+
+                ref sbyte aRef = ref MemoryMarshal.GetReference(a);
+                ref sbyte bRef = ref MemoryMarshal.GetReference(b);
+
+                Loop:
+                // Load 32 signed-bytes from each span
+                Vector256<sbyte> aVec = Vector256.LoadUnsafe(ref aRef);
+                Vector256<sbyte> bVec = Vector256.LoadUnsafe(ref bRef);
+
+                // Unpack signed‐byte → signed‐short for low/high 128‐bit lanes
+                Vector256<short> aVecLo = Avx2.ConvertToVector256Int16(aVec.GetLower());
+                Vector256<short> aVecHi = Avx2.ConvertToVector256Int16(aVec.GetUpper());
+                Vector256<short> bVecLo = Avx2.ConvertToVector256Int16(bVec.GetLower());
+                Vector256<short> bVecHi = Avx2.ConvertToVector256Int16(bVec.GetUpper());
+
+                // Multiply‐add adjacent pairs: produces four i32 results per 128‐bit lane
+
+                // Perform i16×i16→i32 multiply-add on adjacent pairs:
+                //    - ab += a * b
+                //    - a2 += a * a
+                //    - b2 += b * b
+                abLo = Avx2.Add(abLo, Avx2.MultiplyAddAdjacent(aVecLo, bVecLo));
+                abHi = Avx2.Add(abHi, Avx2.MultiplyAddAdjacent(aVecHi, bVecHi));
+
+                a2Lo = Avx2.Add(a2Lo, Avx2.MultiplyAddAdjacent(aVecLo, aVecLo));
+                a2Hi = Avx2.Add(a2Hi, Avx2.MultiplyAddAdjacent(aVecHi, aVecHi));
+
+                b2Lo = Avx2.Add(b2Lo, Avx2.MultiplyAddAdjacent(bVecLo, bVecLo));
+                b2Hi = Avx2.Add(b2Hi, Avx2.MultiplyAddAdjacent(bVecHi, bVecHi));
+
+                i -= Vector256<sbyte>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector256<sbyte>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector256<sbyte>.Count);
+                if (i >= Vector256<sbyte>.Count)
+                    goto Loop;
+
+                // Horizontal reduction across the two 128‐bit halves
+                int ab = Vector256.Sum(Avx2.Add(abLo, abHi));
+                int a2 = Vector256.Sum(Avx2.Add(a2Lo, a2Hi));
+                int b2 = Vector256.Sum(Avx2.Add(b2Lo, b2Hi));
+
+                // Tail loop for remaining elements
+                while (i >= 0)
+                {
+                    ab += aRef * bRef;
+                    a2 += aRef * aRef;
+                    b2 += bRef * bRef;
+
+                    i--;
+                    aRef = ref Unsafe.Add(ref aRef, 1);
+                    bRef = ref Unsafe.Add(ref bRef, 1);
+                }
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (ab == 0)
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Apply magnitudes and normalise
+                TResult fab = TResult.CreateTruncating(ab) * aMagnitude * bMagnitude;
+                TResult fa2 = TResult.CreateTruncating(a2) * aMagnitude * aMagnitude;
+                TResult fb2 = TResult.CreateTruncating(b2) * bMagnitude * bMagnitude;
+                return CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static TResult CosineSimilarityIntegersNeon<TResult>(ReadOnlySpan<sbyte> a, TResult aMagnitude, ReadOnlySpan<sbyte> b, TResult bMagnitude)
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                Vector128<int> abVec = Vector128<int>.Zero;
+                Vector128<int> a2Vec = Vector128<int>.Zero;
+                Vector128<int> b2Vec = Vector128<int>.Zero;
+
+                int i = a.Length;
+
+                ref sbyte aRef = ref MemoryMarshal.GetReference(a);
+                ref sbyte bRef = ref MemoryMarshal.GetReference(b);
+                
+                Loop:
+                
+                // Load 16 signed-bytes from each span
+                Vector128<sbyte> aVec = Vector128.LoadUnsafe(ref aRef);
+                Vector128<sbyte> bVec = Vector128.LoadUnsafe(ref bRef);
+
+                // 4 × dot-product accumulating per 4 lanes
+                abVec = Dp.DotProduct(abVec, aVec, bVec);
+                a2Vec = Dp.DotProduct(a2Vec, aVec, aVec);
+                b2Vec = Dp.DotProduct(b2Vec, bVec, bVec);
+
+                i -= Vector128<sbyte>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector128<sbyte>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector128<sbyte>.Count);
+                if (i >= Vector128<sbyte>.Count)
+                    goto Loop;
+
+                int ab = Vector128.Sum(abVec);
+                int a2 = Vector128.Sum(a2Vec);
+                int b2 = Vector128.Sum(b2Vec);
+                while (i >= 0)
+                {
+                    ab += aRef * bRef;
+                    a2 += aRef * aRef;
+                    b2 += bRef * bRef;
+
+                    i--;
+                    aRef = ref Unsafe.Add(ref aRef, 1);
+                    bRef = ref Unsafe.Add(ref bRef, 1);
+                }
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
+                if (ab == 0)
+                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Apply magnitudes and normalise
+                TResult fab = TResult.CreateTruncating(ab) * aMagnitude * bMagnitude;
+                TResult fa2 = TResult.CreateTruncating(a2) * aMagnitude * aMagnitude;
+                TResult fb2 = TResult.CreateTruncating(b2) * bMagnitude * bMagnitude;
+                return CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+            }
+        }
+    }
+}

--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Net;
 using System.Numerics;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
@@ -133,14 +135,14 @@ namespace Sparrow.Server.Tensors
             {
                 if (typeof(T) == typeof(float))
                 {
-                    return Vectorized512.CosineSimilarityFloatingPoint(
+                    return Vectorized512.CosineSimilarity(
                         MemoryMarshal.Cast<T, float>(a), aMagnitude,
                         MemoryMarshal.Cast<T, float>(b), bMagnitude);
                 }
 
                 if (typeof(T) == typeof(double))
                 {
-                    return Vectorized512.CosineSimilarityFloatingPoint(
+                    return Vectorized512.CosineSimilarity(
                         MemoryMarshal.Cast<T, double>(a), aMagnitude,
                         MemoryMarshal.Cast<T, double>(b), bMagnitude);
                 }
@@ -299,82 +301,15 @@ namespace Sparrow.Server.Tensors
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 512 bits
             ];
 
-
-            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
-            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
-                where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
-                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double CosineSimilarityInternal(ref float aRef, float aMagnitude, ref float bRef, float bMagnitude, nuint size)
             {
-                Vector512<T> abVec = Vector512<T>.Zero;
-                Vector512<T> a2Vec = Vector512<T>.Zero;
-                Vector512<T> b2Vec = Vector512<T>.Zero;
+                Vector512<float> abVec = Vector512<float>.Zero;
+                Vector512<float> a2Vec = Vector512<float>.Zero;
+                Vector512<float> b2Vec = Vector512<float>.Zero;
 
-                int i = a.Length;
-                ref T aRef = ref MemoryMarshal.GetReference(a);
-                ref T bRef = ref MemoryMarshal.GetReference(b);
-
-                Loop:
-
-                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
-                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
-                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
-                // of the instructions themselves.
-                Vector512<T> aVec = Vector512.LoadUnsafe(ref aRef);
-                Vector512<T> bVec = Vector512.LoadUnsafe(ref bRef);
-
-                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
-                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
-                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
-
-                i -= Vector512<T>.Count;
-                aRef = ref Unsafe.Add(ref aRef, Vector512<T>.Count);
-                bRef = ref Unsafe.Add(ref bRef, Vector512<T>.Count);
-                if (i >= Vector512<T>.Count)
-                    goto Loop;
-
-                if (i > 0)
-                {
-                    int offset = Vector512<T>.Count - i;
-                    aRef = ref Unsafe.Subtract(ref aRef, offset);
-                    bRef = ref Unsafe.Subtract(ref bRef, offset);
-
-                    ref var moveMaskTable = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, T>(MoveMaskTable));
-                    var mask = Vector512.LoadUnsafe<T>(ref moveMaskTable, (nuint)i);
-
-                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef), mask);
-                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef), mask);
-
-                    abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
-                    a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
-                    b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
-                }
-
-                T ab = Vector512.Sum(abVec);
-                T a2 = Vector512.Sum(a2Vec);
-                T b2 = Vector512.Sum(b2Vec);
-
-                // Special cases
-                if (T.IsZero(a2) && T.IsZero(b2))
-                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
-                if (T.IsZero(ab))
-                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
-
-                // Normalization
-                return Vectorized256.CosineSimilarityNormalize<T, TResult>(ab, a2, b2);
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
-            internal static TResult CosineSimilarityFloatingPoint<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
-                where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
-                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
-            {
-                Vector512<T> abVec = Vector512<T>.Zero;
-                Vector512<T> a2Vec = Vector512<T>.Zero;
-                Vector512<T> b2Vec = Vector512<T>.Zero;
-
-                int i = a.Length;
-                ref T aRef = ref MemoryMarshal.GetReference(a);
-                ref T bRef = ref MemoryMarshal.GetReference(b);
+                nuint i = 0;
+                nuint oneVectorFromEnd = size - (nuint)Vector512<float>.Count;
 
             Loop:
 
@@ -382,57 +317,272 @@ namespace Sparrow.Server.Tensors
                 // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
                 // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
                 // of the instructions themselves.
-                Vector512<T> aVec = Vector512.LoadUnsafe(ref aRef);
-                Vector512<T> bVec = Vector512.LoadUnsafe(ref bRef);
+                Vector512<float> aVec = Vector512.LoadUnsafe(ref aRef, i);
+                Vector512<float> bVec = Vector512.LoadUnsafe(ref bRef, i);
+
+                i += (nuint)Vector512<float>.Count;
+
+            LoopWithoutLoad:
 
                 abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
                 a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
                 b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
 
-                i -= Vector512<T>.Count;
-                aRef = ref Unsafe.Add(ref aRef, Vector512<T>.Count);
-                bRef = ref Unsafe.Add(ref bRef, Vector512<T>.Count);
-                if (i >= Vector512<T>.Count)
+                if (i <= oneVectorFromEnd)
                     goto Loop;
 
-                if (i > 0)
+                if (i != (nuint)size)
                 {
-                    int offset = Vector512<T>.Count - i;
-                    aRef = ref Unsafe.Subtract(ref aRef, offset);
-                    bRef = ref Unsafe.Subtract(ref bRef, offset);
+                    nuint offset = size - i;
+                    Debug.Assert((int)offset * sizeof(float) + Vector512<byte>.Count <= MoveMaskTable.Length);
 
-                    ref var moveMaskTable = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, T>(MoveMaskTable));
-                    var mask = Vector512.LoadUnsafe<T>(ref moveMaskTable, (nuint)i);
+                    var mask = Vector512.LoadUnsafe<float>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, float>(MoveMaskTable)), (nuint)offset);
 
-                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef), mask);
-                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef), mask);
+                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
 
-                    abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
-                    a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
-                    b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+                    i = (nuint)size;
+                    goto LoopWithoutLoad;
                 }
 
-                T ab = Vector512.Sum(abVec);
-                T a2 = Vector512.Sum(a2Vec);
-                T b2 = Vector512.Sum(b2Vec);
+                float ab = aMagnitude * bMagnitude * Vector512.Sum(abVec);
+                float a2 = aMagnitude * aMagnitude * Vector512.Sum(a2Vec);
+                float b2 = bMagnitude * bMagnitude * Vector512.Sum(b2Vec);
 
                 // Special cases
-                if (T.IsZero(a2) && T.IsZero(b2))
-                    return TResult.CreateTruncating(double.NaN); // Both zero vectors: nan
-                if (T.IsZero(ab))
-                    return TResult.Zero; // Orthogonal or one zero: distance = 1, similarity 0
+                if (a2 == 0 && b2 == 0)
+                    return double.NaN; // Both zero vectors: nan
+                if (ab == 0)
+                    return 0; // Orthogonal or one zero: distance = 1, similarity 0
 
                 // Normalization
-                TResult fab = aMagnitude * bMagnitude * TResult.CreateTruncating(ab);
-                TResult fa2 = aMagnitude * aMagnitude * TResult.CreateTruncating(a2);
-                TResult fb2 = bMagnitude * bMagnitude * TResult.CreateTruncating(b2);
-                return Vectorized256.CosineSimilarityNormalize<TResult, TResult>(fab, fa2, fb2);
+                // Create a 128-bit vector with a2 in the high lane and b2 in the low lane.
+                // Note: _mm_set_pd(a2, b2) in C sets lane1=a2 and lane0=b2.
+                // In .NET, Vector128.Create(x, y) sets lane0 = x and lane1 = y.
+                // So we swap the order.
+                var squares = Vector128.Create((double)b2, (double)a2);
+
+                // Compute approximate reciprocal square root (single precision).
+                var rsqrts = Sse2.ConvertToVector128Double(
+                    Sse.ReciprocalSqrt(
+                        Sse2.ConvertToVector128Single(squares))
+                );
+
+                // Newton-Raphson iteration for reciprocal square root:
+                // https://en.wikipedia.org/wiki/Newton%27s_method
+                rsqrts = Sse2.Add(
+                    Sse2.Multiply(Vector128.Create(1.5d), rsqrts),
+                    Sse2.Multiply(
+                        Sse2.Multiply(
+                            Sse2.Multiply(squares, Vector128.Create(-0.5d)),
+                            rsqrts),
+                        Sse2.Multiply(rsqrts, rsqrts)
+                    )
+                );
+
+                // Extract the results.
+                // According to our lane ordering:
+                //   - Lane 0 contains b2 reciprocal.
+                //   - Lane 1 contains a2 reciprocal.
+                double b2Reciprocal = rsqrts.ToScalar(); // lane 0
+                double a2Reciprocal = Sse2.UnpackHigh(rsqrts, rsqrts).ToScalar(); // lane 1
+                return  ab * a2Reciprocal * b2Reciprocal;
+           }
+
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static double CosineSimilarityInternal(ref double aRef, double aMagnitude, ref double bRef, double bMagnitude, nuint size)
+            {
+                Vector512<double> abVec = Vector512<double>.Zero;
+                Vector512<double> a2Vec = Vector512<double>.Zero;
+                Vector512<double> b2Vec = Vector512<double>.Zero;
+
+                nuint i = 0;
+                nuint oneVectorFromEnd = size - (nuint)Vector512<double>.Count;
+
+            Loop:
+
+                // PERF: The reason why this would work on hardware not supporting 512-bit vectors is
+                // that it will effectively create 2 lanes (xmm and ymm) of 256-bit vectors. And because
+                // there are no overlapping lanes, there will be less pipeline dependencies hiding latency
+                // of the instructions themselves.
+                Vector512<double> aVec = Vector512.LoadUnsafe(ref aRef, i);
+                Vector512<double> bVec = Vector512.LoadUnsafe(ref bRef, i);
+
+                i += (nuint)Vector512<double>.Count;
+
+            LoopWithoutLoad:
+
+                abVec = Arithmetics.MultiplyAddEstimate(aVec, bVec, abVec);
+                a2Vec = Arithmetics.MultiplyAddEstimate(aVec, aVec, a2Vec);
+                b2Vec = Arithmetics.MultiplyAddEstimate(bVec, bVec, b2Vec);
+
+                if (i <= oneVectorFromEnd)
+                    goto Loop;
+
+                if (i != (nuint)size)
+                {
+                    nuint offset = (nuint)size - i;
+                    Debug.Assert((int)offset * sizeof(double) + Vector512<byte>.Count <= MoveMaskTable.Length);
+
+                    var mask = Vector512.LoadUnsafe<double>(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, double>(MoveMaskTable)), (nuint)offset);
+
+                    aVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref aRef, oneVectorFromEnd), mask);
+                    bVec = Vector512.BitwiseAnd(Vector512.LoadUnsafe(ref bRef, oneVectorFromEnd), mask);
+
+                    i = (nuint)size;
+                    goto LoopWithoutLoad;
+                }
+
+                double ab = aMagnitude * bMagnitude * Vector512.Sum(abVec);
+                double a2 = aMagnitude * aMagnitude * Vector512.Sum(a2Vec);
+                double b2 = bMagnitude * bMagnitude * Vector512.Sum(b2Vec);
+
+                // Special cases
+                if (a2 == 0 && b2 == 0)
+                    return double.NaN; // Both zero vectors: nan
+                if (ab == 0)
+                    return 0; // Orthogonal or one zero: distance = 1, similarity 0
+
+                // Normalization
+                // Create a 128-bit vector with a2 in the high lane and b2 in the low lane.
+                // Note: _mm_set_pd(a2, b2) in C sets lane1=a2 and lane0=b2.
+                // In .NET, Vector128.Create(x, y) sets lane0 = x and lane1 = y.
+                // So we swap the order.
+                var squares = Vector128.Create((double)b2, (double)a2);
+
+                // Compute approximate reciprocal square root (single precision).
+                var rsqrts = Sse2.ConvertToVector128Double(
+                    Sse.ReciprocalSqrt(
+                        Sse2.ConvertToVector128Single(squares))
+                );
+
+                // Newton-Raphson iteration for reciprocal square root:
+                // https://en.wikipedia.org/wiki/Newton%27s_method
+                rsqrts = Sse2.Add(
+                    Sse2.Multiply(Vector128.Create(1.5d), rsqrts),
+                    Sse2.Multiply(
+                        Sse2.Multiply(
+                            Sse2.Multiply(squares, Vector128.Create(-0.5d)),
+                            rsqrts),
+                        Sse2.Multiply(rsqrts, rsqrts)
+                    )
+                );
+
+                // Extract the results.
+                // According to our lane ordering:
+                //   - Lane 0 contains b2 reciprocal.
+                //   - Lane 1 contains a2 reciprocal.
+                double b2Reciprocal = rsqrts.ToScalar(); // lane 0
+                double a2Reciprocal = Sse2.UnpackHigh(rsqrts, rsqrts).ToScalar(); // lane 1
+                return ab * a2Reciprocal * b2Reciprocal;
+            }
+
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
+                where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                if (a.Length < Vector512<T>.Count)
+                    return Serial.CosineSimilarity<T, TResult>(a, b);
+
+                double similarity;
+                if (typeof(T) == typeof(float))
+                {
+                    similarity = CosineSimilarityInternal(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a)), 1.0f,
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b)), 1.0f,
+                        (nuint)a.Length);
+                } 
+                else if (typeof(T) == typeof(double))
+                {
+                    similarity = CosineSimilarityInternal(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(a)), 1.0d,
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(b)), 1.0d,
+                        (nuint)a.Length);
+                }
+                else throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+
+                if (typeof(TResult) == typeof(float))
+                {
+                    return (TResult)(object)(float)similarity;
+                }
+
+                return (TResult)(object)similarity;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+            public static TResult CosineSimilarity<T, TResult>(ReadOnlySpan<T> a, TResult aMagnitude, ReadOnlySpan<T> b, TResult bMagnitude)
+                where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
+                where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
+            {
+                if (a.Length < Vector512<T>.Count)
+                    return Serial.CosineSimilarity<T, TResult>(a, b);
+
+                double similarity;
+                if (typeof(T) == typeof(float))
+                {
+                    float aMag, bMag;
+                    if (typeof(TResult) == typeof(float))
+                    {
+                        aMag = (float)(object)aMagnitude;
+                        bMag = (float)(object)bMagnitude;
+                    }
+                    else if (typeof(TResult) == typeof(double))
+                    {
+                        aMag = (float)(double)(object)aMagnitude;
+                        bMag = (float)(double)(object)bMagnitude;
+                    }
+                    else
+                        throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+
+                    similarity = CosineSimilarityInternal(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(a)), aMag,
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, float>(b)), bMag,
+                        (nuint)a.Length);
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    double aMag, bMag;
+                    if (typeof(TResult) == typeof(float))
+                    {
+                        aMag = (float)(object)aMagnitude;
+                        bMag = (float)(object)bMagnitude;
+                    }
+                    else if (typeof(TResult) == typeof(double))
+                    {
+                        aMag = (double)(object)aMagnitude;
+                        bMag = (double)(object)bMagnitude;
+                    }
+                    else
+                        throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+
+                    similarity = CosineSimilarityInternal(
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(a)), aMag,
+                        ref MemoryMarshal.GetReference(MemoryMarshal.Cast<T, double>(b)), bMag,
+                        (nuint)a.Length);
+                }
+                else
+                    throw new NotSupportedException($"Type {typeof(T).Name} is not supported.");
+
+                if (typeof(TResult) == typeof(float))
+                {
+                    return (TResult)(object)(float)similarity;
+                }
+
+                return (TResult)(object)similarity;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal static TResult CosineSimilarityIntegersAvx512<TResult>(ReadOnlySpan<sbyte> a, TResult aMagnitude, ReadOnlySpan<sbyte> b, TResult bMagnitude)
                 where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
             {
+                if (Avx512BW.IsSupported == false || Avx512F.IsSupported == false)
+                    throw new NotSupportedException("This method should not be called on the current architecture");
+
                 // 1) 512-bit accumulators for ab, a2, b2
                 var abVec = Vector512<int>.Zero;
                 var a2Vec = Vector512<int>.Zero;
@@ -449,16 +599,16 @@ namespace Sparrow.Server.Tensors
                 Vector512<short> aVec = Avx512BW.ConvertToVector512Int16(Vector256.LoadUnsafe(ref aRef));
                 Vector512<short> bVec = Avx512BW.ConvertToVector512Int16(Vector256.LoadUnsafe(ref bRef));
 
-                i -= Vector256<sbyte>.Count;
-                aRef = ref Unsafe.Add(ref aRef, Vector256<sbyte>.Count);
-                bRef = ref Unsafe.Add(ref bRef, Vector256<sbyte>.Count);
-
                 // 3) multiply-add pairs: i16×i16→i32
                 abVec = Avx512F.Add(abVec, Avx512BW.MultiplyAddAdjacent(aVec, bVec));
                 a2Vec = Avx512F.Add(a2Vec, Avx512BW.MultiplyAddAdjacent(aVec, aVec));
                 b2Vec = Avx512F.Add(b2Vec, Avx512BW.MultiplyAddAdjacent(bVec, bVec));
 
-                if (i > 0)
+                i -= Vector256<sbyte>.Count;
+                aRef = ref Unsafe.Add(ref aRef, Vector256<sbyte>.Count);
+                bRef = ref Unsafe.Add(ref bRef, Vector256<sbyte>.Count);
+
+                if (i >= Vector256<sbyte>.Count)
                     goto Loop;
 
                 // 4) horizontal reductions
@@ -467,7 +617,7 @@ namespace Sparrow.Server.Tensors
                 int b2 = Vector512.Sum(b2Vec);
 
                 // Tail loop for remaining elements
-                while (i >= 0)
+                while (i > 0)
                 {
                     ab += aRef * bRef;
                     a2 += aRef * aRef;
@@ -574,7 +724,7 @@ namespace Sparrow.Server.Tensors
                 T ab = Vector256.Sum(abVec);
                 T a2 = Vector256.Sum(a2Vec);
                 T b2 = Vector256.Sum(b2Vec);
-                while (i >= 0)
+                while (i > 0)
                 {
                     ab += aRef * bRef;
                     a2 += aRef * aRef;
@@ -599,6 +749,9 @@ namespace Sparrow.Server.Tensors
             internal static TResult CosineSimilarityIntegersAvx2<TResult>(ReadOnlySpan<sbyte> a, TResult aMagnitude, ReadOnlySpan<sbyte> b, TResult bMagnitude)
                 where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
             {
+                if (Avx2.IsSupported == false)
+                    throw new NotSupportedException("This method should not be called on the current architecture");
+
                 //  Prepare six 256-bit accumulators: low/high lanes for ab, a2, b2
                 Vector256<int> abLo = Vector256<int>.Zero, abHi = Vector256<int>.Zero;
                 Vector256<int> a2Lo = Vector256<int>.Zero, a2Hi = Vector256<int>.Zero;
@@ -647,7 +800,7 @@ namespace Sparrow.Server.Tensors
                 int b2 = Vector256.Sum(Avx2.Add(b2Lo, b2Hi));
 
                 // Tail loop for remaining elements
-                while (i >= 0)
+                while (i > 0)
                 {
                     ab += aRef * bRef;
                     a2 += aRef * aRef;
@@ -675,6 +828,9 @@ namespace Sparrow.Server.Tensors
             internal static TResult CosineSimilarityIntegersNeon<TResult>(ReadOnlySpan<sbyte> a, TResult aMagnitude, ReadOnlySpan<sbyte> b, TResult bMagnitude)
                 where TResult : unmanaged, IFloatingPoint<TResult>, IRootFunctions<TResult>, INumber<TResult>
             {
+                if (Dp.IsSupported == false)
+                    throw new NotSupportedException("This method should not be called on the current architecture");
+
                 Vector128<int> abVec = Vector128<int>.Zero;
                 Vector128<int> a2Vec = Vector128<int>.Zero;
                 Vector128<int> b2Vec = Vector128<int>.Zero;
@@ -704,7 +860,7 @@ namespace Sparrow.Server.Tensors
                 int ab = Vector128.Sum(abVec);
                 int a2 = Vector128.Sum(a2Vec);
                 int b2 = Vector128.Sum(b2Vec);
-                while (i >= 0)
+                while (i > 0)
                 {
                     ab += aRef * bRef;
                     a2 += aRef * aRef;

--- a/src/Sparrow.Server/Tensors/Types.cs
+++ b/src/Sparrow.Server/Tensors/Types.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sparrow.Server.Tensors
+{
+    public static class Types
+    {
+        public static TTo Cast<TFrom, TTo>(TFrom value)
+            where TFrom : unmanaged, INumber<TFrom>
+            where TTo : unmanaged, INumber<TTo>
+        {
+            // This is the simple version, it will be completely evicted.
+            if (typeof(TFrom) == typeof(TTo))
+                return (TTo)(object)value;
+
+            // CreateTruncating converts the numeric value into the target type,
+            // possibly discarding fractional parts (similar to an explicit cast).
+            return TTo.CreateTruncating(value);
+        }
+    }
+}

--- a/src/Sparrow/AdvInstructionSet.cs
+++ b/src/Sparrow/AdvInstructionSet.cs
@@ -62,9 +62,13 @@ namespace Sparrow
 
         public static class X86
         {
-            public static readonly bool IsSupportedSse;
-            public static readonly bool IsSupportedAvx256;
-            public static readonly bool IsSupportedAvx512;
+            public static readonly bool IsSupportedSse; // SSE 4.2 + POPCNT
+            public static readonly bool IsSupportedAvx256; // Avx2 + FMA
+            
+            // AVX-512 profile flags
+            public static readonly bool IsSupportedAvx512; // All Supported AVX-512 extensions
+            public static readonly bool IsSupportedAvx512Basic; // F|BW|VL|DQ (Skylake, Zen 3)
+            public static readonly bool IsSupportedAvx512Advanced; // Basic + VBMI (Tiger Lake, Zen 4c AVX-512)
 
             static X86()
             {
@@ -76,11 +80,30 @@ namespace Sparrow
                 IsSupportedSse = false;
                 IsSupportedAvx256 = false;
 #endif
+                
+#if NET9_0_OR_GREATER
+                // Basic AVX-512 (F|BW|VL|DQ)
+                IsSupportedAvx512Basic = IsSupportedAvx256 & Avx512F.IsSupported & Avx512BW.IsSupported & Avx512CD.VL.IsSupported & Avx512DQ.IsSupported;
 
-#if NET8_0_OR_GREATER
-                // We require the full set of instructions set to be enabled in order to support AVX-512
-                IsSupportedAvx512 = IsSupportedAvx256 & Avx512CD.IsSupported & Avx512BW.IsSupported & Avx512DQ.IsSupported & Avx512Vbmi.IsSupported & Avx512F.IsSupported;
+                // Advanced AVX-512 (Basic + CD|VBMI)
+                IsSupportedAvx512Advanced = IsSupportedAvx512Basic & Avx512Vbmi.IsSupported & Avx512CD.IsSupported;
+
+                // Full AVX-512 support check (all extensions).
+                IsSupportedAvx512 = IsSupportedAvx512Advanced & AvxVnni.IsSupported;
+                
+#elif NET8_0_OR_GREATER
+                // Basic AVX-512 (F|BW|VL|DQ)
+                IsSupportedAvx512Basic = IsSupportedAvx256 & Avx512F.IsSupported & Avx512BW.IsSupported & Avx512CD.VL.IsSupported & Avx512DQ.IsSupported;
+                
+                // Advanced AVX-512 (Basic + CD|VBMI)
+                IsSupportedAvx512Advanced = IsSupportedAvx512Basic & Avx512Vbmi.IsSupported & Avx512CD.IsSupported;
+                
+                // Full AVX-512 support check (all extensions). Right now this is equal to Advanced, but it is not guaranteed
+                // to stay that way.
+                IsSupportedAvx512 = IsSupportedAvx512Advanced;
 #else
+                IsSupportedAvx512Basic = false;
+                IsSupportedAvx512Advanced = false;
                 IsSupportedAvx512 = false;
 #endif
 
@@ -92,6 +115,8 @@ namespace Sparrow
                     IsSupportedSse = false;
                     IsSupportedAvx256 = false;
                     IsSupportedAvx512 = false;
+                    IsSupportedAvx512Basic = false;
+                    IsSupportedAvx512Advanced = false;
                 }
 
                 // We assume for simplicity in the testing matrix and to simplify our life that whenever AVX512 also is AVX2, etc.
@@ -103,8 +128,18 @@ namespace Sparrow
                         goto case "avx256";
                     case "avx256":
                         IsSupportedAvx256 = false;
-                        goto case "avx512";
-                    case "avx512":
+                        goto case "avx512-basic";
+                    case "avx512": // This is an alias whose objective is to remain backward compatible
+                    case "avx512-basic":
+                        IsSupportedAvx512Basic = false;
+                        IsSupportedAvx512Advanced = false; // Advanced depends on Basic
+                        IsSupportedAvx512 = false; // Full depends on Advanced
+                        break;
+                    case "avx512-advanced":
+                        IsSupportedAvx512Advanced = false;
+                        IsSupportedAvx512 = false; // Full depends on Advanced
+                        break;                    
+                    case "avx512-full":
                         IsSupportedAvx512 = false;
                         break;
                 }

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using Sparrow;
+using Sparrow.Server.Tensors;
 
 namespace Voron.Data.Graphs;
 
@@ -22,7 +23,7 @@ public partial class Hnsw
     {
         var aSingles = MemoryMarshal.Cast<byte, float>(a);
         var bSingles = MemoryMarshal.Cast<byte, float>(b);
-        return 1f - TensorPrimitives.CosineSimilarity(aSingles, bSingles);
+        return Functions.CosineDistance(aSingles, bSingles);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -31,36 +32,13 @@ public partial class Hnsw
         Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
         var vectorLength = a.Length - sizeof(float);
 
-        ref var aRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, sbyte>(a[..vectorLength]));
-        ref var bRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, sbyte>(b[..vectorLength]));
+        var aRef = MemoryMarshal.Cast<byte, sbyte>(a[..vectorLength]);
+        var bRef = MemoryMarshal.Cast<byte, sbyte>(b[..vectorLength]);
 
-        var magA = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(a[vectorLength..]));
-        var magB = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(b[vectorLength..]));
+        var aMag = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(a[vectorLength..]));
+        var bMag = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(b[vectorLength..]));
 
-        var alpha1 = magA / 127f;
-        var alpha2 = magB / 127f;
-
-        float dotProduct = alpha1 * alpha2 * vectorLength;
-
-        float sq1 = 0;
-        float sq2 = 0;
-
-        for (int i = 0; i < vectorLength; i++)
-        {
-            var aValue = Unsafe.Add(ref aRef, i);
-            var bValue = Unsafe.Add(ref bRef, i);
-            dotProduct += alpha1 * aValue;
-            dotProduct += alpha2 * bValue;
-            dotProduct += aValue * bValue;
-
-            sq1 += aValue * aValue;
-            sq2 += bValue * bValue;
-        }
-
-        sq1 = MathF.Sqrt(sq1);
-        sq2 = MathF.Sqrt(sq2);
-
-        return 1f - Math.Clamp(dotProduct / (sq1 * sq2), -1f, 1f);
+        return Functions.CosineDistance(aRef, aMag, bRef, bMag);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -19,7 +19,7 @@ public partial class Hnsw
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static float CosineSimilaritySingles(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    internal static float CosineDistanceSingles(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         var aSingles = MemoryMarshal.Cast<byte, float>(a);
         var bSingles = MemoryMarshal.Cast<byte, float>(b);
@@ -27,7 +27,7 @@ public partial class Hnsw
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static float CosineSimilarityI8(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    internal static float CosineDistanceI8(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
         var vectorLength = a.Length - sizeof(float);
@@ -47,7 +47,7 @@ public partial class Hnsw
         return Functions.HammingBitDistance(a, b);
     }
     
-    internal static void DistanceToScoreHammingSimilarity(Span<float> scores, int vectorSizeInBytes)
+    internal static void DistanceToScoreHamming(Span<float> scores, int vectorSizeInBytes)
     {
         var pos = 0;
         ref float bufferRef = ref MemoryMarshal.GetReference(scores);
@@ -102,7 +102,7 @@ public partial class Hnsw
             Unsafe.Add(ref bufferRef, pos) = 1f - (Unsafe.Add(ref bufferRef, pos) / (8f * vectorSizeInBytes));
     }
 
-    internal static void DistanceToScoreCosineSimilarity(Span<float> scores)
+    internal static void DistanceToScoreCosine(Span<float> scores)
     {
         var pos = 0;
         ref float bufferRef = ref MemoryMarshal.GetReference(scores);

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -44,7 +44,7 @@ public partial class Hnsw
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static float HammingDistance(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
-        return TensorPrimitives.HammingBitDistance<byte>(a, b);
+        return Functions.HammingBitDistance(a, b);
     }
     
     internal static void DistanceToScoreHammingSimilarity(Span<float> scores, int vectorSizeInBytes)

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -304,8 +304,8 @@ public unsafe partial class Hnsw
             Options = Unsafe.Read<Options>(options);
             SimilarityCalc = Options.SimilarityMethod switch
             {
-                SimilarityMethod.CosineSimilaritySingles => &CosineSimilaritySingles,
-                SimilarityMethod.CosineSimilarityI8 => &CosineSimilarityI8,
+                SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
+                SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
                 SimilarityMethod.HammingDistance => &HammingDistance,
                 _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
             };
@@ -347,10 +347,10 @@ public unsafe partial class Hnsw
             {
                 case SimilarityMethod.CosineSimilaritySingles:
                 case SimilarityMethod.CosineSimilarityI8:
-                    DistanceToScoreCosineSimilarity(distances);
+                    DistanceToScoreCosine(distances);
                     break;
                 case SimilarityMethod.HammingDistance:
-                    DistanceToScoreHammingSimilarity(distances, Options.VectorSizeBytes);
+                    DistanceToScoreHamming(distances, Options.VectorSizeBytes);
                     break;
                 default:
                     throw new InvalidDataException($"Unknown similarity method {Options.SimilarityMethod}");

--- a/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
+++ b/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
@@ -129,7 +129,7 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
         Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
         var similarity = (float)streamResults.Current.Metadata.GetDouble(Constants.Documents.Metadata.IndexScore);
         
-        var expectedSimilarity = 1 - Hnsw.CosineSimilarityI8(MemoryMarshal.Cast<sbyte, byte>(queryVector), MemoryMarshal.Cast<sbyte, byte>(doc.Int8));
+        var expectedSimilarity = 1 - Hnsw.CosineDistanceI8(MemoryMarshal.Cast<sbyte, byte>(queryVector), MemoryMarshal.Cast<sbyte, byte>(doc.Int8));
         Assert.Equal(expectedSimilarity, similarity, 0.0001f);
     }
     

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Numerics.Tensors;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using FastTests.Voron.FixedSize;
@@ -77,6 +77,191 @@ namespace FastTests.Sparrow
             // (If your implementation were really computing similarity, this is what you’d expect.)
             Assert.InRange(similarity, (float)(expectedSim - Eps), (float)(expectedSim + Eps));
             Assert.InRange(distance, (float)(expectedDistance - Eps), (float)(expectedDistance + Eps));
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void Ensure_NoBufferOverflow_Float(int seed)
+        {
+            var generator = new Random(seed);
+
+            float[] a = new float[1024];
+            float[] b = new float[1024];
+
+            for (int i = 0; i < 32; i++)
+            {
+                // We are testing vectorized versions, which won't be called if we call the public versions. 
+                var size = generator.Next(Vector512<float>.Count, 512);
+                for (int j = 0; j < a.Length; j++)
+                {
+                    a[j] = 0;
+                    b[j] = 0;
+                }
+
+                var location = generator.Next(128) + 1;
+
+                a[location - 1] = 0.5f;
+                b[location - 1] = 1f;
+                a[location + size + 1] = 0.5f;
+                b[location + size + 1] = 1f;
+
+                void RunFunc(delegate* managed<ReadOnlySpan<float>, ReadOnlySpan<float>, float> func)
+                {
+                    Span<float> aSpan = a.AsSpan().Slice(location, size);
+                    Span<float> bSpan = b.AsSpan().Slice(location,  size);
+                    Assert.Equal(func(aSpan, bSpan), float.NaN);
+
+                    aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                    bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                    Assert.NotEqual(func(aSpan, bSpan), float.NaN);
+                }
+
+                void RunWithMagnitudeFunc(delegate* managed<ReadOnlySpan<float>, float, ReadOnlySpan<float>, float, float> func)
+                {
+                    Span<float> aSpan = a.AsSpan().Slice(location,size);
+                    Span<float> bSpan = b.AsSpan().Slice(location, size);
+                    Assert.Equal(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+
+                    // Verify they match within a small tolerance.
+                    aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                    bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                    Assert.NotEqual(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+                }
+
+                // These are the normal functions.
+                RunFunc(&Functions.CosineSimilarity);
+                RunFunc(&Functions.CosineDistance);
+                RunWithMagnitudeFunc(&Functions.CosineSimilarity);
+                RunWithMagnitudeFunc(&Functions.CosineDistance);
+                RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarity);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void Ensure_NoBufferOverflow_Double(int seed)
+        {
+            var generator = new Random(seed);
+
+            double[] a = new double[1024];
+            double[] b = new double[1024];
+
+            for (int i = 0; i < 32; i++)
+            {
+                // We are testing vectorized versions, which won't be called if we call the public versions. 
+                var size = generator.Next(Vector512<double>.Count, 512);
+                for (int j = 0; j < a.Length; j++)
+                {
+                    a[j] = 0;
+                    b[j] = 0;
+                }
+
+                var location = generator.Next(128) + 1;
+
+                a[location - 1] = 0.5f;
+                b[location - 1] = 1f;
+                a[location + size + 1] = 0.5f;
+                b[location + size + 1] = 1f;
+
+                void RunFunc(delegate* managed<ReadOnlySpan<double>, ReadOnlySpan<double>, double> func)
+                {
+                    Span<double> aSpan = a.AsSpan().Slice(location, size);
+                    Span<double> bSpan = b.AsSpan().Slice(location, size);
+                    Assert.Equal(func(aSpan, bSpan), float.NaN);
+
+                    aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                    bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                    Assert.NotEqual(func(aSpan, bSpan), float.NaN);
+                }
+
+                void RunWithMagnitudeFunc(delegate* managed<ReadOnlySpan<double>, float, ReadOnlySpan<double>, float, float> func)
+                {
+                    Span<double> aSpan = a.AsSpan().Slice(location, size);
+                    Span<double> bSpan = b.AsSpan().Slice(location, size);
+                    Assert.Equal(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+
+                    // Verify they match within a small tolerance.
+                    aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                    bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                    Assert.NotEqual(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+                }
+
+                // These are the normal functions.
+                RunFunc(&Functions.CosineSimilarity);
+                RunFunc(&Functions.CosineDistance);
+                RunWithMagnitudeFunc(&Functions.CosineSimilarity);
+                RunWithMagnitudeFunc(&Functions.CosineDistance);
+                RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarity);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void Ensure_NoBufferOverflow_Integers(int seed)
+        {
+            var generator = new Random(seed);
+
+            for (int i = 0; i < 32; i++)
+            {
+                sbyte[] a = new sbyte[1024];
+                sbyte[] b = new sbyte[1024];
+
+                // We are testing vectorized versions, which won't be called if we call the public versions. 
+                var size = generator.Next(Vector512<sbyte>.Count, 512);
+                for (int j = 0; j < a.Length; j++)
+                {
+                    a[j] = 0;
+                    b[j] = 0;
+                }
+
+                var location = generator.Next(128) + 1;
+
+                a[location - 1] = 55;
+                b[location - 1] = 45;
+                a[location + size + 1] = 55;
+                b[location + size + 1] = 45;
+
+                void RunFunc(delegate* managed<ReadOnlySpan<sbyte>, float, ReadOnlySpan<sbyte>, float, float> func)
+                {
+                    Span<sbyte> aSpan = a.AsSpan().Slice(location, size);
+                    Span<sbyte> bSpan = b.AsSpan().Slice(location, size);
+                    Assert.Equal(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+
+                    aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                    bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                    Assert.NotEqual(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+                }
+
+                void RunWithMagnitudeFunc(delegate* managed<ReadOnlySpan<sbyte>, float, ReadOnlySpan<sbyte>, float, float> func)
+                {
+                    Span<sbyte> aSpan = a.AsSpan().Slice(location, size);
+                    Span<sbyte> bSpan = b.AsSpan().Slice(location, size);
+                    Assert.Equal(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+
+                    // Verify they match within a small tolerance.
+                    aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                    bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                    Assert.NotEqual(func(aSpan, 1.0f, bSpan, 1.0f), float.NaN);
+                }
+
+
+                // These are the normal functions.
+                RunFunc(&Functions.CosineSimilarity);
+                RunFunc(&Functions.CosineDistance);
+                RunWithMagnitudeFunc(&Functions.CosineSimilarity);
+                RunWithMagnitudeFunc(&Functions.CosineDistance);
+
+                // AVX-2 path
+                if (AdvInstructionSet.X86.IsSupportedAvx256)
+                    RunWithMagnitudeFunc(&Functions.Vectorized256.CosineSimilarityIntegersAvx2);
+
+                if (AdvInstructionSet.Arm.IsSupported && Dp.IsSupported)
+                    RunWithMagnitudeFunc(&Functions.Vectorized256.CosineSimilarityIntegersNeon);
+
+                // AVX-512 path
+                if (Avx512BW.IsSupported && Avx512F.IsSupported)
+                    RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarityIntegersAvx512);
+            }
         }
 
         // Test for vectors that are both zero.
@@ -327,6 +512,42 @@ namespace FastTests.Sparrow
             long expectedDistance = TensorPrimitives.HammingBitDistance<byte>(vector1, vector2);
             long actualDistance = Functions.HammingBitDistance<byte>(vector1, vector2);
             Assert.Equal(expectedDistance, actualDistance);
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void Ensure_NoBufferOverflow_HammingBit(int seed)
+        {
+            var generator = new Random(seed);
+
+            for (int i = 0; i < 32; i++)
+            {
+                byte[] a = new byte[1024];
+                byte[] b = new byte[1024];
+
+                // We are testing vectorized versions, which won't be called if we call the public versions. 
+                var size = generator.Next(Vector512<sbyte>.Count, 512);
+                for (int j = 0; j < a.Length; j++)
+                {
+                    a[j] = 0;
+                    b[j] = 0;
+                }
+
+                var location = generator.Next(128) + 1;
+
+                a[location - 1] = 55;
+                b[location - 1] = 45;
+                a[location + size + 1] = 55;
+                b[location + size + 1] = 45;
+
+                Span<byte> aSpan = a.AsSpan().Slice(location, size);
+                Span<byte> bSpan = b.AsSpan().Slice(location, size);
+                Assert.Equal(Functions.HammingBitDistance<byte>(aSpan, bSpan), 0);
+
+                aSpan = a.AsSpan().Slice(location - 1, size + 1);
+                bSpan = b.AsSpan().Slice(location - 1, size + 1);
+                Assert.NotEqual(Functions.HammingBitDistance<byte>(aSpan, bSpan), 0);
+            }
         }
     }
 }

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -35,6 +35,20 @@ namespace FastTests.Sparrow
             Assert.InRange(distance, (float)(expectedDistance - Eps), (float)(expectedDistance + Eps));
         }
 
+
+        // Test that for identical vectors, we get maximum similarity (and so a distance of zero).
+        [RavenFact(RavenTestCategory.Core)]
+        public void IdenticalVectors_ReturnsMaxHammingSimilarity_ZeroDistance()
+        {
+            byte[] vector = [218, 0, 55, 87, 97, 77, 10, 66, 255, 47];
+            var span = new ReadOnlySpan<byte>(vector);
+
+            float distance = Functions.HammingBitDistance(span, span);
+            float expectedDistance = TensorPrimitives.HammingBitDistance(span, span);
+
+            Assert.Equal(expectedDistance, distance);
+        }
+
         // Test for orthogonal vectors.
         // Conventionally, for orthogonal vectors, cosine similarity should be 0 and so distance should be 1.
         [RavenTheory(RavenTestCategory.Core)]
@@ -97,7 +111,7 @@ namespace FastTests.Sparrow
         // A randomized test to compare your implementation with a reference implementation.
         [RavenTheory(RavenTestCategory.Core)]
         [InlineDataWithRandomSeed]
-        public void RandomVectors_ReferenceComparison(int seed)
+        public void RandomVectors_ReferenceComparison(int seed = 1337)
         {
             var rnd = new Random(seed);
             int size = rnd.Next(1024) + 1;
@@ -290,6 +304,29 @@ namespace FastTests.Sparrow
             // NEON path
             if (AdvInstructionSet.Arm.IsSupported && Dp.IsSupported)
                 RunSimilarityTest(&Functions.Vectorized256.CosineSimilarityIntegersNeon);
+        }
+
+        // A randomized test to compare your implementation with a reference implementation.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void RandomVectors_HammingBitReferenceComparison(int seed)
+        {
+            var rnd = new Random(seed);
+            int size = rnd.Next(1024) + 1;
+
+            // Generate two random vectors of the same size.
+            Span<byte> vector1 = new byte[size];
+            Span<byte> vector2 = new byte[size];
+            for (int i = 0; i < size; i++)
+            {
+                vector1[i] = (byte)rnd.Next(byte.MaxValue);
+                vector2[i] = (byte)rnd.Next(byte.MaxValue);
+            }
+
+            // Compute reference similarity (using conventional cosine similarity).
+            long expectedDistance = TensorPrimitives.HammingBitDistance<byte>(vector1, vector2);
+            long actualDistance = Functions.HammingBitDistance<byte>(vector1, vector2);
+            Assert.Equal(expectedDistance, actualDistance);
         }
     }
 }

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -136,7 +136,105 @@ namespace FastTests.Sparrow
             RunFunc(&Functions.CosineDistance, expectedDistance);
             RunWithMagnitudeFunc(&Functions.CosineSimilarity, expectedSim);
             RunWithMagnitudeFunc(&Functions.CosineDistance, expectedDistance);
-            RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarityFloatingPoint, expectedSim);
+            RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarity, expectedSim);
+        }
+
+        // A randomized test to compare your implementation with a reference implementation.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void RandomVectors_ReferenceComparison_Double(int seed = 1337)
+        {
+            var rnd = new Random(seed);
+            int size = rnd.Next(1024) + 1;
+
+            // Generate two random vectors of the same size.
+            double[] vector1 = new double[size];
+            float[] fvector1 = new float[size];
+            double[] vector2 = new double[size];
+            float[] fvector2 = new float[size];
+            for (int i = 0; i < size; i++)
+            {
+                vector1[i] = rnd.NextDouble();
+                fvector1[i] = (float)vector1[i];
+                vector2[i] = rnd.NextDouble();
+                fvector2[i] = (float)vector2[i];
+            }
+
+            // Compute reference similarity (using conventional cosine similarity).
+            float expectedSim = TensorPrimitives.CosineSimilarity(fvector1, fvector2);
+            float expectedDistance = 1.0f - expectedSim;
+
+            void RunFunc(delegate* managed<ReadOnlySpan<double>, ReadOnlySpan<double>, double> func, float expected)
+            {
+                double actual = func(vector1.AsSpan(), vector2.AsSpan());
+
+                // Verify they match within a small tolerance.
+                Assert.InRange(actual, (float)(expected - Eps), (float)(expected + Eps));
+            }
+
+            void RunWithMagnitudeFunc(delegate* managed<ReadOnlySpan<double>, float, ReadOnlySpan<double>, float, float> func, float expected)
+            {
+                float actual = func(vector1.AsSpan(), 1.0f, vector2.AsSpan(), 1.0f);
+
+                // Verify they match within a small tolerance.
+                Assert.InRange(actual, (float)(expected - Eps), (float)(expected + Eps));
+            }
+
+            // These are the normal functions.
+            RunFunc(&Functions.CosineSimilarity, expectedSim);
+            RunFunc(&Functions.CosineDistance, expectedDistance);
+            RunWithMagnitudeFunc(&Functions.CosineSimilarity, expectedSim);
+            RunWithMagnitudeFunc(&Functions.CosineDistance, expectedDistance);
+            RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarity, expectedSim);
+        }
+
+        // A randomized test to compare your implementation with a reference implementation.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void RandomVectors_ReferenceComparison_Integers(int seed = 1337)
+        {
+            var rnd = new Random(seed);
+            int size = rnd.Next(1024) + 1;
+
+            // Generate two random vectors of the same size.
+            sbyte[] vector1 = new sbyte[size];
+            sbyte[] vector2 = new sbyte[size];
+            float[] fvector1 = new float[size];
+            float[] fvector2 = new float[size];
+            for (int i = 0; i < size; i++)
+            {
+                vector1[i] = (sbyte)rnd.Next();
+                fvector1[i] = vector1[i];
+                vector2[i] = (sbyte)rnd.Next();
+                fvector2[i] = vector2[i];
+            }
+
+            // Compute reference similarity (using conventional cosine similarity).
+            float expectedSim = TensorPrimitives.CosineSimilarity(fvector1, fvector2);
+            float expectedDistance = 1.0f - expectedSim;
+
+            void RunWithMagnitudeFunc(delegate* managed<ReadOnlySpan<sbyte>, float, ReadOnlySpan<sbyte>, float, float> func, float expected)
+            {
+                float actual = func(vector1.AsSpan(), 1.0f, vector2.AsSpan(), 1.0f);
+
+                // Verify they match within a small tolerance.
+                Assert.InRange(actual, (float)(expected - Eps), (float)(expected + Eps));
+            }
+
+            // These are the normal functions.
+            RunWithMagnitudeFunc(&Functions.CosineSimilarity, expectedSim);
+            RunWithMagnitudeFunc(&Functions.CosineDistance, expectedDistance);
+
+            // AVX-2 path
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
+                RunWithMagnitudeFunc(&Functions.Vectorized256.CosineSimilarityIntegersAvx2, expectedSim);
+
+            if (AdvInstructionSet.Arm.IsSupported && Dp.IsSupported)
+                RunWithMagnitudeFunc(&Functions.Vectorized256.CosineSimilarityIntegersNeon, expectedSim);
+
+            // AVX-512 path
+            if (Avx512BW.IsSupported && Avx512F.IsSupported)
+                RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarityIntegersAvx512, expectedSim);
         }
 
         // A randomized test to compare your implementation with a reference implementation.

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -73,7 +73,7 @@ namespace FastTests.Sparrow
             float expectedSim = TensorPrimitives.CosineSimilarity(a, b);
             float expectedDistance = 1.0f - expectedSim;
 
-            // Expected behavior: identical vectors yield similarity==1.0 so distance==0.0.
+            // Expected behavior: orthogonal vectors yield similarity==0.0
             // (If your implementation were really computing similarity, this is what you’d expect.)
             Assert.InRange(similarity, (float)(expectedSim - Eps), (float)(expectedSim + Eps));
             Assert.InRange(distance, (float)(expectedDistance - Eps), (float)(expectedDistance + Eps));

--- a/test/FastTests/Sparrow/TensorsTests.cs
+++ b/test/FastTests/Sparrow/TensorsTests.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics.Tensors;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+using FastTests.Voron.FixedSize;
+using Sparrow;
+using Sparrow.Server.Tensors;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public unsafe class TensorsTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        private const float Eps = 1e-6f;
+
+        // Test that for identical vectors, we get maximum similarity (and so a distance of zero).
+        [RavenFact(RavenTestCategory.Core)]
+        public void IdenticalVectors_ReturnsMaxSimilarity_ZeroDistance()
+        {
+            float[] vector = [1f, 2f, 3f, 4f];
+            var span = new ReadOnlySpan<float>(vector);
+
+            float similarity = Functions.CosineSimilarity(span, span);
+            float distance = Functions.CosineDistance(span, span);
+
+            float expectedSim = TensorPrimitives.CosineSimilarity(span, span);
+            float expectedDistance = 1.0f - expectedSim;
+
+            // Expected behavior: identical vectors yield similarity==1.0 so distance==0.0.
+            // (If your implementation were really computing similarity, this is what you’d expect.)
+            Assert.InRange(similarity, (float)(expectedSim - Eps), (float)(expectedSim + Eps));
+            Assert.InRange(distance, (float)(expectedDistance - Eps), (float)(expectedDistance + Eps));
+        }
+
+        // Test for orthogonal vectors.
+        // Conventionally, for orthogonal vectors, cosine similarity should be 0 and so distance should be 1.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(2)]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(17)]
+        [InlineData(32)]
+        [InlineData(256)]
+        [InlineData(1000)]
+        public void OrthogonalVectors_ShouldYieldLowSimilarity_HighDistance(int size)
+        {
+            float[] a = new float[size];
+            float[] b = new float[size];
+
+            a[size-1] = 1f;
+            b[0] = 1f;
+
+            var similarity = Functions.CosineSimilarity<float>(a, b);
+            var distance = Functions.CosineDistance<float>(a, b);
+
+            float expectedSim = TensorPrimitives.CosineSimilarity(a, b);
+            float expectedDistance = 1.0f - expectedSim;
+
+            // Expected behavior: identical vectors yield similarity==1.0 so distance==0.0.
+            // (If your implementation were really computing similarity, this is what you’d expect.)
+            Assert.InRange(similarity, (float)(expectedSim - Eps), (float)(expectedSim + Eps));
+            Assert.InRange(distance, (float)(expectedDistance - Eps), (float)(expectedDistance + Eps));
+        }
+
+        // Test for vectors that are both zero.
+        // Many definitions choose to define the similarity of two zero vectors as 1 (so that distance is 0).
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(2)]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(17)]
+        [InlineData(32)]
+        [InlineData(33)]
+        [InlineData(256)]
+        [InlineData(1000)]
+        public void BothZeroVectors_ProducesDefinedSimilarityAndDistance(int size)
+        {
+            float[] a = new float[size];
+            float[] b = new float[size];
+
+            var similarity = Functions.CosineSimilarity<float>(a, b);
+            var distance = Functions.CosineDistance<float>(a, b);
+
+            // Compute reference similarity (using conventional cosine similarity).
+            float expectedSim = TensorPrimitives.CosineSimilarity(a, b);
+            float expectedDistance = 1.0f - expectedSim;
+
+            // Verify they match within a small tolerance.
+
+            Assert.InRange(similarity, (float)(expectedSim - Eps), (float)(expectedSim + Eps));
+            Assert.InRange(distance, (float)(expectedDistance - Eps), (float)(expectedDistance + Eps));
+        }
+
+        // A randomized test to compare your implementation with a reference implementation.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void RandomVectors_ReferenceComparison(int seed)
+        {
+            var rnd = new Random(seed);
+            int size = rnd.Next(1024) + 1;
+
+            // Generate two random vectors of the same size.
+            float[] vector1 = new float[size];
+            float[] vector2 = new float[size];
+            for (int i = 0; i < size; i++)
+            {
+                vector1[i] = (float)rnd.NextDouble();
+                vector2[i] = (float)rnd.NextDouble();
+            }
+
+            // Compute reference similarity (using conventional cosine similarity).
+            float expectedSim = TensorPrimitives.CosineSimilarity(vector1, vector2);
+            float expectedDistance = 1.0f - expectedSim;
+
+            void RunFunc(delegate* managed<ReadOnlySpan<float>, ReadOnlySpan<float>, float> func, float expected)
+            {
+                float actual = func(vector1.AsSpan(), vector2.AsSpan());
+
+                // Verify they match within a small tolerance.
+                Assert.InRange(actual, (float)(expected - Eps), (float)(expected + Eps));
+            }
+
+            void RunWithMagnitudeFunc(delegate* managed<ReadOnlySpan<float>, float, ReadOnlySpan<float>, float, float> func, float expected)
+            {
+                float actual = func(vector1.AsSpan(), 1.0f, vector2.AsSpan(), 1.0f);
+
+                // Verify they match within a small tolerance.
+                Assert.InRange(actual, (float)(expected - Eps), (float)(expected + Eps));
+            }
+
+            // These are the normal functions.
+            RunFunc(&Functions.CosineSimilarity, expectedSim);
+            RunFunc(&Functions.CosineDistance, expectedDistance);
+            RunWithMagnitudeFunc(&Functions.CosineSimilarity, expectedSim);
+            RunWithMagnitudeFunc(&Functions.CosineDistance, expectedDistance);
+            RunWithMagnitudeFunc(&Functions.Vectorized512.CosineSimilarityFloatingPoint, expectedSim);
+        }
+
+        // A randomized test to compare your implementation with a reference implementation.
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineDataWithRandomSeed]
+        public void RandomVectors_ReferenceComparisonForQuantization(int seed)
+        {
+            var rnd = new Random(1337);
+            int size = rnd.Next(1024) + 1;
+            float aMagnitude = rnd.NextSingle();
+            float bMagnitude = rnd.NextSingle();
+
+            // Generate two random vectors of the same size.
+            float[] fvector1 = new float[size];
+            sbyte[] bvector1 = new sbyte[size];
+            float[] fvector2 = new float[size];
+            sbyte[] bvector2 = new sbyte[size];
+            
+            for (int i = 0; i < size; i++)
+            {
+                sbyte v1 = (sbyte)rnd.Next(sbyte.MinValue, sbyte.MaxValue);
+                sbyte v2 = (sbyte)rnd.Next(sbyte.MinValue, sbyte.MaxValue);
+
+                bvector1[i] = v1;
+                bvector2[i] = v2;
+
+                fvector1[i] = (float)v1 * aMagnitude;
+                fvector2[i] = (float)v2 * bMagnitude;
+            }
+
+            // Compute reference similarity (using conventional cosine similarity).
+            float expectedSim = Functions.Serial.CosineSimilarity<float, float>(fvector1, fvector2);
+
+            void RunSimilarityTest(delegate* managed<ReadOnlySpan<sbyte>, float, ReadOnlySpan<sbyte>, float, float> func)
+            {
+                float sim = func(bvector1.AsSpan(), aMagnitude, bvector2.AsSpan(), bMagnitude);
+
+                // Verify they match within a small tolerance.
+                Assert.InRange(sim, (float)(expectedSim - Eps), (float)(expectedSim + Eps));
+            }
+
+            // Serial fallback via our non-generic shim
+            RunSimilarityTest(&Functions.Serial.CosineSimilarity);
+
+            // AVX-512 path
+            if (Avx512BW.IsSupported && Avx512F.IsSupported)
+                RunSimilarityTest(&Functions.Vectorized512.CosineSimilarityIntegersAvx512);
+
+            // AVX-2 path
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
+                RunSimilarityTest(&Functions.Vectorized256.CosineSimilarityIntegersAvx2);
+
+            // NEON path
+            if (AdvInstructionSet.Arm.IsSupported && Dp.IsSupported)
+                RunSimilarityTest(&Functions.Vectorized256.CosineSimilarityIntegersNeon);
+        }
+    }
+}

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -289,10 +289,10 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(2, read);
             var v1Pos = matches.AsSpan().Slice(0, read).IndexOf(1L);
             Assert.True(int.IsPositive(v1Pos));
-            Assert.Equal(Hnsw.CosineSimilaritySingles(v1.GetEmbedding(), vQ.GetEmbedding()), distances[v1Pos]);
+            Assert.Equal(Hnsw.CosineDistanceSingles(v1.GetEmbedding(), vQ.GetEmbedding()), distances[v1Pos]);
             var v2Pos = matches.AsSpan().Slice(0, read).IndexOf(2L);
             Assert.True(int.IsPositive(v2Pos));
-            Assert.Equal(Hnsw.CosineSimilaritySingles(v2.GetEmbedding(), vQ.GetEmbedding()), distances[v2Pos]);
+            Assert.Equal(Hnsw.CosineDistanceSingles(v2.GetEmbedding(), vQ.GetEmbedding()), distances[v2Pos]);
         }
     }
     

--- a/test/SlowTests/Corax/RavenDB-23442.cs
+++ b/test/SlowTests/Corax/RavenDB-23442.cs
@@ -99,7 +99,7 @@ public class RavenDB_23442(ITestOutputHelper output) : RavenTestBase(output)
         var originalArray = Enumerable.Range(0, size).Select(x => random.NextSingle()).ToArray();
         var clonedArray = originalArray.ToArray();
 
-        Hnsw.DistanceToScoreCosineSimilarity(clonedArray);
+        Hnsw.DistanceToScoreCosine(clonedArray);
         for (int i = 0; i < originalArray.Length; i++)
             Assert.Equal(1f - originalArray[i], clonedArray[i], float.Epsilon);
     }
@@ -113,7 +113,7 @@ public class RavenDB_23442(ITestOutputHelper output) : RavenTestBase(output)
         var originalArray = Enumerable.Range(0, size).Select(x => (float)random.Next(0, 64)).ToArray();
         var clonedArray = originalArray.ToArray();
 
-        Hnsw.DistanceToScoreHammingSimilarity(clonedArray, 8);
+        Hnsw.DistanceToScoreHamming(clonedArray, 8);
         for (int i = 0; i < originalArray.Length; i++)
             Assert.Equal(1f - (originalArray[i] / 64f), clonedArray[i], float.Epsilon);
     }

--- a/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
@@ -38,11 +38,13 @@ public enum RavenIntrinsics
     Arm64 = 1 << 2,
     Sse = 1 << 3,
     Avx256 = 1 << 4,
-    Avx512 = 1 << 5,
+    Avx512Basic = 1 << 5,
+    Avx512Advanced = 1 << 6,
+    Avx512Full = 1 << 7,
 
-    Vector128 = 1 << 7,
-    Vector256 = 1 << 8,
-    Vector512 = 1 << 9
+    Vector128 = 1 << 8,
+    Vector256 = 1 << 9,
+    Vector512 = 1 << 10
 }
 
 public class RavenMultiplatformFactAttribute : RavenFactAttribute
@@ -181,7 +183,13 @@ public class RavenMultiplatformFactAttribute : RavenFactAttribute
         if (intrinsics.HasFlag(RavenIntrinsics.Avx256) && AdvInstructionSet.X86.IsSupportedAvx256 == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Avx512) && AdvInstructionSet.X86.IsSupportedAvx512 == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Avx512Basic) && AdvInstructionSet.X86.IsSupportedAvx512Basic == false)
+            return false;
+
+        if (intrinsics.HasFlag(RavenIntrinsics.Avx512Advanced) && AdvInstructionSet.X86.IsSupportedAvx512Advanced == false)
+            return false;
+
+        if (intrinsics.HasFlag(RavenIntrinsics.Avx512Full) && AdvInstructionSet.X86.IsSupportedAvx512 == false)
             return false;
 
         return true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24270
https://issues.hibernatingrhinos.com/issue/RavenDB-24020


### Additional description

This PR includes optimizations for CosineSimilarity and HammingBit that beat the Microsoft TensorPrimitives implementation and if optimization is not available it fallbacks to it. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
