### PR TITLE
RavenDB-19994: Fix failing test with wrong assert

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Authentication
 {
     public class AuthenticationDebugPackageTests : RavenTestBase
     {
-        private readonly string[] _routesToSkip = new string[] { "/admin/debug/threads/stack-trace" };
+        private readonly string[] _routesToSkip = RavenTestHelper.ServerEndpointsToIgnore.Select(x => x.Path).Union(RavenTestHelper.DatabaseEndpointsToIgnore.Select(x => x.Path)).ToArray();
 
         public AuthenticationDebugPackageTests(ITestOutputHelper output) : base(output)
         {

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -270,7 +270,9 @@ namespace SlowTests.Authentication
         private void AssertArchiveContainsAllEntriesAndOnlyThem(HashSet<string> debugEntries, ZipArchive archive)
         {
             var archiveEntries = archive.Entries.Select(entry => entry.FullName)
-                .Where(e => e.Contains($"{DateTime.UtcNow:yyyy-MM-dd}") == false && (e.LastIndexOf(".error") == -1 || e.LastIndexOf(".error") != e.Length - 6))
+                .Where(e => 
+                    (e.Contains($"{DateTime.UtcNow:yyyy-MM-dd}") == false && e.Contains($"{DateTime.UtcNow.AddDays(-1):yyyy-MM-dd}") == false) // We might have entries from previous day
+                    && (e.LastIndexOf(".error") == -1 || e.LastIndexOf(".error") != e.Length - 6))
                 .Select(e => e.Replace(".txt", "").Replace(".json", "")).ToHashSet();
             foreach (var e in debugEntries)
                 Assert.True(archiveEntries.Contains(e), $"{e} is missing from the debug package");

--- a/test/StressTests/Authentication/AuthenticationStressTests.cs
+++ b/test/StressTests/Authentication/AuthenticationStressTests.cs
@@ -5,15 +5,10 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using FastTests;
-using Microsoft.VisualStudio.TestPlatform.Common;
-using NuGet.Configuration;
 using Raven.Client.Documents;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -103,45 +98,6 @@ namespace StressTests.Authentication
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
                 }
 
-                var serverEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/admin/replication/conflicts/solver"),    // access handled internally
-                    ("POST", "/setup/dns-n-cert"),                      // only available in setup mode
-                    ("POST", "/setup/user-domains"),                    // only available in setup mode
-                    ("POST", "/setup/populate-ips"),                    // only available in setup mode
-                    ("GET", "/setup/parameters"),                       // only available in setup mode
-                    ("GET", "/setup/ips"),                              // only available in setup mode
-                    ("POST", "/setup/hosts"),                           // only available in setup mode
-                    ("POST", "/setup/unsecured"),                       // only available in setup mode
-                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
-                    ("POST", "/setup/continue/unsecured"),              // only available in setup mode
-                    ("POST", "/setup/secured"),                         // only available in setup mode
-                    ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
-                    ("POST", "/setup/letsencrypt"),                     // only available in setup mode
-                    ("POST", "/setup/continue/extract"),                // only available in setup mode
-                    ("POST", "/setup/continue"),                        // only available in setup mode
-                    ("POST", "/setup/finish"),                          // only available in setup mode
-                    ("POST", "/server/notification-center/dismiss"),    // access handled internally
-                    ("POST", "/server/notification-center/postpone"),   // access handled internally
-                    ("GET", "/admin/debug/cluster-info-package"),       // heavy
-                    ("GET", "/admin/debug/remote-cluster-info-package"),// heavy
-                    ("GET", "/admin/debug/info-package"),               // heavy
-                    ("GET", "/admin/debug/threads/contention"),         // heavy
-                    ("GET", "/admin/debug/gcdump"),                     // heavy
-                    ("GET", "/admin/debug/threads/stack-trace"),        // heavy
-                    ("GET", "/admin/debug/memory/gc-events"),           // heavy
-                    ("GET", "/admin/debug/memory/allocations"),         // heavy
-                    ("GET", "/license/support"),                        // heavy
-                    ("GET", "/admin/debug/threads/runaway"),            // heavy
-
-                };
-
-                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
-                    ("POST", "/databases/*/studio/sample-data") // heavy
-                };
-
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -150,7 +106,7 @@ namespace StressTests.Authentication
                     var httpClient = new HttpClient(httpClientHandler);
                     httpClient.BaseAddress = new Uri(server.WebUrl);
 
-                    AssertServerRoutes(RouteScanner.AllRoutes.Values, serverEndpointsToIgnore, httpClient, (route, statusCode) =>
+                    AssertServerRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.ServerEndpointsToIgnore, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
                         if (route.EndpointType == EndpointType.Write)
@@ -170,7 +126,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
                         if (route.EndpointType == EndpointType.Write)
@@ -188,7 +144,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = false;
 
@@ -235,44 +191,6 @@ namespace StressTests.Authentication
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
                 }
 
-                var serverEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/admin/replication/conflicts/solver"),    // access handled internally
-                    ("POST", "/setup/dns-n-cert"),                      // only available in setup mode
-                    ("POST", "/setup/user-domains"),                    // only available in setup mode
-                    ("POST", "/setup/populate-ips"),                    // only available in setup mode
-                    ("GET", "/setup/parameters"),                       // only available in setup mode
-                    ("GET", "/setup/ips"),                              // only available in setup mode
-                    ("POST", "/setup/hosts"),                           // only available in setup mode
-                    ("POST", "/setup/unsecured"),                       // only available in setup mode
-                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
-                    ("POST", "/setup/continue/unsecured"),              // only available in setup mode
-                    ("POST", "/setup/secured"),                         // only available in setup mode
-                    ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
-                    ("POST", "/setup/letsencrypt"),                     // only available in setup mode
-                    ("POST", "/setup/continue/extract"),                // only available in setup mode
-                    ("POST", "/setup/continue"),                        // only available in setup mode
-                    ("POST", "/setup/finish"),                          // only available in setup mode
-                    ("POST", "/server/notification-center/dismiss"),    // access handled internally
-                    ("POST", "/server/notification-center/postpone"),   // access handled internally
-                    ("GET", "/admin/debug/cluster-info-package"),       // heavy
-                    ("GET", "/admin/debug/remote-cluster-info-package"),// heavy
-                    ("GET", "/admin/debug/info-package"),               // heavy
-                    ("GET", "/admin/debug/threads/contention"),         // heavy
-                    ("GET", "/admin/debug/gcdump"),                     // heavy
-                    ("GET", "/admin/debug/threads/stack-trace"),        // heavy
-                    ("GET", "/admin/debug/memory/gc-events"),           // heavy
-                    ("GET", "/admin/debug/memory/allocations"),         // heavy
-                    ("GET", "/license/support"),                        // heavy
-                    ("GET", "/admin/debug/threads/runaway"),            // heavy
-                };
-
-                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
-                    ("POST", "/databases/*/studio/sample-data") // heavy
-                };
-
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -281,7 +199,7 @@ namespace StressTests.Authentication
                     var httpClient = new HttpClient(httpClientHandler);
                     httpClient.BaseAddress = new Uri(server.WebUrl);
 
-                    AssertServerRoutes(RouteScanner.AllRoutes.Values, serverEndpointsToIgnore, httpClient, (route, statusCode) =>
+                    AssertServerRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.ServerEndpointsToIgnore, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
                         if (route.EndpointType == EndpointType.Write)
@@ -301,7 +219,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = route.AuthorizationStatus == AuthorizationStatus.ValidUser;
 
@@ -313,7 +231,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = false;
 
@@ -360,44 +278,6 @@ namespace StressTests.Authentication
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
                 }
 
-                var serverEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/admin/replication/conflicts/solver"),    // access handled internally
-                    ("POST", "/setup/dns-n-cert"),                      // only available in setup mode
-                    ("POST", "/setup/user-domains"),                    // only available in setup mode
-                    ("POST", "/setup/populate-ips"),                    // only available in setup mode
-                    ("GET", "/setup/parameters"),                       // only available in setup mode
-                    ("GET", "/setup/ips"),                              // only available in setup mode
-                    ("POST", "/setup/hosts"),                           // only available in setup mode
-                    ("POST", "/setup/unsecured"),                       // only available in setup mode
-                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
-                    ("POST", "/setup/continue/unsecured"),              // only available in setup mode
-                    ("POST", "/setup/secured"),                         // only available in setup mode
-                    ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
-                    ("POST", "/setup/letsencrypt"),                     // only available in setup mode
-                    ("POST", "/setup/continue/extract"),                // only available in setup mode
-                    ("POST", "/setup/continue"),                        // only available in setup mode
-                    ("POST", "/setup/finish"),                          // only available in setup mode
-                    ("POST", "/server/notification-center/dismiss"),    // access handled internally
-                    ("POST", "/server/notification-center/postpone"),   // access handled internally
-                    ("GET", "/admin/debug/cluster-info-package"),       // heavy
-                    ("GET", "/admin/debug/remote-cluster-info-package"),// heavy
-                    ("GET", "/admin/debug/info-package"),               // heavy
-                    ("GET", "/admin/debug/threads/contention"),         // heavy
-                    ("GET", "/admin/debug/gcdump"),                     // heavy
-                    ("GET", "/admin/debug/threads/stack-trace"),        // heavy
-                    ("GET", "/admin/debug/memory/gc-events"),           // heavy
-                    ("GET", "/admin/debug/memory/allocations"),         // heavy
-                    ("GET", "/license/support"),                        // heavy
-                    ("GET", "/admin/debug/threads/runaway"),            // heavy
-                };
-
-                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
-                    ("POST", "/databases/*/studio/sample-data") // heavy
-                };
-
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -406,7 +286,7 @@ namespace StressTests.Authentication
                     var httpClient = new HttpClient(httpClientHandler);
                     httpClient.BaseAddress = new Uri(server.WebUrl);
 
-                    AssertServerRoutes(RouteScanner.AllRoutes.Values, serverEndpointsToIgnore, httpClient, (route, statusCode) =>
+                    AssertServerRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.ServerEndpointsToIgnore, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
                         if (route.EndpointType == EndpointType.Write)
@@ -426,7 +306,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -438,7 +318,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = false;
 
@@ -484,44 +364,6 @@ namespace StressTests.Authentication
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
                 }
 
-                var serverEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/admin/replication/conflicts/solver"),    // access handled internally
-                    ("POST", "/setup/dns-n-cert"),                      // only available in setup mode
-                    ("POST", "/setup/user-domains"),                    // only available in setup mode
-                    ("POST", "/setup/populate-ips"),                    // only available in setup mode
-                    ("GET", "/setup/parameters"),                       // only available in setup mode
-                    ("GET", "/setup/ips"),                              // only available in setup mode
-                    ("POST", "/setup/hosts"),                           // only available in setup mode
-                    ("POST", "/setup/unsecured"),                       // only available in setup mode
-                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
-                    ("POST", "/setup/continue/unsecured"),              // only available in setup mode
-                    ("POST", "/setup/secured"),                         // only available in setup mode
-                    ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
-                    ("POST", "/setup/letsencrypt"),                     // only available in setup mode
-                    ("POST", "/setup/continue/extract"),                // only available in setup mode
-                    ("POST", "/setup/continue"),                        // only available in setup mode
-                    ("POST", "/setup/finish"),                          // only available in setup mode
-                    ("POST", "/server/notification-center/dismiss"),    // access handled internally
-                    ("POST", "/server/notification-center/postpone"),   // access handled internally
-                    ("GET", "/admin/debug/cluster-info-package"),       // heavy
-                    ("GET", "/admin/debug/remote-cluster-info-package"),// heavy
-                    ("GET", "/admin/debug/info-package"),               // heavy
-                    ("GET", "/admin/debug/threads/contention"),         // heavy
-                    ("GET", "/admin/debug/gcdump"),                     // heavy
-                    ("GET", "/admin/debug/threads/stack-trace"),        // heavy
-                    ("GET", "/admin/debug/memory/gc-events"),           // heavy
-                    ("GET", "/admin/debug/memory/allocations"),         // heavy
-                    ("GET", "/license/support"),                        // heavy 
-                    ("GET", "/admin/debug/threads/runaway"),            // heavy
-                };
-
-                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
-                    ("POST", "/databases/*/studio/sample-data") // heavy
-                };
-
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -530,7 +372,7 @@ namespace StressTests.Authentication
                     var httpClient = new HttpClient(httpClientHandler);
                     httpClient.BaseAddress = new Uri(server.WebUrl);
 
-                    AssertServerRoutes(RouteScanner.AllRoutes.Values, serverEndpointsToIgnore, httpClient, (route, statusCode) =>
+                    AssertServerRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.ServerEndpointsToIgnore, httpClient, (route, statusCode) =>
                     {
                         var canAccess = route.AuthorizationStatus == AuthorizationStatus.Operator
                             || route.AuthorizationStatus == AuthorizationStatus.ValidUser
@@ -545,7 +387,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -557,7 +399,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -602,37 +444,6 @@ namespace StressTests.Authentication
                     adminStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName2)));
                 }
 
-                var serverEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/admin/replication/conflicts/solver"),    // access handled internally
-                    ("POST", "/setup/dns-n-cert"),                      // only available in setup mode
-                    ("POST", "/setup/user-domains"),                    // only available in setup mode
-                    ("POST", "/setup/populate-ips"),                    // only available in setup mode
-                    ("GET", "/setup/parameters"),                       // only available in setup mode
-                    ("GET", "/setup/ips"),                              // only available in setup mode
-                    ("POST", "/setup/hosts"),                           // only available in setup mode
-                    ("POST", "/setup/unsecured"),                       // only available in setup mode
-                    ("POST", "/setup/unsecured/package"),               // only available in setup mode
-                    ("POST", "/setup/continue/unsecured"),              // only available in setup mode
-                    ("POST", "/setup/secured"),                         // only available in setup mode
-                    ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
-                    ("POST", "/setup/letsencrypt"),                     // only available in setup mode
-                    ("POST", "/setup/continue/extract"),                // only available in setup mode
-                    ("POST", "/setup/continue"),                        // only available in setup mode
-                    ("POST", "/setup/finish"),                          // only available in setup mode
-                    ("POST", "/server/notification-center/dismiss"),    // access handled internally
-                    ("POST", "/server/notification-center/postpone"),   // access handled internally
-                    ("GET", "/admin/debug/cluster-info-package"),       // heavy
-                    ("GET", "/admin/debug/remote-cluster-info-package"),// heavy
-                    ("GET", "/admin/debug/info-package"),               // heavy
-                };
-
-                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
-                {
-                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
-                    ("POST", "/databases/*/studio/sample-data") // heavy
-                };
-
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -641,7 +452,7 @@ namespace StressTests.Authentication
                     var httpClient = new HttpClient(httpClientHandler);
                     httpClient.BaseAddress = new Uri(server.WebUrl);
 
-                    AssertServerRoutes(RouteScanner.AllRoutes.Values, serverEndpointsToIgnore, httpClient, (route, statusCode) =>
+                    AssertServerRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.ServerEndpointsToIgnore, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -653,7 +464,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -665,7 +476,7 @@ namespace StressTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, RavenTestHelper.DatabaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -258,5 +258,43 @@ namespace Tests.Infrastructure
             if (IsRunningOnCI)
                 throw new InvalidOperationException($"Operation '{caller}' is forbidden, because tests are running on CI.");
         }
+
+        internal static HashSet<(string Method, string Path)> ServerEndpointsToIgnore = 
+        [
+            ("POST", "/admin/replication/conflicts/solver"),                          // access handled internally
+            ("POST", "/setup/dns-n-cert"),                                            // only available in setup mode
+            ("POST", "/setup/user-domains"),                                          // only available in setup mode
+            ("POST", "/setup/populate-ips"),                                          // only available in setup mode
+            ("GET", "/setup/parameters"),                                             // only available in setup mode
+            ("GET", "/setup/ips"),                                                    // only available in setup mode
+            ("POST", "/setup/hosts"),                                                 // only available in setup mode
+            ("POST", "/setup/unsecured"),                                             // only available in setup mode
+            ("POST", "/setup/unsecured/package"),                                     // only available in setup mode
+            ("POST", "/setup/continue/unsecured"),                                    // only available in setup mode
+            ("POST", "/setup/secured"),                                               // only available in setup mode
+            ("GET", "/setup/letsencrypt/agreement"),                                  // only available in setup mode
+            ("POST", "/setup/letsencrypt"),                                           // only available in setup mode
+            ("POST", "/setup/continue/extract"),                                      // only available in setup mode
+            ("POST", "/setup/continue"),                                              // only available in setup mode
+            ("POST", "/setup/finish"),                                                // only available in setup mode
+            ("POST", "/server/notification-center/dismiss"),                          // access handled internally
+            ("POST", "/server/notification-center/postpone"),                         // access handled internally
+            ("GET", "/admin/debug/cluster-info-package"),                             // heavy
+            ("GET", "/admin/debug/remote-cluster-info-package"),                      // heavy
+            ("GET", "/admin/debug/info-package"),                                     // heavy
+            ("GET", "/admin/debug/threads/contention"),                               // heavy
+            ("GET", "/admin/debug/gcdump"),                                           // heavy
+            ("GET", "/admin/debug/threads/stack-trace"),                              // heavy
+            ("GET", "/admin/debug/memory/gc-events"),                                 // heavy
+            ("GET", "/admin/debug/memory/allocations"),                               // heavy
+            ("GET", "/license/support"),                                              // heavy 
+            ("GET", "/admin/debug/threads/runaway"),                                  // heavy
+         ];
+
+        internal static HashSet<(string Method, string Path)> DatabaseEndpointsToIgnore = 
+        [
+            ("POST", "/databases/*/admin/pull-replication/generate-certificate"),     // heavy
+            ("POST", "/databases/*/studio/sample-data")                               // heavy
+        ];
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19994

### Additional description

* Sometimes the debug package might get created in one day but asserted in the next one, which lead to a test failure
* Unify list of endpoints to skip in tests

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
