### PR TITLE
RavenDB-23729 - revert changes made in https://github.com/ravendb/ravendb/pull/20117

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -702,21 +702,6 @@ namespace Raven.Server.Documents.Replication
                 // be able to tell (roughly) where it is at on the entire cluster.
                 databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(documentsContext);
                 currentLastEtagMatchingChangeVector = DocumentsStorage.ReadLastEtag(documentsContext.Transaction.InnerTransaction);
-
-                if (currentLastEtagMatchingChangeVector > lastDocumentEtag)
-                {
-                    // RavenDB-19152
-                    // preventing the potential risk of skipping documents in internal replication:
-                    // if this database's current Etag is higher than the one received from the source, we avoid sending it as-is.
-                    // otherwise, when this database later replicates back to the source, it may skip sending 
-                    // certain documents—particularly conflicted revisions when 'ResolveToLatest' is `true` 
-                    // (which is the default setting) in the Conflict Resolution Configuration—because the 
-                    // resolved change vector is a merged result of the original conflicting documents' 
-                    // change vectors, while this database’s Etag continues increasing.
-
-                    var etagFromChangeVector = ChangeVectorUtils.GetEtagById(databaseChangeVector, _database.DbBase64Id);
-                    currentLastEtagMatchingChangeVector = etagFromChangeVector > 0 ? etagFromChangeVector : lastDocumentEtag;
-                }
             }
 
             if (_log.IsInfoEnabled)

--- a/test/SlowTests/Issues/RavenDB-19152.cs
+++ b/test/SlowTests/Issues/RavenDB-19152.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Cluster)]
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Replication | RavenTestCategory.Cluster, Skip = "Skip until RavenDB-21796 is resolved (revision schema upgrade)")]
         public async Task ShouldNotSkipConflictedRevisions_InternalReplication()
         {
             var cluster = await CreateRaftCluster(3);
@@ -193,7 +193,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Cluster)]
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Cluster, Skip = "Skip until RavenDB-21796 is resolved (revision schema upgrade)")]
         public async Task ShouldUpdateSiblingsChangeVector()
         {
             var cluster = await CreateRaftCluster(3, watcherCluster: true, leaderIndex: 0);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23729/SlowTests.Issues.RavenDB21263.RestoreFromSnapshotShouldNotThrowCluster
https://issues.hibernatingrhinos.com/issue/RavenDB-23746/SlowTests.Issues.RavenDB19152.ShouldUpdateSiblingsChangeVector

### Additional description

This reverts the changes made in https://github.com/ravendb/ravendb/pull/20117.
The original fix was based on using `Etag` from the source, which led to incorrect behavior and potential data inconsistencies.

The main concern with using the `Etag` from the source (`lastAcceptedEtag`) is that it doesn't necessarily reflect what the destination node has actually persisted. 
For example, in a cluster with multiple nodes, each one might return a different `Etag` based on what it accepted — leading to inconsistencies and potentially skipping revisions.

While I can’t point to a specific scenario where this caused an issue, the `Etag` we return should always reflect the destination node’s state, not the source’s.

Since the fix was invalid, we are:
- Reverting the code changes to the original logic
- Deleting tests that were added specifically to validate the incorrect behavior 

A proper solution will be implemented as part of the upcoming revisions schema upgrade (https://issues.hibernatingrhinos.com/issue/RavenDB-21577/Revision-schema-upgrade-Create-index-on-the-last-modified), which will introduce change vectors for revisions and enable accurate tracking during replication.


### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
