### PR TITLE
RavenDB-24311 AiWorker: initialize `EmbeddingsGenerationConfiguration` in ctor.

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.ServerWide;
 using Sparrow.Json;
@@ -34,6 +35,12 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public void Initialize(T connectionString)
         {
+            if (Initialized)
+            {
+                Debug.Assert(ReferenceEquals(connectionString, Connection));
+                return;
+            }
+            
             Connection = connectionString;
             Initialized = true;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -33,7 +33,7 @@ namespace Raven.Client.Documents.Operations.ETL
         [JsonIgnore]
         internal T Connection { get; set; }
 
-        public void Initialize(T connectionString)
+        public virtual void Initialize(T connectionString)
         {
             if (Initialized)
             {

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
@@ -25,6 +25,12 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
             return _name ??= Connection?.GetDestination();
         }
 
+        public override void Initialize(OlapConnectionString connectionString)
+        {
+            Connection = connectionString;
+            Initialized = true;
+        }
+
         public override EtlType EtlType => EtlType.Olap;
 
         public override bool UsingEncryptedCommunicationChannel()

--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -102,6 +102,7 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
             _parent = parent;
             Configuration = configuration;
             _connectionString = connectionString;
+            Configuration.Initialize(_connectionString);
             _connectionStringIdentifier = new AiConnectionStringIdentifier(_connectionString.Identifier);
             _embeddingGenerationService = AiHelper.CreateEmbeddingService(connectionString);
             _shutdown = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_24311.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_24311.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.Embeddings;
+#if DEBUG
+public class RavenDB_24311(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Core)]
+    public async Task CanAssertEmbeddingsGenerationChangeInSchema()
+    {
+        using var store = GetDocumentStore(new Options() { RunInMemory = false });
+
+        AddEmbeddingsGenerationTask(store, collectionName: "Dtos");
+        await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, true));
+        await store.Maintenance.Server.SendAsync(new ToggleDatabasesStateOperation(store.Database, false));
+    }
+}
+#endif


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24311

### Additional description

We need `EmbeddingsGenerationConfiguration` to be fully initialized to allow proper comparison on update, so we're allowing `AiWorker` to initialize it before `EtlLoader` initializes it.


### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
