### PR TITLE
RavenDB-24426: Blittable Fast Tests Upgrade

### DIFF
--- a/test/FastTests/Blittable/BlittableJsonEqualityTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonEqualityTests.cs
@@ -1,18 +1,15 @@
 ﻿using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class BlittableJsonEqualityTests : NoDisposalNeeded
+    public class BlittableJsonEqualityTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public BlittableJsonEqualityTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Equals_identical()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -75,7 +72,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Equals_even_though_order_of_properties_is_different()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -137,7 +134,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void GetHashCode_must_not_use_size_if_it_isnt_root()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -181,7 +178,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Equals_with_the_usage_of_memcmp_underneath()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -239,7 +236,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Equals_with_the_usage_of_memcmp_underneath_and_complex_nested_object()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -305,7 +302,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Must_not_be_equal_if_nested_property_name_is_different()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -371,7 +368,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Equals_when_creating_blittable_in_different_ways()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -434,7 +431,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Equals_blittables_created_manually()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ArenaMemoryAllocatorTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ArenaMemoryAllocatorTests.cs
@@ -1,19 +1,15 @@
 ﻿using System;
 using Sparrow.Json;
 using Sparrow.Threading;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable.BlittableJsonWriterTests;
 
-public class ArenaMemoryAllocatorTests : NoDisposalNeeded
+public class ArenaMemoryAllocatorTests(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
-    public ArenaMemoryAllocatorTests(ITestOutputHelper output) : base(output)
-    {
-
-    }
-
-    [Fact]
+    [RavenFact(RavenTestCategory.Memory)]
     public void ShouldUseFragmentedMemorySegment()
     {
         using (var arena = new ArenaMemoryAllocator(SharedMultipleUseFlag.None))

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableFormatTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableFormatTests.cs
@@ -7,18 +7,15 @@ using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.Conventions;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable.BlittableJsonWriterTests
 {
-    public class BlittableFormatTests : NoDisposalNeeded
+    public class BlittableFormatTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public BlittableFormatTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [MemberData(nameof(Samples))]
         public async Task CheckRoundtrip(string name)
         {
@@ -46,7 +43,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void InvalidJSon()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -61,7 +58,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task ShouldNotCrashForManyDifferentProperties()
         {
             foreach (var name in new[] { "geo.json", "comments.json", "blog_post.json" })

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableJsonTestBase.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableJsonTestBase.cs
@@ -6,17 +6,14 @@ using Newtonsoft.Json.Converters;
 using Raven.Server.Documents.Indexes.Static;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable.BlittableJsonWriterTests
 {
-    public abstract class BlittableJsonTestBase : NoDisposalNeeded
+    public abstract class BlittableJsonTestBase(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        protected BlittableJsonTestBase(ITestOutputHelper output) : base(output)
-        {
-        }
-
         public string GenerateSimpleEntityForFunctionalityTest()
         {
             object employee = new

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
@@ -2,18 +2,15 @@
 using Raven.Server.Documents;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable.BlittableJsonWriterTests
 {
-    public unsafe class BlittableMetadataModifierTest : NoDisposalNeeded
+    public unsafe class BlittableMetadataModifierTest(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public BlittableMetadataModifierTest(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BlittableMetadataModifier_WhileIdContainsNoEscapeCharacters_ResultInLazyStringWithoutEscapeInformation()
         {
             const string json = "{\"@metadata\": { \"@id\": \"u1\"}}";

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ConcurrentAccessTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ConcurrentAccessTests.cs
@@ -18,7 +18,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void ConcurrentReadsTest()
         {
             var str = GenerateSimpleEntityForFunctionalityTest2();
@@ -33,7 +33,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void ConcurrentWrite_WhenResetCachedPropertiesForNewDocument_ShouldThrowInformativeException()
         {
             Assert.Throws<InvalidOperationException>(() =>

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/FunctionalityTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/FunctionalityTests.cs
@@ -13,6 +13,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,14 +25,14 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Generating_DictionaryDeserializationRoutine_should_work()
         {
             Func<BlittableJsonReaderObject, Dictionary<string, long>> deserializationFunc = JsonDeserializationBase.GenerateJsonDeserializationRoutine<Dictionary<string, long>>();
             Assert.NotNull(deserializationFunc);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task FunctionalityTest()
         {
             var str = GenerateSimpleEntityForFunctionalityTest();
@@ -56,7 +57,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void FunctionalityTest2()
         {
             var str = GenerateSimpleEntityForFunctionalityTest2();
@@ -67,7 +68,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void EmptyArrayTest()
         {
             var str = "{\"Alias\":\"Jimmy\",\"Data\":[],\"Name\":\"Trolo\",\"SubData\":{\"SubArray\":[]}}";
@@ -84,7 +85,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
@@ -117,7 +118,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             NativeMemory.Free(encodeOutput, maximumOutputLength);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(100)]
@@ -161,7 +162,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task BasicCopyToStream()
         {
             var json = JsonConvert.SerializeObject(new
@@ -187,7 +188,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task UsingBooleans()
         {
             var json = JsonConvert.SerializeObject(new
@@ -206,7 +207,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void UsingChars()
         {
             var deserialize = JsonDeserializationBase.GenerateJsonDeserializationRoutine<CharClass>();

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -7,6 +7,7 @@ using Sparrow.Collections;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Threading;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,7 +19,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BasicObject()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -42,7 +43,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BasicEmptyObject()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -65,7 +66,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BasicNestedEmptyObject()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -96,7 +97,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BasicIntFlatStructure()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -131,7 +132,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BasicIntNestedStructure()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -192,7 +193,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BasicIntDeeperNestedStructure()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -314,7 +315,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void FlatObjectWithEmptyArray()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -353,7 +354,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void FlatObjectWithArrayOfEmptyObjects()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -404,7 +405,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void FlatObjectWithIntArrayTest()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -448,7 +449,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void ObjectWithNestedIntArrayTest()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -505,7 +506,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void FlatObjectWithObjectArray()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -562,7 +563,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void FlatObjectWithObjectArrayWithNestedArray()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -629,7 +630,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void SimpleArrayDocument()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -657,7 +658,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(byte.MaxValue)]
         [InlineData(short.MaxValue)]
         [InlineData(short.MaxValue + 1)]
@@ -700,7 +701,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void ReadDataTypesTest()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
@@ -819,7 +820,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void LargeDocumentsMemoryReuse()
         {
             using (var context = new JsonOperationContext(1024 * 64, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/UnmanageJsonReaderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/UnmanageJsonReaderTests.cs
@@ -3,18 +3,15 @@ using System.IO;
 using System.Text;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable.BlittableJsonWriterTests
 {
-    public unsafe class UnmanageJsonReaderTests : NoDisposalNeeded
+    public unsafe class UnmanageJsonReaderTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public UnmanageJsonReaderTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [MemberData(nameof(Samples))]
         public void CanReadAll(string name)
         {
@@ -51,7 +48,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [MemberData(nameof(InvalidJsons))]
         public void FailsOnInvalidJson(string invalidJson)
         {

--- a/test/FastTests/Blittable/BlittableParsing.cs
+++ b/test/FastTests/Blittable/BlittableParsing.cs
@@ -2,18 +2,15 @@
 using System.Text;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class BlittableParsing : NoDisposalNeeded
+    public class BlittableParsing(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public BlittableParsing(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanParseProperly()
         {
             var json = "{\"Type\":\"Acknowledge\",\"Etag\":194}";

--- a/test/FastTests/Blittable/BlittableValidationTest.cs
+++ b/test/FastTests/Blittable/BlittableValidationTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿﻿﻿﻿﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -8,17 +8,14 @@ using Newtonsoft.Json.Linq;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class BlittableValidationTest : NoDisposalNeeded
+    public class BlittableValidationTest(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public BlittableValidationTest(ITestOutputHelper output) : base(output)
-        {
-        }
-
         private BlittableJsonReaderObject InitSimpleBlittable(JsonOperationContext context, out int size)
         {
             var obj = JObject.FromObject(new Employee
@@ -38,7 +35,7 @@ namespace FastTests.Blittable
             return reader;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WithEscape()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -187,7 +184,7 @@ namespace FastTests.Blittable
             public string LastName { get; set; }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Complex_Valid_Blittable()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -205,7 +202,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Empty_Valid_Blittable()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -223,7 +220,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Bool()
         {
             var blittable = new byte[16]
@@ -239,7 +236,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Compressed_String()
         {
             var blittable = new byte[31]
@@ -257,7 +254,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Float()
         {
             var blittable = new byte[22]
@@ -277,7 +274,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Integer()
         {
             var blittable = new byte[26]
@@ -294,7 +291,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Long()
         {
             var blittable = new byte[26]
@@ -311,7 +308,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Names_Offset()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -359,7 +356,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Null()
         {
             var blittable = new byte[16]
@@ -375,7 +372,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Number_Of_Prop()
         {
             var blittable = new byte[192]
@@ -411,7 +408,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Root_Token()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -434,7 +431,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_String()
         {
             var blittable = new byte[26]
@@ -451,7 +448,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Simple_Valid_Blittable_Test()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -462,7 +459,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Valid_Blittable()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -489,7 +486,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Valid_Compressed_String()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -535,7 +532,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Valid_object_read_from_non_zero_offset()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -586,7 +583,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Valid_String()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -645,7 +642,7 @@ namespace FastTests.Blittable
               .Select(s => s[random.Next(s.Length)]).ToArray());
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Valid_String_With_260_EscChar()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -678,7 +675,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Valid_String_With_66K_EscChar()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -712,7 +709,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Props_Offset()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -731,7 +728,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void Invalid_Root_Metadata_Offset()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -746,7 +743,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public unsafe void ParseBlitAndValidate()
         {
             var assembly = typeof(BlittableFormatTests).Assembly;

--- a/test/FastTests/Blittable/MemoryPoolTests.cs
+++ b/test/FastTests/Blittable/MemoryPoolTests.cs
@@ -4,18 +4,13 @@ using System.Threading.Tasks;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
 using Tests.Infrastructure;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public unsafe class MemoryPoolTests : NoDisposalNeeded
+    public class MemoryPoolTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public MemoryPoolTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public void SerialAllocationAndRelease()
         {
             using (var pool = new UnmanagedBuffersPoolWithLowMemoryHandling(string.Empty))
@@ -32,7 +27,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public void ParallelAllocationAndReleaseSeperately()
         {
             using (var pool = new UnmanagedBuffersPoolWithLowMemoryHandling(string.Empty))
@@ -53,7 +48,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public void ParallelSerialAllocationAndRelease()
         {
             using (var pool = new UnmanagedBuffersPoolWithLowMemoryHandling(string.Empty))

--- a/test/FastTests/Blittable/MutatingJsonTests.cs
+++ b/test/FastTests/Blittable/MutatingJsonTests.cs
@@ -1,29 +1,20 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="MutatingJsonTests.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class MutatingJsonTests : NoDisposalNeeded
+    public class MutatingJsonTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public MutatingJsonTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
         private const string InitialJson = @"{""Name"":""Oren"",""Dogs"":[""Arava"",""Oscar"",""Sunny""],""State"":{""Sleep"":false}}";
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanAddProperty()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -35,7 +26,7 @@ namespace FastTests.Blittable
             }, @"{""Name"":""Oren"",""Dogs"":[""Arava"",""Oscar"",""Sunny""],""State"":{""Sleep"":false},""Age"":34}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanAddNegativeIntegerProperty()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -47,7 +38,7 @@ namespace FastTests.Blittable
             }, @"{""Name"":""Oren"",""Dogs"":[""Arava"",""Oscar"",""Sunny""],""State"":{""Sleep"":false},""Age"":-34}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanCompressFields()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -61,7 +52,7 @@ namespace FastTests.Blittable
                 @"{""Name"":""there goes the man in the moon""}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task WillPreserveEscapes()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -74,7 +65,7 @@ namespace FastTests.Blittable
                 @"{""Name"":""Oren\r\n""}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanModifyArrayProperty()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -90,7 +81,7 @@ namespace FastTests.Blittable
             }, @"{""Name"":""Oren"",""Dogs"":[""Arava"",""Oscar"",""Phoebe""],""State"":{""Sleep"":false}}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanModifyNestedObjectProperty()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -105,7 +96,7 @@ namespace FastTests.Blittable
             }, @"{""Name"":""Oren"",""Dogs"":[""Arava"",""Oscar"",""Sunny""],""State"":{""Sleep"":true}}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanRemoveAndAddProperty()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -118,7 +109,7 @@ namespace FastTests.Blittable
             }, @"{""Name"":""Oren"",""State"":{""Sleep"":false},""Pie"":3.147}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanAddAndRemoveProperty()
         {
             return AssertEqualAfterRoundTripAsync(source =>
@@ -153,7 +144,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task CanModifyRespectingUnitOfWork()
         {
             var ctx = JsonOperationContext.ShortTermSingleUse();

--- a/test/FastTests/Blittable/ObjectJsonParsingTests.cs
+++ b/test/FastTests/Blittable/ObjectJsonParsingTests.cs
@@ -5,18 +5,15 @@ using Raven.Client;
 using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class ObjectJsonParsingTests : NoDisposalNeeded
+    public class ObjectJsonParsingTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public ObjectJsonParsingTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Zzz()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -40,7 +37,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanCompressSmallStrings()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -70,7 +67,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task Dup()
         {
             return AssertEqualAfterRoundTripAsync(new DynamicJsonValue
@@ -81,7 +78,7 @@ namespace FastTests.Blittable
                 "{\"Name\":\"Ayende Rahien\"}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task CanUseNestedObject()
         {
             await AssertEqualAfterRoundTripAsync(new DynamicJsonValue
@@ -106,7 +103,7 @@ namespace FastTests.Blittable
                 "{\"Name\":\"Oren Eini\",\"Dogs\":[\"Arava\",\"Oscar\"]}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public Task CanGenerateJsonProperly_WithEscapePositions()
         {
             return AssertEqualAfterRoundTripAsync(new DynamicJsonValue
@@ -116,7 +113,7 @@ namespace FastTests.Blittable
                 "{\"Name\":\"Oren\\r\\nEini\"}");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task CanGenerateJsonProperly()
         {
             await AssertEqualAfterRoundTripAsync(new DynamicJsonValue

--- a/test/FastTests/Blittable/PartialParsingBugs.cs
+++ b/test/FastTests/Blittable/PartialParsingBugs.cs
@@ -1,17 +1,14 @@
 ﻿using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class PartialParsingBugs : NoDisposalNeeded
+    public class PartialParsingBugs(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public PartialParsingBugs(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("{\"Neg1\":-9223372036854775808,\"Neg\":-6}")]
         [InlineData("{\"Val\": Infinity}")]
         [InlineData("{\"Val\": -Infinity}")]

--- a/test/FastTests/Blittable/PeepingTomTest.cs
+++ b/test/FastTests/Blittable/PeepingTomTest.cs
@@ -4,18 +4,15 @@ using System.Threading;
 using FastTests.Voron.FixedSize;
 using Sparrow;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public class PeepingTomTest : NoDisposalNeeded
+    public class PeepingTomTest(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public PeepingTomTest(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(123456, 65535, 0)]
         [InlineData(1234, 535, 0)]
         [InlineData(4096, 4096, 0)]
@@ -32,7 +29,7 @@ namespace FastTests.Blittable
                 PeepingTomStreamTest(originalSize, chunkSizeToRead, offset, seed: null, context, cts.Token);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineDataWithRandomSeed]
         [InlineData(1291481720)]
         [InlineData(916490010)]

--- a/test/FastTests/Blittable/SerializationDeserializationValidation.cs
+++ b/test/FastTests/Blittable/SerializationDeserializationValidation.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Raven.Client.Documents.Conventions;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,12 +13,8 @@ namespace FastTests.Blittable
         public static readonly Func<BlittableJsonReaderObject, SerializationDeserializationValidation.Values> SerializationDeserializationValidation = GenerateJsonDeserializationRoutine<SerializationDeserializationValidation.Values>();
     }
 
-    public class SerializationDeserializationValidation : NoDisposalNeeded
+    public class SerializationDeserializationValidation(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public SerializationDeserializationValidation(ITestOutputHelper output) : base(output)
-        {
-        }
-
         public class Values
         {
             public int intMinVal;
@@ -53,7 +50,7 @@ namespace FastTests.Blittable
             public string[] stringArray;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void ValidateRanges()
         {
             var values = new Values

--- a/test/FastTests/Blittable/SmallStringCompressionTests.cs
+++ b/test/FastTests/Blittable/SmallStringCompressionTests.cs
@@ -6,18 +6,15 @@
 
 using System.Text;
 using Sparrow.Compression;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public unsafe class SmallStringCompressionTests : NoDisposalNeeded
+    public unsafe class SmallStringCompressionTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public SmallStringCompressionTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("this is a sample string")]
         [InlineData("here is a funny story I have heard")]
         [InlineData("who is here, and who is there, who is everywhere?")]
@@ -45,7 +42,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("this is a sample string")]
         [InlineData("here is a funny story I have heard")]
         [InlineData("who is here, and who is there, who is everywhere?")]
@@ -74,7 +71,7 @@ namespace FastTests.Blittable
         }
 
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("this is a sample string")]
         [InlineData("בארזים נפלה שלהבת")]
         public void CanHandleSmallBufferCompression(string s)
@@ -93,7 +90,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("this is a sample string")]
         [InlineData("here is a funny story I have heard")]
         [InlineData("who is here, and who is there, who is everywhere?")]

--- a/test/FastTests/Blittable/UnmanagedStreamTests.cs
+++ b/test/FastTests/Blittable/UnmanagedStreamTests.cs
@@ -2,18 +2,15 @@
 using System.Collections.Generic;
 using Sparrow;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Blittable
 {
-    public unsafe class UnmanagedStreamTests : NoDisposalNeeded
+    public unsafe class UnmanagedStreamTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public UnmanagedStreamTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void EnsureSingleChunk()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -45,7 +42,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BulkWriteAscendingSizeTest()
         {
             //using (var unmanagedByteArrayPool = new UnmanagedBuffersPool(string.Empty))
@@ -86,7 +83,7 @@ namespace FastTests.Blittable
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BigAlloc()
         {
             var size = 3917701;
@@ -98,7 +95,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void BulkWriteDescendingSizeTest()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())
@@ -134,7 +131,7 @@ namespace FastTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void SingleByteWritesTest()
         {
             using (var ctx = JsonOperationContext.ShortTermSingleUse())

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -90,7 +90,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 4174;
+            const int numberToTolerate = 4077;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24425
https://issues.hibernatingrhinos.com/issue/RavenDB-24426

### Additional description

Upgrading of the Blittable Fast Tests.
Depends on: https://github.com/ravendb/ravendb/pull/20775

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
