### PR TITLE
RavenDB-24198 Refactorization of MultiTermMatch.AndWithFill

### DIFF
--- a/src/Corax/Querying/Matches/Meta/IQueryMatch.cs
+++ b/src/Corax/Querying/Matches/Meta/IQueryMatch.cs
@@ -35,8 +35,7 @@ public static class QueryConfidenceExtensions
 public interface IQueryMatch
 {
     long Count { get; }
-
-
+    
     /// <summary>
     /// This is called when the call is not interested in getting
     /// the results in sorted order (may want to do its own sorting, etc)

--- a/src/Corax/Querying/Matches/Meta/MergeHelper.cs
+++ b/src/Corax/Querying/Matches/Meta/MergeHelper.cs
@@ -45,7 +45,7 @@ namespace Corax.Querying.Matches.Meta
             long* smallerEndPtr, largerEndPtr;
 
             bool applyVectorization;
-            if ( leftLength < rightLength)
+            if (leftLength < rightLength)
             {
                 smallerPtr = left;
                 smallerEndPtr = left + leftLength;

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -367,8 +367,8 @@ namespace Corax.Querying.Matches
         {
             var incomingMatches = buffer.Slice(0, matches);
             using var _ = _context.Allocate(2 * sizeof(long) * buffer.Length, out var bufferHolder);
-            var innerMatchesBuffer = bufferHolder.ToSpan<long>()[..buffer.Length];
-            var workingMatches = bufferHolder.ToSpan<long>()[buffer.Length..];
+            var innerMatchesBuffer = bufferHolder.ToSpan<long>()[matches..];
+            var workingMatches = bufferHolder.ToSpan<long>()[..matches];
             
             // We store all results in a single list - the motivation for this is that we may get the same result from multiple Fill calls
             // (e.g. in case of WhereIn with multiple matching terms). In such case it will be deduplicated.

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -108,7 +108,7 @@ namespace Corax.Querying.Matches
             
             int results = _termReader.Read(ref this, buffer, _maxNumberOfTerms - _readTerms, out var termsRead);
             _readTerms += termsRead;
-            if(results == 0)
+            if (results == 0)
                 _termReader.Dispose();
             _totalResults += results;
             return results;
@@ -365,44 +365,72 @@ namespace Corax.Querying.Matches
 
         private int AndWithFill(Span<long> buffer, int matches)
         {
-            using var _ = _context.Allocate(3 * sizeof(long) * buffer.Length, out var bufferHolder);
-            var longBuffer = MemoryMarshal.Cast<byte, long>(bufferHolder.ToSpan());
+            var incomingMatches = buffer.Slice(0, matches);
+            using var _ = _context.Allocate(2 * sizeof(long) * buffer.Length, out var bufferHolder);
+            var innerMatchesBuffer = bufferHolder.ToSpan<long>()[..buffer.Length];
+            var workingMatches = bufferHolder.ToSpan<long>()[buffer.Length..];
+            
+            // We store all results in a single list - the motivation for this is that we may get the same result from multiple Fill calls
+            // (e.g. in case of WhereIn with multiple matching terms). In such case it will be deduplicated.
+            var allResults = new NativeList<long>();
+            allResults.Initialize(_context);
+            
             _termReader.Reset(ref this);
             
-            Span<long> results = longBuffer.Slice(0, buffer.Length);
-            Span<long> incomingMatches = longBuffer.Slice(buffer.Length, buffer.Length);
-            Span<long> localMatches = longBuffer.Slice(2 * buffer.Length, buffer.Length);
-
-            var actualMatches = buffer.Slice(0, matches);
-            actualMatches.CopyTo(incomingMatches);
-            
-            var currentMatchCount = 0;
-            _totalResults = 0;
-            
-            //The results returned by the Fill method are sorted within one call. If we make multiple calls, we have no
-            //guarantee that concatenated results are sorted, which can lead to invalid results since the AND operation guarantees a sorted result.
-            int fillCounter = 0;
-            //ensure we're not out of range
-            while (results.Length > 0 && Fill(localMatches) is var read and > 0)
+            var fillCounter = 0;
+            bool alreadySorted = false;
+            while (Fill(innerMatchesBuffer) is var read and > 0)
             {
-                fillCounter++;
                 _token.ThrowIfCancellationRequested();
-                _totalResults += read;
-                var common = MergeHelper.And(
-                    dst: results, 
-                    left: localMatches.Slice(0, read),
-                    right: incomingMatches.Slice(0, matches));
                 
-                results = results.Slice(common);
-                currentMatchCount += common;
+                fillCounter++;
+                _totalResults += read;
+
+                var innerMatches = innerMatchesBuffer[..read];
+                
+                var common = MergeHelper.And(
+                    dst: workingMatches, 
+                    left: innerMatches,
+                    right: incomingMatches);
+                
+                if (allResults.HasCapacityFor(common) == false)
+                    allResults.EnsureCapacityFor(_context, common);
+                allResults.AddRangeUnsafe(workingMatches[..common]);
+                
+                // Because we're performing AND operation, we want to do sorting and deduplication when we're sure there are duplicates (allResults.Count > matches)
+                // or (possibly) got all results (allResults.Count == matches).
+                if (allResults.Count >= matches)
+                {
+                    if (fillCounter > 1)
+                    {
+                        var newCount = Sorting.SortAndRemoveDuplicates(allResults.ToSpan());
+                        allResults.Count = newCount;
+                    }
+
+                    // If we matched all results, we can stop processing.
+                    // At this point the results are either sorted, or come from a single Fill call, which guarantees sorted results.
+                    if (allResults.Count == matches)
+                    {
+                        alreadySorted = true;
+                        break;
+                    }
+                }
+            }
+            
+            // The results returned by the Fill method are sorted within one call. If we make multiple calls, we have no
+            // guarantee that concatenated results are sorted, which can lead to invalid results since the AND operation guarantees a sorted result.
+            if (alreadySorted == false && fillCounter > 1)
+            {
+                var newCount = Sorting.SortAndRemoveDuplicates(allResults.ToSpan());
+                allResults.Count = newCount;
             }
 
-            longBuffer.Slice(0, currentMatchCount).CopyTo(buffer);
+            Debug.Assert(allResults.Count <= matches);
+            allResults.CopyTo(buffer, 0);
+            var resultCount = allResults.Count;
+            allResults.Dispose(_context);
             
-            if (fillCounter > 1)
-                currentMatchCount = Sorting.SortAndRemoveDuplicates(buffer[..currentMatchCount]);
-            
-            return currentMatchCount;
+            return resultCount;
         }
 
 #if !DEBUG

--- a/test/FastTests/Corax/AnalyzersIntegration.cs
+++ b/test/FastTests/Corax/AnalyzersIntegration.cs
@@ -57,7 +57,6 @@ public class AnalyzersIntegration : RavenTestBase
         {
             using var session = store.OpenSession();
             var items = session.Query<Record>().Search(x => x.Data, "*tion").ToList();
-            WaitForUserToContinueTheTest(store);
             Assert.Equal(2, items.Count);
         }
     }

--- a/test/FastTests/Corax/CompoundFieldsOnIndex.cs
+++ b/test/FastTests/Corax/CompoundFieldsOnIndex.cs
@@ -84,7 +84,6 @@ public class CompoundFieldsOnIndex : RavenTestBase
                 .Where(x => x.Name == "Corax")
                 .OrderBy(x => x.Birthday)
                 .ToList();
-            WaitForUserToContinueTheTest(store);
 
             Assert.Equal(2, users.Count);
             Assert.Equal(2014, users[0].Birthday.Year);
@@ -117,8 +116,6 @@ public class CompoundFieldsOnIndex : RavenTestBase
             Assert.Equal("Corax", users[0].Name);
             Assert.Equal("Lucene", users[1].Name);
         }
-        
-        WaitForUserToContinueTheTest(store);
     }
 
     [RavenFact(RavenTestCategory.Querying)]

--- a/test/FastTests/Corax/CoraxJavaScriptProjectionIntegration.cs
+++ b/test/FastTests/Corax/CoraxJavaScriptProjectionIntegration.cs
@@ -39,7 +39,6 @@ public class CoraxJavaScriptProjectionIntegration : RavenTestBase
 
         var index = new TestIndex();
         index.Execute(store);
-        WaitForUserToContinueTheTest(store);
         Indexes.WaitForIndexing(store);
         using (var session = store.OpenSession())
         {

--- a/test/FastTests/Corax/CoraxPhraseQueries.cs
+++ b/test/FastTests/Corax/CoraxPhraseQueries.cs
@@ -26,8 +26,6 @@ public class CoraxPhraseQueries : RavenTestBase
         session.Store(new Item(){FtsField = "dog puppy cat puppy horse"});
         session.SaveChanges();
         new Index().Execute(store);
-        WaitForUserToContinueTheTest(store);
-        
     }
     
     [RavenTheory(RavenTestCategory.Querying)]

--- a/test/FastTests/Corax/CoraxProjections.cs
+++ b/test/FastTests/Corax/CoraxProjections.cs
@@ -27,7 +27,7 @@ public class CoraxProjections : RavenTestBase
     {
         using var store = GetDocumentStore(options);
         CreateSampleDb<MyMapReduceIndex>(store);
-WaitForUserToContinueTheTest(store);
+
         using var session = store.OpenAsyncSession();
         var results = await session
             .Query<MyMapReduceIndex.Result, MyMapReduceIndex>()

--- a/test/FastTests/Corax/DynamicFieldsIntegration.cs
+++ b/test/FastTests/Corax/DynamicFieldsIntegration.cs
@@ -24,7 +24,6 @@ public class DynamicFieldsIntegration : RavenTestBase
     public async Task SingleStringDynamicFieldsTest(Options options)
     {
         using var store = await GetStoreWithIndexAndData<IndexString, string>(options, i => $"Container no {i}");
-        WaitForUserToContinueTheTest(store);
         {
             using var session = store.OpenAsyncSession();
             var result = await session.Query<TestClassResult<string>, IndexString>().Where(i => i.Dynamic == $"Container no 50").SingleOrDefaultAsync();

--- a/test/FastTests/Corax/RavenIntegration.cs
+++ b/test/FastTests/Corax/RavenIntegration.cs
@@ -454,7 +454,6 @@ public class RavenIntegration : RavenTestBase
         {
             //  The `11` on the server side will be long ( and the string made of it is "11") but the index doesn't contain the such term (because we indexed it as `11.5`.)
             var query = session.Advanced.RawQuery<Doc>("from Docs where BoostFactor == 11").WaitForNonStaleResults().ToList();
-            WaitForUserToContinueTheTest(store);
             Assert.Equal(1, query.Count);
         }
     }
@@ -485,7 +484,6 @@ public class RavenIntegration : RavenTestBase
         }
 
         Indexes.WaitForIndexing(store);
-        WaitForUserToContinueTheTest(store);
     }
 
     private class SearchIndex : AbstractIndexCreationTask<DtoForDynamics>
@@ -555,7 +553,6 @@ public class RavenIntegration : RavenTestBase
         using (var session = store.OpenSession())
         {
             var classicId = session.Advanced.RawQuery<IdClass>($"from Docs where Name == 'maciej' and  id() == '{doc.Id}'").WaitForNonStaleResults().Count();
-            WaitForUserToContinueTheTest(store);
             var classicIdViaFieldName = session.Advanced.RawQuery<IdClass>($"from Docs where Name == 'maciej' and Id == '{doc.Id}'").WaitForNonStaleResults().Count();
             Assert.Equal(1, classicId);
             Assert.Equal(0, classicIdViaFieldName);
@@ -600,7 +597,6 @@ public class RavenIntegration : RavenTestBase
         var index = new DynamicFieldIndex();
         index.Execute(store);
         Indexes.WaitForIndexing(store);
-        WaitForUserToContinueTheTest(store);
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Corax/RavenDB_23631.cs
+++ b/test/SlowTests/Corax/RavenDB_23631.cs
@@ -56,7 +56,7 @@ public class RavenDB_23631(ITestOutputHelper output) : StorageTest(output)
     }
     
     [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
-    public void Temp()
+    public void MultiTermMatchProperlyHandlesDuplicatesWhenPerformingAndWith()
     {
         using var mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
             .AddBinding(0, "id()")

--- a/test/SlowTests/Corax/RavenDB_23631.cs
+++ b/test/SlowTests/Corax/RavenDB_23631.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Linq;
 using Corax;
 using Corax.Indexing;
 using Corax.Mappings;
@@ -50,6 +50,51 @@ public class RavenDB_23631(ITestOutputHelper output) : StorageTest(output)
             var read = resultMatch.Fill(ids);
             Assert.Distinct(ids[..read].ToArray());
             Assert.Equal(2, read);
+            var nothingLeft = resultMatch.Fill(ids) == 0;
+            Assert.True(nothingLeft);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void Temp()
+    {
+        using var mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, "id()")
+            .AddBinding(1, "name")
+            .Build();
+        
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                using (var builder = writer.Index($"id/{i}"))
+                {
+                    builder.Write(0, Encodings.Utf8.GetBytes($"id/{i}"));
+                    builder.IncrementList();
+                    builder.Write(1, Encodings.Utf8.GetBytes("name/0"));
+                    builder.Write(1, Encodings.Utf8.GetBytes("name/1"));
+                    builder.DecrementList();
+                    builder.EndWriting();
+                }
+            }
+            
+            writer.Commit();
+        }
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            var inTerms = Enumerable.Range(0, 10)
+                .Select(i => $"id/{i}")
+                .ToList();
+            
+            var @in = searcher.InQuery("id()", inTerms);
+            var mtm = searcher.ExistsQuery(mapping.GetByFieldId(1).Metadata);
+
+            var resultMatch = searcher.And(@in, mtm);
+            Span<long> ids = stackalloc long[16];
+            var read = resultMatch.Fill(ids);
+            Assert.Distinct(ids[..read].ToArray());
+            Assert.Equal(10, read);
             var nothingLeft = resultMatch.Fill(ids) == 0;
             Assert.True(nothingLeft);
         }

--- a/test/SlowTests/Issues/RavenDB_24198.cs
+++ b/test/SlowTests/Issues/RavenDB_24198.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24198 : RavenTestBase
+{
+    public RavenDB_24198(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void WhereInWithExistStatementShouldWork(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 20; i++)
+                {
+                    session.Store(new Dto() { Names = ["spaces name", "other name"], Category = $"Category/{i}" });
+                }
+                
+                session.SaveChanges();
+                
+                var inTerms = Enumerable.Range(0, 10)
+                    .Select(i => $"Category/{i}")
+                    .ToList();
+
+                var res = session.Advanced.DocumentQuery<Dto>()
+                    .WhereIn(x => x.Category, inTerms)
+                    .AndAlso()
+                    .WhereExists(x => x.Names)
+                    .ToList();
+                
+                Assert.Equal(10, res.Count);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string[] Names { get; set; }
+        public string Category { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24198/ArgumentOutOfRangeException-in-MultiTermMatch.AndWithFill

### Additional description

We want `MultiTermMatch.AndWithFill` to properly handle repeated matches (e.g. in case of `WhereIn` with multiple matched terms). Previous implementation sliced the results span by too much in such case. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
