### PR TITLE
RavenDB-21968 Use WaitForValue since IndexState could not be persisted on disk yet

### DIFF
--- a/test/SlowTests/Issues/RavenDB-14323.cs
+++ b/test/SlowTests/Issues/RavenDB-14323.cs
@@ -50,15 +50,20 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store, allowErrors: true);
 
-                Assert.True(SpinWait.SpinUntil(() =>
+                Assert.True(WaitForValue(() =>
                 {
                     var stats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
                     return stats.IsInvalidIndex;
-                }, TimeSpan.FromSeconds(10))); //precaution
+                }, true)); //precaution
 
-                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                IndexStats indexStats = null;
 
-                Assert.True(indexStats.IsInvalidIndex);
+                Assert.Equal(IndexState.Error, WaitForValue(() =>
+                {
+                    indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                    return indexStats.State;
+                }, IndexState.Error));;
+
                 Assert.Equal(IndexState.Error, indexStats.State);
 
                 Assert.Equal(numberOfReferencedDocuments, indexStats.MapAttempts);
@@ -121,15 +126,20 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store, allowErrors: true);
 
-                Assert.True(SpinWait.SpinUntil(() =>
+                Assert.True(WaitForValue(() =>
                 {
                     var stats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
                     return stats.IsInvalidIndex;
-                }, TimeSpan.FromSeconds(10))); //precaution
+                }, true)); //precaution
 
-                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                IndexStats indexStats = null;
 
-                Assert.True(indexStats.IsInvalidIndex);
+                Assert.Equal(IndexState.Error, WaitForValue(() =>
+                {
+                    indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                    return indexStats.State;
+                }, IndexState.Error));;
+
                 Assert.Equal(IndexState.Error, indexStats.State);
 
                 Assert.Equal(numberOfReferencedDocuments, indexStats.MapAttempts);


### PR DESCRIPTION
Using WaitForValue instea of SpinUntil so we'll have some reasonable interval between the checks.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21968/SlowTests.Issues.RavenDB14323.IndexStateErrorAfterChangenumberOfReferencedDocuments-5

### Additional description

This is effectively backporting  https://github.com/ravendb/ravendb/pull/18097 test fix to 5.4

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
