### PR TITLE
RavenDB-24112 Handle correct ID with non-ascii character and escaped characters

### DIFF
--- a/src/Raven.Server/Documents/DocumentIdWorker.cs
+++ b/src/Raven.Server/Documents/DocumentIdWorker.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents
         private static JsonParserState _jsonParserState;
 
         public const int MaxIdSize = 512;
-        
+        public const uint MaxAsciiCodePoint = 127;
         public const int RevisionMaxKeySize = MaxIdSize * 3;
 
         static DocumentIdWorker()
@@ -82,15 +82,15 @@ namespace Raven.Server.Documents
             var strLength = id.Length;
 
             var maxStrSize = Encoding.GetMaxByteCount(strLength);
-            var escapePositionsSize = JsonParserState.FindEscapePositionsMaxSize(id, out _);
+            var escapeAndControlSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(id, out _);
 
             if (strLength > MaxIdSize)
                 ThrowDocumentIdTooBig(id.ToString());
 
             var internalScope = allocator.Allocate(
-                maxStrSize // this buffer is allocated to also serve the GetSliceFromUnicodeKey
+                maxStrSize // this buffer is allocated to also serve the ReadFromUnicodeKey
                 + sizeof(char) * id.Length
-                + escapePositionsSize
+                + escapeAndControlSize
                 + (separator != null ? 1 : 0),
                 out var buffer);
 
@@ -111,7 +111,7 @@ namespace Raven.Server.Documents
                     buffer.Ptr[i] = (byte)ch;
             }
 
-            _jsonParserState.FindEscapePositionsIn(buffer.Ptr, ref strLength, escapePositionsSize);
+            _jsonParserState.FindEscapedPositionsAndEscapeControls(buffer.Ptr, ref strLength, escapeAndControlSize);
             if (separator != null)
             {
                 buffer.Ptr[strLength] = separator.Value;
@@ -252,6 +252,7 @@ namespace Raven.Server.Documents
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.InternalScope GetLowerIdSliceAndStorageKey<TTransaction>(
             TransactionOperationContext<TTransaction> context, string str, out Slice lowerIdSlice, out Slice idSlice)
             where TTransaction : RavenTransaction
@@ -259,8 +260,8 @@ namespace Raven.Server.Documents
             return GetLowerIdSliceAndStorageKey(context.Allocator, str, out lowerIdSlice, out idSlice);
         }
 
-        public static ByteStringContext.InternalScope GetLowerIdSliceAndStorageKey(
-            ByteStringContext allocator, string str, out Slice lowerIdSlice, out Slice idSlice)
+        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLowerIdSliceAndStorageKey(ByteStringContext allocator, string str, out Slice lowerIdSlice,
+            out Slice idSlice)
         {
             // Because we need to also store escape positions for the key when we store it
             // we need to store it as a lazy string value.
@@ -286,7 +287,7 @@ namespace Raven.Server.Documents
             if (strLength > MaxIdSize)
                 ThrowDocumentIdTooBig(str);
 
-            int escapePositionsSize = JsonParserState.FindEscapePositionsMaxSize(str, out var escapedCount);
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(str, out var controlCount);
 
             /*
              *  add the size of all control characters
@@ -295,17 +296,16 @@ namespace Raven.Server.Documents
              *  For example: string with two control characters such as '\0\0' will be converted to '\u0000\u0000' (another example: '\b\b' => '\u000b\u000b')
              *  string size = 2, GetMaxByteCount = 9, converted string size = 12, maxStrSize = 19
              */
-            var maxStrSize = Encoding.GetMaxByteCount(strLength) + JsonParserState.ControlCharacterItemSize * escapedCount;
-            var originalMaxStrSize = maxStrSize;
+            var maxIdSize = Encoding.GetMaxByteCount(strLength) + JsonParserState.ControlCharacterItemSize * controlCount;
+            var originalMaxStrSize = maxIdSize;
 
-            int idSize = JsonParserState.VariableSizeIntSize(maxStrSize);
+            int maxIdLenSize = JsonParserState.VariableSizeIntSize(maxIdSize);
 
-            var scope = allocator.Allocate(maxStrSize // lower key
-                                           + idSize // the size of var int for the len of the key
-                                           + maxStrSize // actual key
-                                           + escapePositionsSize, out ByteString buffer);
-
-
+            var scope = allocator.Allocate(maxIdSize // lower key
+                                       + maxIdLenSize // the size of var int for the len of the key
+                                       + maxIdSize // actual key
+                                       + escapePositionsSize, out ByteString buffer);
+            
             byte* ptr = buffer.Ptr;
 
             ReadOnlySpan<char> pChars = str.AsSpan();
@@ -321,20 +321,20 @@ namespace Raven.Server.Documents
                 }
                 else
                 {
-                    if (ch > 127) // not ASCII, use slower mode
+                    if (ch > MaxAsciiCodePoint) // not ASCII, use slower mode
                         goto UnlikelyUnicode;
 
                     ptr[i] = (byte)ch;
                 }
 
-                ptr[i + idSize + maxStrSize] = (byte)ch;
+                ptr[i + maxIdLenSize + maxIdSize] = (byte)ch;
             }
 
-            _jsonParserState.FindEscapePositionsIn(ptr, ref strLength, escapePositionsSize);
+            _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr, ref strLength, escapePositionsSize);
             if (strLength != originalStrLength)
             {
                 var anotherStrLength = originalStrLength;
-                _jsonParserState.FindEscapePositionsIn(ptr + idSize + maxStrSize, ref anotherStrLength, escapePositionsSize);
+                _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr + maxIdLenSize + maxIdSize, ref anotherStrLength, escapePositionsSize);
 
 #if DEBUG
                 if (strLength != anotherStrLength)
@@ -342,35 +342,35 @@ namespace Raven.Server.Documents
 #endif
             }
 
-            var writePos = ptr + maxStrSize;
+            var writePos = ptr + maxIdSize;
 
             Debug.Assert(strLength <= originalMaxStrSize, $"Calculated {nameof(originalMaxStrSize)} value {originalMaxStrSize}, was smaller than actually {nameof(strLength)} value {strLength}");
 
             // in case there were no control characters the idSize could be smaller
-            var sizeDifference = idSize - JsonParserState.VariableSizeIntSize(strLength);
+            var sizeDifference = maxIdLenSize - JsonParserState.VariableSizeIntSize(strLength);
             writePos += sizeDifference;
-            idSize -= sizeDifference;
+            maxIdLenSize -= sizeDifference;
 
             JsonParserState.WriteVariableSizeInt(ref writePos, strLength);
             escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + strLength);
-            idSize = escapePositionsSize + strLength + idSize;
+            maxIdLenSize = escapePositionsSize + strLength + maxIdLenSize;
 
-            Slice.External(allocator, ptr + maxStrSize + sizeDifference, idSize, out idSlice);
+            Slice.External(allocator, ptr + maxIdSize + sizeDifference, maxIdLenSize, out idSlice);
             Slice.External(allocator, ptr, strLength, out lowerIdSlice);
+
+            Debug.Assert(ptr + maxIdSize + sizeDifference + maxIdLenSize <= buffer.Ptr + buffer.Size, "Exceed buffer size");
             return scope;
 
         UnlikelyUnicode:
             scope.Dispose();
-            return UnicodeGetLowerIdAndStorageKey(allocator, str, out lowerIdSlice, out idSlice, maxStrSize, escapePositionsSize);
+            return UnicodeGetLowerIdAndStorageKey(allocator, str, out lowerIdSlice, out idSlice, maxIdSize, maxIdLenSize, escapePositionsSize);
         }
 
         private static ByteStringContext.InternalScope UnicodeGetLowerIdAndStorageKey(
             ByteStringContext allocator, string str,
-            out Slice lowerIdSlice, out Slice idSlice, int maxStrSize, int escapePositionsSize)
+            out Slice lowerIdSlice, out Slice idSlice, int maxStrSize, int maxIdLenSize, int escapePositionsSize)
         {
             // See comment in GetLowerIdSliceAndStorageKey for the format
-
-            var maxIdLenSize = JsonParserState.VariableSizeIntSize(maxStrSize);
 
             int strLength = str.Length;
 
@@ -383,9 +383,6 @@ namespace Raven.Server.Documents
 
             fixed (char* pChars = str)
             {
-                var size = Encoding.GetBytes(pChars, strLength, buffer.Ptr, maxStrSize);
-                _jsonParserState.FindEscapePositionsIn(buffer.Ptr, ref size, escapePositionsSize);
-
                 var destChars = (char*)buffer.Ptr;
                 for (var i = 0; i < strLength; i++)
                     destChars[i] = char.ToLowerInvariant(pChars[i]);
@@ -398,23 +395,25 @@ namespace Raven.Server.Documents
                     ThrowDocumentIdTooBig(str);
 
                 byte* id = buffer.Ptr + strLength * sizeof(char) + maxStrSize;
-                byte* writePos = id;
-                int idSize = Encoding.GetBytes(pChars, strLength, writePos + maxIdLenSize, maxStrSize);
+                int idSize = Encoding.GetBytes(pChars, strLength, id + maxIdLenSize, maxStrSize);
 
                 var actualIdLenSize = JsonParserState.VariableSizeIntSize(idSize);
                 if (actualIdLenSize < maxIdLenSize)
                 {
                     var movePtr = maxIdLenSize - actualIdLenSize;
                     id += movePtr;
-                    writePos += movePtr;
                 }
 
+                byte* writePos = id;
+                _jsonParserState.FindEscapedPositionsAndEscapeControls(id + maxIdLenSize, ref idSize, escapePositionsSize);
                 JsonParserState.WriteVariableSizeInt(ref writePos, idSize);
                 escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + idSize);
-                idSize += escapePositionsSize + maxIdLenSize;
+                idSize += escapePositionsSize + actualIdLenSize;
 
                 Slice.External(allocator, id, idSize, out idSlice);
                 Slice.External(allocator, lowerId, lowerSize, out lowerIdSlice);
+                
+                Debug.Assert(id + idSize <= buffer.Ptr + buffer.Size, "Exceed buffer size");
                 return scope;
             }
         }

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -447,7 +447,7 @@ namespace Sparrow.Json
             if (_intBuffer == null)
                 _intBuffer = new FastList<int>();
 
-            var escapePositionsMaxSize = JsonParserState.FindEscapePositionsMaxSize(str, out _);
+            var escapePositionsMaxSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(str, out _);
             int size = Encodings.Utf8.GetMaxByteCount(str.Length) + escapePositionsMaxSize;
             if (size > 8 * 1024 * 1024)
             {
@@ -460,7 +460,7 @@ namespace Sparrow.Json
                 buffer = _context.GetMemory(size);
 
                 var stringSize = Encodings.Utf8.GetBytes(str.AsSpan(), buffer.AsSpan());
-                JsonParserState.FindEscapePositionsIn(_intBuffer, buffer.Address, ref stringSize, escapePositionsMaxSize);
+                JsonParserState.FindEscapedPositionsAndEscapeControls(_intBuffer, buffer.Address, ref stringSize, escapePositionsMaxSize);
                 return WriteValue(buffer.Address, stringSize, _intBuffer, out token, mode, null);                
             }
             finally

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -484,7 +484,7 @@ namespace Sparrow.Json
             var state = new JsonParserState();
             var maxByteCount = Encodings.Utf8.GetMaxByteCount(field.Length);
 
-            int escapePositionsSize = JsonParserState.FindEscapePositionsMaxSize(field, out _);
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(field, out _);
 
             int memorySize = maxByteCount + escapePositionsSize;
             var memory = longLived ? GetLongLivedMemory(memorySize) : GetMemory(memorySize);
@@ -494,7 +494,7 @@ namespace Sparrow.Json
                 var address = memory.Address;
                 var actualSize = Encodings.Utf8.GetBytes(pField + field.Offset, field.Length, address, memory.SizeInBytes);
 
-                state.FindEscapePositionsIn(address, ref actualSize, escapePositionsSize);
+                state.FindEscapedPositionsAndEscapeControls(address, ref actualSize, escapePositionsSize);
 
                 state.WriteEscapePositionsTo(address + actualSize);
                 LazyStringValue result = longLived == false ? AllocateStringValue(field.Value, address, actualSize) : new LazyStringValue(field.Value, address, actualSize, this);
@@ -513,7 +513,7 @@ namespace Sparrow.Json
             var state = new JsonParserState();
             var maxByteCount = Encodings.Utf8.GetMaxByteCount(size);
 
-            int escapePositionsSize = JsonParserState.FindEscapePositionsMaxSize(ptr, size, out _);
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(ptr, size, out _);
 
             int memorySize = maxByteCount + escapePositionsSize;
             var memory = longLived ? GetLongLivedMemory(memorySize) : GetMemory(memorySize);
@@ -522,7 +522,7 @@ namespace Sparrow.Json
 
             Memory.Copy(address, ptr, size);
 
-            state.FindEscapePositionsIn(address, ref size, escapePositionsSize);
+            state.FindEscapedPositionsAndEscapeControls(address, ref size, escapePositionsSize);
 
             state.WriteEscapePositionsTo(address + size);
             LazyStringValue result = longLived == false ? AllocateStringValue(null, address, size) : new LazyStringValue(null, address, size, this);

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -46,15 +46,15 @@ namespace Sparrow.Json.Parsing
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int FindEscapePositionsMaxSize(string str, out int escapedCount)
+        public static int FindMaxEscapePositionAndControlCharSize(string str, out int controlCount)
         {
-            return FindEscapePositionsMaxSize(str.AsSpan(), out escapedCount);
+            return FindMaxEscapePositionAndControlCharSize(str.AsSpan(), out controlCount);
         }
         
-        public static int FindEscapePositionsMaxSize(ReadOnlySpan<char> str, out int escapedCount)
+        public static int FindMaxEscapePositionAndControlCharSize(ReadOnlySpan<char> str, out int controlCount)
         {
             var count = 0;
-            var controlCount = 0;
+            controlCount = 0;
 
             for (int i = 0; i < str.Length; i++)
             {
@@ -82,7 +82,6 @@ namespace Sparrow.Json.Parsing
                 }
             }
 
-            escapedCount = controlCount;
             // we take 5 because that is the max number of bytes for variable size int
             // plus 1 for the actual number of positions
 
@@ -90,7 +89,7 @@ namespace Sparrow.Json.Parsing
             return (count + 1) * EscapePositionItemSize + controlCount * ControlCharacterItemSize;
         }
 
-        public static int FindEscapePositionsMaxSize(byte* str, int size, out int escapedCount)
+        public static int FindMaxEscapePositionAndControlCharSize(byte* str, int size, out int escapedCount)
         {
             var count = 0;
             var controlCount = 0;
@@ -131,18 +130,18 @@ namespace Sparrow.Json.Parsing
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void FindEscapePositionsIn(byte* str, ref int len, int previousComputedMaxSize)
+        public void FindEscapedPositionsAndEscapeControls(byte* str, ref int len, int previousComputedMaxSize)
         {
-            FindEscapePositionsIn(EscapePositions, str, ref len, previousComputedMaxSize);
+            FindEscapedPositionsAndEscapeControls(EscapePositions, str, ref len, previousComputedMaxSize);
         }
 
-        public static void FindEscapePositionsIn(FastList<int> buffer, byte* str, ref int len, int previousComputedMaxSize)
+        public static void FindEscapedPositionsAndEscapeControls(FastList<int> buffer, byte* str, ref int len, int previousComputedMaxSize)
         {
             var originalLen = len;
             buffer.Clear();
             if (previousComputedMaxSize == EscapePositionItemSize)
             {
-                // if the value is 5, then we got no escape positions, see: FindEscapePositionsMaxSize
+                // if the value is 5, then we got no escape positions, see: FindMaxEscapePositionAndControlCharSize
                 // and we don't have to do any work
                 return;
             }

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -654,7 +654,7 @@ namespace Sparrow.Json.Parsing
             // max possible size - we avoid using GetByteCount because profiling showed it to take 2% of runtime
             // the buffer might be a bit longer, but we'll reuse it, and it is better than the computing cost
            
-            int escapePositionsSize = JsonParserState.FindEscapePositionsMaxSize(str, out _);
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(str, out _);
 
             int byteCount = str.Length * 5 + escapePositionsSize;
             if (_currentStateBuffer == null || _currentStateBuffer.SizeInBytes < byteCount)
@@ -678,7 +678,7 @@ namespace Sparrow.Json.Parsing
             {
                 _state.StringSize = Encodings.Utf8.GetBytes(pChars, str.Length, _state.StringBuffer, _currentStateBuffer.SizeInBytes);
                 _state.CompressedSize = null; // don't even try
-                _state.FindEscapePositionsIn(_state.StringBuffer, ref _state.StringSize, escapePositionsSize);
+                _state.FindEscapedPositionsAndEscapeControls(_state.StringBuffer, ref _state.StringSize, escapePositionsSize);
 
                 var escapePos = _state.StringBuffer + _state.StringSize;
                 _state.WriteEscapePositionsTo(escapePos);

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -777,11 +777,11 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     var lsvStringBytes = Encoding.UTF8.GetBytes(lsvString);
                     fixed (byte* b = lsvStringBytes)
                     {
-                        var escapePositionsMaxSize = JsonParserState.FindEscapePositionsMaxSize(lsvString, out _);
+                        var escapePositionsMaxSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(lsvString, out _);
                         var lsv = context.AllocateStringValue(null, b, lsvStringBytes.Length);
                         var escapePositions = new FastList<int>();
                         var len = lsvStringBytes.Length;
-                        JsonParserState.FindEscapePositionsIn(escapePositions, b, ref len, escapePositionsMaxSize);
+                        JsonParserState.FindEscapedPositionsAndEscapeControls(escapePositions, b, ref len, escapePositionsMaxSize);
                         lsv.EscapePositions = escapePositions.ToArray();
 
                         builder.WritePropertyName("LSVString");

--- a/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
+++ b/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
@@ -1,6 +1,16 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Impl.Paging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -99,6 +109,79 @@ namespace FastTests.Server.Documents
                     Assert.Equal(before, after);
                 }
             }
+        }
+
+        private class TestObj
+        {
+            public string Id { get; set; }
+        }
+
+        public static object[][] Ids =>
+            new object[][]
+            {
+                ["\0{\r\n>"], 
+                [new string('\0', AbstractPager.MaxKeySize / (JsonParserState.ControlCharacterItemSize + 1) - 2)], 
+                ['a' + new string('\r', AbstractPager.MaxKeySize / (JsonParserState.EscapePositionItemSize + 1) - 4)]
+            };
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [MemberData(nameof(Ids))]
+        public async Task DocumentId_WhenWrite_ShouldBeAbleToRead(string id)
+        {
+            const char nonAscii = (char)(DocumentIdWorker.MaxAsciiCodePoint + 1);
+
+            using var memoryStream = new MemoryStream();
+
+            using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(allocator, id, out _, out Slice withoutAsciiSlice))
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(allocator, id + nonAscii, out _, out Slice withAsciiSlice))
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+            {
+                var withoutAsciiLazyString = GetLazyStringValue(context, withoutAsciiSlice);
+                var withAsciiLazyString = GetLazyStringValue(context, withAsciiSlice);
+
+                Assert.True(withAsciiLazyString.StartsWith(withoutAsciiLazyString));
+
+                writer.WriteString(withoutAsciiLazyString);
+                writer.WriteString(withAsciiLazyString);
+            }
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            using (var reader = new StreamReader(memoryStream, Encoding.UTF8))
+            {
+                var result = await reader.ReadToEndAsync();
+                string expected = JsonConvert.DeserializeObject<string>(JsonConvert.SerializeObject(result));
+                Assert.Equal(expected, result);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [MemberData(nameof(Ids))]
+        public async Task DocumentId_WhenStore_ShouldBeAbleToLoad(string id)
+        {
+            var idWithNonAscii = (char)(DocumentIdWorker.MaxAsciiCodePoint + 1) + id;
+            
+            using var store = GetDocumentStore();
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestObj(), id);
+                await session.StoreAsync(new TestObj(), idWithNonAscii);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.NotNull(await session.LoadAsync<TestObj>(id));
+                Assert.NotNull(await session.LoadAsync<TestObj>(idWithNonAscii));
+            }
+        }
+
+        private static unsafe LazyStringValue GetLazyStringValue(JsonOperationContext context, Slice idSlice)
+        {
+            var ret = context.GetLazyStringValue(idSlice.Content.Ptr, out var success);
+            Assert.True(success);
+            return ret;
         }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24112

Previously, when the ID included non-ASCII characters, FindEscapePositions was called on a temporary buffer. During this step, _jsonParserState collected the escape positions and also modified the ID by escaping characters with values lower than 32.

However, WriteEscapePositionsTo was later called on a different copy of the ID that did not include these modifications. As a result, characters that were escaped into \uXXXX increased the size of the ID, and the previously calculated escape positions no longer matched the final content.

I’m not sure what the motivation was for using the temporary buffer in this step. I compared this logic to the case where the ID doesn’t contain non-ASCII characters, where we simply call FindEscapePositionsIn directly on the final ID.

The underlying issue seems to be that FindEscapePositionsIn both finds escape positions and transforms the input by escaping control characters (ASCII < 32). While that transformation is sometimes the desired outcome, the method name doesn’t make this clear — which can cause confusion in its usage and lead to bugs like the one addressed in this PR.


### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
