### PR TITLE
RavenDB-24398 Data Archival Settings View: Add a toggle for MaxItemsToProcess

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.spec.tsx
@@ -4,7 +4,7 @@ import { rtlRender } from "test/rtlTestUtils";
 import * as stories from "./DataArchival.stories";
 import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 
-const { LicenseAllowed, LicenseRestricted } = composeStories(stories);
+const { LicenseAllowed, LicenseRestricted, InitialDataArchival } = composeStories(stories);
 
 describe("DataArchival", () => {
     it("can render", async () => {
@@ -31,5 +31,20 @@ describe("DataArchival", () => {
         const { screen } = rtlRender(<LicenseRestricted />);
 
         expect(await screen.findByText(/Licensing/)).toBeInTheDocument();
+    });
+
+    it("can set default batch size", async () => {
+        const { screen, fireClick } = rtlRender(<InitialDataArchival />);
+        const enableButton = await screen.findByRole("checkbox", { name: "Enable Data Archival" });
+
+        expect(enableButton).not.toBeChecked();
+
+        await fireClick(enableButton);
+
+        const setMaxNumberOfDocumentToProcessCheckbox = await screen.findByLabelText(
+            "Set max number of documents to process in a single run"
+        );
+        expect(setMaxNumberOfDocumentToProcessCheckbox).toBeChecked();
+        expect(await screen.findByName("maxItemsToProcess")).toHaveValue(65536);
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.stories.tsx
@@ -17,19 +17,24 @@ export default {
     },
 } satisfies Meta<typeof DataArchival>;
 
-function commonInit() {
+function commonInit(hasConfiguration: boolean) {
     const { databases } = mockStore;
+    const { databasesService } = mockServices;
+
+    if (hasConfiguration) {
+        databasesService.withDataArchivalConfiguration();
+    } else {
+        databasesService.withoutArchivalConfiguration();
+    }
+
     databases.withActiveDatabase_NonSharded_SingleNode();
 }
 
 export const LicenseAllowed: StoryObj<typeof DataArchival> = {
     render: () => {
-        commonInit();
+        commonInit(true);
 
-        const { databasesService } = mockServices;
         const { license } = mockStore;
-
-        databasesService.withDataArchivalConfiguration();
         license.with_License();
 
         return <DataArchival />;
@@ -38,13 +43,21 @@ export const LicenseAllowed: StoryObj<typeof DataArchival> = {
 
 export const LicenseRestricted: StoryObj<typeof DataArchival> = {
     render: () => {
-        commonInit();
+        commonInit(true);
 
-        const { databasesService } = mockServices;
         const { license } = mockStore;
-
-        databasesService.withDataArchivalConfiguration();
         license.with_LicenseLimited({ HasDataArchival: false });
+
+        return <DataArchival />;
+    },
+};
+
+export const InitialDataArchival: StoryObj<typeof DataArchival> = {
+    render: () => {
+        commonInit(false);
+
+        const { license } = mockStore;
+        license.with_License();
 
         return <DataArchival />;
     },

--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
@@ -35,6 +35,8 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import { useRavenLink } from "hooks/useRavenLink";
 
+const defaultItemsToProcess = 65536;
+
 export default function DataArchival() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
@@ -68,16 +70,34 @@ export default function DataArchival() {
 
     useEffect(() => {
         const { unsubscribe } = watch((values, { name }) => {
-            if (name === "isDataArchivalEnabled" && !values.isDataArchivalEnabled) {
-                setValue("isArchiveFrequencyEnabled", false, { shouldValidate: true });
-            }
-            if (name === "isArchiveFrequencyEnabled" && !values.isArchiveFrequencyEnabled) {
-                setValue("archiveFrequency", null, { shouldValidate: true });
+            switch (name) {
+                case "isDataArchivalEnabled": {
+                    if (values.isDataArchivalEnabled) {
+                        setValue("isLimitMaxItemsToProcessEnabled", true, { shouldValidate: true });
+                    } else {
+                        setValue("isLimitMaxItemsToProcessEnabled", false, { shouldValidate: true });
+                        setValue("isArchiveFrequencyEnabled", false, { shouldValidate: true });
+                    }
+                    break;
+                }
+                case "isLimitMaxItemsToProcessEnabled": {
+                    if (values.isLimitMaxItemsToProcessEnabled) {
+                        setValue("maxItemsToProcess", defaultItemsToProcess, { shouldValidate: true });
+                    } else {
+                        setValue("maxItemsToProcess", null, { shouldValidate: true });
+                    }
+                    break;
+                }
+                case "isArchiveFrequencyEnabled": {
+                    if (!values.isArchiveFrequencyEnabled) {
+                        setValue("archiveFrequency", null, { shouldValidate: true });
+                    }
+                    break;
+                }
             }
         });
-
         return () => unsubscribe();
-    }, [watch, setValue]);
+    }, [setValue, watch]);
 
     const onSave: SubmitHandler<DataArchivalFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
@@ -86,6 +106,7 @@ export default function DataArchival() {
             await databasesService.saveDataArchivalConfiguration(databaseName, {
                 Disabled: !formData.isDataArchivalEnabled,
                 ArchiveFrequencyInSec: formData.isArchiveFrequencyEnabled ? formData.archiveFrequency : null,
+                MaxItemsToProcess: formData.isLimitMaxItemsToProcessEnabled ? formData.maxItemsToProcess : null,
             });
 
             messagePublisher.reportSuccess("Data archival configuration saved successfully");
@@ -166,6 +187,28 @@ export default function DataArchival() {
                                                     addon="seconds"
                                                 />
                                             </div>
+                                            <div>
+                                                <FormSwitch
+                                                    name="isLimitMaxItemsToProcessEnabled"
+                                                    control={control}
+                                                    className="mb-3"
+                                                    disabled={
+                                                        formState.isSubmitting || !formValues.isDataArchivalEnabled
+                                                    }
+                                                >
+                                                    Set max number of documents to process in a single run
+                                                </FormSwitch>
+                                                <FormInput
+                                                    name="maxItemsToProcess"
+                                                    control={control}
+                                                    type="number"
+                                                    disabled={
+                                                        formState.isSubmitting ||
+                                                        !formValues.isLimitMaxItemsToProcessEnabled
+                                                    }
+                                                    addon="items"
+                                                />
+                                            </div>
                                         </div>
                                     </Card.Body>
                                 </Card>
@@ -205,7 +248,6 @@ export default function DataArchival() {
                                         </ul>
                                     </li>
                                 </ul>
-
                                 <p>Sample document:</p>
                                 <Code code={codeExample} language="javascript" />
                                 <hr />
@@ -245,6 +287,8 @@ function mapToFormData(dto: DataArchivalConfiguration): DataArchivalFormData {
             isDataArchivalEnabled: false,
             isArchiveFrequencyEnabled: false,
             archiveFrequency: null,
+            isLimitMaxItemsToProcessEnabled: false,
+            maxItemsToProcess: null,
         };
     }
 
@@ -252,6 +296,8 @@ function mapToFormData(dto: DataArchivalConfiguration): DataArchivalFormData {
         isDataArchivalEnabled: !dto.Disabled,
         isArchiveFrequencyEnabled: dto.ArchiveFrequencyInSec != null,
         archiveFrequency: dto.ArchiveFrequencyInSec,
+        isLimitMaxItemsToProcessEnabled: dto.MaxItemsToProcess != null,
+        maxItemsToProcess: dto.MaxItemsToProcess,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchivalValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchivalValidation.ts
@@ -10,7 +10,20 @@ const schema = yup
             .nullable()
             .positive()
             .integer()
-            .when("isArchiveFrequencyEnabled", { is: true, then: (schema) => schema.required() }),
+            .when("isArchiveFrequencyEnabled", {
+                is: true,
+                then: (schema) => schema.required(),
+            }),
+        isLimitMaxItemsToProcessEnabled: yup.boolean(),
+        maxItemsToProcess: yup
+            .number()
+            .nullable()
+            .positive()
+            .integer()
+            .when("isLimitMaxItemsToProcessEnabled", {
+                is: true,
+                then: (schema) => schema.required(),
+            }),
     })
     .required();
 

--- a/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
@@ -117,6 +117,10 @@ export default class MockDatabasesService extends AutoMockService<DatabasesServi
         );
     }
 
+    withoutArchivalConfiguration() {
+        return this.mockResolvedValue(this.mocks.getDataArchivalConfiguration, null, undefined);
+    }
+
     withDocumentsCompressionConfiguration(dto?: Raven.Client.ServerWide.DocumentsCompressionConfiguration) {
         return this.mockResolvedValue(
             this.mocks.getDocumentsCompressionConfiguration,


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24398/Data-Archival-Settings-View-Add-a-toggle-for-MaxItemsToProcess

### Additional description
Added the `MaxItemsToProcess` toggle in the Data Archival Settings View

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] documentation is handled in issue: 
https://issues.hibernatingrhinos.com/issue/RDoc-2633/Server-Extensions-Data-archival-Fix-article

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
