### PR TITLE
RavenDB-23232 Add idle index state

### DIFF
--- a/src/Raven.Studio/typescript/components/common/PopoverWithHoverWrapper.tsx
+++ b/src/Raven.Studio/typescript/components/common/PopoverWithHoverWrapper.tsx
@@ -7,6 +7,7 @@ interface PopoverWithHoverWrapperProps extends Omit<PopoverWithHoverProps, "targ
     message: ReactNode | ReactNode[];
     isInPopoverBody?: boolean;
     inline?: boolean;
+    wrapperClassName?: string;
 }
 
 export default function PopoverWithHoverWrapper({
@@ -14,12 +15,13 @@ export default function PopoverWithHoverWrapper({
     message,
     isInPopoverBody = true,
     inline = true,
+    wrapperClassName,
     ...rest
 }: PopoverWithHoverWrapperProps) {
     const [target, setTarget] = useState<HTMLElement>();
     return (
         <>
-            <div ref={setTarget} className={classNames({ "d-inline-block": inline })}>
+            <div ref={setTarget} className={classNames({ "d-inline-block": inline }, wrapperClassName)}>
                 {children}
             </div>
             {message && (

--- a/src/Raven.Studio/typescript/components/common/ProgressCircle.tsx
+++ b/src/Raven.Studio/typescript/components/common/ProgressCircle.tsx
@@ -1,14 +1,4 @@
 ﻿import classNames from "classnames";
-
-export interface ProgressCircleProps {
-    state: "success" | "failed" | "running" | "warning";
-    children?: ReactNode;
-    icon?: IconName;
-    progress?: number;
-    inline?: boolean;
-    onClick?: () => void;
-}
-
 import React, { ReactNode } from "react";
 import "./ProgressCircle.scss";
 import { Icon } from "./Icon";
@@ -17,8 +7,18 @@ import IconName from "typings/server/icons";
 const stateIndicatorProgressRadius = 13;
 const circumference = 2 * Math.PI * stateIndicatorProgressRadius;
 
+export interface ProgressCircleProps {
+    state: "success" | "failed" | "running" | "warning";
+    children?: ReactNode;
+    icon?: IconName;
+    progress?: number;
+    inline?: boolean;
+    onClick?: () => void;
+    descClassName?: string;
+}
+
 export function ProgressCircle(props: ProgressCircleProps) {
-    const { state, children, inline, icon, progress, onClick } = props;
+    const { state, children, inline, icon, progress, onClick, descClassName } = props;
 
     const showProgress = progress != null;
 
@@ -27,7 +27,7 @@ export function ProgressCircle(props: ProgressCircleProps) {
             className={classNames("progress-circle", state, { inline }, { "cursor-pointer": onClick })}
             onClick={onClick}
         >
-            <div className="state-desc">
+            <div className={classNames("state-desc", descClassName)}>
                 {showProgress && <strong>{(100 * progress).toFixed(0)}%</strong>}
                 {children}
             </div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -18,6 +18,7 @@ import IconName from "typings/server/icons";
 import IndexDistributionStatusChecker from "./IndexDistributionStatusChecker";
 import moment = require("moment");
 import genUtils = require("common/generalUtils");
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 
 interface IndexDistributionProps {
     index: IndexSharedInfo;
@@ -252,6 +253,9 @@ function getIcon(statusChecker: IndexDistributionStatusChecker): IconName {
     if (statusChecker.somePending()) {
         return iconForState("Pending");
     }
+    if (statusChecker.everyIdle()) {
+        return "check";
+    }
     if (statusChecker.someStale()) {
         return null;
     }
@@ -298,6 +302,9 @@ function getStateText(statusChecker: IndexDistributionStatusChecker): string {
     if (statusChecker.someStale()) {
         return "Running";
     }
+    if (statusChecker.everyIdle()) {
+        return "Idle";
+    }
     return "Up to date";
 }
 
@@ -316,8 +323,10 @@ export function JoinedIndexProgress(props: JoinedIndexProgressProps) {
             icon={getIcon(statusChecker)}
             progress={stateText === "Running" ? overallProgress : null}
             onClick={onClick}
+            descClassName="d-flex align-items-center"
         >
             {stateText}
+            {statusChecker.everyIdle() && <IdleIndexInfoIcon />}
         </ProgressCircle>
     );
 }
@@ -349,6 +358,15 @@ export function IndexProgress(props: IndexProgressProps) {
         return (
             <ProgressCircle state="failed" icon="cancel">
                 Error
+            </ProgressCircle>
+        );
+    }
+
+    if (nodeInfo.details.state === "Idle") {
+        return (
+            <ProgressCircle state="success" icon="check" descClassName="d-flex align-items-center">
+                Idle
+                <IdleIndexInfoIcon />
             </ProgressCircle>
         );
     }
@@ -389,6 +407,25 @@ export function IndexProgress(props: IndexProgressProps) {
         <ProgressCircle state="success" icon={icon}>
             up to date
         </ProgressCircle>
+    );
+}
+
+function IdleIndexInfoIcon() {
+    return (
+        <PopoverWithHoverWrapper
+            message={
+                <ul className="m-0">
+                    <li>An idle index is an index that is running but it&apos;s rarely or never used by queries.</li>
+                    <li className="mt-1">
+                        It still consumes storage and can slow down write operations, since the database must maintain
+                        it during inserts, updates, or deletes.
+                    </li>
+                </ul>
+            }
+            wrapperClassName="d-flex"
+        >
+            <Icon icon="info" color="info" margin="ms-1" className="fs-4" />
+        </PopoverWithHoverWrapper>
     );
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -19,6 +19,7 @@ import IndexDistributionStatusChecker from "./IndexDistributionStatusChecker";
 import moment = require("moment");
 import genUtils = require("common/generalUtils");
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { useRavenLink } from "components/hooks/useRavenLink";
 
 interface IndexDistributionProps {
     index: IndexSharedInfo;
@@ -411,16 +412,25 @@ export function IndexProgress(props: IndexProgressProps) {
 }
 
 function IdleIndexInfoIcon() {
+    const docsLink = useRavenLink({ hash: "2VWBSO" });
+
     return (
         <PopoverWithHoverWrapper
             message={
-                <ul className="m-0">
-                    <li>An idle index is an index that is running but it&apos;s rarely or never used by queries.</li>
-                    <li className="mt-1">
-                        It still consumes storage and can slow down write operations, since the database must maintain
-                        it during inserts, updates, or deletes.
-                    </li>
-                </ul>
+                <>
+                    An auto-index becomes Idle when the time difference between its last-query-time and the most recent
+                    time the database was queried (using any other index) exceeds a configurable threshold (default 30
+                    min).
+                    <br />
+                    <br />
+                    While idle, it is not considered disabled and continues indexing relevant data. If it remains idle,
+                    it will be deleted after a configurable duration (default: 72 hrs).
+                    <br />
+                    <br />
+                    <a href={docsLink} target="_blank">
+                        Docs - Index states
+                    </a>
+                </>
             }
             wrapperClassName="d-flex"
         >

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistributionStatusChecker.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistributionStatusChecker.ts
@@ -38,4 +38,5 @@ export default class IndexDistributionStatusChecker {
     somePaused = (): boolean => this.index.nodesInfo.some((x) => x.details?.status === "Paused");
     somePending = (): boolean => this.index.nodesInfo.some((x) => x.details?.status === "Pending");
     someStale = (): boolean => this.index.nodesInfo.some((x) => x.details?.stale);
+    everyIdle = (): boolean => this.index.nodesInfo.every((x) => x.details?.state === "Idle");
 }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.stories.tsx
@@ -40,6 +40,7 @@ function configureIndexService() {
 function configureDifferentIndexStates() {
     const { indexesService } = mockServices;
 
+    const [idleStats, idleProgress] = IndexesStubs.getIdleIndex();
     const [upToDateStats, upToDateProgress] = IndexesStubs.getUpToDateIndex();
     const [upToDateStatsWithErrors, upToDateProgressWithErrors] = IndexesStubs.getUpToDateIndexWithErrors();
     const [staleStats, staleProgress] = IndexesStubs.getStaleInProgressIndex();
@@ -52,6 +53,7 @@ function configureDifferentIndexStates() {
 
     indexesService.withGetStats(
         [
+            idleStats,
             upToDateStats,
             upToDateStatsWithErrors,
             staleStats,
@@ -65,6 +67,7 @@ function configureDifferentIndexStates() {
     );
     indexesService.withGetProgress(
         [
+            idleProgress,
             upToDateProgress,
             upToDateProgressWithErrors,
             staleProgress,

--- a/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
@@ -43,6 +43,14 @@ export class IndexesStubs {
         return IndexesStubs.getSampleProgress().find((x) => x.Name === "Orders/ByCompany");
     }
 
+    static getIdleIndex(): [IndexStats, IndexProgress] {
+        const stats = IndexesStubs.getGenericStats();
+        stats.Name = "IdleIndex";
+        stats.State = "Idle";
+
+        return [stats, null];
+    }
+
     static getUpToDateIndex(): [IndexStats, IndexProgress] {
         const stats = IndexesStubs.getGenericStats();
         stats.Name = "UpToDateIndex";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23232/Cant-enable-Idle-index

### Additional description

![image](https://github.com/user-attachments/assets/7cea85cf-fd5c-4bb5-b140-a40371b51ac3)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
