### PR TITLE
RavenDB-24251 - Provide a better error when we don't have the Microsoft Visual C++ 2019 Redistributable installed

### DIFF
--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -50,8 +50,7 @@ public static class GenerateEmbeddings
         }
         catch (TypeInitializationException e) when (PlatformDetails.RunningOnWindows)
         {
-            throw new IncorrectDllException("The initialization error is caused by missing 'Microsoft Visual C++ 2019 Redistributable Package' (or newer), " +
-                                            "you can download it here: https://aka.ms/vs/17/release/vc_redist.x64.exe", e);
+            throw new IncorrectDllException($"Could not initialize 'ONNX Runtime'. Initialization error could be caused by missing 'Microsoft Visual C++ 2019 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.", e);
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -13,9 +13,10 @@ using Microsoft.SemanticKernel.Connectors.Onnx;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Queries.Vector;
 using Raven.Server.Config;
-using Raven.Server.Documents.AI.Embeddings;
 using Sparrow;
+using Sparrow.Platform;
 using Sparrow.Server;
+using Sparrow.Utils;
 using VectorValue = Corax.Utils.VectorValue;
 
 namespace Raven.Server.Documents.Indexes.VectorSearch;
@@ -42,8 +43,16 @@ public static class GenerateEmbeddings
     {
         if (Embedder.IsValueCreated)
             throw new InvalidOperationException("Embedder has already been initialized.");
-        
-        OnnxSessionOptions = new SessionOptions() { IntraOpNumThreads = configuration.Indexing.MaxNumberOfThreadsForLocalEmbeddingsGeneration };
+
+        try
+        {
+            OnnxSessionOptions = new SessionOptions { IntraOpNumThreads = configuration.Indexing.MaxNumberOfThreadsForLocalEmbeddingsGeneration };
+        }
+        catch (TypeInitializationException e) when (PlatformDetails.RunningOnWindows)
+        {
+            throw new IncorrectDllException("The initialization error is caused by missing 'Microsoft Visual C++ 2019 Redistributable Package' (or newer), " +
+                                            "you can download it here: https://aka.ms/vs/17/release/vc_redist.x64.exe", e);
+        }
     }
 
     [ThreadStatic]

--- a/src/Sparrow.Server/Platform/Pal.cs
+++ b/src/Sparrow.Server/Platform/Pal.cs
@@ -36,7 +36,7 @@ namespace Sparrow.Server.Platform
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     errString +=
-                        $" Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.";
+                        $" Initialization error could also be caused by missing 'Microsoft Visual C++ 2019 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.";
 
                 errString += $" Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}";
 

--- a/src/Sparrow.Server/Platform/Pal.cs
+++ b/src/Sparrow.Server/Platform/Pal.cs
@@ -36,7 +36,7 @@ namespace Sparrow.Server.Platform
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     errString +=
-                        " Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads.";
+                        " Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://aka.ms/vs/17/release/vc_redist.x64.exe.";
 
                 errString += $" Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}";
 

--- a/src/Sparrow.Server/Platform/Pal.cs
+++ b/src/Sparrow.Server/Platform/Pal.cs
@@ -36,7 +36,7 @@ namespace Sparrow.Server.Platform
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     errString +=
-                        " Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://aka.ms/vs/17/release/vc_redist.x64.exe.";
+                        $" Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.";
 
                 errString += $" Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}";
 

--- a/src/Sparrow.Server/Sodium.tt
+++ b/src/Sparrow.Server/Sodium.tt
@@ -315,7 +315,7 @@ namespace Sparrow
 		#region Windows
 		private sealed class Windows
 		{
-			private const string ErrString = $"'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'";
+			private const string ErrString = $"'Microsoft Visual C++ 2019 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'";
 
 			private static readonly bool _is32bits;
 

--- a/src/Sparrow.Server/Sodium.tt
+++ b/src/Sparrow.Server/Sodium.tt
@@ -315,7 +315,7 @@ namespace Sparrow
 		#region Windows
 		private sealed class Windows
 		{
-			private const string ErrString = "'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads";
+			private const string ErrString = "'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://aka.ms/vs/17/release/vc_redist.x64.exe";
 
 			private static readonly bool _is32bits;
 

--- a/src/Sparrow.Server/Sodium.tt
+++ b/src/Sparrow.Server/Sodium.tt
@@ -315,7 +315,7 @@ namespace Sparrow
 		#region Windows
 		private sealed class Windows
 		{
-			private const string ErrString = "'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://aka.ms/vs/17/release/vc_redist.x64.exe";
+			private const string ErrString = $"'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'";
 
 			private static readonly bool _is32bits;
 

--- a/src/Sparrow/Platform/PlatformDetails.cs
+++ b/src/Sparrow/Platform/PlatformDetails.cs
@@ -85,5 +85,16 @@ namespace Sparrow.Platform
                 return false;
             }
         }
+
+        internal static string GetVcRedistLink()
+        {
+            if (RunningOnWindows == false)
+                return null;
+
+            if (Is32Bits)
+                return "https://aka.ms/vs/17/release/vc_redist.x86.exe";
+
+            return "https://aka.ms/vs/17/release/vc_redist.x64.exe";
+        }
     }
 }

--- a/src/Sparrow/Platform/Sodium.cs
+++ b/src/Sparrow/Platform/Sodium.cs
@@ -23,7 +23,7 @@ namespace Sparrow.Platform
                 var errString = $"{LIBSODIUM} version might be invalid, missing or not usable on current platform.";
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    errString += $" Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.";
+                    errString += $" Initialization error could also be caused by missing 'Microsoft Visual C++ 2019 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.";
 
                 errString += $" Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}";
 

--- a/src/Sparrow/Platform/Sodium.cs
+++ b/src/Sparrow/Platform/Sodium.cs
@@ -23,7 +23,7 @@ namespace Sparrow.Platform
                 var errString = $"{LIBSODIUM} version might be invalid, missing or not usable on current platform.";
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    errString += " Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads.";
+                    errString += " Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://aka.ms/vs/17/release/vc_redist.x64.exe.";
 
                 errString += $" Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}";
 

--- a/src/Sparrow/Platform/Sodium.cs
+++ b/src/Sparrow/Platform/Sodium.cs
@@ -23,7 +23,7 @@ namespace Sparrow.Platform
                 var errString = $"{LIBSODIUM} version might be invalid, missing or not usable on current platform.";
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    errString += " Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from https://aka.ms/vs/17/release/vc_redist.x64.exe.";
+                    errString += $" Initialization error could also be caused by missing 'Microsoft Visual C++ 2015 Redistributable Package' (or newer). It can be downloaded from '{PlatformDetails.GetVcRedistLink()}'.";
 
                 errString += $" Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}";
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24251/Cannot-start-RavenDB-on-a-fresh-Windows-Server

### Additional description

Provide a better error when we don't have the `Microsoft Visual C++ 2019 Redistributable` installed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
