### PR TITLE
RavenDB-23627 Avoid using a "Loading" report when making promotion decisions.

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1319,9 +1319,9 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
-            if (mentorPrevDbStats.Status == Loading)
+            if (mentorPrevDbStats.Status != Loaded)
             {
-                LogMessage($"Can't promote node {promotable}, previous stats for mentor {mentorNode} show the database is still loading", database: dbName);
+                LogMessage($"Can't promote node {promotable}: the database is not loaded on mentor {mentorNode} in previous stats. Current status: {mentorPrevDbStats.Status}", database: dbName);
                 return (false, null);
             }
             

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1319,6 +1319,12 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
+            if (mentorPrevDbStats.Status == Loading)
+            {
+                LogMessage($"Can't promote node {promotable}, previous stats for mentor {mentorNode} show the database is still loading", database: dbName);
+                return (false, null);
+            }
+            
             if (previous.TryGetValue(promotable, out var promotablePrevClusterStats) == false ||
                 promotablePrevClusterStats.Report.TryGetValue(dbName, out var promotablePrevDbStats) == false)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23627

### Additional description
A dedicated PR is required for v6.2

We had a customer who, while dealing with a database issue, removed one of the nodes from the database group and re-added it.  
The cluster consisted of two nodes, and the data size was over 100GB.

During replication troubleshooting, the customer noticed that the re-added node was sometimes promoted to a member before it had finished receiving all documents.  

I investigated this and was able to reproduce the behavior in an environment where the mentor node was running in a Docker container with 1GB of RAM and a database size of nearly 10GB.  
The steps to reproduce were:
1. Add the mentee node to the database group.  
2. Restart the mentor node.

I found that in some scenarios, the `ClusterObserver` relies on previously reported “Loading” statistics from the mentor node. In such cases, the `LastEtag` is `0`, and the `ClusterObserver` mistakenly interprets it as if the mentor has replicated all the data.

This PR addresses the issue by checking the database status and returning `false` when the status is `"Loading"`.

I also attempted to investigate further and create a test. However, I encountered a challenge: the current codebase seems to promote a node early by design in many cases.  
This was surprising to me, but I assume it was previously discussed and intentionally implemented that way.

In my opinion, promoting a `Promotable` node should only happen explicitly via an admin operation. Many of our customers use a replication factor of 2, and similar scenarios can occur either when a second node is added for the first time or when a node is removed and re-added to address an issue.

When the data size is large, replication can take significant time. During that period, the customer may need to restart the mentor node for unrelated maintenance.  
If that downtime is extended, promoting the mentee node in the meantime can be undesirable and potentially harmful.


### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
