### PR TITLE
RavenDB-24007 Added ability to cancel `Commit` operation in Corax.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using Corax.Analyzers;
 using Corax.Mappings;
 using Corax.Pipeline;
@@ -890,9 +891,9 @@ namespace Corax.Indexing
             return fieldTree.TryGetValue(termValue, out idInTree);
         }
 
-        public void Commit() => Commit<EmptyStatsScope>(default);
+        public void Commit(CancellationToken token = default) => Commit<EmptyStatsScope>(default, token);
         
-        public void Commit<TStatsScope>(TStatsScope stats)
+        public void Commit<TStatsScope>(TStatsScope stats, CancellationToken token)
             where TStatsScope : struct, ICoraxStatsScope
         {
             _indexDebugDumper.Commit();
@@ -928,6 +929,7 @@ namespace Corax.Indexing
             uniquePostingList.Sort(sortedFields);
             foreach (var indexedField in sortedFields)
             {
+                token.ThrowIfCancellationRequested();
                 stats.SetAllocatedUnmanagedBytes(_entriesAllocator?._totalAllocated ?? 0);
 
                 //Dynamic terms will be indexed with explicit field terms.
@@ -942,17 +944,17 @@ namespace Corax.Indexing
                 using (staticFieldScope.For(CommitOperation.TextualValues))
                 {
                     using var inserter = new TextualFieldInserter(this, entriesToTermsTree, indexedField, workingBuffer);
-                    inserter.InsertTextualField();
+                    inserter.InsertTextualField(token);
                 }
                 
                 using (staticFieldScope.For(CommitOperation.IntegerValues))
-                    InsertNumericFieldLongs(entriesToTermsTree, indexedField, workingBuffer);
+                    InsertNumericFieldLongs(entriesToTermsTree, indexedField, workingBuffer, token);
                 
                 using (staticFieldScope.For(CommitOperation.FloatingValues))
-                    InsertNumericFieldDoubles(entriesToTermsTree, indexedField, workingBuffer);
+                    InsertNumericFieldDoubles(entriesToTermsTree, indexedField, workingBuffer, token);
 
                 using (staticFieldScope.For(CommitOperation.SpatialValues))
-                    InsertSpatialField(entriesToSpatialTree, indexedField);
+                    InsertSpatialField(entriesToSpatialTree, indexedField, token);
 
                 if (indexedField.HasMultipleTermsPerField)
                 {
@@ -1045,7 +1047,7 @@ namespace Corax.Indexing
             }
         }
 
-        private void InsertSpatialField(Tree entriesToSpatialTree, IndexedField indexedField)
+        private void InsertSpatialField(Tree entriesToSpatialTree, IndexedField indexedField, CancellationToken token)
         {
             if (indexedField.Spatial == null)
                 return;
@@ -1055,8 +1057,11 @@ namespace Corax.Indexing
             var termContainerId = fieldRootPage << 3 | 0b010;
             Debug.Assert(termContainerId >>> 3 == fieldRootPage, "field root too high?");
             var entriesToTerms = entriesToSpatialTree.FixedTreeFor(indexedField.Name, sizeof(double)+sizeof(double));
+
+
             foreach (var (entry, spatialEntry)  in indexedField.Spatial)
             {
+                token.ThrowIfCancellationRequested();
                 spatialEntry.Locations.Sort();
 
                 ref var entryTerms = ref GetEntryTerms(spatialEntry.TermsPerEntryIndex);
@@ -1229,7 +1234,7 @@ namespace Corax.Indexing
                 _pagesToPrefetch.Dispose();
             }
 
-            public void InsertTextualField()
+            public void InsertTextualField(in CancellationToken token)
             {
                 long totalLengthOfTerm = 0;
                 _buffers.PrepareTerms(_indexedField, out var sortedTerms, out var termsOffsets);
@@ -1255,6 +1260,8 @@ namespace Corax.Indexing
                 
                 while (true)
                 {
+                    token.ThrowIfCancellationRequested();
+                    
                     if (sortedTerms.IsEmpty)
                         break;
 
@@ -1938,7 +1945,7 @@ namespace Corax.Indexing
             _largePostingListSet.Remove(containerId);
         }
 
-        private void InsertNumericFieldLongs(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf)
+        private void InsertNumericFieldLongs(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf, CancellationToken token)
         {
             var fieldTree = _fieldsTree.LookupFor<Int64LookupKey>(indexedField.NameLong);
 
@@ -1946,6 +1953,7 @@ namespace Corax.Indexing
 
             foreach (var (term, entriesLocation) in indexedField.Longs)
             {
+                token.ThrowIfCancellationRequested();
                 ref var entries = ref indexedField.Storage.GetAsRef(entriesLocation);
 
                 // We are not going to be using these entries anymore after this. 
@@ -2013,7 +2021,7 @@ namespace Corax.Indexing
             }
         }
 
-        private void InsertNumericFieldDoubles(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf)
+        private void InsertNumericFieldDoubles(Tree entriesToTermsTree, IndexedField indexedField, Span<byte> tmpBuf, CancellationToken token)
         {
             var fieldTree = _fieldsTree.LookupFor<DoubleLookupKey>(indexedField.NameDouble);
 
@@ -2021,6 +2029,8 @@ namespace Corax.Indexing
 
             foreach (var (term, entriesLocation) in indexedField.Doubles)
             {
+                token.ThrowIfCancellationRequested();
+                
                 ref var entries = ref indexedField.Storage.GetAsRef(entriesLocation);
 
                 // We are not going to be using these entries anymore after this. 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2481,7 +2481,7 @@ namespace Raven.Server.Documents.Indexes
                             {
                                 using (var indexWriteOperation = writeOperation.Value)
                                 {
-                                    indexWriteOperation.Commit(stats);
+                                    indexWriteOperation.Commit(stats, cancellationToken);
 
                                     entriesCount = writeOperation.Value.EntriesCount();
                                 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceLuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceLuceneIndexWriteOperation.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
@@ -21,12 +22,12 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             _outputScope = new(index, writeTransaction, indexContext, this);
         }
 
-        public override void Commit(IndexingStatsScope stats)
+        public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
             if (_outputScope.IsActive)
-                base.Commit(stats);
+                base.Commit(stats, token);
             else
-                _outputScope.Commit(stats);
+                _outputScope.Commit(stats, token);
         }
 
         public override void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -73,13 +73,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             UpdateDynamicFieldsBindings();
         }
         
-        public override void Commit(IndexingStatsScope stats)
+        public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
             if (_indexWriter != null)
             {
                 using (var commitStats = stats.For(IndexingOperation.Corax.Commit))
                 {
-                    _indexWriter.Commit(new CoraxIndexingStats(commitStats));
+                    _indexWriter.Commit(new CoraxIndexingStats(commitStats), token);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/OutputReduceCoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/OutputReduceCoraxIndexWriteOperation.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -17,12 +18,12 @@ public sealed class OutputReduceCoraxIndexWriteOperation : CoraxIndexWriteOperat
         _outputScope = new(index, writeTransaction, indexContext, this);
     }
     
-    public override void Commit(IndexingStatsScope stats)
+    public override void Commit(IndexingStatsScope stats, CancellationToken token)
     {
         if (_outputScope.IsActive)
-            base.Commit(stats);
+            base.Commit(stats, token);
         else
-            _outputScope.Commit(stats);
+            _outputScope.Commit(stats, token);
     }
 
     public override void IndexDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats,

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
         {
         }
 
-        public abstract void Commit(IndexingStatsScope stats);
+        public abstract void Commit(IndexingStatsScope stats, CancellationToken token);
 
         public abstract void Optimize(CancellationToken token);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -104,7 +104,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        public override void Commit(IndexingStatsScope stats)
+        public override void Commit(IndexingStatsScope stats, CancellationToken token)
         {
             if (_writer != null)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/OutputReduceIndexWriteOperationScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/OutputReduceIndexWriteOperationScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce.OutputToCollection;
@@ -28,7 +29,7 @@ internal sealed class OutputReduceIndexWriteOperationScope<TWriter> where TWrite
         IsActive = false;
     }
 
-    public void Commit(IndexingStatsScope stats)
+    public void Commit(IndexingStatsScope stats, CancellationToken token)
     {
         using (new IsActiveScope(this))
         {
@@ -36,7 +37,7 @@ internal sealed class OutputReduceIndexWriteOperationScope<TWriter> where TWrite
 
             using (_txHolder.AcquireTransaction(out _))
             {
-                _writer.Commit(stats);
+                _writer.Commit(stats, token);
             }
 
             try

--- a/src/Raven.Server/Documents/Indexes/Test/TestIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Test/TestIndexWriteOperation.cs
@@ -27,9 +27,9 @@ public sealed class TestIndexWriteOperation : IndexWriteOperationBase
         _inner?.Dispose();
     }
 
-    public override void Commit(IndexingStatsScope stats)
+    public override void Commit(IndexingStatsScope stats, CancellationToken token)
     {
-        _inner.Commit(stats);
+        _inner.Commit(stats, token);
     }
 
     public override void Optimize(CancellationToken token)

--- a/test/SlowTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Static/CollisionsOfReduceKeyHashes.cs
@@ -161,7 +161,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                     using (var indexWriteOperation = writeOperation.Value)
                     {
-                        indexWriteOperation.Commit(stats);
+                        indexWriteOperation.Commit(stats, CancellationToken.None);
                     }
 
                     index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -226,7 +226,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -289,7 +289,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);

--- a/test/SlowTests/Server/Documents/Indexing/Static/RavenDB_11469.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Static/RavenDB_11469.cs
@@ -97,7 +97,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                     using (var indexWriteOperation = writeOperation.Value)
                     {
-                        indexWriteOperation.Commit(stats);
+                        indexWriteOperation.Commit(stats, CancellationToken.None);
                     }
 
                     index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -158,7 +158,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -217,7 +217,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);
@@ -277,7 +277,7 @@ namespace SlowTests.Server.Documents.Indexing.Static
 
                         using (var indexWriteOperation = writeOperation.Value)
                         {
-                            indexWriteOperation.Commit(stats);
+                            indexWriteOperation.Commit(stats, CancellationToken.None);
                         }
 
                         index.IndexPersistence.RecreateSearcher(tx.InnerTransaction);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24007

### Additional description
Added ability to cancel `Commit` operation in Corax.
### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
Corax indexing can be cancelled during commit. Previously, even when we cancelled the operation, we waited for commit to finish.
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
