### PR TITLE
RavenDB-24306 : GenAI test should filter metadata properties from input document

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
@@ -403,15 +404,8 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                         // so it needs to be written to storage before the patch.
                         // the write-tx is not commited so this won't be persisted.
 
-                        if (document!.Data.HasParent)
-                        {
-                            using (var old = document.Data)
-                            {
-                                document.Data = document.Data.Clone(context);
-                            }
-                        }
-
-                        context.DocumentDatabase.DocumentsStorage.Put(context, document.Id, expectedChangeVector: null, document.Data);
+                        FilterMetadataProperties(context, document);
+                        context.DocumentDatabase.DocumentsStorage.Put(context, document!.Id, expectedChangeVector: null, document.Data);
                     }
 
                     foreach (var item in items)
@@ -466,6 +460,32 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             OutputDocument = outputDocument,
             TransformationErrors = Statistics.TransformationErrorsInCurrentBatch.Errors.ToList()
         };
+    }
+
+    private static void FilterMetadataProperties(DocumentsOperationContext context, Document document)
+    {
+        if (document!.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))
+        {
+            metadata.Modifications = new DynamicJsonValue(metadata);
+
+            metadata.Modifications.Remove(Constants.Documents.Metadata.Id);
+            metadata.Modifications.Remove(Constants.Documents.Metadata.LastModified);
+            metadata.Modifications.Remove(Constants.Documents.Metadata.IndexScore);
+            metadata.Modifications.Remove(Constants.Documents.Metadata.ChangeVector);
+            metadata.Modifications.Remove(Constants.Documents.Metadata.Flags);
+
+            document.Data.Modifications = new DynamicJsonValue(document.Data)
+            {
+                [Constants.Documents.Metadata.Key] = metadata
+            };
+        }
+        else if (document.Data.HasParent == false)
+            return; // no need to clone
+
+        using (var old = document.Data)
+        {
+            document.Data = document.Data.Clone(context);
+        }
     }
 
     private static List<GenAiResultItem> PrepareItemsBeforeSendingToModel(IEnumerable<GenAiScriptResult> items)

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiTestScript.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiTestScript.cs
@@ -1525,6 +1525,133 @@ for (const comment of this.Comments)
         }
     }
 
+    [RavenTheory(RavenTestCategory.Etl | RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task ShouldStripMetadataPropertiesFromInputDocument(Options options, GenAiConfiguration config)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var database = await GetDocumentDatabaseInstanceFor(store);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                config.Collection = "Posts";
+                config.Prompt = "Check if the following blog post comment is spam or not";
+                config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or harmful" });
+                config.GenAiTransformation = new GenAiTransformation
+                {
+                    Script = @"
+for (const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+                };
+                config.UpdateScript =
+@"const idx = this.Comments.findIndex(c => c.Id == $input.Id);  
+if (idx < 0)
+    return;
+this.Comments[idx].IsSpam = $output.Blocked;
+";
+
+                var testGenAiScript = new TestGenAiScript
+                {
+                    Configuration = config,
+                    TestStage = TestStage.CreateContextObjects
+                };
+
+                // create a sample document to test on
+                var djv = new DynamicJsonValue
+                {
+                    [nameof(GenAiBasics.Post.Title)] = "Understanding Indexing in RavenDB",
+                    [nameof(GenAiBasics.Post.Body)] = "Indexes in RavenDB are a powerful way to optimize query performance. " +
+                                                      "This blog post walks through auto-indexes, static indexes, and best practices when designing queries that scale.",
+
+                    [nameof(GenAiBasics.Post.Comments)] = new DynamicJsonArray
+                    {
+                        new DynamicJsonValue
+                        {
+                            [nameof(GenAiBasics.Comment.Author)] = "sarah_j",
+                            [nameof(GenAiBasics.Comment.Text)] = "This article really helped me understand how indexes work in RavenDB. Great write-up!",
+                            [nameof(GenAiBasics.Comment.Id)] = "1"
+
+                        },
+                        new DynamicJsonValue
+                        {
+                            [nameof(GenAiBasics.Comment.Author)] = "shady_marketer",
+                            [nameof(GenAiBasics.Comment.Text)] = "Learn how to make $5000/month from home! Visit click4cash.biz.example now!!!!",
+                            [nameof(GenAiBasics.Comment.Id)] = "2"
+                        }
+                    },
+
+                    // add metadata properties to the document
+                    [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                    {
+                        [Constants.Documents.Metadata.Id] = "posts/1-A",
+                        [Constants.Documents.Metadata.Collection] = "Posts",
+                        [Constants.Documents.Metadata.LastModified] = DateTime.UtcNow,
+                        [Constants.Documents.Metadata.Flags] = new DynamicJsonArray { "HasCounters", "HasTimeSeries" },
+                        [Constants.Documents.Metadata.IndexScore] = 123
+                    }
+                };
+
+                testGenAiScript.Document = context.ReadObject(djv, "test-document");
+
+                // first stage - test context objects creation
+                var firstRun = GenAiTask.TestScript(testGenAiScript, database, database.ServerStore, context) as GenAiTestScriptResult;
+                Assert.NotNull(firstRun);
+                Assert.Equal(2, firstRun.Results.Count);
+
+                // test model call
+                testGenAiScript.Input = firstRun.Results;
+                testGenAiScript.TestStage = TestStage.SendToModel;
+
+                var secondRun = GenAiTask.TestScript(testGenAiScript, database, database.ServerStore, context) as GenAiTestScriptResult;
+                Assert.NotNull(secondRun);
+                Assert.Equal(2, secondRun.Results.Count);
+
+                foreach (var item in secondRun.Results)
+                {
+                    Assert.NotNull(item.ModelOutput?.Output);
+
+                    Assert.True(item.ModelOutput.Output.TryGet("Blocked", out bool _));
+                    Assert.True(item.ModelOutput.Output.TryGet("Reason", out string r));
+                    Assert.NotNull(r);
+                }
+
+                // final stage - test update script
+                // should not throw on unfiltered metadata properties
+
+                testGenAiScript.Input = secondRun.Results;
+                testGenAiScript.TestStage = TestStage.ApplyUpdateScript;
+                var finalRun = GenAiTask.TestScript(testGenAiScript, database, database.ServerStore, context) as GenAiTestScriptResult;
+
+                Assert.NotNull(finalRun);
+                Assert.Equal(2, finalRun.Results.Count);
+
+                Assert.NotNull(finalRun.OutputDocument);
+                Assert.True(finalRun.OutputDocument.TryGet(nameof(GenAiBasics.Post.Comments), out BlittableJsonReaderArray comments));
+                Assert.Equal(2, comments.Length);
+
+                foreach (var o in comments)
+                {
+                    var comment = o as BlittableJsonReaderObject;
+                    Assert.NotNull(comment);
+
+                    Assert.True(comment.TryGet("IsSpam", out bool _));
+                }
+
+                Assert.True(finalRun.OutputDocument.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
+                Assert.False(metadata.TryGet(Constants.Documents.Metadata.Id, out object _));
+                Assert.False(metadata.TryGet(Constants.Documents.Metadata.LastModified, out object _));
+                Assert.False(metadata.TryGet(Constants.Documents.Metadata.IndexScore, out object _));
+                Assert.False(metadata.TryGet(Constants.Documents.Metadata.Flags, out object _));
+
+                Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject _));
+            }
+        }
+    }
+
     private class GenAiTestCmd : RavenCommand<BlittableJsonReaderObject>
     {
         private readonly DocumentConventions _conventions;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24306/GenAI-failed-to-test-on-document-with-metadata

### Additional description

- filter metadata properties before calling `Put`, in order to avoid getting an error in `ValidateDocument`
- add test

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
