### PR TITLE
RavenDB-24349 Fix dynamic returns detection for JS map syntax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndexUtils.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndexUtils.cs
@@ -17,15 +17,18 @@ namespace Raven.Server.Documents.Indexes.Static
     {
         public static IEnumerable<ReturnStatement> GetReturnStatements(IFunction function)
         {
-            if (function is ArrowFunctionExpression arrowFunction && arrowFunction.Body is ObjectExpression objectExpression)
-            {
-                // looks like we have following case:
-                // x => ({ Name: x.Name })
-                // wrap with return statement and we're done
-                return new[] { new ReturnStatement(objectExpression) };
-            }
+            if (function is not ArrowFunctionExpression arrowFunction)
+                return GetReturnStatements(function.Body);
 
-            return GetReturnStatements(function.Body);
+            // Handle following cases:
+            //      x => ({ Name: x.Name })
+            //      x => someFunction();
+            return arrowFunction.Body.Type switch
+            {
+                NodeType.ObjectExpression => new[] { new ReturnStatement((ObjectExpression)arrowFunction.Body) },
+                NodeType.CallExpression => new[] { new ReturnStatement((CallExpression)arrowFunction.Body) },
+                _ => GetReturnStatements(function.Body)
+            };
         }
         
         public static IEnumerable<ReturnStatement> GetReturnStatements(Node stmt)

--- a/test/SlowTests/Issues/RavenDB-24349.cs
+++ b/test/SlowTests/Issues/RavenDB-24349.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24349 : RavenTestBase
+{
+    public RavenDB_24349(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void DynamicFieldsShouldBeMarked()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Dto { Name = "Name1", Type = "Type1" });
+                session.Store(new Dto { Name = "Name2", Type = "Type2" });
+                
+                session.SaveChanges();
+            }
+
+            var index = new DummyIndex();
+            index.Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<Dto, DummyIndex>().Where(x => x.Name == "Name1").ToList();
+                
+                Assert.Equal(1, results.Count);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public string Type { get; set; }
+    }
+
+    private class DummyIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public DummyIndex()
+        {
+            Maps = new HashSet<string>() { "map('Dtos', (dto) => mapDto(dto))" };
+            AdditionalSources = new Dictionary<string, string>() { { "Helper", 
+                """
+                function mapDto(dto) {
+                  return {
+                    Name: dto.Name, 
+                    Type: dto.Type
+                  }
+                }
+                """ } };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24349/Fix-detection-of-dynamic-returns-in-JavaScript-index-map-syntax

### Additional description

Applying https://github.com/ravendb/ravendb/pull/20714 to v7.0 (different version of Jint)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
