### PR TITLE
 RavenDB-23892 Skip server-wide tasks when restoring from a snapshot

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -45,6 +45,8 @@ using BackupUtils = Raven.Client.Documents.Smuggler.BackupUtils;
 using Index = Raven.Server.Documents.Indexes.Index;
 using RavenServerBackupUtils = Raven.Server.Utils.BackupUtils;
 using System.Threading;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Size = Sparrow.Size;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
@@ -513,6 +515,31 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             }
         }
 
+        private static void FilterOutServerWideTasks(DatabaseRecord databaseRecord)
+        {
+            if (databaseRecord.PeriodicBackups.Count > 0)
+            {
+                var filtered = new List<PeriodicBackupConfiguration>();
+                foreach (var backup in databaseRecord.PeriodicBackups)
+                {
+                    if (backup.Name.StartsWith(ServerWideBackupConfiguration.NamePrefix, StringComparison.OrdinalIgnoreCase) == false)
+                        filtered.Add(backup);
+                }
+                databaseRecord.PeriodicBackups = filtered;
+            }
+
+            if (databaseRecord.ExternalReplications.Count > 0)
+            {
+                var filtered = new List<Client.Documents.Operations.Replication.ExternalReplication>();
+                foreach (var replication in databaseRecord.ExternalReplications)
+                {
+                    if (replication.Name.StartsWith(ServerWideExternalReplication.NamePrefix, StringComparison.OrdinalIgnoreCase) == false)
+                        filtered.Add(replication);
+                }
+                databaseRecord.ExternalReplications = filtered;
+            }
+        }
+
         private static void RemoveSubscriptionFromDatabaseValues(RestoreSettings restoreSettings)
         {
             foreach (var keyValue in restoreSettings.DatabaseValues)
@@ -650,9 +677,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                                     json.BlittableValidation();
 
                                     restoreSettings = JsonDeserializationServer.RestoreSettings(json);
+                                    FilterOutServerWideTasks(restoreSettings.DatabaseRecord);
                                     // It's necessary to modify the subscriptionId to prevent collisions with the current database index.
                                     //we will handle subscription with smuggler
                                     RemoveSubscriptionFromDatabaseValues(restoreSettings);
+
                                     restoreSettings.DatabaseRecord.DatabaseName = RestoreFromConfiguration.DatabaseName;
                                     DatabaseHelper.Validate(RestoreFromConfiguration.DatabaseName, restoreSettings.DatabaseRecord, _serverStore.Configuration);
 

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Http;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -128,5 +130,99 @@ namespace FastTests.Client
                 GetAllDerivedTypesRecursively(types, derivedType, results);
             }
         }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public void AllServerWideCommandsShouldBeListedExplicitly()
+        {
+            var expected = new HashSet<string>
+            {
+                "DeleteServerWideBackupConfigurationCommand",
+                "DeleteServerWideAnalyzerCommand",
+                "PutServerWideAnalyzersCommand",
+                "DeleteServerWideSorterCommand",
+                "PutServerWideSortersCommand",
+                "DeleteServerWideTaskCommand",
+                "ToggleServerWideTaskStateCommand",
+                "PutServerWideBackupConfigurationCommand",
+                "GetServerWideBackupConfigurationCommand",
+                "GetServerWideBackupConfigurationsCommand",
+                "GetServerWideClientConfigurationCommand",
+                "PutServerWideClientConfigurationCommand",
+                "PutServerWideExternalReplicationCommand",
+                "GetServerWideExternalReplicationCommand",
+                "GetServerWideExternalReplicationsCommand",
+                "GetServerWideOperationStateCommand"
+            };
+
+            var commandBaseType = typeof(RavenCommand<>);
+            var types = commandBaseType.Assembly.GetTypes();
+
+            var results = new List<Type>();
+            GetAllDerivedTypesRecursively(types.Where(t => t.IsAbstract == false).ToArray(), commandBaseType, results);
+
+            var serverWideCommands = results
+                .Where(t => t.Name.Contains("ServerWide"))
+                .Select(t => t.Name)
+                .Distinct()
+                .OrderBy(name => name)
+                .ToList();
+
+            var missing = serverWideCommands.Where(c => expected.Contains(c) == false).ToList();
+
+            Assert.True(missing.Count == 0,
+                $"The following server-wide `{nameof(RavenCommand)}`s are missing from the expected list:{Environment.NewLine}" +
+                string.Join(Environment.NewLine, missing.Select(n => $"  - {n}")) +
+                $"{Environment.NewLine}{Environment.NewLine}" +
+                $" Every *Put*/Update server-wide command must also be handled in `FilterOutServerWideTasks` during snapshot restore.{Environment.NewLine}" +
+                $" All server-wide commands (including Delete/Get) must be added to this list to ensure proper handling and visibility." +
+                $"{Environment.NewLine}Please update the `expected` list accordingly.");
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public void AllServerWideCommandsShouldBeExplicitlyListed()
+        {
+            var expected = new HashSet<string>
+            {
+                "DeleteServerWideBackupConfigurationCommand",
+                "DeleteServerWideAnalyzerCommand",
+                "PutServerWideAnalyzerCommand",
+                "DeleteServerWideSorterCommand",
+                "PutServerWideSortersCommand",
+                "DeleteServerWideTaskCommand",
+                "ToggleServerWideTaskStateCommand",
+                "PutServerWideBackupConfigurationCommand",
+                "GetServerWideBackupConfigurationCommand",
+                "GetServerWideBackupConfigurationsCommand",
+                "GetServerWideClientConfigurationCommand",
+                "PutServerWideClientConfigurationCommand",
+                "PutServerWideExternalReplicationCommand",
+                "GetServerWideExternalReplicationCommand",
+                "GetServerWideExternalReplicationsCommand",
+                "GetServerWideOperationStateCommand",
+                "PutServerWideStudioConfigurationCommand",
+                "PutServerWideSorterCommand"
+
+            };
+
+            var clusterVersionList = ClusterCommandsVersionManager.ClusterCommandsVersions
+                .Keys
+                .Where(name => name.Contains("ServerWide"))
+                .Distinct()
+                .ToList();
+
+            var missingFromExpected = clusterVersionList
+                .Distinct()
+                .Where(name => !expected.Contains(name))
+                .ToList();
+
+            Assert.True(missingFromExpected.Count == 0,
+                $"The following server-wide `{nameof(RavenCommand)}`s are missing from the expected list:{Environment.NewLine}" +
+                string.Join(Environment.NewLine, missingFromExpected.Select(n => $"  - {n}")) +
+                $"{Environment.NewLine}{Environment.NewLine}" +
+                $" Every *Put*/Update server-wide command must also be handled in `FilterOutServerWideTasks` during snapshot restore.{Environment.NewLine}" +
+                $" All server-wide commands (including Delete/Get) must be added to this list to ensure proper handling and visibility." +
+                $"{Environment.NewLine}Please update the `expected` list accordingly.");
+        }
     }
+
 }

--- a/test/SlowTests/Issues/RavenDB-23892.cs
+++ b/test/SlowTests/Issues/RavenDB-23892.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Client.ServerWide.Operations.OngoingTasks;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23892 : RavenTestBase
+    {
+        public RavenDB_23892(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task Snapshot_Should_Not_Include_ServerWideBackupConfiguration()
+        {
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options { Server = server }))
+            {
+                var database = store.Database;
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+                var serverWideConfig = new ServerWideBackupConfiguration
+                {
+                    Name = "ServerWideBackup",
+                    Disabled = false,
+                    BackupType = BackupType.Backup,
+                    FullBackupFrequency = "0 1 * * *",
+                    LocalSettings = new LocalSettings { FolderPath = "test/folder" }
+                };
+                var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideConfig));
+                var backupPath = NewDataPath(suffix: "BackupFolder");
+                var config = Backup.CreateBackupConfiguration(backupPath, backupType: BackupType.Snapshot);
+                config.SnapshotSettings = new SnapshotSettings { CompressionLevel = CompressionLevel.Fastest, ExcludeIndexes = false };
+                await Backup.UpdateConfigAndRunBackupAsync(server, config, store);
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+
+                Assert.Equal(2, record.PeriodicBackups.Count);
+                bool exists = record.PeriodicBackups.Exists(x => x.Name.Contains(serverWideConfig.Name));
+                Assert.True(exists);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+                await store.Maintenance.Server.SendAsync(new DeleteServerWideTaskOperation(result.Name, OngoingTaskType.Backup));
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                exists = record.PeriodicBackups.Exists(x => x.Name.Contains(serverWideConfig.Name));
+                Assert.False(exists);
+
+                using (Backup.RestoreDatabase(store,
+                           new RestoreBackupConfiguration { BackupLocation = Directory.GetDirectories(backupPath).First(), DatabaseName = databaseName }))
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+                    exists = record.PeriodicBackups.Exists(x => x.Name.Contains(serverWideConfig.Name));
+                    Assert.False(exists);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Replication)]
+        public async Task Snapshot_Should_Not_Include_ServerWideExternalReplication()
+        {
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options { Server = server }))
+            {
+                var database = store.Database;
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var externalReplication = new ServerWideExternalReplication
+                {
+                    Disabled = false,
+                    TopologyDiscoveryUrls = new[] { store.Urls.First() },
+                    Name = store.Database
+                };
+
+                await store.Maintenance.Server.SendAsync(new PutServerWideExternalReplicationOperation(externalReplication));
+                WaitForUserToContinueTheTest(store);
+                var backupPath = NewDataPath(suffix: "SnapshotReplication");
+                var config = Backup.CreateBackupConfiguration(backupPath, BackupType.Snapshot);
+                config.SnapshotSettings = new SnapshotSettings
+                {
+                    CompressionLevel = CompressionLevel.Fastest,
+                    ExcludeIndexes = false
+                };
+
+                await Backup.UpdateConfigAndRunBackupAsync(server, config, store);
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database));
+                Assert.Contains(record.ExternalReplications, x => x.Name.Contains(externalReplication.Name));
+
+                // Delete the server-wide replication
+                await store.Maintenance.Server.SendAsync(new DeleteServerWideTaskOperation(externalReplication.Name, OngoingTaskType.Replication));
+
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database));
+                Assert.DoesNotContain(record.ExternalReplications, x => x.Name.Contains(externalReplication.Name));
+
+                var restoredDatabase = $"restored-db-{Guid.NewGuid()}";
+
+                using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                {
+                    BackupLocation = Directory.GetDirectories(backupPath).First(),
+                    DatabaseName = restoredDatabase
+                }))
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabase));
+                    Assert.DoesNotContain(record.ExternalReplications, x => x.Name.Contains(externalReplication.Name));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23892

### Additional description

Skip server-wide tasks when restoring from a snapshot

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
