### PR TITLE
RavenDB-24339 - Fix for `SlowTests.Server.Documents.PeriodicBackup.MaxReadOpsPerSecOptionTests.ShouldRespect_Option_MaxReadOpsPerSec_OnRestore`

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Apis.Util;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide.Operations.Configuration;
@@ -517,8 +516,13 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
                     return (DocumentsToCreate - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
 
                 case BackupType.Snapshot:
-                    // snapshot data requires 11 buffer iterations for db with 5 docs (value obtained experimentally)
-                    return 11;
+                    // snapshot data requires 10 or 11 buffer iterations for a database with 5 docs, depending on the system environment's bitness (values obtained experimentally)
+                    return RuntimeInformation.ProcessArchitecture switch
+                    {
+                        Architecture.X86 or Architecture.Arm => 10,
+                        Architecture.X64 or Architecture.Arm64 => 11,
+                        _ => throw new ArgumentOutOfRangeException(nameof(RuntimeInformation.ProcessArchitecture), "Unsupported architecture.")
+                    };
 
                 default:
                     throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24339

### Additional description

Setting up the test for greater tolerance for the Restore scenario in an x86 environment.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes, it's specific for x86 platform
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
