### PR TITLE
RavenDB-23817 Add metadata.one file to keep the journal id

### DIFF
--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -125,6 +125,15 @@ namespace Voron.Impl.Backup
                     env.HeaderAccessor.CopyHeaders(package, copier, env.Options, basePath);
 
                     env._forTestingPurposes?.ActionToCallDuringFullBackupRighAfterCopyHeaders?.Invoke();
+                    
+                    if (env.Options.ReadValidMetadata(MetadataAccessor.MetadataName, out var metadataHeader))
+                    {
+                        var metadata = package.CreateEntry(Path.Combine(basePath, MetadataAccessor.MetadataName));
+                        using (var metadataStream = metadata.Open())
+                        {
+                            copier.ToStream((byte*)&metadataHeader, sizeof(MetadataFile), metadataStream);
+                        }
+                    }
 
                     // journal files snapshot
                     var files = env.Journal.Files; // thread safety copy

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -408,7 +408,7 @@ namespace Voron.Impl.Backup
                 
                 txw.Commit();
 
-                env.HeaderAccessor.MetadataAccessor.Modify((ref MetadataFile header) => header.JournalId = journalId, persist: true);
+                env.HeaderAccessor.MetadataAccessor.Modify((ref MetadataFile header) => header.JournalId = journalId);
                 env.HeaderAccessor.Modify((ref FileHeader header) => 
                 {
                     header.TransactionId = lastTxHeader->TransactionId;

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -262,17 +262,6 @@ namespace Voron.Impl.Backup
                 options.ManualFlushing = true;
                 using (var env = new StorageEnvironment(options))
                 {
-                    // We create a completely new environment... 
-                    if (env.CurrentReadTransactionId is 1)
-                    {
-                        env.HeaderAccessor.Modify((ref FileHeader header) =>
-                        {
-                            // The journal id should come from the first
-                            // real transaction that is being applies here
-                            header.JournalId = Guid.Empty;
-                        });
-                    }
-
                     foreach (var backupPath in backupPaths)
                     {
                         Restore(env, backupPath);
@@ -339,13 +328,13 @@ namespace Voron.Impl.Backup
                 var lastTxHeaderStackLocation = stackalloc TransactionHeader[1];
                 var envHeader = env.HeaderAccessor.CopyHeader();
                 var lastTxId = envHeader.TransactionId;
-                var journalId = envHeader.JournalId;
 
-                long journalNumber = -1;
                 var rc = Pal.rvn_pager_get_file_handle(txw.DataPagerState.Handle, out var fileHandle, out int errorCode);
                 if(rc != PalFlags.FailCodes.Success)
                     PalHelper.ThrowLastError(rc, errorCode, "Failed to get a file handle to " + txw.DataPager.FileName);
                 using var _ = fileHandle;
+                var journalId = Guid.Empty;
+
                 foreach (var entry in entries)
                 {
                     switch (Path.GetExtension(entry.Name))
@@ -364,7 +353,7 @@ namespace Voron.Impl.Backup
                             var (journalPager, journalPagerState) = env.Options.OpenJournalPager(jounalFileName.FullPath);
                             toDispose.Add(journalPager);
 
-                            if (long.TryParse(Path.GetFileNameWithoutExtension(entry.Name), out journalNumber) == false)
+                            if (long.TryParse(Path.GetFileNameWithoutExtension(entry.Name), out var journalNumber) == false)
                             {
                                 throw new InvalidOperationException("Cannot parse journal file number");
                             }
@@ -376,9 +365,7 @@ namespace Voron.Impl.Backup
                                     env.Options.Encryption.IsEnabled);
                             toDispose.Add(recoveryPager);
 
-                            var reader = new JournalReader(env, journalNumber, journalPager, journalPagerState, txw.DataPager, recoveryPager, new HashSet<long>(),
-                                       new JournalInfo { LastSyncedTransactionId = lastTxId }, new FileHeader { HeaderRevision = -1, JournalId = journalId},
-                                       lastTxHeader);
+                            var reader = new JournalReader(env, journalNumber, journalPager, journalPagerState, txw.DataPager, recoveryPager, lastTxHeader, lastTxId);
                             try
                             {
                                 while (reader.ReadOneTransactionToDataFile(ref txw.DataPagerState, ref recoverPagerState, ref txw.PagerTransactionState, fileHandle,
@@ -420,12 +407,12 @@ namespace Voron.Impl.Backup
                 txw.SetNextPageNumber(lastTxHeader->LastPageNumber + 1);
                 
                 txw.Commit();
-                
+
+                env.HeaderAccessor.MetadataAccessor.Modify((ref MetadataFile header) => header.JournalId = journalId, persist: true);
                 env.HeaderAccessor.Modify((ref FileHeader header) => 
                 {
                     header.TransactionId = lastTxHeader->TransactionId;
                     header.LastPageNumber = lastTxHeader->LastPageNumber;
-                    header.JournalId = journalId;
                     header.Journal.LastSyncedTransactionId = lastTxHeader->TransactionId;
                 
                     header.Root = lastTxHeader->Root;

--- a/src/Voron/Impl/Backup/IncrementalBackupInfo.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackupInfo.cs
@@ -18,7 +18,7 @@ namespace Voron.Impl.Backup
         public long LastBackedUpJournalPage;
 
         /// <summary>
-        /// Up until version 7.1 - used to hold LastCreatedJournal, but we now
+        /// Up until version 8.0 - used to hold LastCreatedJournal, but we now
         /// use the existence of the journal file instead to mark this
         /// </summary>
         [FieldOffset(16)]

--- a/src/Voron/Impl/FileHeaders/FileHeader.cs
+++ b/src/Voron/Impl/FileHeaders/FileHeader.cs
@@ -1,5 +1,4 @@
-﻿﻿using System;
- using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Voron.Data.BTrees;
 using Voron.Impl.Backup;
 using Voron.Impl.Journal;
@@ -72,17 +71,9 @@ namespace Voron.Impl.FileHeaders
         public int PageSize;
 
         /// <summary>
-        /// The journal id for all the transactions in shared journals
-        /// for this environment that allows to tell which transactions
-        /// belong to this environment or to others
-        /// </summary>
-        [FieldOffset(154)]
-        public Guid JournalId;
-        
-        /// <summary>
         /// Hash of the header used for validation
         /// </summary>
-        [FieldOffset(170)]
+        [FieldOffset(154)]
         public ulong Hash;
  
         public override string ToString()
@@ -90,7 +81,7 @@ namespace Voron.Impl.FileHeaders
             return
                 $"{nameof(Version)}: {Version}, {nameof(HeaderRevision)}: {HeaderRevision}, {nameof(TransactionId)}: {TransactionId}, {nameof(LastPageNumber)}: {LastPageNumber}, " +
                 $"{nameof(Root.RootPageNumber)}: {Root.RootPageNumber}, " +
-                $"{nameof(JournalId)}: {JournalId},  {nameof(Journal.LastSyncedJournal)}: {Journal.LastSyncedJournal},  {nameof(Journal.LastSyncedTransactionId)}: {Journal.LastSyncedJournal}, {nameof(Journal.Flags)}: {Journal.Flags}";
+                $"{nameof(Journal.LastSyncedJournal)}: {Journal.LastSyncedJournal},  {nameof(Journal.LastSyncedTransactionId)}: {Journal.LastSyncedJournal}, {nameof(Journal.Flags)}: {Journal.Flags}";
         }
     }
 }

--- a/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/HeaderAccessor.cs
@@ -28,6 +28,7 @@ namespace Voron.Impl.FileHeaders
     {
         private readonly ReaderWriterLockSlim _locker = new();
         private long _revision;
+        public readonly MetadataAccessor MetadataAccessor = new (env);
 
         private FileHeader _theHeader;
         private bool _disposed;
@@ -42,6 +43,8 @@ namespace Voron.Impl.FileHeaders
                 if (_disposed)
                     throw new ObjectDisposedException("Cannot access the header after it was disposed");
 
+                MetadataAccessor.Initialize();
+
                 var hasOne = env.Options.ReadValidHeader(HeaderFileNames[0], out var headerOne);
                 var hasTwo = env.Options.ReadValidHeader(HeaderFileNames[1], out var headerTwo);
                 if (hasOne is false && hasTwo is false)
@@ -50,7 +53,6 @@ namespace Voron.Impl.FileHeaders
                     FillInEmptyHeader(ref headerOne);
                     env.Options.WriteHeader(HeaderFileNames[0], headerOne);
                     env.Options.WriteHeader(HeaderFileNames[1], headerOne);
-
                     _theHeader = headerOne;
                     return true; // new
                 }
@@ -128,7 +130,7 @@ namespace Voron.Impl.FileHeaders
             }
         }
 
-        public Guid JournalId => _theHeader.JournalId;
+        public Guid JournalId => MetadataAccessor.JournalId;
 
         public T Get<T>(GetDataFromHeaderAction<T> action)
         {
@@ -189,7 +191,6 @@ namespace Voron.Impl.FileHeaders
             header.IncrementalBackup.LastBackedUpJournal = -1;
             header.IncrementalBackup.LastBackedUpJournalPage = -1;
             header.PageSize = env.Options.PageSize;
-            header.JournalId = Guid.NewGuid();
             var buffer = MemoryMarshal.AsBytes(new Span<FileHeader>(ref header));
             header.Hash = Hashing.XXHash64.CalculateInline(buffer[..^sizeof(ulong)], (ulong)header.TransactionId);
         }
@@ -220,6 +221,7 @@ namespace Voron.Impl.FileHeaders
             {
                 if (_disposed)
                     throw new ObjectDisposedException("Cannot access the header after it was disposed");
+
                 var success = false;
                 foreach (var headerFileName in HeaderFileNames)
                 {

--- a/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Sparrow;
+using Voron.Global;
+
+namespace Voron.Impl.FileHeaders;
+
+public delegate void ModifyMetadataAction(ref MetadataFile header);
+
+public sealed class MetadataAccessor(StorageEnvironment env)
+{
+    internal static string MetadataName = "metadata.one";
+
+    private MetadataFile _metadata;
+    public Guid JournalId => _metadata.JournalId;
+
+    public bool Initialize()
+    {
+        var hasMetadata = env.Options.ReadValidMetadata(MetadataName, out _metadata);
+        if (hasMetadata == false)
+        {
+            Modify(FillMetadata, persist: true);
+            return true;
+        }
+
+        return false;
+    }
+
+    public unsafe void FillMetadata(ref MetadataFile metadata)
+    {
+        metadata.DataSize = sizeof(MetadataFile);
+        metadata.JournalId = Guid.NewGuid();
+        metadata.Version = Constants.CurrentVersion;
+
+        var buffer = MemoryMarshal.AsBytes(new Span<MetadataFile>(ref metadata));
+        metadata.Hash = Hashing.XXHash64.CalculateInline(buffer[(MetadataFile.HashOffset + sizeof(ulong))..]);
+    }
+
+    public void Modify(ModifyMetadataAction modifyAction, bool persist)
+    {
+        modifyAction?.Invoke(ref _metadata);
+
+        var buffer = MemoryMarshal.AsBytes(new Span<MetadataFile>(ref _metadata));
+        _metadata.Hash = Hashing.XXHash64.CalculateInline(buffer[(MetadataFile.HashOffset + sizeof(ulong))..]);
+        if (persist)
+            env.Options.WriteMetadata(MetadataName, _metadata);
+    }
+}

--- a/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
@@ -30,7 +30,6 @@ public sealed class MetadataAccessor(StorageEnvironment env)
     {
         metadata.JournalId = Guid.NewGuid();
         metadata.Version = Constants.CurrentVersion;
-        _metadata = metadata;
     }
 
     public void Modify(ModifyMetadataAction modifyAction)

--- a/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
+++ b/src/Voron/Impl/FileHeaders/MetadataAccessor.cs
@@ -9,7 +9,7 @@ public delegate void ModifyMetadataAction(ref MetadataFile header);
 
 public sealed class MetadataAccessor(StorageEnvironment env)
 {
-    internal static string MetadataName = "metadata.one";
+    internal static string MetadataName = "database.metadata";
 
     private MetadataFile _metadata;
     public Guid JournalId => _metadata.JournalId;
@@ -19,30 +19,26 @@ public sealed class MetadataAccessor(StorageEnvironment env)
         var hasMetadata = env.Options.ReadValidMetadata(MetadataName, out _metadata);
         if (hasMetadata == false)
         {
-            Modify(FillMetadata, persist: true);
+            Modify(FillMetadata);
             return true;
         }
 
         return false;
     }
 
-    public unsafe void FillMetadata(ref MetadataFile metadata)
+    public void FillMetadata(ref MetadataFile metadata)
     {
-        metadata.DataSize = sizeof(MetadataFile);
         metadata.JournalId = Guid.NewGuid();
         metadata.Version = Constants.CurrentVersion;
-
-        var buffer = MemoryMarshal.AsBytes(new Span<MetadataFile>(ref metadata));
-        metadata.Hash = Hashing.XXHash64.CalculateInline(buffer[(MetadataFile.HashOffset + sizeof(ulong))..]);
+        _metadata = metadata;
     }
 
-    public void Modify(ModifyMetadataAction modifyAction, bool persist)
+    public void Modify(ModifyMetadataAction modifyAction)
     {
         modifyAction?.Invoke(ref _metadata);
 
         var buffer = MemoryMarshal.AsBytes(new Span<MetadataFile>(ref _metadata));
-        _metadata.Hash = Hashing.XXHash64.CalculateInline(buffer[(MetadataFile.HashOffset + sizeof(ulong))..]);
-        if (persist)
-            env.Options.WriteMetadata(MetadataName, _metadata);
+        _metadata.Hash = Hashing.XXHash64.CalculateInline(buffer[sizeof(ulong)..]);
+        env.Options.WriteMetadata(MetadataName, _metadata);
     }
 }

--- a/src/Voron/Impl/FileHeaders/MetadataFile.cs
+++ b/src/Voron/Impl/FileHeaders/MetadataFile.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Voron.Impl.FileHeaders;
+
+[StructLayout(LayoutKind.Explicit, Pack = 1)]
+public struct MetadataFile
+{
+    public static int HashOffset = (int)Marshal.OffsetOf<MetadataFile>(nameof(Hash));
+
+    /// <summary>
+    /// Current size of the metadata.
+    /// Should allow more easily to extend this file and add more fields 
+    /// </summary>
+    [FieldOffset(0)]
+    public int DataSize;
+
+    /// <summary>
+    /// Hash of the metadata used for validation
+    /// </summary>
+    [FieldOffset(4)]
+    public ulong Hash;
+
+    /// <summary>
+    /// The version of the data, used for versioning / conflicts
+    /// </summary>
+    [FieldOffset(12)]
+    public int Version;
+
+    /// <summary>
+    /// The journal id for all the transactions in shared journals
+    /// for this environment that allows to tell which transactions
+    /// belong to this environment or to others
+    /// </summary>
+    [FieldOffset(16)]
+    public Guid JournalId;
+}

--- a/src/Voron/Impl/FileHeaders/MetadataFile.cs
+++ b/src/Voron/Impl/FileHeaders/MetadataFile.cs
@@ -6,25 +6,16 @@ namespace Voron.Impl.FileHeaders;
 [StructLayout(LayoutKind.Explicit, Pack = 1)]
 public struct MetadataFile
 {
-    public static int HashOffset = (int)Marshal.OffsetOf<MetadataFile>(nameof(Hash));
-
-    /// <summary>
-    /// Current size of the metadata.
-    /// Should allow more easily to extend this file and add more fields 
-    /// </summary>
-    [FieldOffset(0)]
-    public int DataSize;
-
     /// <summary>
     /// Hash of the metadata used for validation
     /// </summary>
-    [FieldOffset(4)]
+    [FieldOffset(0)]
     public ulong Hash;
 
     /// <summary>
     /// The version of the data, used for versioning / conflicts
     /// </summary>
-    [FieldOffset(12)]
+    [FieldOffset(8)]
     public int Version;
 
     /// <summary>
@@ -32,6 +23,6 @@ public struct MetadataFile
     /// for this environment that allows to tell which transactions
     /// belong to this environment or to others
     /// </summary>
-    [FieldOffset(16)]
+    [FieldOffset(12)]
     public Guid JournalId;
 }

--- a/src/Voron/Impl/Journal/JournalInfo.cs
+++ b/src/Voron/Impl/Journal/JournalInfo.cs
@@ -15,7 +15,7 @@ namespace Voron.Impl.Journal
         public const int NumberOfReservedBytes = 3;
 
         /// <summary>
-        /// Up until version 7.1 - this used to be CurrentJournal,
+        /// Up until version 8.0 - this used to be CurrentJournal,
         /// this is no longer needed since we are using the existence
         /// of the actual journal file instead...
         /// </summary>

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -53,6 +53,18 @@ namespace Voron.Impl.Journal
         public long Next4Kb => _next4Kb;
 
         public JournalReader(StorageEnvironment environment, long journalNumber, Pager journalPager, Pager.State journalPagerState, Pager dataPager, Pager recoveryPager,
+            TransactionHeader* lastTxHeader, long lastTxId) : this(environment, journalNumber, journalPager, journalPagerState, dataPager, recoveryPager, new HashSet<long>(),
+            new JournalInfo { LastSyncedTransactionId = lastTxId }, new FileHeader { HeaderRevision = -1}, lastTxHeader)
+        {
+            // We create a completely new environment... 
+            // The journal id should come from the first
+            // real transaction that is being applies here
+
+            if (environment.CurrentReadTransactionId == 1)
+                JournalId = Guid.Empty;
+        }
+
+        public JournalReader(StorageEnvironment environment, long journalNumber, Pager journalPager, Pager.State journalPagerState, Pager dataPager, Pager recoveryPager,
             HashSet<long> modifiedPages, JournalInfo journalInfo, FileHeader currentFileHeader, TransactionHeader* previous)
         {
             RequireHeaderUpdate = false;
@@ -68,7 +80,9 @@ namespace Voron.Impl.Journal
             _readAt4Kb = 0;
             LastTransactionHeader = previous;
             _journalPagerNumberOfAllocated4Kb = _journalPagerState.TotalAllocatedSize / (4 * Constants.Size.Kilobyte);
-            JournalId = _currentFileHeader.JournalId;
+            
+            JournalId = environment.HeaderAccessor.MetadataAccessor.JournalId;
+
             if (journalPager.Options.Encryption.IsEnabled)
                 _encryptionBuffers = new List<Pager.EncryptionBuffer>();
             _log = RavenLogManager.Instance.GetLoggerForVoron<StorageEnvironment>(_environment.Options, _journalPager.FileName);

--- a/src/Voron/Schema/Updates/From23.cs
+++ b/src/Voron/Schema/Updates/From23.cs
@@ -21,8 +21,7 @@ public class From23  : IVoronSchemaUpdate
             }
         }
 
-        Span<MetadataFile> metadata = stackalloc MetadataFile[1];
-        headerAccessor.MetadataAccessor.FillMetadata(ref metadata[0]);
+        headerAccessor.MetadataAccessor.Modify(headerAccessor.MetadataAccessor.FillMetadata);
 
         versionAfterUpgrade = 24;
         return true;

--- a/src/Voron/Schema/Updates/From23.cs
+++ b/src/Voron/Schema/Updates/From23.cs
@@ -20,8 +20,9 @@ public class From23  : IVoronSchemaUpdate
                 // to recover some disk space, and everything will still functions fine with this
             }
         }
-        
-        headerAccessor.MetadataAccessor.Modify(headerAccessor.MetadataAccessor.FillMetadata, persist: false);
+
+        Span<MetadataFile> metadata = stackalloc MetadataFile[1];
+        headerAccessor.MetadataAccessor.FillMetadata(ref metadata[0]);
 
         versionAfterUpgrade = 24;
         return true;

--- a/src/Voron/Schema/Updates/From23.cs
+++ b/src/Voron/Schema/Updates/From23.cs
@@ -21,12 +21,7 @@ public class From23  : IVoronSchemaUpdate
             }
         }
         
-        headerAccessor.Modify((ref FileHeader header) =>
-        {
-            // We are moving from a legacy system with no journals 
-            // to having a dedicated journal id for each env
-            header.JournalId = Guid.NewGuid();
-        });
+        headerAccessor.MetadataAccessor.Modify(headerAccessor.MetadataAccessor.FillMetadata, persist: false);
 
         versionAfterUpgrade = 24;
         return true;

--- a/src/Voron/Schema/VoronSchemaUpdater.cs
+++ b/src/Voron/Schema/VoronSchemaUpdater.cs
@@ -32,7 +32,7 @@ namespace Voron.Schema
                     break;
 
                 _headerAccessor.Modify((ref FileHeader header) => header.Version = versionAfterUpdate);
-                _headerAccessor.MetadataAccessor.Modify((ref MetadataFile metadata) => metadata.Version = versionAfterUpdate, persist: true);
+                _headerAccessor.MetadataAccessor.Modify((ref MetadataFile metadata) => metadata.Version = versionAfterUpdate);
             }
         }
     }

--- a/src/Voron/Schema/VoronSchemaUpdater.cs
+++ b/src/Voron/Schema/VoronSchemaUpdater.cs
@@ -32,6 +32,7 @@ namespace Voron.Schema
                     break;
 
                 _headerAccessor.Modify((ref FileHeader header) => header.Version = versionAfterUpdate);
+                _headerAccessor.MetadataAccessor.Modify((ref MetadataFile metadata) => metadata.Version = versionAfterUpdate, persist: true);
             }
         }
     }

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -617,7 +617,7 @@ namespace Voron
                 var fileSize = new FileInfo(path.FullPath).Length;
                 using (var fs = SafeFileStream.Create(path.FullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.None))
                 {
-                    Span<byte> buffer = stackalloc byte[(int)fileSize];
+                    Span<byte> buffer = stackalloc byte[checked((int)fileSize)];
                     var totalRead = 0;
                     while (totalRead < buffer.Length)
                     {

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 using Sparrow;
+using Sparrow.Binary;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Server;
@@ -543,8 +544,6 @@ namespace Voron
                 return JournalPath.Combine(name);
             }
 
-
-
             protected override void Disposing()
             {
                 if (Disposed)
@@ -604,6 +603,50 @@ namespace Voron
                 }
 
                 return true;
+            }
+
+            public override unsafe bool ReadValidMetadata(string filename, out MetadataFile metadata)
+            {
+                metadata = default;
+                var path = _basePath.Combine(filename);
+                if (File.Exists(path.FullPath) == false)
+                {
+                    return false;
+                }
+
+                using (var fs = SafeFileStream.Create(path.FullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.None))
+                {
+                    var metadataBuf = stackalloc MetadataFile[1];
+
+                    Span<byte> sizeBuffer = stackalloc byte[sizeof(int)];
+                    fs.ReadExactly(sizeBuffer);
+                    var size = metadataBuf[0].DataSize = BitConverter.ToInt32(sizeBuffer);
+
+                    Span<byte> bodyBuffer = new ((byte*)metadataBuf + sizeof(int), size - sizeof(int));
+                    var totalRead = 0;
+                    while (totalRead < bodyBuffer.Length)
+                    {
+                        var read = fs.Read(bodyBuffer[totalRead..]);
+                        if (read == 0)
+                            break;
+                        totalRead += read;
+                    }
+
+                    ulong hash = Hashing.XXHash64.CalculateInline(bodyBuffer[sizeof(ulong)..]);
+                    if (metadataBuf->Hash != hash)
+                        return false;
+
+                    metadata = metadataBuf[0];
+                    return true;
+                }
+            }
+
+            public override unsafe void WriteMetadata(string filename, MetadataFile metadata)
+            {
+                var path = _basePath.Combine(filename);
+                var rc = Pal.rvn_write_header(path.FullPath, (byte*)&metadata, metadata.DataSize, out var errorCode);
+                if (rc != PalFlags.FailCodes.Success)
+                    PalHelper.ThrowLastError(rc, errorCode, $"Failed to rvn_write_header '{filename}', reason : {((PalFlags.FailCodes)rc).ToString()}");
             }
 
             public override bool ReadValidHeader(string filename, out FileHeader header)
@@ -807,6 +850,7 @@ namespace Voron
             private readonly Dictionary<string, JournalWriter> _logs = new(StringComparer.OrdinalIgnoreCase);
             private readonly HashSet<SafeFileHandle> _handles = [];
             private readonly Dictionary<string, FileHeader> _headers = new(StringComparer.OrdinalIgnoreCase);
+            private MetadataFile _metadata;
             private readonly int _instanceId;
 
 
@@ -960,6 +1004,23 @@ namespace Voron
                 return true;
             }
 
+            public override bool ReadValidMetadata(string filename, out MetadataFile metadata)
+            {
+                if (Disposed)
+                    throw new ObjectDisposedException("PureMemoryStorageEnvironmentOptions");
+
+                metadata = _metadata;
+                return _metadata.DataSize != 0;
+            }
+
+            public override void WriteMetadata(string filename, MetadataFile metadata)
+            {
+                if (Disposed)
+                    throw new ObjectDisposedException("PureMemoryStorageEnvironmentOptions");
+
+                _metadata = metadata;
+            }
+
             public override bool ReadValidHeader(string filename, out FileHeader header)
             {
                 if (Disposed)
@@ -1062,16 +1123,12 @@ namespace Voron
 
         public abstract bool JournalExists(long number);
 
-
         public bool TryGetJournalId(string basePath, out Guid journalId)
         {
-            foreach (var fileHeader in HeaderAccessor.HeaderFileNames)
+            if (ReadValidMetadata(Path.Combine(basePath, MetadataAccessor.MetadataName), out var metadata))
             {
-                if (ReadValidHeader(Path.Combine(basePath, fileHeader), out var header))
-                {
-                    journalId = header.JournalId;
-                    return true;
-                }       
+                journalId = metadata.JournalId;
+                return true;
             }
 
             journalId = Guid.Empty;
@@ -1079,6 +1136,10 @@ namespace Voron
         }
 
         public abstract bool TryDeleteJournal(long number);
+
+        public abstract bool ReadValidMetadata(string filename, out MetadataFile metadata);
+        
+        public abstract void WriteMetadata(string filename, MetadataFile metadata);
 
         public abstract bool ReadValidHeader(string filename, out FileHeader header);
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -614,29 +614,24 @@ namespace Voron
                     return false;
                 }
 
+                var fileSize = new FileInfo(path.FullPath).Length;
                 using (var fs = SafeFileStream.Create(path.FullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.None))
                 {
-                    var metadataBuf = stackalloc MetadataFile[1];
-
-                    Span<byte> sizeBuffer = stackalloc byte[sizeof(int)];
-                    fs.ReadExactly(sizeBuffer);
-                    var size = metadataBuf[0].DataSize = BitConverter.ToInt32(sizeBuffer);
-
-                    Span<byte> bodyBuffer = new ((byte*)metadataBuf + sizeof(int), size - sizeof(int));
+                    Span<byte> buffer = stackalloc byte[(int)fileSize];
                     var totalRead = 0;
-                    while (totalRead < bodyBuffer.Length)
+                    while (totalRead < buffer.Length)
                     {
-                        var read = fs.Read(bodyBuffer[totalRead..]);
+                        var read = fs.Read(buffer[totalRead..]);
                         if (read == 0)
                             break;
                         totalRead += read;
                     }
 
-                    ulong hash = Hashing.XXHash64.CalculateInline(bodyBuffer[sizeof(ulong)..]);
-                    if (metadataBuf->Hash != hash)
+                    ulong hash = Hashing.XXHash64.CalculateInline(buffer[sizeof(ulong)..]);
+                    if (BitConverter.ToUInt64(buffer[..sizeof(ulong)]) != hash)
                         return false;
 
-                    metadata = metadataBuf[0];
+                    metadata = MemoryMarshal.Cast<byte, MetadataFile>(buffer)[0];
                     return true;
                 }
             }
@@ -644,7 +639,7 @@ namespace Voron
             public override unsafe void WriteMetadata(string filename, MetadataFile metadata)
             {
                 var path = _basePath.Combine(filename);
-                var rc = Pal.rvn_write_header(path.FullPath, (byte*)&metadata, metadata.DataSize, out var errorCode);
+                var rc = Pal.rvn_write_header(path.FullPath, (byte*)&metadata, sizeof(MetadataFile), out var errorCode);
                 if (rc != PalFlags.FailCodes.Success)
                     PalHelper.ThrowLastError(rc, errorCode, $"Failed to rvn_write_header '{filename}', reason : {((PalFlags.FailCodes)rc).ToString()}");
             }
@@ -1010,7 +1005,7 @@ namespace Voron
                     throw new ObjectDisposedException("PureMemoryStorageEnvironmentOptions");
 
                 metadata = _metadata;
-                return _metadata.DataSize != 0;
+                return _metadata.Version != 0;
             }
 
             public override void WriteMetadata(string filename, MetadataFile metadata)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23817

### Additional description

This is done for backward compatibility concerns, to ensure we thrown when rolling back from 8.0 to 7.x.

We can't change the size of the header file. 

Because will think it is a new header file here:
https://github.com/ravendb/ravendb/blob/ddbf530fc1d1be8acd04bb43bf20b85bb56cc4ef/src/Voron/Impl/FileHeaders/HeaderAccessor.cs#L56-L73

Win & linux will fail here but due to different reasons a bit.. 
win will yield false because of this check:
https://github.com/ravendb/ravendb/blob/ddbf530fc1d1be8acd04bb43bf20b85bb56cc4ef/src/Voron/Platform/Win32/Win32Helper.cs#L22-L23

linux will yield false because of different position of the hash
https://github.com/ravendb/ravendb/blob/ddbf530fc1d1be8acd04bb43bf20b85bb56cc4ef/src/Voron/StorageEnvironmentOptions.cs#L771

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
