### PR TITLE
RavenDB-24227 - Improve `MaxReadOpsPerSec` testing by computing page read iterations at runtime instead of using hardcoded estimates, with process architecture awareness

### DIFF
--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -85,6 +85,10 @@ namespace Voron.Impl.Backup
                 var env = e.Env;
                 var dataPager = env.Options.DataPager;
                 var copier = new DataCopier(Constants.Storage.PageSize * 16, rateGate);
+
+                if (ForTestingPurposes?.OnBeforeRateGateWaitToProceed != null)
+                    copier.ForTestingPurposesOnly().OnBeforeRateGateWaitToProceed = ForTestingPurposes?.OnBeforeRateGateWaitToProceed;
+
                 Backup(env, compressionAlgorithm, compressionLevel, dataPager, archive, basePath, copier, infoNotify, cancellationToken);
             }
 
@@ -365,6 +369,21 @@ namespace Voron.Impl.Backup
                 return ZstdStream.Decompress(backupStream);
 
             return backupStream;
+        }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal sealed class TestingStuff
+        {
+            internal Action OnBeforeRateGateWaitToProceed;
         }
     }
 }

--- a/src/Voron/Util/DataCopier.cs
+++ b/src/Voron/Util/DataCopier.cs
@@ -61,7 +61,11 @@ namespace Voron.Util
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    _rateGate?.WaitToProceed();
+                    if (_rateGate != null)
+                    {
+                        ForTestingPurposes?.OnBeforeRateGateWaitToProceed?.Invoke();
+                        _rateGate.WaitToProceed();
+                    }
 
                     var pagesToCopy = (int) (i + steps > numberOfPages ? numberOfPages - i : steps);
                     src.EnsureMapped(tempTx, i, pagesToCopy);
@@ -135,6 +139,21 @@ namespace Voron.Util
                                 $"{new Size((long)(totalCopied / totalSecElapsed), SizeUnit.Bytes)}/sec");
 
             Debug.Assert(numberOf4KbsToCopy == 0);
+        }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal sealed class TestingStuff
+        {
+            internal Action OnBeforeRateGateWaitToProceed;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
@@ -268,12 +268,13 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
             switch (BackupType)
             {
                 case BackupType.Snapshot when BackupKind == BackupKind.Full:
-                    return (NumberOfRateGateWaitsToProceed - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
+                    // Minus `MaxReadOpsPerSecToTest` * 2 because rateGate will not wait after the last operation, and we want to have some additional tolerance
+                    return (NumberOfRateGateWaitsToProceed - MaxReadOpsPerSecToTest * 2) / MaxReadOpsPerSecToTest;
 
                 case BackupType.Snapshot when BackupKind == BackupKind.Incremental: // Incremental for snapshot is a logical backup
                 case BackupType.Backup:
-                    // Minus `MaxReadOpsPerSecToTest` because rateGate will not wait after the last operation
-                    return (DocumentsToCreate - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
+                    // Minus `MaxReadOpsPerSecToTest` * 2 because rateGate will not wait after the last operation, and we want to have some additional tolerance
+                    return (DocumentsToCreate - MaxReadOpsPerSecToTest * 2) / MaxReadOpsPerSecToTest;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(BackupType), BackupType, null);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
@@ -3,14 +3,17 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Apis.Util;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Voron.Impl.Backup;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,6 +22,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup;
 public class MaxReadOpsPerSecOptionTests : ClusterTestBase
 {
     private readonly ITestOutputHelper _output;
+    private static readonly string ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString();
 
     public MaxReadOpsPerSecOptionTests(ITestOutputHelper output) : base(output)
     {
@@ -70,7 +74,7 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
         var backupDurationWithMaxReadOps = await scenario.MeasurePeriodicBackupDurationAsync();
 
         scenario.AssertResults(backupDurationWithDefaults, backupDurationWithMaxReadOps);
-        _output.WriteLine($"Backup duration with defaults: {backupDurationWithDefaults}, Backup duration with MaxReadOpsPerSec: {backupDurationWithMaxReadOps}");
+        _output.WriteLine($"Backup duration with defaults: {backupDurationWithDefaults}, Backup duration with MaxReadOpsPerSec: {backupDurationWithMaxReadOps}, process architecture: {ProcessArchitecture}");
     }
 
     [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
@@ -94,7 +98,7 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
         var backupDurationWithMaxReadOps = await scenario.MeasureOneTimeBackupDurationAsync();
 
         scenario.AssertResults(backupDurationWithDefaults, backupDurationWithMaxReadOps);
-        _output.WriteLine($"Backup duration with defaults: {backupDurationWithDefaults}, Backup duration with MaxReadOpsPerSec: {backupDurationWithMaxReadOps}");
+        _output.WriteLine($"Backup duration with defaults: {backupDurationWithDefaults}, Backup duration with MaxReadOpsPerSec: {backupDurationWithMaxReadOps}, process architecture: {ProcessArchitecture}");
     }
 
     [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
@@ -115,7 +119,7 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
         var restoreDurationWithMaxReadOps = scenario.MeasureShardedDatabaseRestoreDuration();
 
         scenario.AssertResults(restoreDurationWithDefaults, restoreDurationWithMaxReadOps);
-        _output.WriteLine($"Restore duration with defaults: {restoreDurationWithDefaults}, Restore duration with MaxReadOpsPerSec: {restoreDurationWithMaxReadOps}");
+        _output.WriteLine($"Restore duration with defaults: {restoreDurationWithDefaults}, Restore duration with MaxReadOpsPerSec: {restoreDurationWithMaxReadOps}, process architecture: {ProcessArchitecture}");
     }
 
     public enum BackupScope
@@ -191,15 +195,15 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
         {
             Assert.True(rateControlledDuration > defaultDuration,
                 $"{OperationName} with MaxReadOpsPerSecond = {MaxReadOpsPerSecToTest} should take more time than {OperationName} with default value, " +
-                $"but it took '{rateControlledDuration}', while with default value took '{defaultDuration}'");
+                $"but it took '{rateControlledDuration}', while with default value took '{defaultDuration}', process architecture: {ProcessArchitecture}");
 
             Assert.True(defaultDuration.TotalSeconds < ExpectedMinimumOperationDurationInSeconds,
                 $"{OperationName} with default options should take less than '{ExpectedMinimumOperationDurationInSeconds}' seconds, but it took " +
-                $"'{defaultDuration}' despite MaxReadOpsPerSecond was not set");
+                $"'{defaultDuration}' despite MaxReadOpsPerSecond was not set, process architecture: {ProcessArchitecture}");
 
             Assert.True(rateControlledDuration.TotalSeconds > ExpectedMinimumOperationDurationInSeconds,
                 $"{OperationName} with MaxReadOpsPerSecond = {MaxReadOpsPerSecToTest} should take more than " +
-                $"'{ExpectedMinimumOperationDurationInSeconds}' seconds, but it took '{rateControlledDuration}'");
+                $"'{ExpectedMinimumOperationDurationInSeconds}' seconds, but it took '{rateControlledDuration}', process architecture: {ProcessArchitecture}");
         }
 
         public void Dispose()
@@ -222,9 +226,40 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
         private PeriodicBackupConfiguration PeriodicBackupConfiguration { get; set; }
         private ServerWideBackupConfiguration ServerWideBackupConfiguration { get; set; }
         internal BackupConfiguration OneTimeBackupConfiguration { get; private set; }
+        private int NumberOfRateGateWaitsToProceed { get; set; }
 
-        protected override int DocumentsToCreate => BackupType == BackupType.Snapshot ? 200 : 150;
-        protected internal override int MaxReadOpsPerSecToTest => BackupType == BackupType.Snapshot ? 16 : 10;
+        private int? _documentsToCreate;
+        protected override int DocumentsToCreate
+        {
+            get
+            {
+                _documentsToCreate ??= RuntimeInformation.ProcessArchitecture switch
+                {
+                    Architecture.X86 or Architecture.Arm => BackupType == BackupType.Snapshot && BackupKind == BackupKind.Full ? 500 : 150,
+                    Architecture.X64 or Architecture.Arm64 => BackupType == BackupType.Snapshot && BackupKind == BackupKind.Full ? 200 : 150,
+                    _ => throw new ArgumentOutOfRangeException(nameof(RuntimeInformation.ProcessArchitecture), "Unsupported architecture.")
+                };
+                return _documentsToCreate.Value;
+            }
+        }
+
+        protected internal override int MaxReadOpsPerSecToTest
+        {
+            get
+            {
+                switch (RuntimeInformation.ProcessArchitecture)
+                {
+                    case Architecture.X86 or Architecture.Arm:
+                        return BackupType == BackupType.Snapshot && BackupKind == BackupKind.Full ? 5 : 10;
+
+                    case Architecture.X64 or Architecture.Arm64:
+                        return BackupType == BackupType.Snapshot && BackupKind == BackupKind.Full ? 16 : 10;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
 
         protected override string OperationName => $"{BackupKind} {(BackupType == BackupType.Backup ? "Logical" : nameof(BackupType.Snapshot))} backup of {DatabaseMode} database";
 
@@ -233,10 +268,7 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
             switch (BackupType)
             {
                 case BackupType.Snapshot when BackupKind == BackupKind.Full:
-                    // Snapshots are created by copying data page by page, rather than one document at a time. Due to specific data storage characteristics,
-                    // creating 200 documents results in 257 pages for the document data. (value obtained experimentally)
-                    // And minus `MaxReadOpsPerSecToTest` because rateGate will not wait after the last operation
-                    return (257 - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
+                    return (NumberOfRateGateWaitsToProceed - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
 
                 case BackupType.Snapshot when BackupKind == BackupKind.Incremental: // Incremental for snapshot is a logical backup
                 case BackupType.Backup:
@@ -254,6 +286,9 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
             {
                 case RavenDatabaseMode.Single when BackupKind == BackupKind.Full:
                     await CreateDocumentsForNonShardedDatabaseAsync();
+
+                    if (BackupType == BackupType.Snapshot)
+                        BackupMethods.Full.ForTestingPurposesOnly().OnBeforeRateGateWaitToProceed = () => NumberOfRateGateWaitsToProceed++;
                     break;
 
                 case RavenDatabaseMode.Sharded when BackupKind == BackupKind.Full:
@@ -356,8 +391,6 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
                     case RavenDatabaseMode.Single:
                         var database = await ClusterTestBase.Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(Store.Database);
                         database.Configuration.Backup.MaxReadOpsPerSecond = MaxReadOpsPerSecToTest;
-
-
                         break;
 
                     case RavenDatabaseMode.Sharded:
@@ -564,9 +597,10 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
             var cw = Stopwatch.StartNew();
 
             using (ClusterTestBase.Sharding.Backup.ReadOnly(BackupPath))
-            using (ClusterTestBase.Backup.RestoreDatabase(Store, RestoreBackupConfiguration));
-
-            return cw.Elapsed;
+            using (ClusterTestBase.Backup.RestoreDatabase(Store, RestoreBackupConfiguration, timeout: TimeSpan.FromMinutes(5)))
+            {
+                return cw.Elapsed;
+            }
         }
 
         public void SetMaxReadOpsPerSecond()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24227
https://issues.hibernatingrhinos.com/issue/RavenDB-24228
https://issues.hibernatingrhinos.com/issue/RavenDB-24229
https://issues.hibernatingrhinos.com/issue/RavenDB-24230
https://issues.hibernatingrhinos.com/issue/RavenDB-24299

### Additional description

Some of our backup tests involving the `MaxReadOpsPerSec` configuration were failing on 32-bit systems due to differences in the number of pages created during snapshot generation.

The root cause was that the test logic assumed a fixed number of pages would be created when inserting a certain number of documents—an assumption that held on 64-bit systems but not on 32-bit ones. On 32-bit systems, memory layout and page allocation patterns differ, leading to a different number of rate-limited read operations and thus invalidating the test’s timing expectations.

To make the test more robust and architecture-independent, the following changes were made:

* **Dynamic read operation tracking**: For snapshot-based backup tests, we now measure the actual number of `RateGate.WaitToProceed()` invocations using a dedicated test-only hook (`OnBeforeRateGateWaitToProceed`). This allows the test to calculate the expected minimum operation duration based on real runtime behavior instead of relying on hardcoded estimates.
* **Architecture-aware test configuration**: The number of test documents and the value of `MaxReadOpsPerSec` are now dynamically chosen based on the current process architecture (`x86`/`x64`) to ensure a realistic and consistent test load across environments.

These improvements make the test suite more reliable across various architectures and reduce false positives caused by differences in paging behavior.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed