### PR TITLE
RavenDB-24243 Remove minimumSimilarity from queries since we're testing correctness of distances and it may happen that random vector is not similar within certain level to any vector.

### DIFF
--- a/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
+++ b/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
@@ -59,7 +59,7 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
         var queryVector = Enumerable.Range(0, dimensions).Select(_ => random.NextSingle()).ToArray();
 
         var query = session.Query<Dto, TIndex>()
-            .VectorSearch(f => f.WithField(d => d.Singles), v => v.ByEmbedding(queryVector), 0.1f)
+            .VectorSearch(f => f.WithField(d => d.Singles), v => v.ByEmbedding(queryVector))
             .OrderByScore();
 
 
@@ -88,6 +88,7 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
     [InlineDataWithRandomSeed]
     [InlineData(1253422244)]
     [InlineData(1351777189)]
+    [InlineData(1833646005)]
     public void TestInt8Similarity(int seed) => TestInt8SimilarityBase<Index>(seed);
     
     [RavenTheory(RavenTestCategory.Vector)]
@@ -115,10 +116,13 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
         using var session = store.OpenSession();
         var doc = session.Advanced.DocumentQuery<Dto>().NoTracking().NoCaching().First();
 
+        
+        
+        
         var queryVector = VectorQuantizer.ToInt8(Enumerable.Range(0, dimensions).Select(_ => random.NextSingle()).ToArray());
 
         var query = session.Query<Dto, TIndex>()
-            .VectorSearch(f => f.WithField(d => d.Int8), v => v.ByEmbedding(queryVector), 0.1f)
+            .VectorSearch(f => f.WithField(d => d.Int8), v => v.ByEmbedding(queryVector))
             .OrderByScore();
 
 
@@ -177,7 +181,7 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
         } while (commonsBits <= 0);
 
         var query = session.Query<Dto, TIndex>()
-            .VectorSearch(f => f.WithField(d => d.Binary), v => v.ByEmbedding(queryVector), 0.01f)
+            .VectorSearch(f => f.WithField(d => d.Binary), v => v.ByEmbedding(queryVector))
             .OrderByScore();
         
         using IEnumerator<StreamResult<Dto>> streamResults = session.Advanced.Stream(query, out _);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24243

### Additional description

Explained in the title.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
