### PR TITLE
RavenDB-24232 Fixed waiting for index errors in SlowTests.Issues.RavenDB_23909.AlreadyQuantizedVectorShouldThrow

### DIFF
--- a/test/SlowTests/Issues/RavenDB-23909.cs
+++ b/test/SlowTests/Issues/RavenDB-23909.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
-using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
 using SlowTests.Server.Documents.AI.Embeddings;
 using Tests.Infrastructure;
 using Xunit;
@@ -59,18 +60,27 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
                 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                
-                _ = session.Query<Dto>()
-                    .Statistics(out var stats)
-                    .VectorSearch(x => 
-                            x.WithText("Name")
-                                .UsingTask(configuration.Identifier)
-                                .TargetQuantization(VectorEmbeddingType.Binary), 
-                        factory => factory.ByText("fruit"))
-                    .ToList();
-                
-                var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { stats.IndexName }));
 
+                try
+                {
+                    _ = session.Query<Dto>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .VectorSearch(x =>
+                                x.WithText("Name")
+                                    .UsingTask(configuration.Identifier)
+                                    .TargetQuantization(VectorEmbeddingType.Binary),
+                            factory => factory.ByText("fruit"))
+                        .ToList();
+                }
+                catch (Exception ex) when (ex is RavenException { InnerException: InvalidOperationException innerEx }
+                                           && innerEx.Message.Contains("is marked as errored"))
+                {
+                    // Expected exception
+                }
+                
+                Indexes.WaitForIndexing(store, allowErrors: true);
+                var indexErrors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: true);
+                
                 Assert.Single(indexErrors);
                 Assert.Contains("Quantization cannot be performed on already quantized vector.", indexErrors[0].Errors.First().Error);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24232

### Additional description

Fixed waiting for index errors in `SlowTests.Issues.RavenDB_23909.AlreadyQuantizedVectorShouldThrow`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
