### PR TITLE
RavenDB-24361 Use CosineSimilarity from TensorPrimitives when running on x86.

### DIFF
--- a/src/Sparrow.Server/Tensors/Functions.cs
+++ b/src/Sparrow.Server/Tensors/Functions.cs
@@ -8,6 +8,7 @@ using System.Runtime.Intrinsics.X86;
 using System.Runtime.Intrinsics;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.Arm;
+using Sparrow.Platform;
 
 namespace Sparrow.Server.Tensors
 {
@@ -32,6 +33,9 @@ namespace Sparrow.Server.Tensors
         public static T CosineSimilarity<T>(ReadOnlySpan<T> a, ReadOnlySpan<T> b)
             where T : unmanaged, IFloatingPoint<T>, IRootFunctions<T>, INumber<T>
         {
+            if (PlatformDetails.Is32Bits)
+                return TensorPrimitives.CosineSimilarity(a, b);
+            
             if (a.Length >= Vector512<T>.Count)
             {
                 if (typeof(T) == typeof(float))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24361

### Additional description

This is a temporary solution.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
