### PR TITLE
RavenDB-24116 Remove DatabaseTopologyIdBase64 from potentialUnusedId

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/useUnusedDatabaseIds.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/unusedDatabaseIds/useUnusedDatabaseIds.ts
@@ -7,6 +7,7 @@ import DatabaseUtils from "components/utils/DatabaseUtils";
 import { useState } from "react";
 import { useAsync, useAsyncCallback } from "react-async-hook";
 import { compareSets } from "common/typeUtils";
+import * as yup from "yup";
 
 interface LocationStats {
     databaseId: string;
@@ -29,10 +30,29 @@ export function useUnusedDatabaseIds() {
     const { databasesService } = useServices();
 
     const [unusedIds, setUnusedIds] = useState<string[]>([]);
+    const [databaseTopologyIdBase64, setDatabaseTopologyIdBase64] = useState<string>("");
 
     const asyncGetUnusedIds = useAsync(
         async () => {
             const databaseRecordDto = await databasesService.getDatabaseRecord(db.name);
+
+            // It's just a document so we need to check if it has Topology.DatabaseTopologyIdBase64
+            try {
+                const dto = yup
+                    .object({
+                        Topology: yup
+                            .object({
+                                DatabaseTopologyIdBase64: yup.string().required(),
+                            })
+                            .required(),
+                    })
+                    .validateSync(databaseRecordDto);
+
+                setDatabaseTopologyIdBase64(dto.Topology.DatabaseTopologyIdBase64);
+            } catch (e) {
+                // ignore
+            }
+
             if ("UnusedDatabaseIds" in databaseRecordDto && Array.isArray(databaseRecordDto.UnusedDatabaseIds)) {
                 return databaseRecordDto.UnusedDatabaseIds;
             }
@@ -102,7 +122,9 @@ export function useUnusedDatabaseIds() {
     );
 
     const usedIds = asyncGetStats.result?.usedIds ?? [];
-    const potentialUnusedId = asyncGetStats.result?.potentialUnusedId ?? [];
+    const potentialUnusedId = (asyncGetStats.result?.potentialUnusedId ?? []).filter(
+        (x) => x !== databaseTopologyIdBase64
+    );
 
     const addUnusedId = (idToAdd: string): boolean => {
         if (unusedIds.includes(idToAdd)) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24116/Unused-database-view-should-not-suggest-the-DatabaseTopologyIdBase64

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
