### PR TITLE
RavenDB-24132 Vectors exposed as index terms in base64.

### DIFF
--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -19,6 +19,7 @@ using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Fixed;
+using Voron.Data.Graphs;
 using Voron.Data.Lookups;
 using Voron.Impl;
 using InvalidOperationException = System.InvalidOperationException;
@@ -571,6 +572,24 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
 
         _vectorFieldsMarkers ??= _metadataTree?.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice)?.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray() ?? [];
+    }
+
+    public bool TryGetVectorsOfField(string fieldName, out Hnsw.IndexedVectorsRetriever retriever)
+    {
+        using var _ = Slice.From(Allocator, fieldName, out var fieldNameAsSlice);
+        var exists = TryGetRootPageByFieldName(fieldNameAsSlice, out var fieldRootPage);
+        
+        if (_vectorFieldsMarkers is null)
+            InitializeSpecialTermsMarkers();
+
+        if (_vectorFieldsMarkers.AsSpan().Contains(fieldRootPage) == false)
+        {
+            retriever = null;
+            return false;
+        }
+        
+        retriever = new Hnsw.IndexedVectorsRetriever(_transaction.LowLevelTransaction, fieldName);
+        return true;
     }
     
     public static void LoadSpecialTermMarkers(Tree postingList, out HashSet<long> termsMarkers)

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -574,7 +574,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         _vectorFieldsMarkers ??= _metadataTree?.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice)?.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray() ?? [];
     }
 
-    public bool TryGetVectorsOfField(string fieldName, out Hnsw.IndexedVectorsRetriever retriever)
+    public bool IsVectorField(string fieldName)
     {
         using var _ = Slice.From(Allocator, fieldName, out var fieldNameAsSlice);
         var exists = TryGetRootPageByFieldName(fieldNameAsSlice, out var fieldRootPage);
@@ -583,6 +583,16 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             InitializeSpecialTermsMarkers();
 
         if (_vectorFieldsMarkers.AsSpan().Contains(fieldRootPage) == false)
+        {
+            return false;
+        }
+
+        return true;
+    }
+    
+    public bool TryGetVectorsOfField(string fieldName, out Hnsw.IndexedVectorsRetriever retriever)
+    {
+        if (IsVectorField(fieldName) == false)
         {
             retriever = null;
             return false;

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Corax.Indexing;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
@@ -10,12 +9,13 @@ using Sparrow;
 using Sparrow.Compression;
 using Sparrow.Server;
 using Voron.Data.CompactTrees;
+using Voron.Data.Graphs;
 using Voron.Data.Lookups;
 using Voron.Data.PostingLists;
 
 namespace Corax.Querying.Matches.TermProviders
 {
-    public struct ExistsTermProvider<TLookupIterator> : ITermProvider, IAggregationProvider
+    public struct ExistsTermProvider<TLookupIterator> : ITermProvider, IAggregationProvider, IIndexedTermsRetriever
         where TLookupIterator : struct, ILookupIterator
     {
         private readonly long _numberOfTerms;
@@ -134,7 +134,9 @@ namespace Corax.Querying.Matches.TermProviders
             term = Span<byte>.Empty;
             return false;
         }
-        
+
+        public ConvertTo Type => ConvertTo.String;
+
         public QueryInspectionNode Inspect()
         {
             return new QueryInspectionNode($"{nameof(ExistsTermProvider<TLookupIterator>)}",

--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -602,6 +602,7 @@ namespace Raven.Client
             private const string EmbeddingPrefix = "embedding.";
 
             internal const string EmbeddingForDocument = EmbeddingPrefix + "forDoc";
+            internal const string EmbeddingForRaw = EmbeddingPrefix + "Raw";
             internal const string EmbeddingText = EmbeddingPrefix + "text";
             internal const string EmbeddingTextInt8 = EmbeddingPrefix + "text_i8";
             internal const string EmbeddingTextInt1 = EmbeddingPrefix + "text_i1";

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForDebug.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForDebug.cs
@@ -76,16 +76,33 @@ internal sealed class IndexHandlerProcessorForDebug : AbstractIndexHandlerProces
             if (string.Equals(operation, "entries-fields", StringComparison.OrdinalIgnoreCase))
             {
                 var fields = index.GetEntriesFields();
+                
+                bool isFirst = true;
+                writer.WriteStartArray();
+                foreach (var field in fields)
+                {
+                    if (isFirst == false)
+                        writer.WriteComma();
+                    isFirst = false;
 
-                writer.WriteStartObject();
-
-                writer.WriteArray(nameof(fields.Static), fields.Static);
-                writer.WriteComma();
-
-                writer.WriteArray(nameof(fields.Dynamic), fields.Dynamic);
-
-                writer.WriteEndObject();
-
+                    writer.WriteStartObject();
+                    
+                    writer.WritePropertyName(nameof(field.Name));
+                    writer.WriteString(field.Name);
+                    writer.WriteComma();
+                    
+                    writer.WritePropertyName(nameof(field.FieldType));
+                    writer.WriteString(field.FieldType.ToString());
+                    writer.WriteComma();
+                    
+                    writer.WritePropertyName(nameof(field.ValueType));
+                    writer.WriteString(field.ValueType.ToString());
+                    
+                    writer.WriteEndObject();
+                }
+                
+                writer.WriteEndArray();
+                
                 return;
             }
             

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -7,12 +7,14 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
 using Raven.Server.Documents.Queries;
 using Raven.Server.ServerWide.Context;
 using Voron;
+using IndexFieldType = Raven.Server.Documents.Indexes.Debugging.IndexFieldType;
 
 namespace Raven.Server.Documents.Indexes.Auto
 {
@@ -151,18 +153,11 @@ namespace Raven.Server.Documents.Indexes.Auto
             Definition.State = state;
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
-            var staticEntries = Definition
-                .IndexFields
-                .Keys
-                .ToHashSet();
-            
-            staticEntries.Add(Constants.Documents.Indexing.Fields.DocumentIdFieldName);
-
-            var dynamicEntries = GetDynamicEntriesFields(staticEntries);
-
-            return (staticEntries, dynamicEntries);
+            var allFields = GetEntriesFields(Definition.IndexFields.Keys);
+            allFields.Add(new(Constants.Documents.Indexing.Fields.DocumentIdFieldName, IndexFieldType.Static, IndexedValueType.Term));
+            return allFields;
         }
 
         protected override void LoadValues()

--- a/src/Raven.Server/Documents/Indexes/Debugging/FieldDebugInfo.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/FieldDebugInfo.cs
@@ -1,0 +1,14 @@
+namespace Raven.Server.Documents.Indexes.Debugging;
+
+public record FieldDebugInfo(string Name, IndexFieldType FieldType, IndexedValueType ValueType)
+{
+    public virtual bool Equals(FieldDebugInfo other)
+    {
+        return Name.Equals(other.Name);
+    }
+    
+    public override int GetHashCode()
+    {
+        return Name.GetHashCode();
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexFieldType.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexFieldType.cs
@@ -1,0 +1,7 @@
+namespace Raven.Server.Documents.Indexes.Debugging;
+
+public enum IndexFieldType
+{
+    Static,
+    Dynamic
+}

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexedValueType.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexedValueType.cs
@@ -1,0 +1,7 @@
+namespace Raven.Server.Documents.Indexes.Debugging;
+
+public enum IndexedValueType
+{
+    Term,
+    Vector
+}

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -9,6 +9,7 @@ using Raven.Server.Config;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Queries;
@@ -181,7 +182,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
             throw new NotSupportedException($"Index {Name} is in-memory implementation of a faulty index", _e);
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3816,7 +3816,7 @@ namespace Raven.Server.Documents.Indexes
 
                 using (var reader = IndexPersistence.OpenIndexReader(tx.InnerTransaction))
                 {
-                    result.Terms = reader.Terms(field, fromValue, pageSize, token.Token).ToList();
+                    result.Terms = reader.Terms(field, fromValue, pageSize, token.Token);
                 }
 
                 return result;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -30,6 +30,7 @@ using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
 using Raven.Server.Documents.Handlers.Admin;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Exceptions;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
@@ -3913,15 +3914,15 @@ namespace Raven.Server.Documents.Indexes
             return result;
         }
 
-        public abstract (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields();
+        public abstract ICollection<FieldDebugInfo> GetEntriesFields();
 
-        protected List<string> GetDynamicEntriesFields(HashSet<string> staticFields)
+        protected HashSet<FieldDebugInfo> GetEntriesFields(ICollection<string> unknownTypeStaticFields)
         {
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
             using (var indexTx = indexContext.OpenReadTransaction())
             using (var reader = IndexPersistence.OpenIndexReader(indexTx.InnerTransaction))
             {
-                return reader.DynamicEntriesFields(staticFields).ToList();
+                return reader.GetEntriesFields(unknownTypeStaticFields);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
@@ -95,16 +96,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             Definition.State = state;
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override ICollection<FieldDebugInfo> GetEntriesFields()
         {
-            var staticEntries = Definition
-                .IndexFields
-                .Keys
-                .ToHashSet();
-
-            var dynamicEntries = GetDynamicEntriesFields(staticEntries);
-
-            return (staticEntries, dynamicEntries);
+            return GetEntriesFields(Definition.IndexFields.Keys);
         }
 
         protected override void LoadValues()

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -14,6 +14,7 @@ using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes.Configuration;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.MapReduce.OutputToCollection;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
@@ -454,15 +455,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             return StaticIndexHelper.IsStaleDueToReferences(this, queryContext, indexContext, referenceCutoff, compareExchangeReferenceCutoff, stalenessReasons) || isStale;
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
-            var staticEntries = _compiled.OutputFields.ToHashSet();
-
-            var dynamicEntries = GetDynamicEntriesFields(staticEntries)
-                .Except(staticEntries)
-                .ToArray();
-
-            return (staticEntries, dynamicEntries);
+            var staticEntries = _compiled.OutputFields;
+            return GetEntriesFields(staticEntries);
         }
 
         protected override long CalculateIndexEtag(QueryOperationContext queryContext, TransactionOperationContext indexContext, QueryMetadata query, bool isStale)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1452,15 +1452,19 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
             
             var fieldsInIndex = IndexSearcher.GetFields();
-            foreach (var field in fieldsInIndex)
+            foreach (var fieldName in fieldsInIndex)
             {
-                if (fields.Select(x => x.Name).Contains(field))
+                if (fields.Select(x => x.Name).Contains(fieldName))
                     continue;
-                var termType = IndexSearcher.IsVectorField(field) ? 
+                
+                if (IsDynamicFieldKnownAsStatic(fieldName))
+                    continue;
+                
+                var termType = IndexSearcher.IsVectorField(fieldName) ? 
                     IndexedValueType.Vector 
                     : IndexedValueType.Term;
                 
-                fields.Add(new (field, IndexFieldType.Dynamic, termType));
+                fields.Add(new (fieldName, IndexFieldType.Dynamic, termType));
             }
 
             return fields;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using Corax.Querying;
 using Corax.Mappings;
@@ -28,7 +29,6 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
-using Sparrow.Logging;
 using Sparrow.Server;
 using Voron;
 using Voron.Impl;
@@ -37,6 +37,7 @@ using CoraxConstants = Corax.Constants;
 using IndexSearcher = Corax.Querying.IndexSearcher;
 using CoraxSpatialResult = global::Corax.Utils.Spatial.SpatialResult;
 using Sparrow.Server.Logging;
+using Voron.Data.Graphs;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax
 {
@@ -1138,34 +1139,66 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             throw new NotImplementedException($"{nameof(Corax)} does not support intersect queries.");
         }
 
-        public override SortedSet<string> Terms(string field, string fromValue, long pageSize, CancellationToken token)
+        public override List<string> Terms(string field, string fromValue, long pageSize, CancellationToken token)
         {
-            SortedSet<string> results = new();
+            if (IndexSearcher.TryGetVectorsOfField(field, out var vectorsRetriever))
+            {
+                List<string> terms = new();
+                return TermsInternal(fromValue, pageSize, vectorsRetriever, terms, token);
+            }
 
-            if (IndexSearcher.TryGetTermsOfField(IndexSearcher.FieldMetadataBuilder(field), out var terms) == false)
-                return results;
+            if (IndexSearcher.TryGetTermsOfField(IndexSearcher.FieldMetadataBuilder(field), out var termsRetriever))
+            {
+                SortedSet<string> terms = new(StringComparer.Ordinal);
+                return TermsInternal(fromValue, pageSize, termsRetriever, terms, token).ToList();
+            }
 
+            return [];
+        }
+
+        private TResult TermsInternal<TRetriever, TResult>(string fromValue, long pageSize, TRetriever retriever, TResult results, CancellationToken token)
+            where TRetriever : IIndexedTermsRetriever
+            where TResult : ICollection<string> 
+        {
             if (string.IsNullOrEmpty(fromValue) == false)
             {
-                Span<byte> fromValueBytes = Encodings.Utf8.GetBytes(fromValue);
-                while (terms.GetNextTerm(out var termSlice))
+                Span<byte> fromValueBytes = StringToValue(fromValue);
+                while (retriever.GetNextTerm(out var currentTerm) && currentTerm.SequenceEqual(fromValueBytes) == false)
                 {
                     token.ThrowIfCancellationRequested();
-                    if (termSlice.SequenceEqual(fromValueBytes))
-                        break;
                 }
             }
 
-            while (pageSize > 0 && terms.GetNextTerm(out var termSlice))
+            while (pageSize > 0 && retriever.GetNextTerm(out var currentTerm))
             {
                 token.ThrowIfCancellationRequested();
-                results.Add(Encodings.Utf8.GetString(termSlice));
+                results.Add(ValueToString(currentTerm));
                 pageSize--;
             }
 
             return results;
-        }
+            
+            string ValueToString(ReadOnlySpan<byte> bytes)
+            {
+                return retriever.Type switch
+                {
+                    ConvertTo.Base64 => Convert.ToBase64String(bytes),
+                    ConvertTo.String => Encodings.Utf8.GetString(bytes),
+                    _ => throw new NotSupportedException($"The type {retriever.Type} is not supported.")
+                };
+            }
 
+            Span<byte> StringToValue(string value)
+            {
+                return retriever.Type switch
+                {
+                    ConvertTo.Base64 => Convert.FromBase64String(value),
+                    ConvertTo.String => Encodings.Utf8.GetBytes(value),
+                    _ => throw new NotSupportedException($"The type {retriever.Type} is not supported.")
+                };
+            }
+        }
+        
         public override IEnumerable<QueryResult> MoreLikeThis(IndexQueryServerSide query, IQueryResultRetriever retriever, DocumentsOperationContext context,
             CancellationToken token)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -17,6 +17,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries.Explanation;
 using Raven.Client.Documents.Queries.MoreLikeThis;
 using Raven.Client.Exceptions.Corax;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
@@ -38,6 +39,7 @@ using IndexSearcher = Corax.Querying.IndexSearcher;
 using CoraxSpatialResult = global::Corax.Utils.Spatial.SpatialResult;
 using Sparrow.Server.Logging;
 using Voron.Data.Graphs;
+using IndexFieldType = Raven.Server.Documents.Indexes.Debugging.IndexFieldType;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax
 {
@@ -1437,15 +1439,31 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
         }
 
-        public override IEnumerable<string> DynamicEntriesFields(HashSet<string> staticFields)
+        public override HashSet<FieldDebugInfo> GetEntriesFields(ICollection<string> unknownTypeStaticFields)
         {
+            var fields = new HashSet<FieldDebugInfo>();
+            foreach (var staticField in unknownTypeStaticFields)
+            {
+                var termType = IndexSearcher.IsVectorField(staticField) ? 
+                    IndexedValueType.Vector 
+                    : IndexedValueType.Term;
+                
+                fields.Add(new FieldDebugInfo(staticField, IndexFieldType.Static, termType));
+            }
+            
             var fieldsInIndex = IndexSearcher.GetFields();
             foreach (var field in fieldsInIndex)
             {
-                if (staticFields.Contains(field))
+                if (fields.Select(x => x.Name).Contains(field))
                     continue;
-                yield return field;
+                var termType = IndexSearcher.IsVectorField(field) ? 
+                    IndexedValueType.Vector 
+                    : IndexedValueType.Term;
+                
+                fields.Add(new (field, IndexFieldType.Dynamic, termType));
             }
+
+            return fields;
         }
 
         public override void Dispose()

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -58,26 +58,30 @@ public static partial class CoraxQueryBuilder
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters, fieldName, hasBoost: builderParameters.HasBoost);
         QueryExpression srcVector = me.Arguments[1];
 
-        if (srcVector is MethodExpression forId) // embedding.forDoc(docId) ...
+        if (srcVector is MethodExpression methodValue) // embedding.forDoc(docId) ...
         {
-            PortableExceptions.ThrowIf<InvalidDataException>(forId.Name != Constants.VectorSearch.EmbeddingForDocument,
-                $"Expected {Constants.VectorSearch.EmbeddingForDocument}() method call, but got: {forId.Name}");
+            PortableExceptions.ThrowIf<InvalidDataException>(methodValue.Name != Constants.VectorSearch.EmbeddingForDocument && methodValue.Name != Constants.VectorSearch.EmbeddingForRaw,
+                $"Expected {Constants.VectorSearch.EmbeddingForDocument}() method call, but got: {methodValue.Name}");
 
-            var (forIdValue, _) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)forId.Arguments[0],
+            var (methodParameter, _) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)methodValue.Arguments[0],
                 allowObjectsInParameters: false, allowArraysInParameters: true);
             
-            switch (forIdValue)
+            var isForDoc = methodValue.Name == Constants.VectorSearch.EmbeddingForDocument;
+
+            return (isForDoc, methodParameter) switch
             {
-                case string docId:
-                    return builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docId, minimumMatch, numberOfCandidates, exact,
-                        builderParameters.IsVectorSingleClause);
-                case StringSegment docIdSegment:
-                    return builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docIdSegment.Value, minimumMatch, numberOfCandidates, exact,
-                        builderParameters.IsVectorSingleClause);
-                case BlittableJsonReaderArray {Length:> 0} arr:
-                    break;
-            }
-            
+                (isForDoc: true, string docId) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docId, minimumMatch, numberOfCandidates, exact,
+                    builderParameters.IsVectorSingleClause),
+                (isForDoc: true, StringSegment docIdSegment) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docIdSegment.Value, minimumMatch,
+                    numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
+                (isForDoc: false, string vectorAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
+                    GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, vectorAsBase64, false), minimumMatch, numberOfCandidates,
+                    exact, builderParameters.IsVectorSingleClause),
+                (isForDoc: false, StringSegment stringSegmentAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
+                    GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString(), false), minimumMatch,
+                    numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
+                (_, BlittableJsonReaderArray { Length: > 0 }) => throw new InvalidDataException("Cannot perform search on empty value.")
+            };
         }
         
         var (value, valueType) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)srcVector,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -80,7 +80,8 @@ public static partial class CoraxQueryBuilder
                 (isForDoc: false, StringSegment stringSegmentAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
                     GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString(), false), minimumMatch,
                     numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
-                (_, BlittableJsonReaderArray { Length: > 0 }) => throw new InvalidDataException("Cannot perform search on empty value.")
+                (_, BlittableJsonReaderArray { Length: > 0 }) => throw new InvalidDataException("Cannot perform search on empty value."),
+                _ => throw new InvalidQueryException($"Unknown method in value ({methodValue.Name}. Parameter type: {methodParameter.GetType().FullName}, Value: {methodParameter}")
             };
         }
         

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -67,6 +67,16 @@ namespace Raven.Server.Documents.Indexes.Persistence
 
         public abstract HashSet<FieldDebugInfo> GetEntriesFields(ICollection<string> unknownTypeStaticFields);
 
+        protected static bool IsDynamicFieldKnownAsStatic(string fieldName)
+        {
+            return fieldName
+                is Client.Constants.Documents.Indexing.Fields.ReduceKeyHashFieldName 
+                or Client.Constants.Documents.Indexing.Fields.ReduceKeyValueFieldName
+                or Client.Constants.Documents.Indexing.Fields.ValueFieldName
+                or Client.Constants.Documents.Indexing.Fields.DocumentIdFieldName
+                or Client.Constants.Documents.Indexing.Fields.SourceDocumentIdFieldName;
+        }
+
         public override void Dispose()
         {
             if ((_logger.IsInfoEnabled || (_logger.IsWarnEnabled && _index.IsLowMemory)) &&

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
             Reference<long> skippedResults, Reference<long> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField,
             CancellationToken token);
 
-        public abstract SortedSet<string> Terms(string field, string fromValue, long pageSize, CancellationToken token);
+        public abstract List<string> Terms(string field, string fromValue, long pageSize, CancellationToken token);
 
         public abstract IEnumerable<QueryResult> MoreLikeThis(
             IndexQueryServerSide query,

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Explanation;
@@ -64,7 +65,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
         public abstract IEnumerable<BlittableJsonReaderObject> IndexEntries(IndexQueryServerSide query, Reference<long> totalResults, DocumentsOperationContext documentsContext,
             Func<string, SpatialField> getSpatialField, bool ignoreLimit, CancellationToken token);
 
-        public abstract IEnumerable<string> DynamicEntriesFields(HashSet<string> staticFields);
+        public abstract HashSet<FieldDebugInfo> GetEntriesFields(ICollection<string> unknownTypeStaticFields);
 
         public override void Dispose()
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -990,11 +990,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 if (fields.Select(x => x.Name).Contains(fieldName))
                     continue;
 
-                if (fieldName == Constants.Documents.Indexing.Fields.ReduceKeyHashFieldName
-                    || fieldName == Constants.Documents.Indexing.Fields.ReduceKeyValueFieldName
-                    || fieldName == Constants.Documents.Indexing.Fields.ValueFieldName
-                    || fieldName == Constants.Documents.Indexing.Fields.DocumentIdFieldName
-                    || fieldName == Constants.Documents.Indexing.Fields.SourceDocumentIdFieldName)
+                if (IsDynamicFieldKnownAsStatic(fieldName))
                     continue;
 
                 if (fieldName.EndsWith(LuceneDocumentConverterBase.ConvertToJsonSuffix) ||

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -756,7 +756,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public override SortedSet<string> Terms(string field, string fromValue, long pageSize, CancellationToken token)
+        public override List<string> Terms(string field, string fromValue, long pageSize, CancellationToken token)
         {
             var results = new SortedSet<string>(StringComparer.Ordinal);
             using (var termDocs = _searcher.IndexReader.HasDeletions ? _searcher.IndexReader.TermDocs(_state) : null)
@@ -769,7 +769,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         token.ThrowIfCancellationRequested();
 
                         if (termEnum.Next(_state) == false)
-                            return results;
+                            return results.ToList();
                     }
                 }
                 while (termEnum.Term == null ||
@@ -800,7 +800,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 }
             }
 
-            return results;
+            return results.ToList();
         }
 
         public override IEnumerable<QueryResult> MoreLikeThis(

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Queries.Explanation;
 using Raven.Client.Documents.Queries.MoreLikeThis;
 using Raven.Client.Exceptions;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Collectors;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
@@ -39,6 +40,7 @@ using Sparrow.Json;
 using Sparrow.Logging;
 using Spatial4n.Shapes;
 using Voron.Impl;
+using IndexFieldType = Raven.Server.Documents.Indexes.Debugging.IndexFieldType;
 using Query = Lucene.Net.Search.Query;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Lucene
@@ -972,13 +974,20 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public override IEnumerable<string> DynamicEntriesFields(HashSet<string> staticFields)
+        public override HashSet<FieldDebugInfo> GetEntriesFields(ICollection<string> unknownTypeStaticFields)
         {
+            var fields = new HashSet<FieldDebugInfo>();
+
+            foreach (var staticField in unknownTypeStaticFields)
+            {
+                fields.Add(new(staticField, IndexFieldType.Static, IndexedValueType.Term));
+            }
+            
             foreach (var fieldName in _searcher
                 .IndexReader
                 .GetFieldNames(IndexReader.FieldOption.ALL))
             {
-                if (staticFields.Contains(fieldName))
+                if (fields.Select(x => x.Name).Contains(fieldName))
                     continue;
 
                 if (fieldName == Constants.Documents.Indexing.Fields.ReduceKeyHashFieldName
@@ -994,8 +1003,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                     fieldName.EndsWith(Constants.Documents.Indexing.Fields.TimeFieldSuffix))
                     continue;
 
-                yield return fieldName;
+                fields.Add(new FieldDebugInfo(fieldName, IndexFieldType.Dynamic, IndexedValueType.Term));
             }
+
+            return fields;
         }
 
         public override void Dispose()

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Server.Config;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Configuration;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
@@ -188,13 +189,9 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             return DocumentDatabase.DocumentsStorage.CountersStorage.GetLastCounterEtag(queryContext.Documents, collection);
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
-            var staticEntries = _compiled.OutputFields.ToHashSet();
-
-            var dynamicEntries = GetDynamicEntriesFields(staticEntries);
-
-            return (staticEntries, dynamicEntries);
+            return GetEntriesFields(_compiled.OutputFields);
         }
 
         public override IIndexedItemEnumerator GetMapEnumerator(IEnumerable<IndexItem> items, string collection, TransactionOperationContext indexContext, IndexingStatsScope stats, IndexType type)

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -7,12 +7,14 @@ using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes.Configuration;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
 using Raven.Server.Documents.Queries;
 using Raven.Server.ServerWide.Context;
 using Voron;
+using IndexFieldType = Raven.Server.Documents.Indexes.Debugging.IndexFieldType;
 
 namespace Raven.Server.Documents.Indexes.Static
 {
@@ -124,14 +126,12 @@ namespace Raven.Server.Documents.Indexes.Static
             _mre.Set();
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
-            var staticEntries = _compiled.OutputFields.ToHashSet();
-            staticEntries.Add(Constants.Documents.Indexing.Fields.DocumentIdFieldName);
-
-            var dynamicEntries = GetDynamicEntriesFields(staticEntries);
-
-            return (staticEntries, dynamicEntries);
+            var allFields = GetEntriesFields(_compiled.OutputFields);
+            allFields.Add(new(Constants.Documents.Indexing.Fields.DocumentIdFieldName, IndexFieldType.Static, IndexedValueType.Term));
+            
+            return allFields;
         }
 
         protected override long CalculateIndexEtag(QueryOperationContext queryContext, TransactionOperationContext indexContext, QueryMetadata query, bool isStale)

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Server.Config;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Configuration;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
@@ -203,13 +204,11 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             return DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetLastTimeSeriesDeletedRangesEtag(queryContext.Documents, collection);
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
-            var staticEntries = _compiled.OutputFields.ToHashSet();
-
-            var dynamicEntries = GetDynamicEntriesFields(staticEntries);
-
-            return (staticEntries, dynamicEntries);
+            var staticEntries = _compiled.OutputFields;
+            var allEntries = GetEntriesFields(staticEntries);
+            return allEntries;
         }
 
         public override IIndexedItemEnumerator GetMapEnumerator(IEnumerable<IndexItem> items, string collection, TransactionOperationContext indexContext, IndexingStatsScope stats, IndexType type)

--- a/src/Raven.Studio/typescript/commands/database/index/getIndexEntriesFieldsCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/getIndexEntriesFieldsCommand.ts
@@ -17,7 +17,7 @@ class getIndexEntriesFieldsCommand extends commandBase {
         this.reportFailure = reportFailure;
     }
 
-    execute(): JQueryPromise<getIndexEntriesFieldsCommandResult> {
+    execute(): JQueryPromise<getIndexEntriesFieldsCommandResult[]> {
         const task = this.getIndexEntries();
 
         if (this.reportFailure) {
@@ -29,7 +29,7 @@ class getIndexEntriesFieldsCommand extends commandBase {
         return task;
     }
 
-    private getIndexEntries(): JQueryPromise<getIndexEntriesFieldsCommandResult> {
+    private getIndexEntries(): JQueryPromise<getIndexEntriesFieldsCommandResult[]> {
         const args = {
             name: this.indexName,
             op: "entries-fields",

--- a/src/Raven.Studio/typescript/common/autoComplete/remoteMetadataProvider.ts
+++ b/src/Raven.Studio/typescript/common/autoComplete/remoteMetadataProvider.ts
@@ -26,7 +26,7 @@ class remoteMetadataProvider implements queryCompleterProviders {
         new getIndexEntriesFieldsCommand(indexName, this.db.name, locations[0], false)
             .execute()
             .done(result => {
-                callback(result.Static.filter(x => !IndexUtils.default.FieldsToHideOnUi.includes(x)));
+                callback(result.filter(x => x.FieldType === "Static").map(x => x.Name).filter(x => !IndexUtils.default.FieldsToHideOnUi.includes(x)));
             });
     }
 

--- a/src/Raven.Studio/typescript/common/queryUtil.ts
+++ b/src/Raven.Studio/typescript/common/queryUtil.ts
@@ -43,20 +43,30 @@ class queryUtil {
         
         return ` between "${start}" and "${end}"`;
     }
-    
-    static formatIndexQuery(indexName: string, fieldName: string, value: string) {
+
+    static formatIndexQuery(indexName: string, fieldName: string, value: string, termType: IndexEntriesValueType) {
         const escapedFieldName = queryUtil.escapeName(fieldName);
         const escapedIndexName = queryUtil.escapeName(indexName);
         const escapedValueName = queryUtil.escapeName(value);
-        
+
         const fromPart = `from index ${escapedIndexName}`;
-        let wherePart = `where ${escapedFieldName} == ${escapedValueName}`;
-        
+        let wherePart;
+
+        if (termType === "Vector") {
+            wherePart = `where vector.search(${escapedFieldName}, embedding.Raw(${escapedValueName}))`;
+        } else {
+            wherePart = `where ${escapedFieldName} == ${escapedValueName}`;
+        }
+
         if (indexName.startsWith("Auto") &&
             ((value.startsWith("{") && (queryUtil.hasUpperCase(value))) || value === "NULL_VALUE")) {
-            wherePart = `where exact(${escapedFieldName} == ${escapedValueName})`;
+            if (termType === "Vector") {
+                wherePart = `where exact(vector.search(${escapedFieldName}, embedding.Raw(${escapedValueName})))`;
+            } else {
+                wherePart = `where exact(${escapedFieldName} == ${escapedValueName})`;
+            }
         }
-        
+
         return `${fromPart} ${wherePart}`;
     }
     

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.spec.tsx
@@ -21,15 +21,12 @@ const testIdSelectors = {
 
 type IndexTermsMockupType = Record<
     "indexFieldsDto" | "indexTerms",
-    Record<string, TermsQueryResult | getIndexEntriesFieldsCommandResult>
+    Record<string, TermsQueryResult | getIndexEntriesFieldsCommandResult[]>
 >;
 
 const indexTermsMockups: IndexTermsMockupType = {
     indexFieldsDto: {
-        empty: {
-            Dynamic: [],
-            Static: [],
-        },
+        empty: [],
     },
     indexTerms: {
         empty: {
@@ -58,7 +55,7 @@ describe("IndexTerms", () => {
         const accordions = await screen.findAllByTestId(testIdSelectors.termAccordion);
 
         const expectedAccordionsLength =
-            IndexesStubs.getIndexTermFields().Static.length + IndexesStubs.getIndexTermFields().Dynamic.length;
+            IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Static").length + IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Dynamic").length;
 
         expect(accordions).toHaveLength(expectedAccordionsLength);
     });
@@ -68,7 +65,7 @@ describe("IndexTerms", () => {
 
         const dynamicTermFields = await screen.findAllByTestId(testIdSelectors.termDynamicField);
 
-        const termDynamicLength = IndexesStubs.getIndexTermFields().Dynamic.length;
+        const termDynamicLength = IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Dynamic").length;
         expect(dynamicTermFields).toHaveLength(termDynamicLength);
     });
 
@@ -76,7 +73,7 @@ describe("IndexTerms", () => {
         const { screen } = rtlRender(
             <IndexTermsStory
                 pathParams={pathParams}
-                indexFieldsDto={indexTermsMockups.indexFieldsDto.empty as getIndexEntriesFieldsCommandResult}
+                indexFieldsDto={indexTermsMockups.indexFieldsDto.empty as getIndexEntriesFieldsCommandResult[]}
             />
         );
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.spec.tsx
@@ -15,6 +15,7 @@ const indexName = pathParams[0];
 const testIdSelectors = {
     termAccordion: "term-accordion",
     termDynamicField: "term-dynamic-field",
+    termVectorField: "term-vector-field",
     termPill: "term-pill",
     termLoadMoreButton: "term-load-more-btn",
 };
@@ -66,6 +67,15 @@ describe("IndexTerms", () => {
         const dynamicTermFields = await screen.findAllByTestId(testIdSelectors.termDynamicField);
 
         const termDynamicLength = IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Dynamic").length;
+        expect(dynamicTermFields).toHaveLength(termDynamicLength);
+    });
+
+    it("can render accordion with 'vector field' badge", async () => {
+        const { screen } = rtlRender(<IndexTermsStory pathParams={pathParams} />);
+
+        const dynamicTermFields = await screen.findAllByTestId(testIdSelectors.termVectorField);
+
+        const termDynamicLength = IndexesStubs.getIndexTermFields().filter(x => x.ValueType === "Vector").length;
         expect(dynamicTermFields).toHaveLength(termDynamicLength);
     });
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.spec.tsx
@@ -56,7 +56,8 @@ describe("IndexTerms", () => {
         const accordions = await screen.findAllByTestId(testIdSelectors.termAccordion);
 
         const expectedAccordionsLength =
-            IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Static").length + IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Dynamic").length;
+            IndexesStubs.getIndexTermFields().filter((x) => x.FieldType === "Static").length +
+            IndexesStubs.getIndexTermFields().filter((x) => x.FieldType === "Dynamic").length;
 
         expect(accordions).toHaveLength(expectedAccordionsLength);
     });
@@ -66,7 +67,7 @@ describe("IndexTerms", () => {
 
         const dynamicTermFields = await screen.findAllByTestId(testIdSelectors.termDynamicField);
 
-        const termDynamicLength = IndexesStubs.getIndexTermFields().filter(x => x.FieldType === "Dynamic").length;
+        const termDynamicLength = IndexesStubs.getIndexTermFields().filter((x) => x.FieldType === "Dynamic").length;
         expect(dynamicTermFields).toHaveLength(termDynamicLength);
     });
 
@@ -75,7 +76,7 @@ describe("IndexTerms", () => {
 
         const dynamicTermFields = await screen.findAllByTestId(testIdSelectors.termVectorField);
 
-        const termDynamicLength = IndexesStubs.getIndexTermFields().filter(x => x.ValueType === "Vector").length;
+        const termDynamicLength = IndexesStubs.getIndexTermFields().filter((x) => x.ValueType === "Vector").length;
         expect(dynamicTermFields).toHaveLength(termDynamicLength);
     });
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.stories.tsx
@@ -12,7 +12,7 @@ export default {
 } satisfies Meta;
 
 interface IndexTermsStoryArgs {
-    indexFieldsDto?: getIndexEntriesFieldsCommandResult;
+    indexFieldsDto?: getIndexEntriesFieldsCommandResult[];
     indexTerms?: TermsQueryResult;
     pathParams?: string[];
 }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.tsx
@@ -79,9 +79,14 @@ function IndexTermsAccordions({ field, indexName, loadMore }: IndexTermsAccordio
                     <div className="d-flex align-items-center gap-2">
                         <span className="m-0">{field.name}</span>
                         <HStack className="gap-1">
-                            {field.type === "dynamic" && (
+                            {field.type === "Dynamic" && (
                                 <Badge data-testid="term-dynamic-field" bg="light" className="rounded-pill">
                                     Dynamic field
+                                </Badge>
+                            )}
+                            {field.termType === "Vector" && (
+                                <Badge data-testid="term-vector-field" bg="light" pill>
+                                    Vector field
                                 </Badge>
                             )}
                             <Badge bg="secondary" pill>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.tsx
@@ -147,7 +147,7 @@ function IndexTermItem({ index, term, indexName, field, fieldTerms }: IndexTermI
 
     const navigateToQuery = () => {
         const query = queryCriteria.empty();
-        const queryText = queryUtil.formatIndexQuery(indexName, field.name, term);
+        const queryText = queryUtil.formatIndexQuery(indexName, field.name, term, field.termType);
 
         query.queryText(queryText);
         query.name(`Index terms for ${indexName} (${field.name}: ${term})`);

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/IndexTerms.tsx
@@ -80,7 +80,7 @@ function IndexTermsAccordions({ field, indexName, loadMore }: IndexTermsAccordio
                         <span className="m-0">{field.name}</span>
                         <HStack className="gap-1">
                             {field.type === "Dynamic" && (
-                                <Badge data-testid="term-dynamic-field" bg="light" className="rounded-pill">
+                                <Badge data-testid="term-dynamic-field" bg="light" pill>
                                     Dynamic field
                                 </Badge>
                             )}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/termsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/termsUtils.ts
@@ -1,12 +1,13 @@
-import { FieldType, TermsForField } from "components/pages/database/indexes/list/terms/useIndexTerms";
+import { TermsForField } from "components/pages/database/indexes/list/terms/useIndexTerms";
 
-const createTermsForField = (fieldName: string, type: FieldType): TermsForField => {
+const createTermsForField = (fieldName: string, type: IndexEntriesFieldType, termType: IndexEntriesValueType): TermsForField => {
     return {
         fromValue: null,
         name: fieldName,
         hasMoreTerms: true,
         terms: [],
         type,
+        termType,
         loadError: "",
     };
 };
@@ -16,21 +17,31 @@ const getTermsLoadedAmount = (indexTerms: TermsForField[]) => {
 };
 
 const getTermsFields = (perNodeFields: getIndexEntriesFieldsCommandResult[]) => {
-    const dynamicFields = new Set<string>();
-    const staticFields = new Set<string>();
+    const allFields = perNodeFields;
 
-    perNodeFields.forEach((fields) => {
-        fields.Dynamic.forEach((d) => dynamicFields.add(d));
-        fields.Static.forEach((d) => staticFields.add(d));
+    const dynamicFields = new Map<string, getIndexEntriesFieldsCommandResult>();
+    const staticFields = new Map<string, getIndexEntriesFieldsCommandResult>();
+
+    allFields.forEach(field => {
+        switch (field.FieldType) {
+            case "Dynamic":
+                dynamicFields.set(field.Name, field);
+                break;
+            case "Static":
+                staticFields.set(field.Name, field);
+                break;
+            default:
+                break;
+        }
     });
 
-    const joinedResult: getIndexEntriesFieldsCommandResult = {
-        Dynamic: Array.from(dynamicFields),
-        Static: Array.from(staticFields),
-    };
+    const processedStaticFields = Array.from(staticFields.values()).map(field =>
+        createTermsForField(field.Name, field.FieldType, field.ValueType),
+    );
 
-    const processedStaticFields = joinedResult.Static.map((fieldName) => createTermsForField(fieldName, "static"));
-    const processedDynamicFields = joinedResult.Dynamic.map((fieldName) => createTermsForField(fieldName, "dynamic"));
+    const processedDynamicFields = Array.from(dynamicFields.values()).map(field =>
+        createTermsForField(field.Name, field.FieldType, field.ValueType),
+    );
 
     return processedStaticFields.concat(processedDynamicFields);
 };

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/termsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/termsUtils.ts
@@ -1,6 +1,10 @@
 import { TermsForField } from "components/pages/database/indexes/list/terms/useIndexTerms";
 
-const createTermsForField = (fieldName: string, type: IndexEntriesFieldType, termType: IndexEntriesValueType): TermsForField => {
+const createTermsForField = (
+    fieldName: string,
+    type: IndexEntriesFieldType,
+    termType: IndexEntriesValueType
+): TermsForField => {
     return {
         fromValue: null,
         name: fieldName,
@@ -22,7 +26,7 @@ const getTermsFields = (perNodeFields: getIndexEntriesFieldsCommandResult[]) => 
     const dynamicFields = new Map<string, getIndexEntriesFieldsCommandResult>();
     const staticFields = new Map<string, getIndexEntriesFieldsCommandResult>();
 
-    allFields.forEach(field => {
+    allFields.forEach((field) => {
         switch (field.FieldType) {
             case "Dynamic":
                 dynamicFields.set(field.Name, field);
@@ -35,12 +39,12 @@ const getTermsFields = (perNodeFields: getIndexEntriesFieldsCommandResult[]) => 
         }
     });
 
-    const processedStaticFields = Array.from(staticFields.values()).map(field =>
-        createTermsForField(field.Name, field.FieldType, field.ValueType),
+    const processedStaticFields = Array.from(staticFields.values()).map((field) =>
+        createTermsForField(field.Name, field.FieldType, field.ValueType)
     );
 
-    const processedDynamicFields = Array.from(dynamicFields.values()).map(field =>
-        createTermsForField(field.Name, field.FieldType, field.ValueType),
+    const processedDynamicFields = Array.from(dynamicFields.values()).map((field) =>
+        createTermsForField(field.Name, field.FieldType, field.ValueType)
     );
 
     return processedStaticFields.concat(processedDynamicFields);

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/useIndexTerms.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/useIndexTerms.tsx
@@ -14,12 +14,12 @@ export type TermsForField = {
     name: string;
     terms: string[];
     fromValue: string;
-    type: FieldType;
+    type: IndexEntriesFieldType;
+    termType: IndexEntriesValueType;
     hasMoreTerms: boolean;
     loadError: string;
 };
 
-export type FieldType = "static" | "dynamic";
 
 export const INDEX_TERMS_PAGE_LIMIT = 800;
 
@@ -39,7 +39,8 @@ export function useIndexTerms(indexName: string) {
             );
 
             const perNodeFields = await Promise.all(tasks);
-            const termFields = getTermsFields(perNodeFields);
+            // @ts-expect-error using spread operator instead of concat or flat because of performance - spread operator is faster around 3x.
+            const termFields = getTermsFields(...perNodeFields);
 
             return await Promise.all(termFields.map((field) => loadTerms.execute(indexName, field)));
         },

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/useIndexTerms.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/terms/useIndexTerms.tsx
@@ -20,7 +20,6 @@ export type TermsForField = {
     loadError: string;
 };
 
-
 export const INDEX_TERMS_PAGE_LIMIT = 800;
 
 export function useIndexTerms(indexName: string) {

--- a/src/Raven.Studio/typescript/test/mocks/services/MockIndexesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockIndexesService.ts
@@ -40,7 +40,7 @@ export default class MockIndexesService extends AutoMockService<IndexesService> 
         return this.mockResolvedValue(this.mocks.getIndexErrorDetails, dto, IndexesStubs.getIndexErrorDetails());
     }
 
-    withGetIndexFields(dto?: MockedValue<getIndexEntriesFieldsCommandResult>) {
+    withGetIndexFields(dto?: MockedValue<getIndexEntriesFieldsCommandResult[]>) {
         return this.mockResolvedValue(this.mocks.getIndexEntriesFields, dto, IndexesStubs.getIndexTermFields());
     }
 

--- a/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
@@ -336,11 +336,19 @@ export class IndexesStubs {
         ];
     }
 
-    static getIndexTermFields(): getIndexEntriesFieldsCommandResult {
-        return {
-            Static: ["Date", "Country", "Volume"],
-            Dynamic: ["Test"],
-        };
+    static getIndexTermFields(): getIndexEntriesFieldsCommandResult[] {
+        return [
+            {
+                "Name": "vector.search(embedding.text(Name))",
+                "FieldType": "Static",
+                "ValueType": "Vector",
+            },
+            {
+                "Name": "id()",
+                "FieldType": "Static",
+                "ValueType": "Term",
+            },
+        ];
     }
 
     static getIndexTerms(): Raven.Client.Documents.Queries.TermsQueryResult {

--- a/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
@@ -339,19 +339,19 @@ export class IndexesStubs {
     static getIndexTermFields(): getIndexEntriesFieldsCommandResult[] {
         return [
             {
-                "Name": "vector.search(embedding.text(Name))",
-                "FieldType": "Static",
-                "ValueType": "Vector",
+                Name: "vector.search(embedding.text(Name))",
+                FieldType: "Static",
+                ValueType: "Vector",
             },
             {
-                "Name": "id()",
-                "FieldType": "Static",
-                "ValueType": "Term",
+                Name: "id()",
+                FieldType: "Static",
+                ValueType: "Term",
             },
             {
-                "Name": "Name__PQ",
-                "FieldType": "Dynamic",
-                "ValueType": "Term",
+                Name: "Name__PQ",
+                FieldType: "Dynamic",
+                ValueType: "Term",
             },
         ];
     }

--- a/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
@@ -348,6 +348,11 @@ export class IndexesStubs {
                 "FieldType": "Static",
                 "ValueType": "Term",
             },
+            {
+                "Name": "Name__PQ",
+                "FieldType": "Dynamic",
+                "ValueType": "Term",
+            },
         ];
     }
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -761,9 +761,13 @@ interface confirmationDialogOptions {
     wideDialog?: boolean;
 }
 
+type IndexEntriesFieldType = "Static" | "Dynamic";
+type IndexEntriesValueType = "Term" | "Vector";
+
 interface getIndexEntriesFieldsCommandResult {
-    Static: string[];
-    Dynamic: string[];
+    Name: string;
+    FieldType: IndexEntriesFieldType;
+    ValueType: IndexEntriesValueType
 }
 
 interface scrollColorConfig {

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -1282,7 +1282,29 @@ public unsafe partial class Hnsw
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
         return new NearestSearch(searchState, nearestNodesByLevel, vector, minimumSimilarity);
     }
+    
+    public class IndexedVectorsRetriever(LowLevelTransaction llt, string name) : IIndexedTermsRetriever
+    {
+        private readonly SearchState _searchState = new(llt, name);
+        private long _lastReadNodeId = 1;
 
+        public bool GetNextTerm(out ReadOnlySpan<byte> term)
+        {
+            if (_lastReadNodeId > _searchState.Options.CountOfVectors)
+            {
+                term = [];
+                return false;
+            }
+
+            _searchState.ReadNode(_lastReadNodeId, out var reader);
+            term = reader.ReadVector(in _searchState).ToReadOnlySpan();
+            _lastReadNodeId++;
+            return true;
+        }
+
+        public ConvertTo Type => ConvertTo.Base64;
+    }
+    
     public struct NearestSearch : IDisposable
     {
         public NearestSearch(SearchState searchState, ContextBoundNativeList<int> indexes, ReadOnlySpan<byte> vector, float minimumSimilarity)

--- a/src/Voron/Data/Graphs/IIndexedTermsRetriever.cs
+++ b/src/Voron/Data/Graphs/IIndexedTermsRetriever.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Voron.Data.Graphs;
+
+public interface IIndexedTermsRetriever
+{
+    public bool GetNextTerm(out ReadOnlySpan<byte> term);
+    
+    public ConvertTo Type { get; }
+}
+
+public enum ConvertTo
+{
+    String,
+    Base64
+}

--- a/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
+++ b/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
@@ -12,6 +12,7 @@ using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
@@ -235,7 +236,7 @@ namespace FastTests.Server.Documents.Indexing
             throw new NotImplementedException();
         }
 
-        public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+        public override HashSet<FieldDebugInfo> GetEntriesFields()
         {
             throw new NotImplementedException();
         }

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
@@ -8,6 +8,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
@@ -503,7 +504,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             {
             }
 
-            public override (ICollection<string> Static, ICollection<string> Dynamic) GetEntriesFields()
+            public override HashSet<FieldDebugInfo> GetEntriesFields()
             {
                 throw new System.NotImplementedException();
             }

--- a/test/SlowTests/Corax/RavenDB-24132.cs
+++ b/test/SlowTests/Corax/RavenDB-24132.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_24132(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void CanGetVectorsFromIndex()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        
+        using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                bulkInsert.Store(new Dto(i));
+            }
+        }
+        
+        var index = new Index();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        string from = string.Empty;
+
+        List<string> all = new();
+        do
+        {
+            var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, "Vector", from, 30));
+            all.AddRange(terms);
+            
+            from = terms.LastOrDefault();
+        } while (string.IsNullOrEmpty(from) == false);
+        
+        Assert.Equal(1000, all.Count);
+        Assert.Distinct(all);
+    }
+    
+    private record Dto(int Number, string Id = null);
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from dto in dtos
+                select new { Vector = CreateVector(dto.Number.ToString()) };
+        }
+    }
+}

--- a/test/SlowTests/Corax/RavenDB-24132.cs
+++ b/test/SlowTests/Corax/RavenDB-24132.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Tests.Infrastructure;
@@ -20,7 +21,7 @@ public class RavenDB_24132(ITestOutputHelper output) : RavenTestBase(output)
         {
             for (int i = 0; i < 1000; i++)
             {
-                bulkInsert.Store(new Dto(i));
+                bulkInsert.Store(new Dto(i.ToString()));
             }
         }
         
@@ -40,16 +41,21 @@ public class RavenDB_24132(ITestOutputHelper output) : RavenTestBase(output)
         
         Assert.Equal(1000, all.Count);
         Assert.Distinct(all);
+
+        using (var session = store.OpenSession())
+            session.Query<Dto>().VectorSearch(x => x.WithText(p => p.Number), v => v.ByText("0")).ToList();
+        
+        WaitForUserToContinueTheTest(store);
     }
     
-    private record Dto(int Number, string Id = null);
+    private record Dto(string Number, string Id = null);
 
     private class Index : AbstractIndexCreationTask<Dto>
     {
         public Index()
         {
             Map = dtos => from dto in dtos
-                select new { Vector = CreateVector(dto.Number.ToString()) };
+                select new { Vector = CreateVector(dto.Number) };
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-23710.cs
+++ b/test/SlowTests/Issues/RavenDB-23710.cs
@@ -1,9 +1,11 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
+using Raven.Server.Documents.Indexes.Debugging;
 using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
@@ -11,16 +13,13 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 
-public class RavenDB_23710 : RavenTestBase
+public class RavenDB_23710(ITestOutputHelper output) : RavenTestBase(output)
 {
-    public RavenDB_23710(ITestOutputHelper output) : base(output)
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task IdFieldShouldBeDisplayedAsStatic(Options options)
     {
-    }
-
-    [RavenFact(RavenTestCategory.Indexes)]
-    public async Task IdFieldShouldBeDisplayedAsStatic()
-    {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenAsyncSession())
             {
@@ -39,23 +38,18 @@ public class RavenDB_23710 : RavenTestBase
                     var response = (await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url))).Content;
                     var data = await response.ReadAsByteArrayAsync();
                     Assert.NotNull(data);
-                    var indexFields = JsonConvert.DeserializeObject<Response>(Encodings.Utf8.GetString(data));
+                    var indexFields = JsonConvert.DeserializeObject<List<FieldDebugInfo>>(Encodings.Utf8.GetString(data));
 
-                    Assert.Equal(2, indexFields.Static.Length);
-                    Assert.Equal(0, indexFields.Dynamic.Length);
-                    
-                    Assert.Contains("id()", indexFields.Static);
+                    Assert.Equal(2, indexFields.Count(x => x.FieldType == IndexFieldType.Static));
+                    Assert.Equal(0, indexFields.Count(x => x.FieldType == IndexFieldType.Dynamic));
+                    var idField = indexFields.FirstOrDefault(x => x.Name == "id()");
+                    Assert.NotNull(idField);
+                    Assert.Equal(IndexFieldType.Static, idField.FieldType);
                 }
             }
         }
     }
     
-    private class Response
-    {
-        public string[] Static { get; set; }
-        public string[] Dynamic { get; set; }
-    }
-
     private class Dto
     {
         public string Name { get; set; }   

--- a/test/SlowTests/Issues/RavenDB_21889.cs
+++ b/test/SlowTests/Issues/RavenDB_21889.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Indexes.Debugging;
 using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
@@ -55,15 +57,16 @@ public class RavenDB_21889 : RavenTestBase
             await Indexes.WaitForIndexingAsync(store, databaseName);
             var fields = await GetFieldsAsync();
 
-            Assert.DoesNotContain(fieldName, fields.Dynamic);
-            Assert.DoesNotContain(fieldName, fields.Static);
+            Assert.DoesNotContain(fieldName, fields.Select(x => x.Name));
 
             await store.Maintenance.ForDatabase(databaseName).SendAsync(new ResetIndexOperation(new Index().IndexName));
             await Indexes.WaitForIndexingAsync(store, databaseName: databaseName);
 
             fields = await GetFieldsAsync();
-            Assert.Contains(fieldName, fields.Dynamic);
-
+            Assert.Contains(fieldName, fields.Select(x=> x.Name));
+            Assert.Equal(IndexFieldType.Dynamic, fields.First(x => x.Name == fieldName).FieldType);
+            
+            
             query = session.Query<Item, Index>()
                 .Customize(x => x.WaitForNonStaleResults())
                 .Search(x => x.FtsField, "\"word3 word2\"")
@@ -72,19 +75,13 @@ public class RavenDB_21889 : RavenTestBase
             Assert.Equal(0, query.Count);
         }
 
-        async Task<Response> GetFieldsAsync()
+        async Task<List<FieldDebugInfo>> GetFieldsAsync()
         {
             var response = (await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url))).Content;
             var data = await response.ReadAsByteArrayAsync();
             Assert.NotNull(data);
-            return JsonConvert.DeserializeObject<Response>(Encodings.Utf8.GetString(data));
+            return JsonConvert.DeserializeObject<List<FieldDebugInfo>>(Encodings.Utf8.GetString(data));
         }
-    }
-
-    private class Response
-    {
-        public string[] Static { get; set; }
-        public string[] Dynamic { get; set; }
     }
 
     private class Item


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24132

### Additional description

Vectors exposed as index terms in base64.
![image](https://github.com/user-attachments/assets/c013bce6-da7a-4875-9cff-ad5dd17520d2)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
