### PR TITLE
RavenDB-24298 : GenAI - editing the configuration doesn't seems to affect

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -108,4 +108,16 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
         return json;
     }
+
+    internal bool Equals(GenAiConfiguration other)
+    {
+        if (other == null)
+            return false;
+
+        return Prompt == other.Prompt &&
+               UpdateScript == other.UpdateScript &&
+               JsonSchema == other.JsonSchema &&
+               SampleObject == other.SampleObject &&
+               MaxConcurrency == other.MaxConcurrency;
+    }
 }

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -109,15 +109,19 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         return json;
     }
 
-    internal bool Equals(GenAiConfiguration other)
+    internal override EtlConfigurationCompareDifferences Compare(EtlConfiguration<AiConnectionString> config, Dictionary<string, AiConnectionString> connectionStrings, List<(string TransformationName, EtlConfigurationCompareDifferences Difference)> transformationDiffs = null)
     {
-        if (other == null)
-            return false;
+        var differences = base.Compare(config, connectionStrings, transformationDiffs);
+        if (config is not GenAiConfiguration other)
+            return differences;
 
-        return Prompt == other.Prompt &&
-               UpdateScript == other.UpdateScript &&
-               JsonSchema == other.JsonSchema &&
-               SampleObject == other.SampleObject &&
-               MaxConcurrency == other.MaxConcurrency;
+        if (Prompt != other.Prompt ||
+            UpdateScript != other.UpdateScript ||
+            JsonSchema != other.JsonSchema ||
+            SampleObject != other.SampleObject ||
+            MaxConcurrency != other.MaxConcurrency)
+            differences |= EtlConfigurationCompareDifferences.Other;
+
+        return differences;
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -141,7 +141,7 @@ namespace Raven.Client.Documents.Operations.ETL
             return ToJson();
         }
 
-        internal EtlConfigurationCompareDifferences Compare(
+        internal virtual EtlConfigurationCompareDifferences Compare(
             EtlConfiguration<T> config,
             Dictionary<string, T> connectionStrings,
             List<(string TransformationName, EtlConfigurationCompareDifferences Difference)> transformationDiffs = null)

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
@@ -17,6 +17,6 @@ namespace Raven.Client.Documents.Operations.ETL
         MentorNode = 1 << 9,
         ConfigurationDisabled = 1 << 10,
         TransformationDocumentIdPostfix = 1 << 11,
-        ConnectionString = 1 << 12,
+        ConnectionString = 1 << 12
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
@@ -17,6 +17,7 @@ namespace Raven.Client.Documents.Operations.ETL
         MentorNode = 1 << 9,
         ConfigurationDisabled = 1 << 10,
         TransformationDocumentIdPostfix = 1 << 11,
-        ConnectionString = 1 << 12
+        ConnectionString = 1 << 12,
+        Other = 1 << 13
     }
 }

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -863,6 +863,9 @@ namespace Raven.Server.Documents.ETL
 
                         foreach (var config in myGenAiEtl)
                         {
+                            if (genAiTask.Configuration.Equals(config) == false)
+                                continue;
+
                             var diff = genAiTask.Configuration.Compare(config, record.AiConnectionStrings);
 
                             if (diff == EtlConfigurationCompareDifferences.None)

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -863,9 +863,6 @@ namespace Raven.Server.Documents.ETL
 
                         foreach (var config in myGenAiEtl)
                         {
-                            if (genAiTask.Configuration.Equals(config) == false)
-                                continue;
-
                             var diff = genAiTask.Configuration.Compare(config, record.AiConnectionStrings);
 
                             if (diff == EtlConfigurationCompareDifferences.None)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -100,7 +100,7 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
 
         var context = JsBlittableBridge.Translate(Context, DocumentScript.ScriptEngine, args[0].AsObject());
         string hash = CalculateHash(context);
-        var isCached = ShouldSendContext(hash, _configuration.Name, Current.Document) == false;
+        var isCached = ShouldSendContext(hash, _configuration.Identifier, Current.Document) == false;
 
         using (context)
         {
@@ -110,11 +110,11 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
         return JsValue.Null;
     }
 
-    private static bool ShouldSendContext(string hash, string taskName, Document doc)
+    private static bool ShouldSendContext(string hash, string taskIdentifier, Document doc)
     {
         if (doc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
             metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection) == false ||
-            hashesSection.TryGet(taskName, out BlittableJsonReaderArray existingHashes) == false)
+            hashesSection.TryGet(taskIdentifier, out BlittableJsonReaderArray existingHashes) == false)
             return true; // hash not found, should send
 
         foreach (var h in existingHashes)

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24298.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24298.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server.Documents.AI.GenAi;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_24298(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    private async Task ConfigurationUpdateShouldTakeAffect(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore();
+        const string docId = "posts/1";
+
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var sampleObject = JsonConvert.SerializeObject(new { Translation = "translated text" });
+        var schema = OllamaChatCompletionClient.GetSchemaFor(sampleObject);
+
+        config.Prompt = "Translate this text to Polish";
+        config.JsonSchema = schema;
+        config.UpdateScript = "this.TextInPolish = $output.Translation;";
+        config.Collection = "Posts";
+        config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
+        config.Identifier = "posts-translation-check";
+
+        store.Maintenance.Send(new AddGenAiOperation(config));
+
+        var etlDone = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new GenAiBasics.Post([new GenAiBasics.Comment("RavenDB is amazing", "Alex")], 
+                "Understanding RavenDB Indexing", 
+                "Indexes in RavenDB are powerful..."), 
+                docId);
+            session.SaveChanges();
+        }
+
+        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+
+        var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
+        var taskId = taskInfo.TaskId;
+
+        // update the configuration
+        config.UpdateScript = "this.Translated = $output.Translation;";
+        var result = store.Maintenance.Send(new UpdateEtlOperation<AiConnectionString>(taskId, config));
+        await Server.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex, TimeSpan.FromSeconds(15));
+
+        using (var session = store.OpenSession())
+        {
+            var post = session.Load<GenAiBasics.Post>(docId);
+            post.Comments.Add(new GenAiBasics.Comment("spam", "evil bot"));
+            session.SaveChanges();
+        }
+
+        Assert.True(await WaitForValueAsync(async () =>
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+                doc.TryGet("Translated", out string translation);
+                return translation != null;
+            }
+        }, expectedVal: true, timeout: 30_000));
+
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24298/GenAI-editing-the-gen-ai-task-doesnt-seems-to-affect

### Additional description

Compare specific GenAI configuration properties when deciding if we should reload the ETL process 
 
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
