### PR TITLE
RavenDB-24317 Lookup<CompactKey> splitting page - dangling reference fix

### DIFF
--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -189,6 +189,17 @@ public sealed partial class CompactTree : IPrepareForCommit
             return GetKey(parent).ToString();
         }
 
+        public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+        {
+            if (ContainerId < 0)
+            {
+                return -1;
+            }
+
+            var term = Container.Get(parent.Llt, ContainerId);
+            return term.ToSpan()[0] & 0xF;
+        }
+
         public override string ToString()
         {
             return Key?.ToString() ?? "ContainerId: " + ContainerId;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -216,8 +216,8 @@ public sealed partial class CompactTree : IPrepareForCommit
             {
                 GetEncodedKey(llt, ContainerId, out keyLenInBits, out keyPtr);
             }
-            
-            var clonedKey = llt.AcquireCompactKey();
+
+            var clonedKey = new CompactKey();
             clonedKey.Initialize(llt);
             clonedKey.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
             return (T)(object)(new CompactKeyLookup(clonedKey));

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -200,6 +200,12 @@ public sealed partial class CompactTree : IPrepareForCommit
             return term.ToSpan()[0] & 0xF;
         }
 
+        public T Clone<T>(Lookup<T> parent) where T : struct, ILookupKey
+        {
+            var key = this.GetKey(parent);
+            return (T)(object)(new CompactKeyLookup(key));
+        }
+
         public override string ToString()
         {
             return Key?.ToString() ?? "ContainerId: " + ContainerId;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -202,8 +202,25 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public T Clone<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            var key = this.GetKey(parent);
-            return (T)(object)(new CompactKeyLookup(key));
+            Debug.Assert(typeof(T) == typeof(CompactKeyLookup));
+            
+            var llt = parent.Llt;
+            byte* keyPtr;
+            int keyLenInBits;
+            if (ContainerId == 0)
+            {
+                keyPtr = null;
+                keyLenInBits = 0;
+            }
+            else
+            {
+                GetEncodedKey(llt, ContainerId, out keyLenInBits, out keyPtr);
+            }
+            
+            var clonedKey = llt.AcquireCompactKey();
+            clonedKey.Initialize(llt);
+            clonedKey.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
+            return (T)(object)(new CompactKeyLookup(clonedKey));
         }
 
         public override string ToString()

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -96,6 +96,11 @@ public struct DoubleLookupKey : ILookupKey
         return 1;
     }
 
+    public T Clone<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+        return (T)(object)new DoubleLookupKey(Value);
+    }
+
     public int CompareTo<T>(T l) where T : ILookupKey
     {
         if (typeof(T) != typeof(DoubleLookupKey))

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -91,6 +91,11 @@ public struct DoubleLookupKey : ILookupKey
         return ToString();
     }
 
+    public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+        return 1;
+    }
+
     public int CompareTo<T>(T l) where T : ILookupKey
     {
         if (typeof(T) != typeof(DoubleLookupKey))

--- a/src/Voron/Data/Lookups/ILookupKey.cs
+++ b/src/Voron/Data/Lookups/ILookupKey.cs
@@ -26,4 +26,6 @@ public interface ILookupKey
     void OnKeyRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey;
     
     string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey;
+
+    int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey;
 }

--- a/src/Voron/Data/Lookups/ILookupKey.cs
+++ b/src/Voron/Data/Lookups/ILookupKey.cs
@@ -28,4 +28,6 @@ public interface ILookupKey
     string ToString<T>(Lookup<T> parent) where T : struct, ILookupKey;
 
     int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey;
+    
+    T Clone<T>(Lookup<T> parent) where T : struct, ILookupKey;
 }

--- a/src/Voron/Data/Lookups/Int64LookupKey.cs
+++ b/src/Voron/Data/Lookups/Int64LookupKey.cs
@@ -82,6 +82,11 @@ public struct Int64LookupKey : ILookupKey
         return ToString();
     }
 
+    public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+        return 1;
+    }
+
     public Int64LookupKey(long value)
     {
         Value = value;

--- a/src/Voron/Data/Lookups/Int64LookupKey.cs
+++ b/src/Voron/Data/Lookups/Int64LookupKey.cs
@@ -86,6 +86,11 @@ public struct Int64LookupKey : ILookupKey
     {
         return 1;
     }
+    
+    public T Clone<T>(Lookup<T> parent) where T : struct, ILookupKey
+    {
+        return (T)(object)new Int64LookupKey(Value);
+    }
 
     public Int64LookupKey(long value)
     {

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -674,7 +674,6 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
 
     private void RemovePageFromParent(ref CursorState destinationState, ref CursorState parent)
     {
-        
         // can just remove the whole thing
         int position = parent.LastSearchPosition == 0 ? 1 : parent.LastSearchPosition - 1;
         if (position < 0 || position >= parent.Header->NumberOfEntries)
@@ -994,15 +993,31 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             
             if (state.Header->IsBranch) // we cannot allow a branch with a single element, steal another one
             {
-                DecodeEntry(ref state, state.Header->NumberOfEntries - 1, out var k, out var v);
-                RemoveFromPage(allowRecurse: false, state.Header->NumberOfEntries - 1, isExplicitRemove: false);
+                var entryPosition = state.Header->NumberOfEntries - 1;
+                DecodeEntry(ref state, entryPosition, out var k, out var v);
+                splitMarker = TLookupKey.FromLong<TLookupKey>(k);
+
+                if (splitMarker.GetTermRefCount(this) == 1)
+                {
+                    // When we're using CompactKeys, we need to ensure that the key won't be lost
+                    // after calling RemoveFromPage down below.
+                    // This may happen when our term has only 1 term reference (exists only as leaf/branch key
+                    // but actual Key-Value is already removed).
+                    // The `Clone` method itself does not clone the key on the disk
+                    // but rather reads the actual data into the memory.
+                    // In such a scenario, the upper caller will take care of writing it to disk
+                    // again (since ContainerId is invalid).
+                    // This is not duplicating the key it since it's removed in this method.
+                    splitMarker = splitMarker.Clone(this);
+                }
+                
+                RemoveFromPage(allowRecurse: false, entryPosition, isExplicitRemove: false);
                 // the first item in a branch is always the smallest
                 var prevEntryLen = EncodeEntry(newPageState.Header, TLookupKey.MinValue, v, entryBufferPtr);
                 AddEntryToPage(ref newPageState, prevEntryLen, entryBufferPtr, isUpdate: false);
          
                 newPageState.LastSearchPosition++;
                 
-                splitMarker = TLookupKey.FromLong<TLookupKey>(k);
             }
             
             var entryLength = EncodeEntry(newPageState.Header, causeForSplit.ToLong(), valueForSplit, entryBufferPtr);

--- a/src/Voron/Debugging/DebugStuff.cs
+++ b/src/Voron/Debugging/DebugStuff.cs
@@ -337,7 +337,7 @@ namespace Voron.Debugging
                 {
                     if (i % steps == 0)
                     {
-                        sw.Write($"<li>{lookupKey.ToString(tree)} --> {val}</li>");
+                        sw.Write($"<li>{lookupKey.ToString(tree)} --> {val} (RefCount: {lookupKey.GetTermRefCount(tree)})</li>");
                     }
                 }
                 else

--- a/test/SlowTests/Voron/CompactTrees/RavenDB_24317.cs
+++ b/test/SlowTests/Voron/CompactTrees/RavenDB_24317.cs
@@ -1,0 +1,42 @@
+﻿using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron.Data.CompactTrees;
+using Voron.Impl;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.CompactTrees;
+
+public class RavenDB_24317(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CanSplitLastLeafWhenTermExistsOnlyAsLeafKey()
+    {
+        const string rootTreeName = nameof(RavenDB_24317);
+        const string compactTreeName = nameof(CanSplitLastLeafWhenTermExistsOnlyAsLeafKey);
+
+
+        using (var wTx = GetWriteTransaction(out var compactTree))
+        {
+            for (int i = 0; i < 1_000_000; ++i)
+            {
+                compactTree.Add(GetKey(i), i);
+                if (i == 965_643)
+                {
+                    compactTree.TryRemove(GetKey(964_585), out _);
+                }
+            }
+            
+            wTx.Commit();
+        }
+        
+        Transaction GetWriteTransaction(out CompactTree compactTree)
+        {
+            var wTx = Env.WriteTransaction();
+            var rootTree = wTx.CreateTree(rootTreeName);
+            compactTree = rootTree.CompactTreeFor(compactTreeName);
+            return wTx;
+        }
+        
+        string GetKey(int keyAsInt) => keyAsInt.ToString().PadLeft(totalWidth: 64, '0');
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24317 

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
