### PR TITLE
RavenDB-24100 Optimized search for the first free bit in bitmap.

### DIFF
--- a/bench/Micro.Benchmark/PageLocatorImpl/FindFirstFreeBitInBitmapBenchmark.cs
+++ b/bench/Micro.Benchmark/PageLocatorImpl/FindFirstFreeBitInBitmapBenchmark.cs
@@ -1,0 +1,98 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using Sparrow.Binary;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Voron.Data.Tables;
+
+namespace Micro.Benchmark.PageLocatorImpl;
+
+[Config(typeof(Config))]
+public unsafe class FindFirstFreeBitInBitmapBenchmark
+{
+    private class Config : ManualConfig
+    {
+        public Config()
+        {
+            AddJob(Job.Default
+                .WithWarmupCount(100)
+                .WithIterationCount(200)
+                .WithInvocationCount(40000)
+            );
+        }
+    }
+
+    private readonly int _bitmapsCount = 1024;
+    private ByteStringContext _context;
+    private ulong* _workingBuffer; 
+    
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _context = new ByteStringContext(SharedMultipleUseFlag.None);
+        _context.Allocate(_bitmapsCount * sizeof(ulong) * 4, out ByteString workingBufferPtr);
+        _workingBuffer = (ulong*)workingBufferPtr.Ptr;
+        for (int i = 0; i < _bitmapsCount; ++i)
+        {
+            int j = 0;
+            var k = i % 256;
+            do
+            {
+                PtrBitVector.SetBitInPointer(_workingBuffer + k * 4, j++, true);
+            } while (j < k);
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _context.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public long Naive()
+    {
+        long sumOfOffset = 0;
+        for (int i = 0; i < _bitmapsCount; ++i)
+        {
+            sumOfOffset += FindFirstUnsetBitInBitmapNaive(_workingBuffer + i * 4);
+        }
+
+        return sumOfOffset;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe int FindFirstUnsetBitInBitmapNaive(ulong* buffer)
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            if (buffer[i] == ulong.MaxValue)
+                continue;
+                
+            var currentBitOffset = 64 * i;
+
+            for (int j = 0; j < 64; ++j)
+            {
+                if (PtrBitVector.GetBitInPointer(buffer, currentBitOffset + j) == false)
+                    return currentBitOffset + j;
+            }
+        }
+
+        return -1;
+    }
+    
+    [Benchmark]
+    public long LeadingZeros()
+    {
+        long sumOfOffset = 0;
+        for (int i = 0; i < _bitmapsCount; ++i)
+        {
+            NewPageAllocator.TryFindFirstFreeBitInBitmap(_workingBuffer + i * 4, out var offset);
+            sumOfOffset += offset;
+        }
+
+        return sumOfOffset;
+    }
+}

--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -12,6 +12,7 @@ using Voron.Data.Fixed;
 using Voron.Impl;
 using Constants = Voron.Global.Constants;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 
 namespace Voron.Data.Tables
 {
@@ -181,48 +182,49 @@ namespace Voron.Data.Tables
                         return page;
                     }
                 }
+
                 var startPage = it.CurrentKey;
-                while (true)
+                do
                 {
-                    using (it.Value(out Slice slice))
+                    using var _ = it.Value(out Slice slice);
+                    var bitmapPtr = (ulong*)(slice.Content.Ptr);
+                    if (TryFindFirstFreeBitInBitmap(bitmapPtr, out var bitPosition))
                     {
-                        var hasSpace = false;
-                        var buffer = (ulong*) (slice.Content.Ptr);
-                        for (int i = 0; i < BitmapSize / sizeof(ulong); i++)
-                        {
-                            if (buffer[i] != ulong.MaxValue)
-                            {
-                                hasSpace = true;
-                                break;
-                            }
-                        }
-
-                        if (hasSpace == false)
-                        {
-                            if (TryMoveNextCyclic(it, startPage) == false)
-                                break;
-
-                            continue;
-                        }
-
-                        for (int i = 0; i < BitmapSize*8; i++)
-                        {
-                            if (PtrBitVector.GetBitInPointer(buffer, i)) 
-                                continue;
-
-                            var currentSectionStart = it.CurrentKey;
-                            SetValue(fst, currentSectionStart, i);
-                                
-                            return _llt.ModifyPage(currentSectionStart + i);
-                        }
+                        var currentSectionStart = it.CurrentKey;
+                        SetValue(fst, currentSectionStart, bitPosition);
+                        return _llt.ModifyPage(currentSectionStart + bitPosition);
                     }
-                }
+                } while (TryMoveNextCyclic(it, startPage));
+                
                 page = AllocateMoreSpace(fst);
                 SetValue(fst, page.PageNumber, 0);
                 return page;
             }
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe bool TryFindFirstFreeBitInBitmap(ulong* bitmap, out int bitPosition)
+        {
+            Debug.Assert(BitmapSize / sizeof(ulong) == 4);
+            for (int currentBitmapChunkId = 0; currentBitmapChunkId < BitmapSize / sizeof(ulong); ++currentBitmapChunkId)
+            {
+                var currentBitmapChunk = bitmap[currentBitmapChunkId];
+                if (currentBitmapChunk == ulong.MaxValue)
+                    continue;
 
+                //We've to reverse endianness, since bitmap works on bytes, not ulongs.
+                var swapped = Bits.SwapBytes(currentBitmapChunk);
+                
+                bitPosition = BitVector.BitsPerByte * sizeof(ulong) * currentBitmapChunkId 
+                               + BitOperations.LeadingZeroCount(~swapped);
+
+                return true;
+            }
+
+            bitPosition = -1;
+            return false;
+        }
+        
         private static bool TryMoveNextCyclic(FixedSizeTree.IFixedSizeIterator it, long startPage)
         {
             if (it.MoveNext())

--- a/test/FastTests/Corax/RavenDB_24100.cs
+++ b/test/FastTests/Corax/RavenDB_24100.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using FastTests.Voron.FixedSize;
+using Sparrow.Binary;
+using Tests.Infrastructure;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class RavenDB_24100(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public unsafe void FindFirstFreeBitInBitmapTest()
+    {
+        const int bits = 256;
+        ulong* buffer = stackalloc ulong[4];
+
+        for (int bitIdx = 0; bitIdx < bits - 1; bitIdx++)
+        {
+            PtrBitVector.SetBitInPointer(buffer, bitIdx, true);
+            var foundFreeBit = NewPageAllocator.TryFindFirstFreeBitInBitmap(buffer, out var result);
+            var foundFreeBitManual = ManuallyCheck(buffer, out var positionManual);
+
+            Assert.Equal(foundFreeBitManual, foundFreeBit);
+            Assert.Equal(positionManual, result);
+            Assert.Equal(bitIdx + 1, result);
+        }
+
+        PtrBitVector.SetBitInPointer(buffer, bits - 1, true);
+
+        var foundFreeBitInFullBitmap = NewPageAllocator.TryFindFirstFreeBitInBitmap(buffer, out var resultInFullBitmap);
+        var foundFreeBitInFullBitmapManual = ManuallyCheck(buffer, out var positionManualInFullBitmap);
+        Assert.Equal(foundFreeBitInFullBitmapManual, foundFreeBitInFullBitmap);
+        Assert.Equal(positionManualInFullBitmap, resultInFullBitmap);
+        Assert.Equal(-1, resultInFullBitmap);
+        Assert.False(foundFreeBitInFullBitmap);
+    }
+
+    [RavenTheory(RavenTestCategory.Voron)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    public unsafe void FindFirstFreeBitInBitmapTestFuzzy(int seed)
+    {
+        var random = new Random(seed);
+        const int bits = 256;
+        ulong* buffer = stackalloc ulong[4];
+        var bufferAsSpan = new Span<ulong>(buffer, 4);
+        for (int iteration = 0; iteration < 1000; ++iteration)
+        {
+            bufferAsSpan.Fill(ulong.MaxValue); // set as high
+            var howManyToSetLow = random.Next(8, bits);
+            var workingSet = GetListToSetLow(howManyToSetLow);
+            foreach (var bitIdx in workingSet)
+                PtrBitVector.SetBitInPointer(buffer, bitIdx, false);
+            
+            
+            foreach (var bitIdx in workingSet)
+            {
+                var hasFreeSpace = NewPageAllocator.TryFindFirstFreeBitInBitmap(buffer, out var position);
+                var hasFreeSpaceManual = ManuallyCheck(buffer, out var positionManualCheck);
+                Assert.Equal(hasFreeSpaceManual, hasFreeSpace);
+                Assert.Equal(positionManualCheck, position);
+                PtrBitVector.SetBitInPointer(buffer, bitIdx, true);
+            }
+        }
+
+
+        Span<int> GetListToSetLow(int count)
+        {
+            var result = Enumerable.Range(0, bits).ToArray().AsSpan();
+            random.Shuffle(result);
+            return result[..count];
+        }
+    }
+    
+    private static unsafe bool ManuallyCheck(ulong* buffer, out int position)
+    {
+        var bitsToCheck = 256;
+
+        for (int bitIdx = 0; bitIdx < bitsToCheck; bitIdx++)
+        {
+            if (PtrBitVector.GetBitInPointer(buffer, bitIdx) == false)
+            {
+                position = bitIdx;
+                return true;
+            }
+        }
+
+        position = -1;
+        return false;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24100

### Additional description


| Method       | Mean       | Error    | StdDev    | Median     | Ratio | RatioSD |
|------------- |-----------:|---------:|----------:|-----------:|------:|--------:|
| Naive        | 4,831.6 ns | 26.52 ns | 112.27 ns | 4,873.0 ns |  1.00 |    0.03 |
| LeadingZeros |   725.7 ns |  4.30 ns |  18.23 ns |   724.5 ns |  0.15 |    0.01 |

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
