### PR TITLE
RavenDB-24269 License limit alerts are being displayed even though Sorter/Analyzer is not yet created

### DIFF
--- a/src/Raven.Studio/typescript/components/common/customAnalyzers/useCustomAnalyzers.ts
+++ b/src/Raven.Studio/typescript/components/common/customAnalyzers/useCustomAnalyzers.ts
@@ -3,17 +3,25 @@ import { useState } from "react";
 
 export interface CustomAnalyzer extends CustomAnalyzerFormData {
     id: string;
+    isSaved: boolean;
 }
 
 export function useCustomAnalyzers() {
     const [analyzers, setAnalyzers] = useState<CustomAnalyzer[]>([]);
 
     const addNewAnalyzer = () => {
-        setAnalyzers((prev) => [{ id: createId(), name: "", code: "" } satisfies CustomAnalyzer, ...prev]);
+        setAnalyzers((prev) => [
+            { id: createId(), name: "", code: "", isSaved: false } satisfies CustomAnalyzer,
+            ...prev,
+        ]);
     };
 
     const removeAnalyzer = (idx: number) => {
         setAnalyzers((prev) => prev.filter((_, i) => i !== idx));
+    };
+
+    const markAsSaved = (idx: number) => {
+        setAnalyzers((prev) => prev.map((x, i) => (i === idx ? { ...x, isSaved: true } : x)));
     };
 
     return {
@@ -22,11 +30,12 @@ export function useCustomAnalyzers() {
         addNewAnalyzer,
         removeAnalyzer,
         mapFromDto,
+        markAsSaved,
     };
 }
 
 function mapFromDto(dto: Raven.Client.Documents.Indexes.Analysis.AnalyzerDefinition[]): CustomAnalyzer[] {
-    return dto.map((x) => ({ id: createId(), code: x.Code, name: x.Name }) satisfies CustomAnalyzer);
+    return dto.map((x) => ({ id: createId(), code: x.Code, name: x.Name, isSaved: true }) satisfies CustomAnalyzer);
 }
 
 function createId() {

--- a/src/Raven.Studio/typescript/components/common/customSorters/useCustomSorters.ts
+++ b/src/Raven.Studio/typescript/components/common/customSorters/useCustomSorters.ts
@@ -3,17 +3,22 @@ import { useState } from "react";
 
 export interface CustomSorter extends CustomSorterFormData {
     id: string;
+    isSaved: boolean;
 }
 
 export function useCustomSorters() {
     const [sorters, setSorters] = useState<CustomSorter[]>([]);
 
     const addNewSorter = () => {
-        setSorters((prev) => [{ id: createId(), name: "", code: "" } satisfies CustomSorter, ...prev]);
+        setSorters((prev) => [{ id: createId(), name: "", code: "", isSaved: false } satisfies CustomSorter, ...prev]);
     };
 
     const removeSorter = (idx: number) => {
         setSorters((prev) => prev.filter((_, i) => i !== idx));
+    };
+
+    const markAsSaved = (idx: number) => {
+        setSorters((prev) => prev.map((x, i) => (i === idx ? { ...x, isSaved: true } : x)));
     };
 
     return {
@@ -22,11 +27,12 @@ export function useCustomSorters() {
         addNewSorter,
         removeSorter,
         mapFromDto,
+        markAsSaved,
     };
 }
 
 function mapFromDto(dto: Raven.Client.Documents.Queries.Sorting.SorterDefinition[]): CustomSorter[] {
-    return dto.map((x) => ({ id: createId(), code: x.Code, name: x.Name }) satisfies CustomSorter);
+    return dto.map((x) => ({ id: createId(), code: x.Code, name: x.Name, isSaved: true }) satisfies CustomSorter);
 }
 
 function createId() {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
@@ -28,7 +28,7 @@ export default function DatabaseCustomAnalyzers() {
 
     const { databasesService, manageServerService } = useServices();
 
-    const { analyzers, setAnalyzers, addNewAnalyzer, removeAnalyzer, mapFromDto } = useCustomAnalyzers();
+    const { analyzers, setAnalyzers, addNewAnalyzer, removeAnalyzer, mapFromDto, markAsSaved } = useCustomAnalyzers();
 
     // Changing the database causes re-mount
     const asyncGetDatabaseAnalyzers = useAsync(() => databasesService.getCustomAnalyzers(db.name), [], {
@@ -52,7 +52,7 @@ export default function DatabaseCustomAnalyzers() {
     const numberOfCustomAnalyzersInCluster = useAppSelector(licenseSelectors.limitsUsage).NumberOfAnalyzersInCluster;
     const hasServerWideCustomAnalyzers = useAppSelector(licenseSelectors.statusValue("HasServerWideAnalyzers"));
 
-    const databaseResultsCount = analyzers.length;
+    const databaseResultsCount = analyzers.filter((x) => x.isSaved).length;
     const serverWideResultsCount = asyncGetServerWideAnalyzers.result?.length ?? null;
 
     const databaseLimitReachStatus = getLicenseLimitReachStatus(databaseResultsCount, licenseDatabaseLimit);
@@ -112,6 +112,7 @@ export default function DatabaseCustomAnalyzers() {
                         reload={asyncGetDatabaseAnalyzers.execute}
                         serverWideAnalyzerNames={asyncGetServerWideAnalyzers.result?.map((x) => x.Name) ?? []}
                         remove={removeAnalyzer}
+                        markAsSaved={markAsSaved}
                     />
 
                     <HrHeader

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersList.tsx
@@ -12,10 +12,11 @@ interface DatabaseCustomAnalyzersListProps {
     reload: () => void;
     serverWideAnalyzerNames: string[];
     remove: (idx: number) => void;
+    markAsSaved: (idx: number) => void;
 }
 
 export default function DatabaseCustomAnalyzersList(props: DatabaseCustomAnalyzersListProps) {
-    const { analyzers, fetchStatus, reload, remove, serverWideAnalyzerNames } = props;
+    const { analyzers, fetchStatus, reload, remove, serverWideAnalyzerNames, markAsSaved } = props;
 
     if (fetchStatus === "loading") {
         return <LoadingView />;
@@ -35,6 +36,7 @@ export default function DatabaseCustomAnalyzersList(props: DatabaseCustomAnalyze
             initialAnalyzer={analyzer}
             serverWideAnalyzerNames={serverWideAnalyzerNames}
             remove={() => remove(idx)}
+            markAsSaved={() => markAsSaved(idx)}
         />
     ));
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersListItem.tsx
@@ -39,10 +39,11 @@ interface DatabaseCustomAnalyzersListItemProps {
     initialAnalyzer: CustomAnalyzerFormData;
     serverWideAnalyzerNames: string[];
     remove: () => void;
+    markAsSaved: () => void;
 }
 
 export default function DatabaseCustomAnalyzersListItem(props: DatabaseCustomAnalyzersListItemProps) {
-    const { initialAnalyzer, serverWideAnalyzerNames, remove } = props;
+    const { initialAnalyzer, serverWideAnalyzerNames, remove, markAsSaved } = props;
     const form = useForm<CustomAnalyzerFormData>({
         resolver: customAnalyzerYupResolver,
         defaultValues: initialAnalyzer,
@@ -79,6 +80,7 @@ export default function DatabaseCustomAnalyzersListItem(props: DatabaseCustomAna
                 Name: formData.name,
                 Code: formData.code,
             });
+            markAsSaved();
             toggleIsEditMode();
             reset(formData);
             throttledUpdateLicenseLimitsUsage();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
@@ -29,7 +29,7 @@ export default function DatabaseCustomSorters() {
 
     const { databasesService, manageServerService } = useServices();
 
-    const { sorters, setSorters, addNewSorter, removeSorter, mapFromDto } = useCustomSorters();
+    const { sorters, setSorters, addNewSorter, removeSorter, mapFromDto, markAsSaved } = useCustomSorters();
 
     // Changing the database causes re-mount
     const asyncGetDatabaseSorters = useAsync(() => databasesService.getCustomSorters(db.name), [], {
@@ -53,7 +53,7 @@ export default function DatabaseCustomSorters() {
     const numberOfCustomSortersInCluster = useAppSelector(licenseSelectors.limitsUsage).NumberOfCustomSortersInCluster;
     const hasServerWideCustomSorters = useAppSelector(licenseSelectors.statusValue("HasServerWideCustomSorters"));
 
-    const databaseResultsCount = sorters.length;
+    const databaseResultsCount = sorters.filter((x) => x.isSaved).length;
     const serverWideResultsCount = asyncGetServerWideSorters.result?.length ?? null;
 
     const databaseLimitReachStatus = getLicenseLimitReachStatus(databaseResultsCount, licenseDatabaseLimit);
@@ -119,6 +119,7 @@ export default function DatabaseCustomSorters() {
                     reload={asyncGetDatabaseSorters.execute}
                     serverWideSorterNames={asyncGetServerWideSorters.result?.map((x) => x.Name) ?? []}
                     remove={removeSorter}
+                    markAsSaved={markAsSaved}
                 />
 
                 <HrHeader

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersList.tsx
@@ -12,10 +12,11 @@ interface DatabaseCustomSortersListProps {
     reload: () => void;
     serverWideSorterNames: string[];
     remove: (idx: number) => void;
+    markAsSaved: (idx: number) => void;
 }
 
 export default function DatabaseCustomSortersList(props: DatabaseCustomSortersListProps) {
-    const { sorters, fetchStatus, reload, remove, serverWideSorterNames } = props;
+    const { sorters, fetchStatus, reload, remove, serverWideSorterNames, markAsSaved } = props;
 
     if (fetchStatus === "loading") {
         return <LoadingView />;
@@ -35,6 +36,7 @@ export default function DatabaseCustomSortersList(props: DatabaseCustomSortersLi
             initialSorter={sorter}
             serverWideSorterNames={serverWideSorterNames}
             remove={() => remove(idx)}
+            markAsSaved={() => markAsSaved(idx)}
         />
     ));
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersListItem.tsx
@@ -41,10 +41,11 @@ interface DatabaseCustomSortersListItemProps {
     initialSorter: CustomSorterFormData;
     serverWideSorterNames: string[];
     remove: () => void;
+    markAsSaved: () => void;
 }
 
 export default function DatabaseCustomSortersListItem(props: DatabaseCustomSortersListItemProps) {
-    const { initialSorter, serverWideSorterNames, remove } = props;
+    const { initialSorter, serverWideSorterNames, remove, markAsSaved } = props;
 
     const form = useForm<CustomSorterFormData>({
         resolver: customSorterYupResolver,
@@ -83,7 +84,7 @@ export default function DatabaseCustomSortersListItem(props: DatabaseCustomSorte
                 Name: formData.name,
                 Code: formData.code,
             });
-
+            markAsSaved();
             toggleIsEditMode();
             reset(formData);
             throttledUpdateLicenseLimitsUsage();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24269

### Additional description

Count only saved items to show license limit.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
