### PR TITLE
RavenDB-23089 Fixing the test. Making sure that we do the assertion on the actual value that satisfied the condition of WaitForValue()

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22369.cs
+++ b/test/SlowTests/Issues/RavenDB-22369.cs
@@ -30,16 +30,16 @@ public class RavenDB_22369 : RavenTestBase
         var index = new TIndex();
         index.Execute(store);
         Indexes.WaitForIndexing(store, allowErrors: true);
-        WaitForValue(ErrorExist, true);
-        var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {index.IndexName}));
+        
+        IndexErrors[] indexErrors = null;
+        
+        Assert.True(WaitForValue(() => {
+            indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
+            return indexErrors != null && indexErrors.Length > 0 && indexErrors[0].Errors != null && indexErrors[0].Errors.Length > 0;
+        }, true));
+        
         Assert.Contains($"Your spatial field 'Location' has 'Indexing' set to 'No'. Spatial fields cannot be stored, so this field is useless because it cannot be searched or retrieved.",
             indexErrors[0].Errors[0].ToString());
-
-        bool ErrorExist()
-        {
-            var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
-            return errors != null && errors.Length > 0 && errors[0].Errors != null && errors[0].Errors.Length > 0;
-        }
     }
 
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23089/SlowTests.Issues.RavenDB22369.CannotCreateSpatialFieldWithoutIndexingCSharp

### Additional description

Test fix

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
