### PR TITLE
RavenDB-23935 : fixed the problem with Query improperly serializes when having [EnumMember]

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -345,7 +345,15 @@ namespace Raven.Client.Documents.Linq
                 if (val == null)
                     return null;
                 if (_conventions.SaveEnumsAsIntegers == false)
-                    return Enum.GetName(enumType, val);
+                {
+                    var enumName = Enum.GetName(enumType, val);
+                    if (enumName == null) 
+                        return null;
+                    
+                    var field = enumType.GetField(enumName);
+                    var attr = field?.GetCustomAttribute<EnumMemberAttribute>();
+                    return attr?.Value ?? enumName;
+                }
                 return Convert.ToInt32(val);
             }
         }

--- a/test/SlowTests/Issues/RavenDB_23935.cs
+++ b/test/SlowTests/Issues/RavenDB_23935.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using System.Runtime.Serialization;
+using Elastic.Transport.Extensions;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23935 : RavenTestBase
+    { 
+        public RavenDB_23935(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void EnumMemberAttributeTest()
+        {
+            using var store = GetDocumentStore();
+            using var session = store.OpenSession();
+            var str = new MyClass(MyEnum.First);
+            session.Store(new MyClass(MyEnum.First));
+            session.SaveChanges();
+
+            var result = session.Query<MyClass>()
+                .Customize(p => p.WaitForNonStaleResults())
+                .Where(x => x.MyEnum == MyEnum.First)
+                .ToList();
+
+            Assert.Single(result);
+            Assert.Equal(MyEnum.First.GetStringValue(), result.First().MyEnum.GetStringValue());
+        }
+
+        record MyClass(MyEnum MyEnum);
+
+        enum MyEnum
+        {
+            [EnumMember(Value = "first_my_name")]
+            First,
+
+            [EnumMember(Value = "second_my_name")]
+            Second
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23935/Query-improperly-serializes-an-enum-when-the-enum-has-an-EnumMember-attribute

### Additional description

Queries now support [EnumMember] attribute.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
