### PR TITLE
RavenDB-24294 - workaround for connectivity testing to the model

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
@@ -203,4 +203,27 @@ public sealed class AiConnectionString : ConnectionString
                HuggingFaceSettings ??
                (AbstractAiSettings)MistralAiSettings;
     }
+
+    internal bool TryGetParametersForGenAiTesting(out string uri, out string apiKey, out string model)
+    {
+        uri = null;
+        apiKey = null;
+        model = null;
+
+        var provider = GetActiveProvider();
+        switch (provider)
+        {
+            case AiConnectorType.OpenAi:
+                uri = OpenAiSettings.Endpoint;
+                apiKey = OpenAiSettings.ApiKey;
+                model = OpenAiSettings.Model;
+                return true;
+            case AiConnectorType.Ollama:
+                uri = OllamaSettings.Uri; 
+                model = OllamaSettings.Model;
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Raven.Server/Documents/AI/AbstractChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/AbstractChatCompletionClient.cs
@@ -59,7 +59,7 @@ public abstract class AbstractChatCompletionClient<TContext> : IChatCompletionCl
             }
         });
 
-        _structuredOutputSchema = structuredOutputSchema ?? string.Empty;
+        _structuredOutputSchema = structuredOutputSchema ?? GetSchemaFor("{}");
         _contextPool = contextPool;
     }
 

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsMismatchException.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsMismatchException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Raven.Server.Documents.AI.Embeddings;
+
+public class EmbeddingsMismatchException : Exception
+{
+    public EmbeddingsMismatchException(string message) : base(message)
+    {
+    }
+}

--- a/src/Raven.Server/Documents/AI/GenAi/ChatCompletionClients.cs
+++ b/src/Raven.Server/Documents/AI/GenAi/ChatCompletionClients.cs
@@ -2,6 +2,7 @@
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI.GenAi
 {
@@ -20,6 +21,12 @@ namespace Raven.Server.Documents.AI.GenAi
             model: configuration.Connection.OllamaSettings.Model, apiKey: null, structuredOutputSchema: configuration.JsonSchema, contextPool, conventions)
         {
         }
+    }
 
+    public class GenericChatCompletionClientForTesting : AbstractChatCompletionClient<TransactionOperationContext>
+    {
+        public GenericChatCompletionClientForTesting(string uri, string model, string apiKey, JsonContextPoolBase<TransactionOperationContext> contextPool) : base(new Uri(uri), model, apiKey, structuredOutputSchema: null, contextPool, conventions: DocumentConventions.DefaultForServer)
+        {
+        }
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -5,6 +5,7 @@ using Microsoft.SemanticKernel.Embeddings;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.AI.GenAi;
 using Raven.Server.Documents.Handlers.Processors;
 using Raven.Server.Json;
 using Raven.Server.Web.System;
@@ -79,14 +80,31 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                         throw new ArgumentOutOfRangeException();
                 }
 
-                var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
+                try
+                {
+                    var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
+                    (ITextEmbeddingGenerationService service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
+                    var embeddings = await service.GenerateEmbeddingsAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
 
-                (ITextEmbeddingGenerationService service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
-                var embeddings = await service.GenerateEmbeddingsAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
-
-                if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
-                    throw new Exception(
-                        $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
+                    if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
+                        throw new EmbeddingsMismatchException(
+                            $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
+                }
+                // TODO: remove this ugly workaround
+                catch (Exception e) when (e is not EmbeddingsMismatchException)
+                {
+                    if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model))
+                    {
+                        using (var client = new GenericChatCompletionClientForTesting(uri, model, apiKey, ServerStore.ContextPool))
+                        {
+                            await client.CompleteAsync("foo", "bar", HttpContext.RequestAborted);
+                        }
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
 
                 var result = new DynamicJsonValue { [nameof(NodeConnectionTestResult.Success)] = true };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24294 

### Additional description
 
This is just a workaround for the testing the gen ai connection string

### Type of change

- [x] Workaround
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
