### PR TITLE
RavenDB-24105: Allow Microsoft Logs to be enabled if required.

### DIFF
--- a/src/Raven.Server/Config/Categories/LogsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LogsConfiguration.cs
@@ -71,6 +71,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Logs.Compress", ConfigurationEntryScope.ServerWideOnly)]
         public bool EnableArchiveFileCompression { get; set; }
 
+        [Description("Determines whether the Microsoft logs are active or not. Beware: enabling this is known to impact request latency on certain conditions.")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Logs.Microsoft.Enabled", ConfigurationEntryScope.ServerWideOnly)]
+        public bool MicrosoftEnabled { get; set; }
+
         [Description("The minimum logging level for Microsoft logs.")]
         [DefaultValue(LogLevel.Error)]
         [ConfigurationEntry("Logs.Microsoft.MinLevel", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                     AssertCanPersistConfiguration();
 
                 if (configuration.MicrosoftLogs != null && ServerStore.Configuration.Logs.MicrosoftEnabled == false)
-                    throw new InvalidOperationException($"Configuration cannot be persisted because Microsoft Logs are disabled. You can enable them by using '${RavenConfiguration.GetKey(x => x.Logs.MicrosoftEnabled)}' to true");
+                    throw new InvalidOperationException($"Configuration cannot be modified because Microsoft Logs are disabled. You can enable them by setting '${RavenConfiguration.GetKey(x => x.Logs.MicrosoftEnabled)}' configuration to true.");
 
                 RavenLogManager.Instance.ConfigureLogging(configuration);
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -83,6 +83,9 @@ namespace Raven.Server.Documents.Handlers.Admin
                 if (configuration.Persist)
                     AssertCanPersistConfiguration();
 
+                if (configuration.MicrosoftLogs != null && ServerStore.Configuration.Logs.MicrosoftEnabled == false)
+                    throw new InvalidOperationException($"Configuration cannot be persisted because Microsoft Logs are disabled. You can enable them by using '${RavenConfiguration.GetKey(x => x.Logs.MicrosoftEnabled)}' to true");
+
                 RavenLogManager.Instance.ConfigureLogging(configuration);
 
                 if (configuration.Persist)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -272,14 +272,6 @@ namespace Raven.Server
                 }
 
                 var webHostBuilder = new WebHostBuilder()
-                    .UseNLog(new NLogAspNetCoreOptions
-                    {
-                        IncludeScopes = false,
-                        CaptureMessageTemplates = false,
-                        RegisterHttpContextAccessor = false,
-                        IncludeActivityIdsWithBeginScope = false,
-                    })
-
                     .CaptureStartupErrors(captureStartupErrors: true)
                     .UseKestrel(ConfigureKestrel)
                     .UseUrls(Configuration.Core.ServerUrls)
@@ -320,6 +312,18 @@ namespace Raven.Server
                         services.AddSingleton(this);
                         services.Configure<FormOptions>(options => { options.MultipartBodyLengthLimit = long.MaxValue; });
                     });
+
+                if (Configuration.Logs.MicrosoftEnabled)
+                {
+                    webHostBuilder = webHostBuilder.UseNLog(
+                        new NLogAspNetCoreOptions
+                        {
+                            IncludeScopes = false, 
+                            CaptureMessageTemplates = false, 
+                            RegisterHttpContextAccessor = false, 
+                            IncludeActivityIdsWithBeginScope = false,
+                        });
+                }
 
                 _webHost = webHostBuilder.Build();
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24105

### Additional description

Since the performance impact of Microsoft Logs is high, it was decided to leave them disabled by default and provide a configuration option.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
