### PR TITLE
RavenDB-23531 Adjust the timeout of TryTake to TimeToWaitVeforeConnectionRetry value

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17451.cs
+++ b/test/SlowTests/Issues/RavenDB-17451.cs
@@ -240,10 +240,11 @@ namespace SlowTests.Issues
                         Query = "from Users"
                     };
                     var subsId = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+                    var timeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5);
                     using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subsId)
-                    {
-                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
-                    }))
+                           {
+                               TimeToWaitBeforeConnectionRetry = timeToWaitBeforeConnectionRetry
+                           }))
                     {
                         var list = new BlockingCollection<User>();
                         GC.KeepAlive(subscription.Run(u =>
@@ -256,7 +257,7 @@ namespace SlowTests.Issues
                         User user;
                         for (var i = 0; i < 10; i++)
                         {
-                            Assert.True(list.TryTake(out user, 1000));
+                            Assert.True(list.TryTake(out user, timeToWaitBeforeConnectionRetry * 2));
                         }
                         Assert.False(list.TryTake(out user, 50));
                         List<TcpConnectionOptions> tcpConnections;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23531

### Additional description

Possible fix for occasionally failing test

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
