### PR TITLE
RavenDB-24185 NativeList<T>: better memory allocation size and maximum capacity tracking.

### DIFF
--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -21,6 +21,7 @@ public unsafe struct NativeList<T>
 {
     // We're using ByteStringContext to allocate the underlying storage, and we've to take into account the overhead of the metadata.
     private static readonly int MaxCapacity = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(T);
+    private static readonly int MaxCapacityInBytes = MaxCapacity * sizeof(T);
     private ByteString _storage;
 
     public T* RawItems => Capacity > 0 ? (T*)_storage.Ptr : null;
@@ -130,7 +131,7 @@ public unsafe struct NativeList<T>
 
         var newSize = count == 1 ? 
             sizeof(T) 
-            : Math.Max(sizeof(T), Bits.NextAllocationSize(sizeof(T) * count));
+            : Math.Max(sizeof(T), Math.Min(MaxCapacityInBytes, Bits.NextAllocationSize(sizeof(T) * count)));
        
         if (newSize <= 0)
             ThrowMaxCapacityExceeded(count);
@@ -144,7 +145,8 @@ public unsafe struct NativeList<T>
         if (addition > MaxCapacity - Capacity)
             ThrowMaxCapacityExceeded(addition + (long)Capacity);
 
-        var newSize = Math.Max(sizeof(T), Bits.NextAllocationSize(sizeof(T) * (addition + Capacity)));
+        var newSize = Math.Max(sizeof(T), 
+            Math.Min(MaxCapacityInBytes, Bits.NextAllocationSize(sizeof(T) * (addition + Capacity))));
         ctx.Allocate(newSize, out var mem);
 
         if (_storage.HasValue)

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -19,7 +19,8 @@ namespace Voron.Util;
 public unsafe struct NativeList<T>
     where T: unmanaged
 {
-    private static readonly int MaxCapacity = int.MaxValue / sizeof(T);
+    // We're using ByteStringContext to allocate the underlying storage, and we've to take into account the overhead of the metadata.
+    private static readonly int MaxCapacity = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(T);
     private ByteString _storage;
 
     public T* RawItems => Capacity > 0 ? (T*)_storage.Ptr : null;
@@ -121,26 +122,30 @@ public unsafe struct NativeList<T>
 
         Count = newSize;
     }
-
+    
     public void Initialize(ByteStringContext ctx, int count = 1)
     {
-        var capacity = count == 1 ? 1 : Math.Max(1, Bits.NextAllocationSize(count));
-        
-        if (capacity > MaxCapacity)
-            ThrowMaxCapacityExceeded(capacity);
-        
-        ctx.Allocate(capacity * sizeof(T), out _storage);
+        if (count > MaxCapacity)
+            ThrowMaxCapacityExceeded(count);
+
+        var newSize = count == 1 ? 
+            sizeof(T) 
+            : Math.Max(sizeof(T), Bits.NextAllocationSize(sizeof(T) * count));
+       
+        if (newSize <= 0)
+            ThrowMaxCapacityExceeded(count);
+            
+        ctx.Allocate(newSize, out _storage);
         Capacity = _storage.Length / sizeof(T);
     }
     
     public void Grow(ByteStringContext ctx, int addition)
     {
-        var capacity = Math.Max(1, Bits.NextAllocationSize(Capacity + addition));
-        
-        if (capacity > MaxCapacity)
-            ThrowMaxCapacityExceeded(capacity);
-        
-        ctx.Allocate(capacity * sizeof(T), out var mem);
+        if (addition > MaxCapacity - Capacity)
+            ThrowMaxCapacityExceeded(addition + (long)Capacity);
+
+        var newSize = Math.Max(sizeof(T), Bits.NextAllocationSize(sizeof(T) * (addition + Capacity)));
+        ctx.Allocate(newSize, out var mem);
 
         if (_storage.HasValue)
         {
@@ -219,9 +224,9 @@ public unsafe struct NativeList<T>
         Count = 0;
     }
     
-    private static void ThrowMaxCapacityExceeded(int requestedSize)
+    private static void ThrowMaxCapacityExceeded(long requestedSize)
     {
-        throw new InvalidOperationException($"{nameof(NativeList<T>)} cannot be larger than {MaxCapacity} items. Requested size: {requestedSize})");
+        throw new InvalidOperationException($"{nameof(NativeList<T>)}<{typeof(T).FullName}> cannot be larger than {MaxCapacity} items. Requested size: {requestedSize}");
     }
 
     public Enumerator GetEnumerator() => new(RawItems, Count);

--- a/test/SlowTests/Voron/RavenDB-24185.cs
+++ b/test/SlowTests/Voron/RavenDB-24185.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using FastTests;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Voron.Util;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron;
+
+public class RavenDB_24185(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
+    public void ThrowWhenNativeListHasCapacityHigherThanPossibleOnInit()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        var nextCapacity = (int.MaxValue / sizeof(long)) + 1;
+        var nativeList = new NativeList<long>();
+        var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Initialize(allocator, nextCapacity));
+        Assert.Equal("NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: 268435456", ex.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
+    public void ThrowWhenNativeListHasCapacityHigherThanPossibleOnGrow()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        var nativeList = new NativeList<long>();
+        nativeList.Initialize(allocator);
+
+        var nextCapacity = (int.MaxValue / sizeof(long));
+        var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Grow(allocator, nextCapacity));
+        Assert.Equal("NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: 268435456", ex.Message);
+    }
+    
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
+    public void ThrowWhenNativeListHasCapacityHigherThanPossibleOnInitMaximum()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        var nativeList = new NativeList<long>();
+        var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Initialize(allocator, int.MaxValue / sizeof(long)));
+        
+        Assert.Equal($"NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: {int.MaxValue / sizeof(long)}", ex.Message);
+    }
+}

--- a/test/SlowTests/Voron/RavenDB-24185.cs
+++ b/test/SlowTests/Voron/RavenDB-24185.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FastTests;
+using Sparrow.Binary;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Tests.Infrastructure;
@@ -41,5 +42,14 @@ public class RavenDB_24185(ITestOutputHelper output) : NoDisposalNeeded(output)
         var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Initialize(allocator, int.MaxValue / sizeof(long)));
         
         Assert.Equal($"NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: {int.MaxValue / sizeof(long)}", ex.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
+    public unsafe void EnsureThatNextBitsSizeIsNotLimitingCapacityDueToAligning()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        var maxSize = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(long);
+        var nativeList = new NativeList<long>();
+        nativeList.Initialize(allocator, maxSize - 1);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24185

### Additional description

#### `NativeList<T>`:
- Calculate allocation size by actually requested amount of bytes instead relying on the capacity.
- Taking maximum possible amount of bytes we can allocate via `ByteStringContext`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
