### PR TITLE
RavenDB-24204 : GenAI - require providing a unique identifier in configuration

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -9,8 +9,8 @@ namespace Raven.Client.Documents.Operations.AI;
 
 public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 {
-    public override string GetDestination() => Name;
-    public override string GetDefaultTaskName() => Name;
+    public override string GetDestination() => Identifier;
+    public override string GetDefaultTaskName() => Identifier;
 
     public string Identifier { get; set; }
     public string Collection { get; set; }
@@ -95,6 +95,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
     {
         var json = base.ToJson();
 
+        json[nameof(Identifier)] = Identifier;
         json[nameof(AiConnectorType)] = AiConnectorType;
         json[nameof(Identifier)] = Identifier;
         json[nameof(Collection)] = Collection;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -18,7 +18,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 {
     private readonly List<GenAiResultItem> _items;
     private readonly PatchRequest _patchRequest;
-    private readonly string _taskName;
+    private readonly string _taskIdentifier;
     private readonly RavenLogger _logger;
     private readonly EtlProcessStatistics _statistics;
     private readonly DocumentDatabase _database;
@@ -26,7 +26,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
     public GenAiBatchPatchCommand(DocumentsOperationContext context,
         List<GenAiResultItem> items,
         PatchRequest patchRequest,
-        string taskName,
+        string taskIdentifier,
         RavenLogger logger, 
         EtlProcessStatistics statistics)
     {
@@ -35,9 +35,9 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
         _logger = logger ?? throw new ArgumentException(nameof(logger));
         _statistics = statistics ?? throw new ArgumentException(nameof(statistics));
 
-        if (string.IsNullOrEmpty(taskName))
-            throw new ArgumentException(nameof(taskName));
-        _taskName = taskName;
+        if (string.IsNullOrEmpty(taskIdentifier))
+            throw new ArgumentException(nameof(taskIdentifier));
+        _taskIdentifier = taskIdentifier;
 
         if (context == null)
             throw new ArgumentNullException(nameof(context));
@@ -101,7 +101,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
             if (allHashes.Count is 0)
                 continue;
 
-            UpdateHashesInMetadata(id, doc, _taskName, allHashes, context);
+            UpdateHashesInMetadata(id, doc, _taskIdentifier, allHashes, context);
         }
 
         return _items.Count;
@@ -118,7 +118,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
         return context.ReadObject(djv, item.DocId);
     }
 
-    internal static BlittableJsonReaderObject UpdateHashesInMetadata(string id, BlittableJsonReaderObject doc, string taskName, List<string> allHashes, DocumentsOperationContext context)
+    internal static BlittableJsonReaderObject UpdateHashesInMetadata(string id, BlittableJsonReaderObject doc, string taskIdentifier, List<string> allHashes, DocumentsOperationContext context)
     {
         if (doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
         {
@@ -130,7 +130,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                 {
                     [Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue
                     {
-                        [taskName] = allHashes
+                        [taskIdentifier] = allHashes
                     }
                 }
             };
@@ -144,7 +144,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
             {
                 [Constants.Documents.Metadata.GenAiHashes] = new DynamicJsonValue
                 {
-                    [taskName] = allHashes
+                    [taskIdentifier] = allHashes
                 }
             };
             doc.Modifications = new DynamicJsonValue(doc)
@@ -157,7 +157,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
         {
             // we already have the hashes section, need to modify it
 
-            if (hashes.TryGet(taskName, out BlittableJsonReaderArray existingHashes) && existingHashes != null && 
+            if (hashes.TryGet(taskIdentifier, out BlittableJsonReaderArray existingHashes) && existingHashes != null && 
                 existingHashes.Length == allHashes.Count)
             {
                 bool needToUpdate = false;
@@ -179,7 +179,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
             hashes.Modifications = new DynamicJsonValue(hashes)
             {
-                [taskName] = allHashes
+                [taskIdentifier] = allHashes
             };
 
             metadata.Modifications = new DynamicJsonValue(metadata)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -309,7 +309,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
     private void ApplyUpdateScript(DocumentsOperationContext context, List<GenAiResultItem> results)
     {
         PatchRequest req = new(Configuration.UpdateScript, PatchRequestType.GenAi);
-        var cmd = new GenAiBatchPatchCommand(context, results, req, Configuration.Name, Logger, Statistics);
+        var cmd = new GenAiBatchPatchCommand(context, results, req, Configuration.Identifier, Logger, Statistics);
 
         Database.TxMerger.EnqueueSync(cmd);
     }
@@ -448,7 +448,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     }
 
                     if (lastPatch?.PatchResult?.ModifiedDocument != null)
-                        outputDocument = GenAiBatchPatchCommand.UpdateHashesInMetadata(document.Id, lastPatch.PatchResult.ModifiedDocument, Configuration.Name, hashes, context);
+                        outputDocument = GenAiBatchPatchCommand.UpdateHashesInMetadata(document.Id, lastPatch.PatchResult.ModifiedDocument, Configuration.Identifier, hashes, context);
 
                     break;
                 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -329,7 +329,6 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
     public TestEtlScriptResult RunTest(TestGenAiScript testGenAiScript, DocumentsOperationContext context)
     {
         List<GenAiResultItem> items;
-        List<Exception> exceptions = null;
         BlittableJsonReaderObject outputDocument = null;
 
         Document document = null;
@@ -380,7 +379,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             case TestStage.SendToModel:
                 _chatCompletionClient ??= GetClient();
                 items = testGenAiScript.Input;
-                exceptions = SendToModel(items, context, scope);
+                List<Exception> exceptions = SendToModel(items, context, scope);
                 if (exceptions is not null)
                     throw new AggregateException(exceptions);
 
@@ -394,6 +393,9 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     PatchRequest req = new(Configuration.UpdateScript, PatchRequestType.GenAi);
                     PatchDocumentCommand lastPatch = null;
                     var hashes = new List<string>();
+
+                    if (string.IsNullOrEmpty(Configuration.Identifier))
+                        Configuration.Identifier = Configuration.GenerateIdentifier();
 
                     if (testGenAiScript.Document != null)
                     {

--- a/src/Raven.Server/ServerWide/Commands/AI/AddGenAiCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AI/AddGenAiCommand.cs
@@ -21,6 +21,16 @@ public sealed class AddGenAiCommand : AddEtlCommand<GenAiConfiguration, AiConnec
 
     public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
     {
+        try
+        {
+            if (string.IsNullOrEmpty(Configuration.Identifier))
+                Configuration.Identifier = Configuration.GenerateIdentifier();
+        }
+        catch (Exception e)
+        {
+            throw new RachisApplyException("Failed to generate GenAI task identifier", e);
+        }
+
         Validate(record);
 
         Add(ref record.GenAis, record, etag);
@@ -28,9 +38,6 @@ public sealed class AddGenAiCommand : AddEtlCommand<GenAiConfiguration, AiConnec
 
     private void Validate(DatabaseRecord databaseRecord)
     {
-        return;
-
-        // TODO
         if (databaseRecord == null)
             throw new RachisApplyException("Failed to get database record, but it is required for further validation");
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Exceptions;
 using Raven.Server.Documents;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.GenAi;
@@ -571,6 +572,122 @@ for(const comment of this.Comments)
         await ShouldResendContextOnConfigChange(configuration,
             changeConfig: config => config.UpdateScript = "this.Translated = $output.Translation;"
         );
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task ShouldUseTaskIdentifierInMetadataHashes(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Check if the following blog post comment is spam or not";
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or ham" });
+        config.UpdateScript = @"    
+const idx = this.Comments.findIndex(c => c.Id == $input.Id);  
+if($output.Blocked)
+{
+    this.Comments.splice(idx, 1); // remove
+}";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+        };
+
+        store.Maintenance.Send(new AddGenAiOperation(config));
+
+        var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
+        var genAiTaskInfo = taskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
+        Assert.NotNull(genAiTaskInfo);
+
+        var identifier = genAiTaskInfo.Configuration.Identifier;
+        Assert.False(string.IsNullOrEmpty(identifier));
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        const string id = "posts/1";
+        using (var session = store.OpenSession())
+        {
+            var p = new Post(
+                [
+                    new Comment("Surefire investment property in caiman islands, win $$$$ for sure, qucik!", "homepage"),
+                    new Comment("Probably... That piece of code was written (and never looked at) in 2017, IIRC It wasn't a real issue (since it is cached) except for this particular scenario.", "Oren Eini")
+                ],
+                "I, pencil",
+                "A B52 pencil...");
+            session.Store(p, id);
+            session.SaveChanges();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(30)));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<BlittableJsonReaderObject>(id);
+            Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
+            Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
+            Assert.True(hashesSection.TryGet(identifier, out BlittableJsonReaderArray hashesArray));
+            Assert.NotNull(hashesArray);
+            Assert.Equal(1, hashesArray.Length);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task ShouldThrowOnNonUniqueIdentifier(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Check if the following blog post comment is spam or not";
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or ham" });
+        config.UpdateScript = @"    
+const idx = this.Comments.findIndex(c => c.Id == $input.Id);  
+if($output.Blocked)
+{
+    this.Comments.splice(idx, 1); // remove
+}";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+        };
+
+        store.Maintenance.Send(new AddGenAiOperation(config));
+
+        var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
+        var genAiTaskInfo = taskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
+        Assert.NotNull(genAiTaskInfo);
+
+        var identifier = genAiTaskInfo.Configuration.Identifier;
+        Assert.False(string.IsNullOrEmpty(identifier));
+
+        var config2 = new GenAiConfiguration
+        {
+            Name = "PostsSpamCheck2",
+            ConnectionStringName = config.ConnectionStringName,
+            Prompt = config.Prompt,
+            Collection = config.Collection,
+            SampleObject = config.SampleObject,
+            UpdateScript = config.UpdateScript,
+            GenAiTransformation = config.GenAiTransformation,
+            Identifier = identifier // using the same identifier
+        };
+
+        var e = Assert.Throws<RavenException>(() => store.Maintenance.Send(new AddGenAiOperation(config2)));
+        Assert.Contains("Can't create GenAI task", e.Message);
+        Assert.Contains($"The identifier '{identifier}' is already used", e.Message);
     }
 
     private async Task ShouldResendContextOnConfigChange(GenAiConfiguration config, Action<GenAiConfiguration> changeConfig)

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
@@ -12,7 +11,6 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents;
-using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.GenAi;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;
@@ -586,14 +584,14 @@ for(const comment of this.Comments)
         config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or ham" });
         config.UpdateScript = @"    
 const idx = this.Comments.findIndex(c => c.Id == $input.Id);  
-if($output.Blocked)
+if ($output.Blocked)
 {
     this.Comments.splice(idx, 1); // remove
 }";
         config.GenAiTransformation = new GenAiTransformation
         {
             Script = @"
-for(const comment of this.Comments)
+for (const comment of this.Comments)
 {
     ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
 }
@@ -634,7 +632,7 @@ for(const comment of this.Comments)
             Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
             Assert.True(hashesSection.TryGet(identifier, out BlittableJsonReaderArray hashesArray));
             Assert.NotNull(hashesArray);
-            Assert.Equal(1, hashesArray.Length);
+            Assert.Equal(2, hashesArray.Length);
         }
     }
 
@@ -705,6 +703,7 @@ for(const comment of this.Comments)
         config.UpdateScript = "this.TextInPolish = $output.Translation;";
         config.Collection = "Posts";
         config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
+        config.Identifier = "posts-translation-check";
 
         store.Maintenance.Send(new AddGenAiOperation(config));
 
@@ -724,7 +723,7 @@ for(const comment of this.Comments)
             var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
             Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
             Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-            Assert.True(hashesSection.TryGet(config.Name, out BlittableJsonReaderArray hashesArray));
+            Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashesArray));
             Assert.NotNull(hashesArray);
             originalHash = hashesArray.Last().ToString();
         }
@@ -811,7 +810,7 @@ for(const comment of this.Comments)
             var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
             Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
             Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-            Assert.True(hashesSection.TryGet(config.Name, out BlittableJsonReaderArray hashesArray));
+            Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashesArray));
             Assert.NotNull(hashesArray);
 
             var newHash = hashesArray.Last().ToString();

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
@@ -224,6 +224,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
     ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
 }"
             };
+            config.Identifier = "blog-post-spam-check";
 
             store.Maintenance.Send(new AddGenAiOperation(config));
 
@@ -274,13 +275,13 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
                 var doc = session.Load<BlittableJsonReaderObject>(docId);
                 Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
                 Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-                Assert.True(hashesSection.TryGet(config.Name, out BlittableJsonReaderArray hashes));
+                Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashes));
 
                 Assert.Equal(3, hashes.Length); // all 3 context hashes should be in metadata (refusal is considered a success) 
             }
 
             // assert stats
-            var stats = etlProcess.GetPerformanceStats().Last();
+            var stats = etlProcess.GetPerformanceStats().Last(s => s.NumberOfLoadedItems > 0);
             Assert.True(stats.SuccessfullyLoaded);
 
             // assert that next ETL batch does not start from etag 0 (batch was successful)
@@ -303,6 +304,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
         config.SampleObject = JsonConvert.SerializeObject(new { Result = "text" });
         config.UpdateScript = "this.Result = $output.Result;";
         config.GenAiTransformation = new GenAiTransformation { Script = "for (const comment of this.Comments) ai.genContext({Text: comment.Text, Id: comment.Id});" };
+        config.Identifier = "sanskrit-translation";
 
         store.Maintenance.Send(new AddGenAiOperation(config));
 
@@ -351,7 +353,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
             var doc = session.Load<BlittableJsonReaderObject>(docId);
             Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
             Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashes));
-            Assert.True(hashes.TryGet(config.Name, out BlittableJsonReaderArray arr));
+            Assert.True(hashes.TryGet(config.Identifier, out BlittableJsonReaderArray arr));
 
             Assert.Equal(1, arr.Length); // only some processed
         }
@@ -417,6 +419,8 @@ this.Comments[idx].IsSpam = $output.Blocked;";
     ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
 }"
         };
+        config.Identifier = "blog-post-spam-check";
+
 
         store.Maintenance.Send(new AddGenAiOperation(config));
         var db = await GetDatabase(store.Database);
@@ -460,7 +464,7 @@ this.Comments[idx].IsSpam = $output.Blocked;";
             var doc = session.Load<BlittableJsonReaderObject>(docId);
             Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
             Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-            Assert.True(hashesSection.TryGet(config.Name, out BlittableJsonReaderArray hashes));
+            Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashes));
 
             // Only one comment should have succeeded
             Assert.Equal(1, hashes.Length);
@@ -495,7 +499,7 @@ this.Comments[idx].IsSpam = $output.Blocked;";
             var doc = session.Load<BlittableJsonReaderObject>(docId);
             Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
             Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
-            Assert.True(hashesSection.TryGet(config.Name, out BlittableJsonReaderArray hashes));
+            Assert.True(hashesSection.TryGet(config.Identifier, out BlittableJsonReaderArray hashes));
 
             // now both contexts should have their hash in metadata
             Assert.Equal(2, hashes.Length);

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiTestScript.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiTestScript.cs
@@ -13,7 +13,6 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Server.Documents;
-using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.GenAi;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24204/GenAI-require-providing-a-unique-identifier-in-configuration-and-use-it-as-the-name-for-metadata-hashes

### Additional description

require providing a unique identifier in configuration and use it as the name for metadata hashes 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
