### PR TITLE
RavenDB-24376 add additional overloads to IHiLoIdGenerator

### DIFF
--- a/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
@@ -73,9 +73,9 @@ namespace Raven.Client.Documents.Identity
         /// <summary>
         /// Generates the document ID.
         /// </summary>
-        /// <param name="entity">The entity.</param>
+        /// <param name="collectionName">The collection name.</param>
         /// <returns></returns>
-        public virtual async Task<string> GenerateDocumentIdAsync(object entity)
+        public virtual async Task<string> GenerateDocumentIdAsync(string collectionName)
         {
             var result = await GetNextIdAsync().ConfigureAwait(false);
             _forTestingPurposes?.BeforeGeneratingDocumentId?.Invoke();

--- a/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncHiLoIdGenerator.cs
@@ -73,9 +73,22 @@ namespace Raven.Client.Documents.Identity
         /// <summary>
         /// Generates the document ID.
         /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns></returns>
+        [Obsolete("This method is deprecated and will be removed in RavenDB 8.0, use the overload with collectionName instead")]
+        public virtual async Task<string> GenerateDocumentIdAsync(object entity)
+        {
+            var result = await GetNextIdAsync().ConfigureAwait(false);
+            _forTestingPurposes?.BeforeGeneratingDocumentId?.Invoke();
+            return GetDocumentIdFromId(result);
+        }
+
+        /// <summary>
+        /// Generates the document ID.
+        /// </summary>
         /// <param name="collectionName">The collection name.</param>
         /// <returns></returns>
-        public virtual async Task<string> GenerateDocumentIdAsync(string collectionName)
+        public async Task<string> GenerateDocumentIdAsync(string collectionName)
         {
             var result = await GetNextIdAsync().ConfigureAwait(false);
             _forTestingPurposes?.BeforeGeneratingDocumentId?.Invoke();

--- a/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
@@ -25,9 +25,21 @@ namespace Raven.Client.Documents.Identity
 
         public Task<string> GenerateDocumentIdAsync(string database, object entity)
         {
+            var collectionName = Store.Conventions.GetCollectionName(entity);
+            return GenerateDocumentIdAsync(database, collectionName);
+        }
+
+        public Task<string> GenerateDocumentIdAsync(string database, Type type)
+        {
+            var collectionName = Store.Conventions.GetCollectionName(type);
+            return GenerateDocumentIdAsync(database, collectionName);
+        }
+
+        public Task<string> GenerateDocumentIdAsync(string database, string collectionName)
+        {
             database = Store.GetDatabase(database);
             var generator = _generators.GetOrAdd(database, GenerateAsyncMultiTypeHiLoFunc);
-            return generator.GenerateDocumentIdAsync(entity);
+            return generator.GenerateDocumentIdAsync(collectionName);
         }
 
         public Task<long> GenerateNextIdForAsync(string database, object entity)

--- a/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiDatabaseHiLoIdGenerator.cs
@@ -25,8 +25,15 @@ namespace Raven.Client.Documents.Identity
 
         public Task<string> GenerateDocumentIdAsync(string database, object entity)
         {
-            var collectionName = Store.Conventions.GetCollectionName(entity);
-            return GenerateDocumentIdAsync(database, collectionName);
+            // todo: use the collection name overload starting with RavenDB 8.0. See https://github.com/ravendb/ravendb/pull/20692/files#r2127161848
+            // var collectionName = Store.Conventions.GetCollectionName(entity);
+            // return GenerateDocumentIdAsync(database, collectionName);
+
+            database = Store.GetDatabase(database);
+            var generator = _generators.GetOrAdd(database, GenerateAsyncMultiTypeHiLoFunc);
+#pragma warning disable CS0618 // Type or member is obsolete
+            return generator.GenerateDocumentIdAsync(entity);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public Task<string> GenerateDocumentIdAsync(string database, Type type)

--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -33,28 +33,27 @@ namespace Raven.Client.Documents.Identity
             _identityPartsSeparator = Conventions.IdentityPartsSeparator;
         }
 
-        public async Task<string> GenerateDocumentIdAsync(object entity)
+        public async Task<string> GenerateDocumentIdAsync(string collectionName)
         {
             var identityPartsSeparator = Conventions.IdentityPartsSeparator;
             if (_identityPartsSeparator != identityPartsSeparator)
                 await MaybeRefresh(identityPartsSeparator).ConfigureAwait(false);
 
-            var typeTagName = Conventions.GetCollectionName(entity);
-            if (string.IsNullOrEmpty(typeTagName)) //ignore empty tags
+            if (string.IsNullOrEmpty(collectionName)) //ignore empty tags
             {
                 return null;
             }
-            var tag = Conventions.TransformTypeCollectionNameToDocumentIdPrefix(typeTagName);
+            var tag = Conventions.TransformTypeCollectionNameToDocumentIdPrefix(collectionName);
             if (_idGeneratorsByTag.TryGetValue(tag, out var value))
             {
-                return await value.GenerateDocumentIdAsync(entity).ConfigureAwait(false);
+                return await value.GenerateDocumentIdAsync(collectionName).ConfigureAwait(false);
             }
 
             await _generatorLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 if (_idGeneratorsByTag.TryGetValue(tag, out value))
-                    return await value.GenerateDocumentIdAsync(entity).ConfigureAwait(false);
+                    return await value.GenerateDocumentIdAsync(collectionName).ConfigureAwait(false);
 
                 value = CreateGeneratorFor(tag);
                 _idGeneratorsByTag.TryAdd(tag, value);
@@ -64,7 +63,7 @@ namespace Raven.Client.Documents.Identity
                 _generatorLock.Release();
             }
 
-            return await value.GenerateDocumentIdAsync(entity).ConfigureAwait(false);
+            return await value.GenerateDocumentIdAsync(collectionName).ConfigureAwait(false);
         }
 
         private async Task MaybeRefresh(char identityPartsSeparator)
@@ -102,7 +101,7 @@ namespace Raven.Client.Documents.Identity
         public async Task<long> GenerateNextIdForAsync(string collectionName)
         {
             collectionName = Conventions.TransformTypeCollectionNameToDocumentIdPrefix(collectionName);
-            
+
             if (_idGeneratorsByTag.TryGetValue(collectionName, out var value))
             {
                 return (await value.GetNextIdAsync().ConfigureAwait(false)).Id;

--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,6 +32,42 @@ namespace Raven.Client.Documents.Identity
             DbName = dbName;
             Conventions = store.GetRequestExecutor(dbName).Conventions;
             _identityPartsSeparator = Conventions.IdentityPartsSeparator;
+        }
+
+
+        [Obsolete("This method is deprecated and will be removed in RavenDB 8.0, use the overload with collectionName instead")]
+        public async Task<string> GenerateDocumentIdAsync(object entity)
+        {
+            var identityPartsSeparator = Conventions.IdentityPartsSeparator;
+            if (_identityPartsSeparator != identityPartsSeparator)
+                await MaybeRefresh(identityPartsSeparator).ConfigureAwait(false);
+
+            var typeTagName = Conventions.GetCollectionName(entity);
+            if (string.IsNullOrEmpty(typeTagName)) //ignore empty tags
+            {
+                return null;
+            }
+            var tag = Conventions.TransformTypeCollectionNameToDocumentIdPrefix(typeTagName);
+            if (_idGeneratorsByTag.TryGetValue(tag, out var value))
+            {
+                return await value.GenerateDocumentIdAsync(entity).ConfigureAwait(false);
+            }
+
+            await _generatorLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_idGeneratorsByTag.TryGetValue(tag, out value))
+                    return await value.GenerateDocumentIdAsync(entity).ConfigureAwait(false);
+
+                value = CreateGeneratorFor(tag);
+                _idGeneratorsByTag.TryAdd(tag, value);
+            }
+            finally
+            {
+                _generatorLock.Release();
+            }
+
+            return await value.GenerateDocumentIdAsync(entity).ConfigureAwait(false);
         }
 
         public async Task<string> GenerateDocumentIdAsync(string collectionName)
@@ -97,6 +134,7 @@ namespace Raven.Client.Documents.Identity
                 }
             }
         }
+
 
         public async Task<long> GenerateNextIdForAsync(string collectionName)
         {

--- a/src/Raven.Client/Documents/Identity/IHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/IHiLoIdGenerator.cs
@@ -12,5 +12,9 @@ namespace Raven.Client.Documents.Identity
         Task<long> GenerateNextIdForAsync(string database, string collectionName);
 
         Task<string> GenerateDocumentIdAsync(string database, object entity);
+
+        Task<string> GenerateDocumentIdAsync(string database, Type type);
+
+        Task<string> GenerateDocumentIdAsync(string database, string collectionName);
     }
 }

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -152,38 +152,40 @@ namespace FastTests.Client
                 Assert.Equal(count * 4, productsIds.Count);
             }
         }
-        
+
         [RavenFact(RavenTestCategory.ClientApi)]
         public async Task GenerateNextIdAndGenerateDocumentIdUseTheSameHiLoRange()
         {
             using (var store = GetDocumentStore())
             {
-                    // Call GenerateNextIdForAsync methods:
-                    var id1 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User());
-                    Assert.Equal(1, id1);
-                    
-                    var id2 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User)); 
-                    Assert.Equal(2, id2);
+                // Call GenerateNextIdForAsync methods:
+                var id1 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User());
+                Assert.Equal(1, id1);
 
-                    var id3 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users"); 
-                    Assert.Equal(3, id3);
-                    
-                    // Call GenerateDocumentIdAsync:
-                    var fullDocumentId = await store.HiLoIdGenerator.GenerateDocumentIdAsync(null, new User());
-                    Assert.Equal("users/4-A", fullDocumentId);
+                var id2 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User));
+                Assert.Equal(2, id2);
 
-                    using (var session = store.OpenSession())
-                    {
-                        var user = new User();
-                        session.Store(user);
-                        var userId = session.Advanced.GetDocumentId(user); 
-                        Assert.Equal("users/5-A", userId);
-                    }
+                var id3 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users");
+                Assert.Equal(3, id3);
 
-                    var id4 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User());
-                    var id5 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User)); 
-                    var id6 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users"); 
-                    Assert.Equal(8, id6);
+                // Call GenerateDocumentIdAsync:
+                var fullDocumentId4 = await store.HiLoIdGenerator.GenerateDocumentIdAsync(null, new User());
+                var fullDocumentId5 = await store.HiLoIdGenerator.GenerateDocumentIdAsync(null, typeof(User));
+                var fullDocumentId6 = await store.HiLoIdGenerator.GenerateDocumentIdAsync(null, "Users");
+                Assert.Equal("users/4-A", fullDocumentId4);
+
+                using (var session = store.OpenSession())
+                {
+                    var user = new User();
+                    session.Store(user);
+                    var userId = session.Advanced.GetDocumentId(user);
+                    Assert.Equal("users/7-A", userId);
+                }
+
+                var id8 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User());
+                var id9 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User));
+                var id10 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users");
+                Assert.Equal(10, id10);
             }
         }
 
@@ -206,7 +208,7 @@ namespace FastTests.Client
                     session.SaveChanges();
 
                     for (var i = 0; i < 32; i++)
-                        await hiLoKeyGenerator.GenerateDocumentIdAsync(new User());
+                        await hiLoKeyGenerator.GenerateDocumentIdAsync("Users");
                 }
 
                 using (var session = store.OpenSession())
@@ -216,7 +218,7 @@ namespace FastTests.Client
                     Assert.Equal(max, 96);
 
                     //we should be receiving a range of 64 now
-                    await hiLoKeyGenerator.GenerateDocumentIdAsync(new User());
+                    await hiLoKeyGenerator.GenerateDocumentIdAsync("Users");
                 }
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Issues/RavenDB-19659.cs
+++ b/test/SlowTests/Issues/RavenDB-19659.cs
@@ -5,7 +5,6 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Identity;
 using Raven.Server;
 using Raven.Server.Config;
-using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -61,7 +60,7 @@ namespace SlowTests.Issues
                 for (var i = 0; i < 32; i++)
                 {
 
-                    var id = await hiLoKeyGenerator1.GenerateDocumentIdAsync(new User());
+                    var id = await hiLoKeyGenerator1.GenerateDocumentIdAsync("Users");
                     uniqueIds.Add(id);
                 }
 
@@ -83,7 +82,7 @@ namespace SlowTests.Issues
                 {
                     for (var i = 0; i < 31; i++)
                     {
-                        var id = await hiLoKeyGenerator2.GenerateDocumentIdAsync(new User());
+                        var id = await hiLoKeyGenerator2.GenerateDocumentIdAsync("Users");
                         uniqueIds.Add(id);
                     }
                 }
@@ -95,7 +94,7 @@ namespace SlowTests.Issues
                     mre.WaitOne();
                 };
 
-                var generateIdTask = Task.Run(async () => await hiLoKeyGenerator2.GenerateDocumentIdAsync(new User()));
+                var generateIdTask = Task.Run(async () => await hiLoKeyGenerator2.GenerateDocumentIdAsync("Users"));
 
                 using (GetNewServer(new ServerCreationOptions
                 {
@@ -105,7 +104,7 @@ namespace SlowTests.Issues
                     CustomSettings = settings1
                 }))
                 {
-                    var id = await hiLoKeyGenerator2.GenerateDocumentIdAsync(new User());
+                    var id = await hiLoKeyGenerator2.GenerateDocumentIdAsync("Users");
                     uniqueIds.Add(id);
                     mre.Set();
                 }


### PR DESCRIPTION
Closes #20659

### Issue link

#20659 

### Additional description

This change adds overloads to `GenerateDocumentIdAsync` in `IHiLoIdGenerator` to match the existing overloads for `GenerateNextIdForAsync`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

The public interface has changed and custom implementations would also need to implement these new methods. 
Also the signature of `AsyncMultiTypeHiLoIdGenerator` and `AsyncHiLoIdGenerator` have changed and these classes are public, so if somebody relied on that implementation they need to adjust.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
