### PR TITLE
RavenDB-24007 Added ability to cancel `Commit` operation in Corax.

### DIFF
--- a/bench/Vector.Benchmark/Program.cs
+++ b/bench/Vector.Benchmark/Program.cs
@@ -111,7 +111,7 @@ async Task ImportData(string path)
                         var vector = new Memory<float>(vectors, i * 768, 768);
                         registration.Register(ids[i] * 100, MemoryMarshal.Cast<float, byte>(vector.Span));
                     }
-                    registration.Commit();
+                    registration.Commit(CancellationToken.None);
                 }
                 txw.Commit();
             }

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using Corax.Analyzers;
 using Corax.Mappings;
 using Corax.Pipeline;
@@ -944,9 +945,9 @@ namespace Corax.Indexing
             return fieldTree.TryGetValue(termValue, out idInTree);
         }
 
-        public void Commit() => Commit<EmptyStatsScope>(default);
+        public void Commit(CancellationToken token = default) => Commit<EmptyStatsScope>(default, token);
         
-        public void Commit<TStatsScope>(TStatsScope stats)
+        public void Commit<TStatsScope>(TStatsScope stats, CancellationToken token)
             where TStatsScope : struct, ICoraxStatsScope
         {
             _indexDebugDumper.Commit();
@@ -982,6 +983,7 @@ namespace Corax.Indexing
             uniquePostingList.Sort(sortedFields);
             foreach (var indexedField in sortedFields)
             {
+                token.ThrowIfCancellationRequested();
                 stats.SetAllocatedUnmanagedBytes(_entriesAllocator?._totalAllocated ?? 0);
 
                 //Dynamic terms will be indexed with explicit field terms.
@@ -1007,17 +1009,17 @@ namespace Corax.Indexing
                 using (staticFieldScope.For(CommitOperation.TextualValues))
                 {
                     using var inserter = new TextualFieldInserter(this, entriesToTermsTree, indexedField, workingBuffer);
-                    inserter.InsertTextualField();
+                    inserter.InsertTextualField(token);
                 }
                 
                 using (staticFieldScope.For(CommitOperation.IntegerValues))
-                    InsertNumericFieldLongs(entriesToTermsTree, indexedField, workingBuffer);
+                    InsertNumericFieldLongs(entriesToTermsTree, indexedField, workingBuffer, token);
                 
                 using (staticFieldScope.For(CommitOperation.FloatingValues))
-                    InsertNumericFieldDoubles(entriesToTermsTree, indexedField, workingBuffer);
+                    InsertNumericFieldDoubles(entriesToTermsTree, indexedField, workingBuffer, token);
 
                 using (staticFieldScope.For(CommitOperation.SpatialValues))
-                    InsertSpatialField(entriesToSpatialTree, indexedField);
+                    InsertSpatialField(entriesToSpatialTree, indexedField, token);
 
                 if (indexedField.HasMultipleTermsPerField)
                 {
@@ -1112,7 +1114,7 @@ namespace Corax.Indexing
             }
         }
 
-        private void InsertSpatialField(Tree entriesToSpatialTree, IndexedField indexedField)
+        private void InsertSpatialField(Tree entriesToSpatialTree, IndexedField indexedField, CancellationToken token)
         {
             if (indexedField.Spatial == null)
                 return;
@@ -1122,8 +1124,11 @@ namespace Corax.Indexing
             var termContainerId = fieldRootPage << 3 | 0b010;
             Debug.Assert(termContainerId >>> 3 == fieldRootPage, "field root too high?");
             var entriesToTerms = entriesToSpatialTree.FixedTreeFor(indexedField.Name, sizeof(double)+sizeof(double));
+
+
             foreach (var (entry, spatialEntry)  in indexedField.Spatial)
             {
+                token.ThrowIfCancellationRequested();
                 spatialEntry.Locations.Sort();
 
                 ref var entryTerms = ref GetEntryTerms(spatialEntry.TermsPerEntryIndex);
@@ -1296,7 +1301,7 @@ namespace Corax.Indexing
                 _pagesToPrefetch.Dispose();
             }
 
-            public void InsertTextualField()
+            public void InsertTextualField(in CancellationToken token)
             {
                 long totalLengthOfTerm = 0;
                 _buffers.PrepareTerms(_indexedField, out var sortedTerms, out var termsOffsets);
@@ -1322,6 +1327,8 @@ namespace Corax.Indexing
                 
                 while (true)
                 {
+                    token.ThrowIfCancellationRequested();
+                    
                     if (sortedTerms.IsEmpty)
                         break;
 
@@ -2005,7 +2012,7 @@ namespace Corax.Indexing
             _largePostingListSet.Remove(containerId);
         }
 
-        private void InsertNumericFieldLongs(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf)
+        private void InsertNumericFieldLongs(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf, CancellationToken token)
         {
             var fieldTree = _fieldsTree.LookupFor<Int64LookupKey>(indexedField.NameLong);
 
@@ -2013,6 +2020,7 @@ namespace Corax.Indexing
 
             foreach (var (term, entriesLocation) in indexedField.Longs)
             {
+                token.ThrowIfCancellationRequested();
                 ref var entries = ref indexedField.Storage.GetAsRef(entriesLocation);
 
                 // We are not going to be using these entries anymore after this. 
@@ -2080,7 +2088,7 @@ namespace Corax.Indexing
             }
         }
 
-        private void InsertNumericFieldDoubles(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf)
+        private void InsertNumericFieldDoubles(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf, CancellationToken token)
         {
             var fieldTree = _fieldsTree.LookupFor<DoubleLookupKey>(indexedField.NameDouble);
 
@@ -2088,6 +2096,8 @@ namespace Corax.Indexing
 
             foreach (var (term, entriesLocation) in indexedField.Doubles)
             {
+                token.ThrowIfCancellationRequested();
+                
                 ref var entries = ref indexedField.Storage.GetAsRef(entriesLocation);
 
                 // We are not going to be using these entries anymore after this. 

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1000,7 +1000,7 @@ namespace Corax.Indexing
                     RegisterVectorRootPage(indexedField.FieldRootPage);
                     if (MaximumConcurrentBatchesForHnswAcceleration != null)
                         indexedField.VectorIndexer.MaxConcurrentBatches = MaximumConcurrentBatchesForHnswAcceleration.Value;
-                    indexedField.VectorIndexer.Commit();
+                    indexedField.VectorIndexer.Commit(token);
                 }
                 
                 if (indexedField.Textual.Count == 0)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2493,7 +2493,7 @@ namespace Raven.Server.Documents.Indexes
                             {
                                 using (var indexWriteOperation = writeOperation.Value)
                                 {
-                                    indexWriteOperation.Commit(stats);
+                                    indexWriteOperation.Commit(stats, cancellationToken);
 
                                     entriesCount = writeOperation.Value.EntriesCount();
                                 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceLuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceLuceneIndexWriteOperation.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
@@ -21,12 +22,12 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             _outputScope = new(index, writeTransaction, indexContext, this);
         }
 
-        public override void Commit(IndexingStatsScope stats)
+        public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
             if (_outputScope.IsActive)
-                base.Commit(stats);
+                base.Commit(stats, token);
             else
-                _outputScope.Commit(stats);
+                _outputScope.Commit(stats, token);
         }
 
         public override void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -79,13 +79,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             UpdateDynamicFieldsBindings();
         }
         
-        public override void Commit(IndexingStatsScope stats)
+        public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
             if (_indexWriter != null)
             {
                 using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
                 {
-                    _indexWriter.Commit(new CoraxIndexingStats(commitStats));
+                    _indexWriter.Commit(new CoraxIndexingStats(commitStats), token);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/OutputReduceCoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/OutputReduceCoraxIndexWriteOperation.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -18,12 +19,12 @@ public sealed class OutputReduceCoraxIndexWriteOperation : CoraxIndexWriteOperat
         _outputScope = new(index, writeTransaction, indexContext, this);
     }
     
-    public override void Commit(IndexingStatsScope stats)
+    public override void Commit(IndexingStatsScope stats, CancellationToken token)
     {
         if (_outputScope.IsActive)
-            base.Commit(stats);
+            base.Commit(stats, token);
         else
-            _outputScope.Commit(stats);
+            _outputScope.Commit(stats, token);
     }
 
     public override void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
         {
         }
 
-        public abstract void Commit(IndexingStatsScope stats);
+        public abstract void Commit(IndexingStatsScope stats, CancellationToken token);
 
         public abstract void Optimize(CancellationToken token);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public override void Commit(IndexingStatsScope stats)
+        public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
             if (_writer != null)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/OutputReduceIndexWriteOperationScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/OutputReduceIndexWriteOperationScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce.OutputToCollection;
@@ -28,7 +29,7 @@ internal sealed class OutputReduceIndexWriteOperationScope<TWriter> where TWrite
         IsActive = false;
     }
 
-    public void Commit(IndexingStatsScope stats)
+    public void Commit(IndexingStatsScope stats, CancellationToken token)
     {
         using (new IsActiveScope(this))
         {
@@ -36,7 +37,7 @@ internal sealed class OutputReduceIndexWriteOperationScope<TWriter> where TWrite
 
             using (_txHolder.AcquireTransaction(out _))
             {
-                _writer.Commit(stats);
+                _writer.Commit(stats, token);
             }
 
             try

--- a/src/Raven.Server/Documents/Indexes/Test/TestIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Test/TestIndexWriteOperation.cs
@@ -28,9 +28,9 @@ public sealed class TestIndexWriteOperation : IndexWriteOperationBase
         _inner?.Dispose();
     }
 
-    public override void Commit(IndexingStatsScope stats)
+    public override void Commit(IndexingStatsScope stats, CancellationToken token)
     {
-        _inner.Commit(stats);
+        _inner.Commit(stats, token);
     }
 
     public override void Optimize(CancellationToken token)

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -107,7 +107,7 @@ public partial class Hnsw
         private int _nextNodeIndex;
 
         public int MaxConcurrentBatches = 512;
-        void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer)
+        void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer, CancellationToken token)
         {
             if (_searchState.TryGetLocationForNode(EntryPointId, out var entryPointNode) is false)
             {
@@ -126,7 +126,7 @@ public partial class Hnsw
             int numberOfBatches = Math.Max(1, _searchState.CreatedNodes / MaxConcurrentBatches);
             // but not too much...
             int maxTasks = Math.Min(numberOfBatches, MaxConcurrentBatches);
-            NodePlacementRunner runner = new(this, maxTasks);
+            NodePlacementRunner runner = new(this, maxTasks, token);
             runner.Run();
         }
 
@@ -598,11 +598,12 @@ public partial class Hnsw
             private readonly ConcurrentQueue<(Exception Error, IEnumerator<WorkItem> It)> _placementErrors = [];
             private readonly List<WorkItem> _items = [];
             private readonly SearchState _searchState;
-            private readonly CancellationTokenSource _cts = new();
+            private readonly CancellationTokenSource _errorCts = new();
+            private readonly CancellationTokenSource _mainCts;
             private readonly List<Exception> _errors = [];
             private readonly LinkedList<int> _inFlightIndexes = [];
 
-            public bool IsCancelled => _cts.IsCancellationRequested;
+            public bool IsCancelled => _mainCts.IsCancellationRequested;
             
 
             public void AddInFlight(LinkedListNode<int> node)
@@ -615,8 +616,9 @@ public partial class Hnsw
                 _inFlightIndexes.Remove(node);
             }
 
-            public NodePlacementRunner(Registration parent, int activeTasksCount)
+            public NodePlacementRunner(Registration parent, int activeTasksCount, CancellationToken token)
             {
+                _mainCts = CancellationTokenSource.CreateLinkedTokenSource(token, _errorCts.Token);
                 _activeTasksCount = activeTasksCount;
                 _searchState = parent._searchState;
                 for (int i = 0; i < activeTasksCount; i++)
@@ -671,6 +673,13 @@ public partial class Hnsw
                     {
                         if(_errors.Count > 0)
                             throw new AggregateException(_errors);
+                        if (_errorCts.IsCancellationRequested == false && _mainCts.IsCancellationRequested)
+                        {
+                            // If _mainCts is canceled and _errorCts is not, then we need to throw 
+                            // to indicate that we're done due to operation cancellation!
+                            _mainCts.Token.ThrowIfCancellationRequested();
+                        }
+                            
                         return; // done
                     }
                     
@@ -726,7 +735,7 @@ public partial class Hnsw
             private void HandleError(Exception error, IEnumerator<WorkItem> it)
             {
                 // force all pending work to stop now, instead of when it is all done
-                _cts.Cancel();
+                _errorCts.Cancel();
                 _errors.Add(error);
                 try
                 {

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Threading;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Compression;
@@ -1003,7 +1004,7 @@ public unsafe partial class Hnsw
             return hashBuffer;
         }
 
-        public void Commit()
+        public void Commit(CancellationToken token)
         {
             PortableExceptions.ThrowIfOnDebug<InvalidOperationException>(_searchState.Llt.Committed);
             
@@ -1024,7 +1025,7 @@ public unsafe partial class Hnsw
             nodes = Span<Node>.Empty;
             _ = nodes;
 
-            InsertVectorsToGraph(ref byteBuffer);
+            InsertVectorsToGraph(ref byteBuffer, token);
 
             nodes = _searchState.Nodes;
             for (int i = 0; i < nodes.Length; i++)

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics.Tensors;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
+using System.Threading;
 using FastTests.Voron.FixedSize;
 using Raven.Server.Documents.Indexes.VectorSearch;
 using Tests.Infrastructure;
@@ -97,13 +98,13 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             {
                 registration.Register(1, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Register(2, MemoryMarshal.Cast<float, byte>(v2));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Register(3, MemoryMarshal.Cast<float, byte>(v1));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();
@@ -153,13 +154,13 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             {
                 registration.Register(4, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Register(8, MemoryMarshal.Cast<float, byte>(v2));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Register(12, MemoryMarshal.Cast<float, byte>(v1));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();
@@ -212,13 +213,13 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             {
                 vectorHashToRemove = registration.Register(entryIdToRemove, MemoryMarshal.Cast<float, byte>(v1)).ToSpan().ToArray();
                 registration.Register(8, MemoryMarshal.Cast<float, byte>(v2));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Register(12, MemoryMarshal.Cast<float, byte>(v1));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();
@@ -231,7 +232,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Remove(entryIdToRemove, vectorHashToRemove);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();
@@ -274,7 +275,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             {
                 registration.Register(1, v1.GetEmbedding());
                 registration.Register(2, v2.GetEmbedding());
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             wTx.Commit();
@@ -325,7 +326,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
                     elementInGraph.Add((id, vec.ToSpan().ToArray()));
                 }
                 
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();
@@ -358,7 +359,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             {
                 foreach (var el in toRemove)
                     registration.Remove(el.entryId, el.vectorHash);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             txw.Commit();
@@ -390,7 +391,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
                 foreach (var id in toRemove)
                     registration.Remove(id.entryId, id.vectorHash);
                 
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             txw.Commit();
@@ -419,7 +420,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Remove(elementInGraph[0].entryId, elementInGraph[0].vectorHash);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             txw.Commit();
@@ -472,13 +473,13 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
             {
                 registration.Register(4, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Register(8, MemoryMarshal.Cast<float, byte>(v2));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
             {
                 registration.Register(12, MemoryMarshal.Cast<float, byte>(v1));
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();

--- a/test/FastTests/Voron/Graphs/GraphsVectorRemovals.cs
+++ b/test/FastTests/Voron/Graphs/GraphsVectorRemovals.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using FastTests.Voron.FixedSize;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -32,7 +33,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
             using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, TreeName, random))
             {
                 vectorHash = registration.Register(entryId, v1AsBytes).ToSpan().ToArray();
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             wTx.Commit();
@@ -53,7 +54,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
             using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, TreeName, random))
             {
                 registration.Remove(entryId, vectorHash);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             wTx.Commit();
@@ -90,7 +91,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
             {
                 v1Id = registration.Register(entryId1, v1AsBytes).ToSpan().ToArray();
                 registration.Register(entryId2, v2AsBytes);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
     
             wTx.Commit();
@@ -110,7 +111,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
             using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, "test", random))
             {
                 registration.Remove(entryId1, v1Id);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             wTx.Commit();
         }
@@ -159,7 +160,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
                 using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, "test", random))
                 {
                     vecId = registration.Register(EntryId(id), v1AsBytes).ToSpan().ToArray();
-                    registration.Commit();
+                    registration.Commit(CancellationToken.None);
                 }
 
                 wTx.Commit();
@@ -177,7 +178,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
                 using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, "test", random))
                 {
                     registration.Remove(EntryId(id), vecId);
-                    registration.Commit();
+                    registration.Commit(CancellationToken.None);
                 }
 
                 wTx.Commit();
@@ -218,7 +219,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", random))
             {
                 vectorTermContainer = registration.Register(4, MemoryMarshal.Cast<float, byte>(v1)).ToSpan().ToArray();
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             txw.Commit();
@@ -240,7 +241,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
             using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", random))
             {
                 registration.Remove(entryId, vectorTermContainer);
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
 
             txw.Commit();

--- a/test/SlowTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
@@ -163,7 +163,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                     using (var indexWriteOperation = writeOperation.Value)
                     {
-                        indexWriteOperation.Commit(stats);
+                        indexWriteOperation.Commit(stats, CancellationToken.None);
                     }
 
                     index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -228,7 +228,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -291,7 +291,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);

--- a/test/SlowTests/Server/Documents/Indexing/Static/RavenDB_11469.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Static/RavenDB_11469.cs
@@ -99,7 +99,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                     using (var indexWriteOperation = writeOperation.Value)
                     {
-                        indexWriteOperation.Commit(stats);
+                        indexWriteOperation.Commit(stats, CancellationToken.None);
                     }
 
                     index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -160,7 +160,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -219,7 +219,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -279,7 +279,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);

--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron.Data.Graphs;
@@ -32,7 +33,7 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
                 foreach (var (id, vector) in storage)
                     registration.Register(id, MemoryMarshal.Cast<float, byte>(vector));
                 
-                registration.Commit();
+                registration.Commit(CancellationToken.None);
             }
             
             wTx.Commit();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24007

### Additional description
Added ability to cancel `Commit` operation in Corax.
### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
Corax indexing can be cancelled during commit. Previously, even when we cancelled the operation, we waited for commit to finish.
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
