### PR TITLE
RavenDB-24322 adjust shared journal config

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -655,6 +655,18 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.MaximumConcurrentBatchesForHnswAcceleration", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int MaximumConcurrentBatchesForHnswAcceleration { get; set; }
 
+        [Description("EXPERT: Disable shared journals between indexes.")]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.Storage.DisableSharedJournals", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool DisableSharedJournals { get; set; }
+        
+        [Description("EXPERT: Minimum amount of additional journals writes from indexes that we will merge before we'll let the transaction merger run. Higher values here means higher latency but better throughput")]
+        [DefaultValue(8)]
+        [IndexUpdateType(IndexUpdateType.Reset)]
+        [ConfigurationEntry("Indexing.Storage.MinimumSharedJournalsMergeCount", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int MinimumSharedJournalsMergeCount { get; set; }
+
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -164,16 +164,6 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Storage.DisableSparseRegions", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool DisableSparseRegions { get; set; }
-
-        [Description("EXPERT: Avoid shared journals between database & indexes.")]
-        [DefaultValue(false)]
-        [ConfigurationEntry("Storage.AvoidSharedJournals", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public bool AvoidSharedJournals { get; set; }
-        
-        [Description("EXPERT: Minimum amount of additional journals writes from indexes that we will merge before we'll let the transaction merger run database transactions. Higher values here means higher latency but throughput")]
-        [DefaultValue(8)]
-        [ConfigurationEntry("Storage.MinimumSharedJournalsMergeCount", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public int MinimumSharedJournalsMergeCount { get; set; }
         
         [Description("EXPERT: I/O for flush and sync operation is issued for a low priority thread, giving transaction commits higher priority")]
         [DefaultValue(false)]

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents
 
             options.DisableSparseRegions = _db.Configuration.Storage.DisableSparseRegions;
             options.JournalsCompressionAcceleration = _db.Configuration.Storage.JournalsCompressionAcceleration;
-            options.MinimumSharedJournalsMergeCount = _db.Configuration.Storage.MinimumSharedJournalsMergeCount;
+            options.MinimumSharedJournalsMergeCount = _db.Configuration.Indexing.MinimumSharedJournalsMergeCount;
             options.MaxLogFileSize = _db.Configuration.Storage.MaxJournalFileSize.GetValue(SizeUnit.Bytes);
             try
             {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -208,7 +208,7 @@ namespace Raven.Server.Documents
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = DocumentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.DisableSparseRegions = DocumentDatabase.Configuration.Storage.DisableSparseRegions;
             options.JournalsCompressionAcceleration = DocumentDatabase.Configuration.Storage.JournalsCompressionAcceleration;
-            options.MinimumSharedJournalsMergeCount = DocumentDatabase.Configuration.Storage.MinimumSharedJournalsMergeCount;
+            options.MinimumSharedJournalsMergeCount = DocumentDatabase.Configuration.Indexing.MinimumSharedJournalsMergeCount;
             options.MaxLogFileSize = DocumentDatabase.Configuration.Storage.MaxJournalFileSize.GetValue(SizeUnit.Bytes);
             try
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -606,7 +606,7 @@ namespace Raven.Server.Documents.Indexes
 
         private static void AttemptToLinkDatabaseAndIndexJournals(string name, StorageEnvironmentOptions indexOptions, DocumentDatabase documentDatabase)
         {
-            if (documentDatabase.Configuration.Storage.AvoidSharedJournals is false &&
+            if (documentDatabase.Configuration.Indexing.DisableSharedJournals is false &&
                 indexOptions.CanJournalsBeLinkedWith(documentDatabase.DocumentsStorage.Environment.Options))
             {
                 // here we enable the root / branch model for this index
@@ -777,7 +777,7 @@ namespace Raven.Server.Documents.Indexes
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = documentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.DisableSparseRegions = documentDatabase.Configuration.Storage.DisableSparseRegions;
             options.JournalsCompressionAcceleration = documentDatabase.Configuration.Storage.JournalsCompressionAcceleration;
-            options.MinimumSharedJournalsMergeCount = documentDatabase.Configuration.Storage.MinimumSharedJournalsMergeCount;
+            options.MinimumSharedJournalsMergeCount = documentDatabase.Configuration.Indexing.MinimumSharedJournalsMergeCount;
             options.MaxLogFileSize = documentDatabase.Configuration.Storage.MaxJournalFileSize.GetValue(SizeUnit.Bytes);
 
 

--- a/src/Raven.Server/Documents/Indexes/SharedIndexJournals.cs
+++ b/src/Raven.Server/Documents/Indexes/SharedIndexJournals.cs
@@ -48,7 +48,7 @@ public class SharedIndexJournals : IJournalMerger, IDisposable
         options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = documentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
         options.DisableSparseRegions = documentDatabase.Configuration.Storage.DisableSparseRegions;
         options.JournalsCompressionAcceleration = documentDatabase.Configuration.Storage.JournalsCompressionAcceleration;
-        options.MinimumSharedJournalsMergeCount = documentDatabase.Configuration.Storage.MinimumSharedJournalsMergeCount;
+        options.MinimumSharedJournalsMergeCount = documentDatabase.Configuration.Indexing.MinimumSharedJournalsMergeCount;
         options.MaxLogFileSize = documentDatabase.Configuration.Storage.MaxJournalFileSize.GetValue(SizeUnit.Bytes);
 
         options.OnNonDurableFileSystemError += documentDatabase.HandleNonDurableFileSystemError;

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -54,7 +54,8 @@ class configurationItem {
         "Indexing.Corax.VectorSearch.MaximumConcurrentBatchesForHnswAcceleration",
         "Indexing.Corax.VectorSearch.OrderByScoreAutomatically",
         "Storage.DisableSparseRegions",
-        "Storage.JournalsCompressionAcceleration"
+        "Storage.JournalsCompressionAcceleration",
+        "Indexing.Storage.DisableSharedJournals"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -110,6 +110,7 @@ namespace FastTests.Issues
                 "Indexing.MergeFactor",
                 "Indexing.NumberOfLargeSegmentsToMergeInSingleBatch",
                 "Indexing.UseCompoundFileInMerging",
+                "Indexing.Storage.DisableSharedJournals"
             };
 
             var sortedStudioList = propertiesDeclaredInStudio.OrderBy(x => x).ToList();

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -72,7 +72,7 @@ namespace SlowTests.Cluster
             // is waiting for the indexes to complete.
             // As we don't have an actual need for testing shared journals, it is easiest to simply 
             // skip this behavior for this test
-            databaseRecord.Settings[RavenConfiguration.GetKey(x => x.Storage.AvoidSharedJournals)] = "true"; 
+            databaseRecord.Settings[RavenConfiguration.GetKey(x => x.Indexing.DisableSharedJournals)] = "true"; 
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.Cluster, RavenArchitecture.X64)]
@@ -1717,7 +1717,7 @@ namespace SlowTests.Cluster
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
             {
-                Assert.True(context.DocumentDatabase.Configuration.Storage.AvoidSharedJournals, 
+                Assert.True(context.DocumentDatabase.Configuration.Indexing.DisableSharedJournals, 
                     "This test requires a shared journal to be disabled, since we try to coordinate db & indexes work in this test");
                 _manualResetEvent.WaitOne(_timeout);
                 return 1;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24322

### Additional description

Refactors the configuration settings related to shared journals, moving them from the `StorageConfiguration` to the `IndexingConfiguration`. 

- Kept the polarity `AvoidSharedJournals` but renamed to `DisableSharedJournals`
- Made `DisableSharedJournals` as `ServerWideOrPerDatabaseOrPerIndex`


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
