### PR TITLE
RavenDB-23051 Added logging for high-latency requests and large response sizes with the usage of the following thresholds:

### DIFF
--- a/src/Raven.Server/NotificationCenter/AbstractNotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/AbstractNotificationCenter.cs
@@ -36,6 +36,8 @@ public abstract class AbstractNotificationCenter : NotificationsBase
     }
 
     public bool IsInitialized { get; set; }
+    
+    public RavenConfiguration Configuration => _configuration;
 
     protected abstract PostponedNotificationsSender PostponedNotificationSender { get; }
 

--- a/src/Raven.Server/NotificationCenter/Paging.cs
+++ b/src/Raven.Server/NotificationCenter/Paging.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Util;
+using Raven.Server.Config.Settings;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
@@ -26,11 +27,15 @@ namespace Raven.Server.NotificationCenter
         private Timer _pagingTimer;
         private readonly Logger _logger;
 
+        private readonly long _totalDocumentsSizeInBytesLoggingThreshold = 16 * 1024 * 1024;
+        private readonly long _durationInMsLoggingThreshold;
+
         public Paging([NotNull] AbstractDatabaseNotificationCenter notificationCenter)
         {
             _notificationCenter = notificationCenter ?? throw new ArgumentNullException(nameof(notificationCenter));
 
             _logger = LoggingSource.Instance.GetLogger(notificationCenter.Database, GetType().FullName);
+            _durationInMsLoggingThreshold = _notificationCenter.Configuration.PerformanceHints.TooLongRequestThreshold.GetValue(TimeUnit.Milliseconds);
         }
 
         public void Add(PagingOperationType operation, string action, string details, long numberOfResults, long pageSize, long duration, long totalDocumentsSizeInBytes)
@@ -47,6 +52,12 @@ namespace Raven.Server.NotificationCenter
             if (ForTestingPurposes?.DisableDequeue == true)
                 return;
 
+            if ((totalDocumentsSizeInBytes > _totalDocumentsSizeInBytesLoggingThreshold || duration > _durationInMsLoggingThreshold) && _logger.IsOperationsEnabled)
+            {
+                _logger.Operations($"Excessive amount of results detected - Operation: {action}, Count: {numberOfResults} {operation}, " +
+                                   $"Size: {new Size(totalDocumentsSizeInBytes).HumaneSize}, Duration: {TimeSpan.FromMilliseconds(duration)}");
+            }
+            
             while (_pagingQueue.Count > 50)
                 _pagingQueue.TryDequeue(out _);
 

--- a/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
+++ b/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
@@ -62,6 +62,9 @@ namespace Raven.Server.NotificationCenter
 
                 _notificationCenter.RequestLatency
                     .AddHint(_sw.ElapsedMilliseconds, _source, queryWithParameters);
+                
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"High latency request detected - Source: {_source}, Duration: {_sw.Elapsed}, Query: {queryWithParameters}");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- Duration > 30 seconds
- Response size > 16 MB

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23051/Studio-alerts-information-should-be-also-available-in-the-logs

### Additional description

Added logging about expensive requests in addition to adding them as performance hints the notification center.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Enhancement

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
