### PR TITLE
RavenDB-24337 Replaced `IncludeNullMatch` in `CoraxBooleanItem` since it is only for streaming queries.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -107,7 +107,7 @@ public struct CoraxBooleanItem : IQueryMatch
                 var existsQuery = indexSearcher.ExistsQuery(field, streamingEnabled: false, forward: true);
                 
                 // matching lucene results, nulls included
-                return indexSearcher.IncludeNullMatch(field, existsQuery, forward: false);
+                return indexSearcher.Or(indexSearcher.TermQuery(field, null), existsQuery);
             }
             
             case (IsLeftUnbounded: true, IsRightUnbounded: false):
@@ -129,7 +129,7 @@ public struct CoraxBooleanItem : IQueryMatch
                     _ => query
                 };
                 
-                return indexSearcher.IncludeNullMatch(field, materializedQuery, false);
+                return indexSearcher.Or(indexSearcher.TermQuery(field, null), materializedQuery);
             }
 
             case (IsLeftUnbounded: false, IsRightUnbounded: false):

--- a/test/SlowTests/Issues/RavenDB-23642.cs
+++ b/test/SlowTests/Issues/RavenDB-23642.cs
@@ -106,7 +106,6 @@ public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
             .WhereBetween(x => x.Textual, null, "aa")
             .ToList();
 
-        WaitForUserToContinueTheTest(store);
         Assert.Equal(3, results.Count);
         Assert.Equal(u0.Id, results[0].Id);
         Assert.Equal(u1.Id, results[1].Id);
@@ -128,6 +127,21 @@ public class RavenDB_23642(ITestOutputHelper output) : RavenTestBase(output)
         results = session.Advanced
             .DocumentQuery<User>()
             .WaitForNonStaleResults()
+            .WhereBetween(x => x.Textual, null, null)
+            .ToList();
+        
+        Assert.Equal(5, results.Count);
+        Assert.Equal(u0.Id, results[0].Id);
+        Assert.Equal(u1.Id, results[1].Id);
+        Assert.Equal(u2.Id, results[2].Id);
+        Assert.Equal(u3.Id, results[3].Id);
+        Assert.Equal(u4.Id, results[4].Id);
+        
+        results = session.Advanced
+            .DocumentQuery<User>()
+            .WaitForNonStaleResults()
+            .WhereExists(x => x.Textual)
+            .AndAlso()
             .WhereBetween(x => x.Textual, null, null)
             .ToList();
         


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24337

### Additional description

IncludeNullMatch is designed only for streaming queries, but it was incorrectly used as a normal querying primitive.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
