### PR TITLE
RavenDB-23850 Exposed vector storage in StorageReport

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Constants.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Constants.cs
@@ -5,12 +5,13 @@ namespace Voron.Data.Graphs;
 public partial class Hnsw
 {
     public const long EntryPointId = 1;
-    
-    private static readonly Slice VectorsContainerIdSlice;
+
+    internal static readonly Slice VectorContainerStorageSlice;
+    internal static readonly Slice VectorsContainerIdSlice;
     private static readonly Slice NodeIdToLocationSlice;
     private static readonly Slice NodesByVectorIdSlice;
     public static readonly Slice VectorsIdByHashSlice;
-    private static readonly Slice HnswGlobalConfigSlice;
+    internal static readonly Slice HnswGlobalConfigSlice;
     internal static readonly Slice OptionsSlice;
     
     static Hnsw()
@@ -25,6 +26,7 @@ public partial class Hnsw
             Slice.From(ctx, "NodeIdToLocation", ByteStringType.Immutable, out NodeIdToLocationSlice);
             Slice.From(ctx, "NodesByVectorId", ByteStringType.Immutable, out NodesByVectorIdSlice);
             Slice.From(ctx, "Options", ByteStringType.Immutable, out OptionsSlice);
+            Slice.From(ctx, "Vector storage", ByteStringType.Immutable, out VectorContainerStorageSlice);
         }
     }
 }

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -118,6 +118,14 @@ namespace Voron.Debugging
             {
                 var treeReport = GetReport(tree, input.IncludeDetails);
                 trees.Add(treeReport);
+                
+                if (SliceComparer.AreEqual(tree.Name, Hnsw.HnswGlobalConfigSlice))
+                {
+                    var globalContainer = tree.DirectRead(Hnsw.VectorsContainerIdSlice);
+                    if (globalContainer != null)
+                        input.Containers.Add(Hnsw.VectorContainerStorageSlice, Unsafe.Read<long>(globalContainer));
+                }
+                
                 if (tree.State.Header.Flags.HasFlag(TreeFlags.CompactTrees) ||
                     tree.State.Header.Flags.HasFlag(TreeFlags.Lookups))
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23850

### Additional description

![image](https://github.com/user-attachments/assets/c4a98cba-0ae2-43e9-a802-6dde77e6be91)


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
