### PR TITLE
RavenDB-24036 : Log import/export audit before the operation starts

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForExport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForExport.cs
@@ -35,6 +35,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
 
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
 
+            RequestHandler.LogTaskToAudit(Operations.OperationType.DatabaseExport.ToString(), operationId, configuration: null);
+
             try
             {
                 var startDocumentEtag = RequestHandler.GetLongQueryString("startEtag", false) ?? 0;
@@ -88,8 +90,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
 
                 HttpContext.Abort();
             }
-
-            RequestHandler.LogTaskToAudit(Operations.OperationType.DatabaseExport.ToString(), operationId, configuration: null);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImport.cs
@@ -67,6 +67,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
             var result = new SmugglerResult();
             BlittableJsonReaderObject blittableJson = null;
 
+            RequestHandler.LogTaskToAudit(OperationType.DatabaseImport.ToString(), operationId, configuration: null);
+
             await operations.AddLocalOperation(
                 operationId,
                 OperationType.DatabaseImport,
@@ -134,8 +136,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
                 token: token).ConfigureAwait(false);
 
             await WriteSmugglerResultAsync(context, result, RequestHandler.ResponseBodyStream());
-
-            RequestHandler.LogTaskToAudit(OperationType.DatabaseImport.ToString(), operationId, configuration: null);
         }
 
         private void IgnoreDatabaseItemTypesIfCurrentVersionIsOlderThenClientVersion(JsonOperationContext context, ref BlittableJsonReaderObject blittableJson)

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportDir.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportDir.cs
@@ -40,11 +40,12 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportDir<TRequestHan
 
         files.CompleteAdding();
         operationId ??= GetOperationId();
-        await BulkImport(files, directory, operationId.Value);
 
         if (LoggingSource.AuditLog.IsInfoEnabled)
             RequestHandler.LogAuditFor(RequestHandler.DatabaseName, "IMPORT", $"{EnumHelper.GetDescription(Operations.OperationType.DatabaseImport)} " +
-                                                 $"from directory: '{directory}', files count: '{files.Count}'");
+                                                                              $"from directory: '{directory}', files count: '{files.Count}'");
+
+        await BulkImport(files, directory, operationId.Value);
     }
 
     private async Task BulkImport(BlockingCollection<Func<Task<Stream>>> files, string directory, long operationId)

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Http;
+using Raven.Server.Documents.Operations;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Handlers;
 using Raven.Server.Utils;
+using Raven.Server.Web.System;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.Smuggler;
 
@@ -32,7 +36,15 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
             throw new ArgumentException("'file' or 'url' are mandatory when using GET /smuggler/import");
         }
 
+        var fileParam = HttpContext.Request.Query["file"].FirstOrDefault();
+        var urlParam = HttpContext.Request.Query["url"].FirstOrDefault();
+        var source = fileParam ?? urlParam;
+
         operationId ??= GetOperationId();
+
+        if (LoggingSource.Instance.IsInfoEnabled)
+            RequestHandler.LogAuditFor(
+                RequestHandler.DatabaseName, "IMPORT", $"{EnumHelper.GetDescription(OperationType.DatabaseImport)} from '{source}'");
 
         var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext, RequestHandler.GetAuthorizationStatusForSmuggler(RequestHandler.DatabaseName));
         await using (var file = await GetImportStream())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24036/Import-audit-log-line-is-logged-AFTER-the-import

### Additional description

This change moves the audit-logging call for both import and export operations so that it fires immediately at request start (before any data is streamed or processed) rather than at request end. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Import/export audit entries are now recorded at request start instead of request completion. This only affects audit-log timing and does not change any data processing logic.
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
