### PR TITLE
RavenDB-21094 Test fix: Index's EntriesCount - WaitForValue, since updates to entries count in indexing happen in different transactions

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19426.cs
+++ b/test/SlowTests/Issues/RavenDB-19426.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 
-public class RavenDB_19426 : RavenTestBase
+public class RavenDB_19426(ITestOutputHelper output) : RavenTestBase(output)
 {
     private const string DocName = "doc/1";
 
@@ -41,12 +41,8 @@ public class RavenDB_19426 : RavenTestBase
         
         AssertIndexIsNotCorrupted(index, store);
     }
-    
-    
-    public RavenDB_19426(ITestOutputHelper output) : base(output)
-    {
-    }
-    
+
+
     [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void DeletionOfItemFromFanoutIndexReturnsCorrectCountOfTerms(Options options)
@@ -61,8 +57,8 @@ public class RavenDB_19426 : RavenTestBase
         index.Execute(store);
         Indexes.WaitForIndexing(store);
 
-        var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
-        Assert.Equal(2, indexStats.EntriesCount);
+        var entriesCount = WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).EntriesCount, 2);
+        Assert.Equal(2, entriesCount);
 
         {
             //Swap in place, no new item.
@@ -73,9 +69,8 @@ public class RavenDB_19426 : RavenTestBase
         }
 
         Indexes.WaitForIndexing(store);
-
-        indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
-        Assert.Equal(0, indexStats.EntriesCount);
+        entriesCount = WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).EntriesCount, 0);
+        Assert.Equal(0, entriesCount);
     }
 
     [RavenTheory(RavenTestCategory.Indexes)]
@@ -129,7 +124,6 @@ public class RavenDB_19426 : RavenTestBase
         Indexes.WaitForIndexing(store);
         var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
         Assert.NotEqual(IndexState.Error ,indexStats.State);
-        WaitForUserToContinueTheTest(store);
     }
 
     private T CreateIndex<T>(IDocumentStore store) where T : AbstractIndexCreationTask, new()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21094

### Additional description

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
