### PR TITLE
RavenDB-24379 & RavenDB-24380 & RavenDB-24381 & RavenDB-24382:  Adjusted `RavenDB-24185` for X86

### DIFF
--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -20,7 +20,7 @@ public unsafe struct NativeList<T>
     where T: unmanaged
 {
     // We're using ByteStringContext to allocate the underlying storage, and we've to take into account the overhead of the metadata.
-    private static readonly int MaxCapacity = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(T);
+    internal static readonly int MaxCapacity = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(T);
     private static readonly int MaxCapacityInBytes = MaxCapacity * sizeof(T);
     private ByteString _storage;
 

--- a/test/SlowTests/Voron/RavenDB-24185.cs
+++ b/test/SlowTests/Voron/RavenDB-24185.cs
@@ -19,7 +19,11 @@ public class RavenDB_24185(ITestOutputHelper output) : NoDisposalNeeded(output)
         var nextCapacity = (int.MaxValue / sizeof(long)) + 1;
         var nativeList = new NativeList<long>();
         var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Initialize(allocator, nextCapacity));
-        Assert.Equal("NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: 268435456", ex.Message);
+        Assert.Equal($"NativeList<System.Int64> cannot be larger than {NativeList<long>.MaxCapacity} items. Requested size: 268435456", ex.Message);
+
+        // MaxCapacity takes into account the size of the ByteStringStorage. It contains a ptr, so the max capacity is dependent on the platform.
+        var maxCapacity = Sparrow.Platform.PlatformDetails.Is32Bits ? 268435453 : 268435452;
+        Assert.Equal(maxCapacity, NativeList<long>.MaxCapacity);
     }
 
     [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
@@ -31,7 +35,7 @@ public class RavenDB_24185(ITestOutputHelper output) : NoDisposalNeeded(output)
 
         var nextCapacity = (int.MaxValue / sizeof(long));
         var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Grow(allocator, nextCapacity));
-        Assert.Equal("NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: 268435456", ex.Message);
+        Assert.Equal($"NativeList<System.Int64> cannot be larger than {NativeList<long>.MaxCapacity} items. Requested size: 268435456", ex.Message);
     }
     
     [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
@@ -41,10 +45,10 @@ public class RavenDB_24185(ITestOutputHelper output) : NoDisposalNeeded(output)
         var nativeList = new NativeList<long>();
         var ex = Assert.Throws<InvalidOperationException>(() => nativeList.Initialize(allocator, int.MaxValue / sizeof(long)));
         
-        Assert.Equal($"NativeList<System.Int64> cannot be larger than 268435452 items. Requested size: {int.MaxValue / sizeof(long)}", ex.Message);
+        Assert.Equal($"NativeList<System.Int64> cannot be larger than {NativeList<long>.MaxCapacity} items. Requested size: {int.MaxValue / sizeof(long)}", ex.Message);
     }
 
-    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
+    [RavenMultiplatformFact(category: RavenTestCategory.Voron | RavenTestCategory.Memory, platform: RavenPlatform.All, architecture: RavenArchitecture.AllX64)]
     public unsafe void EnsureThatNextBitsSizeIsNotLimitingCapacityDueToAligning()
     {
         using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24379
https://issues.hibernatingrhinos.com/issue/RavenDB-24380
https://issues.hibernatingrhinos.com/issue/RavenDB-24381
https://issues.hibernatingrhinos.com/issue/RavenDB-24382

### Additional description

 Adjusted `RavenDB-24185` for X86:
- MaxCapacity depends on the size of `ByteStringStorage`, which contains pointer size.
- Turn off max allocation test on X86 platform

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
