### PR TITLE
RavenDB-24118 Wrong LicenseLimitException type from server

### DIFF
--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Changes;
-using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Util;
@@ -292,7 +291,8 @@ namespace Raven.Client.Documents.Operations
                             Type = exceptionResult.Type,
                             Url = _requestExecutor.Url
                         };
-                        _result.TrySetException(ExceptionDispatcher.Get(ex, exceptionResult.StatusCode));
+
+                        _result.TrySetException(ExceptionDispatcher.Get(ex, exceptionResult.StatusCode, limitType: exceptionResult.LimitType));
                         break;
                     case OperationStatus.Canceled:
                         StopProcessing();

--- a/src/Raven.Client/Documents/Operations/OperationExceptionResult.cs
+++ b/src/Raven.Client/Documents/Operations/OperationExceptionResult.cs
@@ -15,6 +15,8 @@ namespace Raven.Client.Documents.Operations
 
         public HttpStatusCode StatusCode { get; set; } //http status code for special results like 409		
 
+        internal LimitType? LimitType { get; set; } // used for WaitForCompletionAsync when we check for the operation result
+
         public OperationExceptionResult()
         {
             // .ctor required for deserialization
@@ -27,6 +29,7 @@ namespace Raven.Client.Documents.Operations
             Message = exception.Message;
             Error = ExceptionToString(exception);
             StatusCode = statusCode;
+            LimitType = exception is LicenseLimitException lle ? lle.LimitType : null;
         }
 
         public DynamicJsonValue ToJson()
@@ -36,7 +39,8 @@ namespace Raven.Client.Documents.Operations
                 [nameof(Type)] = Type,
                 [nameof(Message)] = Message,
                 [nameof(Error)] = Error,
-                [nameof(StatusCode)] = (int)StatusCode
+                [nameof(StatusCode)] = (int)StatusCode,
+                [nameof(LimitType)] = LimitType,
             };
         }
 

--- a/src/Raven.Client/Documents/Operations/OperationExceptionResult.cs
+++ b/src/Raven.Client/Documents/Operations/OperationExceptionResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using Raven.Client.Exceptions.Commercial;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations
@@ -7,6 +8,8 @@ namespace Raven.Client.Documents.Operations
     public sealed class OperationExceptionResult : IOperationResult
     {
         public string Type { get; set; }
+
+        public LimitType? LicenseLimitSubType { get; set; }
 
         public string Message { get; set; }
 
@@ -23,6 +26,8 @@ namespace Raven.Client.Documents.Operations
         {
             ShouldPersist = shouldBePersistent;
             Type = exception.GetType().FullName;
+            if (exception is LicenseLimitException lle)
+                LicenseLimitSubType = lle.Type;
             Message = exception.Message;
             Error = ExceptionToString(exception);
             StatusCode = statusCode;
@@ -33,6 +38,7 @@ namespace Raven.Client.Documents.Operations
             return new DynamicJsonValue(GetType())
             {
                 [nameof(Type)] = Type,
+                [nameof(LicenseLimitSubType)] = LicenseLimitSubType?.ToString(),
                 [nameof(Message)] = Message,
                 [nameof(Error)] = Error,
                 [nameof(StatusCode)] = (int)StatusCode

--- a/src/Raven.Client/Documents/Operations/OperationExceptionResult.cs
+++ b/src/Raven.Client/Documents/Operations/OperationExceptionResult.cs
@@ -9,8 +9,6 @@ namespace Raven.Client.Documents.Operations
     {
         public string Type { get; set; }
 
-        public LimitType? LicenseLimitSubType { get; set; }
-
         public string Message { get; set; }
 
         public string Error { get; set; }
@@ -26,8 +24,6 @@ namespace Raven.Client.Documents.Operations
         {
             ShouldPersist = shouldBePersistent;
             Type = exception.GetType().FullName;
-            if (exception is LicenseLimitException lle)
-                LicenseLimitSubType = lle.Type;
             Message = exception.Message;
             Error = ExceptionToString(exception);
             StatusCode = statusCode;
@@ -38,7 +34,6 @@ namespace Raven.Client.Documents.Operations
             return new DynamicJsonValue(GetType())
             {
                 [nameof(Type)] = Type,
-                [nameof(LicenseLimitSubType)] = LicenseLimitSubType?.ToString(),
                 [nameof(Message)] = Message,
                 [nameof(Error)] = Error,
                 [nameof(StatusCode)] = (int)StatusCode

--- a/src/Raven.Client/Exceptions/Commercial/LicenseLimitException.cs
+++ b/src/Raven.Client/Exceptions/Commercial/LicenseLimitException.cs
@@ -4,7 +4,7 @@ namespace Raven.Client.Exceptions.Commercial
 {
     public sealed class LicenseLimitException : RavenException
     {
-        public LimitType Type { get; }
+        public LimitType LimitType { get; internal set; }
 
         public LicenseLimitException()
         {
@@ -15,10 +15,10 @@ namespace Raven.Client.Exceptions.Commercial
         {
         }
 
-        public LicenseLimitException(LimitType type, string message)
+        public LicenseLimitException(LimitType limitType, string message)
             : base(message)
         {
-            Type = type;
+            LimitType = limitType;
         }
 
         public LicenseLimitException(string message, Exception e)

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -30,7 +30,7 @@ namespace Raven.Client.Exceptions
             public string Error { get; set; }
         }
 
-        public static Exception Get(ExceptionSchema schema, HttpStatusCode code, Exception inner = null)
+        public static Exception Get(ExceptionSchema schema, HttpStatusCode code, Exception inner = null, LimitType? limitType = null)
         {
             var message = schema.Message;
             var typeAsString = schema.Type;
@@ -63,6 +63,9 @@ namespace Raven.Client.Exceptions
 
             if (typeof(RavenException).IsAssignableFrom(type) == false)
                 return new RavenException(error, exception);
+
+            if (exception is LicenseLimitException lle && limitType != null)
+                lle.LimitType = (LimitType)limitType;
 
             return exception;
         }

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Compilation;
@@ -23,6 +24,8 @@ namespace Raven.Client.Exceptions
             public string Url { get; set; }
 
             public string Type { get; set; }
+
+            public LimitType? LicenseLimitSubType { get; set; }
 
             public string Message { get; set; }
 
@@ -105,8 +108,21 @@ namespace Raven.Client.Exceptions
                 try
                 {
                     var message = schema.Error;
-
-                    exception = (Exception)Activator.CreateInstance(type, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, new[] { message }, null, null);
+                    if (type == typeof(LicenseLimitException) && schema.LicenseLimitSubType != null)
+                    {
+                         exception = (Exception)Activator.CreateInstance(
+                             type,
+                             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                             null,
+                             new object[] { schema.LicenseLimitSubType.Value, message },
+                             null,
+                             null
+                          );
+                    }
+                    else
+                    {
+                        exception = (Exception)Activator.CreateInstance(type, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, new[] { message }, null, null);
+                    }
                 }
                 catch (Exception)
                 {

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -25,8 +25,6 @@ namespace Raven.Client.Exceptions
 
             public string Type { get; set; }
 
-            public LimitType? LicenseLimitSubType { get; set; }
-
             public string Message { get; set; }
 
             public string Error { get; set; }
@@ -108,21 +106,7 @@ namespace Raven.Client.Exceptions
                 try
                 {
                     var message = schema.Error;
-                    if (type == typeof(LicenseLimitException) && schema.LicenseLimitSubType != null)
-                    {
-                         exception = (Exception)Activator.CreateInstance(
-                             type,
-                             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
-                             null,
-                             new object[] { schema.LicenseLimitSubType.Value, message },
-                             null,
-                             null
-                          );
-                    }
-                    else
-                    {
-                        exception = (Exception)Activator.CreateInstance(type, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, new[] { message }, null, null);
-                    }
+                    exception = (Exception)Activator.CreateInstance(type, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, new[] { message }, null, null);
                 }
                 catch (Exception)
                 {
@@ -153,6 +137,10 @@ namespace Raven.Client.Exceptions
                 case BackupAlreadyRunningException backupAlreadyRunningException:
                     json.TryGet(nameof(BackupAlreadyRunningException.OperationId), out backupAlreadyRunningException.OperationId);
                     json.TryGet(nameof(BackupAlreadyRunningException.NodeTag), out backupAlreadyRunningException.NodeTag);
+                    break;
+                case LicenseLimitException licenseLimitException:
+                    if (json.TryGet(nameof(LicenseLimitException.LimitType), out string limitType) && Enum.TryParse(limitType, out LimitType type))
+                        licenseLimitException.LimitType = type;
                     break;
             }
         }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/LicenseLimitWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/LicenseLimitWarning.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
 
         private LicenseLimitWarning(LicenseLimitException licenseLimit)
         {
-            Type = licenseLimit.Type;
+            Type = licenseLimit.LimitType;
             Message = licenseLimit.Message;
         }
 
@@ -34,11 +34,11 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
         {
             var alert = AlertRaised.Create(
                 null,
-                $@"You've reached your license limit ({EnumHelper.GetDescription(licenseLimit.Type)})",
+                $@"You've reached your license limit ({EnumHelper.GetDescription(licenseLimit.LimitType)})",
                 licenseLimit.Message,
                 AlertType.LicenseManager_LicenseLimit,
                 NotificationSeverity.Warning,
-                key: licenseLimit.Type.ToString(),
+                key: licenseLimit.LimitType.ToString(),
                 details: new LicenseLimitWarning(licenseLimit));
 
             notificationCenter.Add(alert, updateExisting: true);

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -215,11 +215,6 @@ namespace Raven.Server
                             [nameof(ExceptionDispatcher.ExceptionSchema.Message)] = e.Message,
                             [nameof(ExceptionDispatcher.ExceptionSchema.Error)] = e.ToString()
                         };
-                        if (e is LicenseLimitException licenseLimitException)
-                        {
-                            djv[nameof(ExceptionDispatcher.ExceptionSchema.LicenseLimitSubType)] = licenseLimitException.Type;
-                        }
-
 
 #if EXCEPTION_ERROR_HUNT
                     var f = Guid.NewGuid() + ".error";
@@ -389,6 +384,10 @@ namespace Raven.Server
             {
                 djv[nameof(BackupAlreadyRunningException.OperationId)] = backupAlreadyRunningException.OperationId;
                 djv[nameof(BackupAlreadyRunningException.NodeTag)] = backupAlreadyRunningException.NodeTag;
+            }
+            if (exception is LicenseLimitException licenseLimitException)
+            {
+                djv[nameof(LicenseLimitException.LimitType)] = licenseLimitException.LimitType;
             }
         }
 

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -215,6 +215,11 @@ namespace Raven.Server
                             [nameof(ExceptionDispatcher.ExceptionSchema.Message)] = e.Message,
                             [nameof(ExceptionDispatcher.ExceptionSchema.Error)] = e.ToString()
                         };
+                        if (e is LicenseLimitException licenseLimitException)
+                        {
+                            djv[nameof(ExceptionDispatcher.ExceptionSchema.LicenseLimitSubType)] = licenseLimitException.Type;
+                        }
+
 
 #if EXCEPTION_ERROR_HUNT
                     var f = Guid.NewGuid() + ".error";

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -826,12 +826,18 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (serverStore.LicenseManager.LicenseStatus.HasExternalReplication == false && databaseRecord.ExternalReplications.Count > 0)
-            throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding External Replication.");
+        {
+            if (databaseRecord.ExternalReplications.All(exRep => exRep.DelayReplicationFor == TimeSpan.Zero))
+                throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding External Replication.");
 
-        if (databaseRecord.ExternalReplications.All(exRep => exRep.DelayReplicationFor == TimeSpan.Zero))
+            throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+        }
+
+        if (serverStore.LicenseManager.LicenseStatus.HasDelayedExternalReplication)
             return;
 
-        throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+        if (databaseRecord.ExternalReplications.Any(exRep => exRep.DelayReplicationFor != TimeSpan.Zero))
+            throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding External Replication.");
     }
 
     private void AssertRavenEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
@@ -923,10 +929,7 @@ public sealed partial class ClusterStateMachine
 
     private void AssertDocumentsCompressionLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
     {
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
-            return;
-
-        if (serverStore.LicenseManager.LicenseStatus.HasDocumentsCompression)
+        if (AssertDocumentsCompression(serverStore, context)) 
             return;
 
         if (databaseRecord.DocumentsCompression == null)
@@ -936,6 +939,14 @@ public sealed partial class ClusterStateMachine
             return;
 
         throw new LicenseLimitException(LimitType.DocumentsCompression, "Your license doesn't support adding Documents Compression feature.");
+    }
+
+    private bool AssertDocumentsCompression(ServerStore serverStore, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return true;
+
+        return serverStore.LicenseManager.LicenseStatus.HasDocumentsCompression;
     }
 
     private void AssertAdditionalAssembliesFromNuGetLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)

--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -103,7 +103,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.SnapshotBackup, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
                 }
             }
@@ -111,8 +111,6 @@ namespace SlowTests.Issues
             {
                 File.Delete(file);
             }
-
-
         }
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
@@ -144,7 +142,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.SnapshotBackup, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
                 }
             }
@@ -195,7 +193,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.ExternalReplication, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
                 }
             }
@@ -209,47 +207,49 @@ namespace SlowTests.Issues
         public async Task ExceptionWhenImportingDelayedExternalReplicationWithProLicense()
         {
             DoNotReuseServer();
-
-            var file = GetTempFileName();
-            var dbName = $"db/{Guid.NewGuid()}";
-            var csName = $"cs/{Guid.NewGuid()}";
-            try
+            using (var server = GetNewServer())
             {
-                using (var store = GetDocumentStore())
+                var file = GetTempFileName();
+                var dbName = $"db/{Guid.NewGuid()}";
+                var csName = $"cs/{Guid.NewGuid()}";
+                try
                 {
-                    var connectionString = new RavenConnectionString
+                    using (var store = GetDocumentStore())
                     {
-                        Name = csName,
-                        Database = dbName,
-                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
-                    };
+                        var connectionString = new RavenConnectionString
+                        {
+                            Name = csName,
+                            Database = dbName,
+                            TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                        };
 
-                    var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
-                    Assert.NotNull(result.RaftCommandIndex);
+                        var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                        Assert.NotNull(result.RaftCommandIndex);
 
-                    var watcher = new ExternalReplication(dbName, csName);
-                    await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                        var watcher = new ExternalReplication(dbName, csName);
+                        await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
 
-                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
-                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                        var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                        await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                    }
+
+                    using (var store = GetDocumentStore())
+                    {
+                        await ChangeLicense(server, RL_COMM);
+
+                        var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                        {
+                            var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                            await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        });
+                        Assert.Equal(LimitType.ExternalReplication, exception.Type);
+                        Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
+                    }
                 }
-
-                using (var store = GetDocumentStore())
+                finally
                 {
-                    await ChangeLicense(Server, RL_COMM);
-
-                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
-                    {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-                    });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
+                    File.Delete(file);
                 }
-            }
-            finally
-            {
-                File.Delete(file);
             }
         }
 
@@ -290,7 +290,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.TimeSeriesRollupsAndRetention, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Time Series Rollups And Retention feature."));
                 }
             }
@@ -326,7 +326,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.DocumentsCompression, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Documents Compression feature."));
                 }
             }
@@ -362,7 +362,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.DocumentsCompression, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Documents Compression feature."));
                 }
             }
@@ -401,7 +401,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.PullReplicationAsSink, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Sink Replication feature."));
                 }
             }
@@ -436,9 +436,8 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.PullReplicationAsHub, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
-                    WaitForUserToContinueTheTest(store);
                 }
             }
             finally
@@ -472,7 +471,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.PullReplicationAsHub, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
                 }
             }
@@ -523,7 +522,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.Equal(LimitType.RavenEtl, exception.Type);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Raven ETL feature."));
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -44,7 +45,6 @@ namespace SlowTests.Issues
                     var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
                     dbrecord.DocumentsCompression.CompressRevisions = false;
                     store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
-
 
                     store.Maintenance.Send(new PutIndexesOperation(new[]
                     {
@@ -103,7 +103,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.SnapshotBackup, exception.Type);
+                    Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
                 }
             }
@@ -111,6 +111,8 @@ namespace SlowTests.Issues
             {
                 File.Delete(file);
             }
+
+
         }
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
@@ -142,7 +144,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.SnapshotBackup, exception.Type);
+                    Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
                 }
             }
@@ -150,8 +152,6 @@ namespace SlowTests.Issues
             {
                 File.Delete(file);
             }
-
-
         }
 
 
@@ -193,7 +193,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.ExternalReplication, exception.Type);
+                    Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
                 }
             }
@@ -210,39 +210,32 @@ namespace SlowTests.Issues
             using (var server = GetNewServer())
             {
                 var file = GetTempFileName();
-                var dbName = $"db/{Guid.NewGuid()}";
+                var dbName = $"cs/{Guid.NewGuid()}";
                 var csName = $"cs/{Guid.NewGuid()}";
                 try
                 {
-                    using (var store = GetDocumentStore())
+                    using (var store1 = GetDocumentStore())
+                    using (var store2 = GetDocumentStore(new Options(){Server = server}))
                     {
-                        var connectionString = new RavenConnectionString
-                        {
-                            Name = csName,
-                            Database = dbName,
-                            TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
-                        };
+                        var connectionString = new RavenConnectionString { Name = csName, Database = dbName, TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" } };
 
-                        var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                        var result = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
                         Assert.NotNull(result.RaftCommandIndex);
 
                         var watcher = new ExternalReplication(dbName, csName);
-                        await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                        await store1.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
 
-                        var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                        var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-                    }
 
-                    using (var store = GetDocumentStore())
-                    {
                         await ChangeLicense(server, RL_COMM);
 
                         var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                         {
-                            var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                            var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                             await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                         });
-                        Assert.Equal(LimitType.ExternalReplication, exception.Type);
+                        Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
                         Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
                     }
                 }
@@ -290,7 +283,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.TimeSeriesRollupsAndRetention, exception.Type);
+                    Assert.Equal(LimitType.TimeSeriesRollupsAndRetention, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Time Series Rollups And Retention feature."));
                 }
             }
@@ -326,7 +319,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.DocumentsCompression, exception.Type);
+                    Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Documents Compression feature."));
                 }
             }
@@ -362,7 +355,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.DocumentsCompression, exception.Type);
+                    Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Documents Compression feature."));
                 }
             }
@@ -401,7 +394,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.PullReplicationAsSink, exception.Type);
+                    Assert.Equal(LimitType.PullReplicationAsSink, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Sink Replication feature."));
                 }
             }
@@ -436,7 +429,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.PullReplicationAsHub, exception.Type);
+                    Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
                 }
             }
@@ -471,7 +464,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.PullReplicationAsHub, exception.Type);
+                    Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
                 }
             }
@@ -522,7 +515,7 @@ namespace SlowTests.Issues
                         var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
-                    Assert.Equal(LimitType.RavenEtl, exception.Type);
+                    Assert.Equal(LimitType.RavenEtl, exception.LimitType);
                     Assert.True(exception.Message.Contains("Your license doesn't support adding Raven ETL feature."));
                 }
             }
@@ -540,6 +533,5 @@ namespace SlowTests.Issues
 
             await server.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
         }
-
     }
 }

--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -451,7 +451,7 @@ namespace SlowTests.Issues
 
             var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId()));
 
-            Assert.Equal(limitType, exception.Type);
+            Assert.Equal(limitType, exception.LimitType);
         }
 
 

--- a/test/SlowTests/Issues/RavenDB-24118.cs
+++ b/test/SlowTests/Issues/RavenDB-24118.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
@@ -25,7 +22,7 @@ namespace SlowTests.Issues
         }
         private const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
 
-        [RavenFactAttribute(RavenTestCategory.Licensing)]
+        [RavenFact(RavenTestCategory.Licensing)]
         public async Task Prevent_Put_Revision()
         {
             DoNotReuseServer();
@@ -33,16 +30,16 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM, store);
+                await PutLicense(Server, RL_COMM);
 
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration)));
-                Assert.Equal(LimitType.RevisionsConfiguration, exception.Type);
+                Assert.Equal(LimitType.RevisionsConfiguration, exception.LimitType);
 
             }
         }
 
-        [RavenFactAttribute(RavenTestCategory.Licensing)]
+        [RavenFact(RavenTestCategory.Licensing)]
         public async Task Prevent_Change_license()
         {
             DoNotReuseServer();
@@ -53,12 +50,12 @@ namespace SlowTests.Issues
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
-                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_COMM, store));
-                Assert.Equal(LimitType.RevisionsConfiguration, exception.Type);
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_COMM));
+                Assert.Equal(LimitType.RevisionsConfiguration, exception.LimitType);
             }
         }
 
-        private static async Task PutLicense(RavenServer leader, string licenseType, DocumentStore store)
+        private static async Task PutLicense(RavenServer leader, string licenseType)
         {
             var license = Environment.GetEnvironmentVariable(licenseType);
             LicenseHelper.TryDeserializeLicense(license, out License li);

--- a/test/SlowTests/Issues/RavenDB-24118.cs
+++ b/test/SlowTests/Issues/RavenDB-24118.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide;
+using Raven.Client.Util;
+using Raven.Server.Commercial;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24118 : RavenTestBase
+    {
+        public RavenDB_24118(ITestOutputHelper output) : base(output)
+        {
+        }
+        private const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
+
+        [RavenFactAttribute(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_Revision()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM, store);
+
+                var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration)));
+                Assert.Equal(LimitType.RevisionsConfiguration, exception.Type);
+
+            }
+        }
+
+        [RavenFactAttribute(RavenTestCategory.Licensing)]
+        public async Task Prevent_Change_license()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+
+                var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_COMM, store));
+                Assert.Equal(LimitType.RevisionsConfiguration, exception.Type);
+            }
+        }
+
+        private static async Task PutLicense(RavenServer leader, string licenseType, DocumentStore store)
+        {
+            var license = Environment.GetEnvironmentVariable(licenseType);
+            LicenseHelper.TryDeserializeLicense(license, out License li);
+
+            await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+        }
+
+        private static async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
+        {
+            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
+                RaftIdGenerator.NewId());
+            await leader.ServerStore.SendToLeaderAsync(command);
+        }
+    }
+}

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -2,13 +2,14 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using Tests.Infrastructure;
+using FastTests.Voron.Util;
 using Raven.Server.Utils;
 using SlowTests.Corax;
-using SlowTests.Sharding.Cluster;
-using Xunit;
-using FastTests.Voron.Util;
+using SlowTests.Issues;
 using SlowTests.Server;
+using SlowTests.Sharding.Cluster;
+using Tests.Infrastructure;
+using Xunit;
 
 namespace Tryouts;
 
@@ -23,18 +24,18 @@ public static class Program
     {
         Console.WriteLine(Process.GetCurrentProcess().Id);
 
-        for (int i = 0; i < 1; i++)
+        for (int i = 0; i < 10; i++)
         {
             Console.WriteLine($"Starting to run {i}");
 
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new RecordingTransactionOperationsMergerTests(testOutputHelper))
+                using (var test = new RavenDB_21273(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
                     //test.CanRoundTripSmallContainer("GreaterThan42B");
-                    await test.RecordingDeleteRevisionsCommand();
+                    await test.ExceptionWhenImportingDelayedExternalReplicationWithProLicense();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24118

### Additional description

Extended the ExceptionSchema to optionally store the sub-type of LicenseLimitException.
This allows us to preserve more detailed information when such exceptions occur.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
