### PR TITLE
RavenDB-24426: Utils Fast Tests Upgrade

### DIFF
--- a/test/FastTests/Utils/ChunkedMmapStreamTests.cs
+++ b/test/FastTests/Utils/ChunkedMmapStreamTests.cs
@@ -4,19 +4,16 @@ using System.Linq;
 using FastTests.Voron.FixedSize;
 using Raven.Client.Extensions.Streams;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Voron.Util;
 using Xunit.Abstractions;
 
 namespace FastTests.Utils
 {
-    public class ChunkedMmapStreamTests : NoDisposalNeeded
+    public class ChunkedMmapStreamTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public ChunkedMmapStreamTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(13, 3)]
         [InlineDataWithRandomSeed(94, 7)]
         public unsafe void Can_seek_and_read_from_chunked_mmap_file(int totalSize, int chunkSize, int seed)

--- a/test/FastTests/Utils/IncludeUtilTests.cs
+++ b/test/FastTests/Utils/IncludeUtilTests.cs
@@ -4,18 +4,15 @@ using System.Linq;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Utils
 {
-    public class IncludeUtilTests : NoDisposalNeeded
+    public class IncludeUtilTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public IncludeUtilTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_of_nested_objects_should_work1()
         {
             var obj = new DynamicJsonValue
@@ -99,7 +96,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData('/')]
         [InlineData(':')]
         public void FindDocIdFromPath_with_array_of_arrays_with_simple_values_should_work(char identityPartsSeparator)
@@ -148,7 +145,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData('/')]
         [InlineData(':')]
         public void FindDocIdFromPath_with_array_of_arrays_of_objects_should_work(char identityPartsSeparator)
@@ -198,7 +195,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData('/')]
         [InlineData(':')]
         public void FindDocIdFromPath_with_array_of_with_of_arrays_of_nested_objects_should_work1(char identityPartsSeparator)
@@ -247,7 +244,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData('/')]
         [InlineData(':')]
         public void FindDocIdFromPath_with_array_of_with_of_arrays_of_nested_objects_should_work2(char identityPartsSeparator)
@@ -305,7 +302,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData('/')]
         [InlineData(':')]
         public void FindDocIdFromPath_with_array_of_with_of_arrays_of_nested_objects_should_work3(char identityPartsSeparator)
@@ -424,7 +421,7 @@ namespace FastTests.Utils
             });
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_of_nested_objects_should_work2()
         {
             var obj = new DynamicJsonValue
@@ -500,7 +497,7 @@ namespace FastTests.Utils
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_of_nested_objects_with_prefix_should_work()
         {
             var obj = new DynamicJsonValue
@@ -575,7 +572,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_of_nested_objects_with_suffix_should_work()
         {
             var obj = new DynamicJsonValue
@@ -650,7 +647,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_flat_object_with_prefix1()
         {
             var obj = new DynamicJsonValue
@@ -667,7 +664,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_flat_object_with_suffix1()
         {
             var obj = new DynamicJsonValue
@@ -684,7 +681,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_flat_object_with_prefix2()
         {
             var obj = new DynamicJsonValue
@@ -719,7 +716,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_flat_object_with_suffix2()
         {
             var obj = new DynamicJsonValue
@@ -754,7 +751,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_flat_object1()
         {
             var obj = new DynamicJsonValue
@@ -771,7 +768,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_nested_object2()
         {
             var obj = new DynamicJsonValue
@@ -799,7 +796,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_array_selection_should_work_in_flat_object2()
         {
             var obj = new DynamicJsonValue
@@ -826,7 +823,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_value_for_single_level_nested_path()
         {
             var obj = new DynamicJsonValue
@@ -847,7 +844,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_value_for_single_level_nested_path_with_prefix()
         {
             var obj = new DynamicJsonValue
@@ -884,7 +881,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_value_for_single_level_nested_path_with_suffix()
         {
             var obj = new DynamicJsonValue
@@ -921,7 +918,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_value_for_single_level_nested_path_with_prefix_and_string_value()
         {
             var obj = new DynamicJsonValue
@@ -958,7 +955,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_value_for_single_level_nested_path_with_suffix_and_string_value()
         {
             var obj = new DynamicJsonValue
@@ -995,7 +992,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_value_for_multiple_level_nested_path()
         {
             var obj = new DynamicJsonValue
@@ -1032,7 +1029,7 @@ namespace FastTests.Utils
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_empty_for_incorrect_path()
         {
             var obj = new DynamicJsonValue
@@ -1050,7 +1047,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_work_in_flat_object1()
         {
             var obj = new DynamicJsonValue
@@ -1067,7 +1064,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_work_in_flat_object2()
         {
             var obj = new DynamicJsonValue
@@ -1095,7 +1092,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_empty_with_incomplete_prefix_in_flat_object()
         {
             var obj = new DynamicJsonValue
@@ -1113,7 +1110,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_return_empty_with_incomplete_suffix_in_flat_object()
         {
             var obj = new DynamicJsonValue
@@ -1140,7 +1137,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_work_with_prefix_in_flat_object()
         {
             var obj = new DynamicJsonValue
@@ -1158,7 +1155,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_work_with_suffix_in_flat_object()
         {
             var obj = new DynamicJsonValue
@@ -1177,7 +1174,7 @@ namespace FastTests.Utils
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_work_with_very_short_prefix_in_flat_object()
         {
             var obj = new DynamicJsonValue
@@ -1203,7 +1200,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_should_work_with_very_short_suffix_in_flat_object()
         {
             var obj = new DynamicJsonValue
@@ -1229,7 +1226,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void FindDocIdFromPath_with_multiple_targets_should_work_in_flat_object()
         {
             var obj = new DynamicJsonValue

--- a/test/FastTests/Utils/LimitedStreamTests.cs
+++ b/test/FastTests/Utils/LimitedStreamTests.cs
@@ -4,18 +4,15 @@ using System.Linq;
 using FastTests.Voron.FixedSize;
 using FastTests.Voron.Util;
 using Raven.Client.Documents.Operations.Attachments;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Utils
 {
-    public class LimitedStreamTests : NoDisposalNeeded
+    public class LimitedStreamTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public LimitedStreamTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Attachments)]
         [InlineDataWithRandomSeed]
         public void Should_properly_read_ranges(int seed)
         {
@@ -62,7 +59,7 @@ namespace FastTests.Utils
         }
 
         
-        [Theory]
+        [RavenTheory(RavenTestCategory.Attachments)]
         [InlineDataWithRandomSeed]
         public void Should_properly_seek(int seed)
         {

--- a/test/FastTests/Utils/OperationIdEncoderTests.cs
+++ b/test/FastTests/Utils/OperationIdEncoderTests.cs
@@ -1,17 +1,14 @@
-﻿using FastTests.Voron.FixedSize;
+﻿﻿using FastTests.Voron.FixedSize;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Utils;
 
-public class OperationIdEncoderTests : NoDisposalNeeded
+public class OperationIdEncoderTests(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
-    public OperationIdEncoderTests(ITestOutputHelper output) : base(output)
-    {
-    }
-
-    [Theory]
+    [RavenTheory(RavenTestCategory.Core)]
     [InlineData("?", 1)]
     [InlineData("?", 8_589_934_591)]
     [InlineDataWithRandomSeed("?")]

--- a/test/FastTests/Utils/TimeParsing.cs
+++ b/test/FastTests/Utils/TimeParsing.cs
@@ -11,13 +11,9 @@ using Xunit.Abstractions;
 
 namespace FastTests.Utils
 {
-    public unsafe class TimeParsing : NoDisposalNeeded
+    public unsafe class TimeParsing(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public TimeParsing(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("2016-10-05T21:07:32.2082285Z")]
         [InlineData("2016-10-05T21:07:32.2082285")]
         [InlineData("2016-10-05T21:07:32")]
@@ -37,7 +33,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("21:07:32.2082285")]
         [InlineData("21:07:32")]
         [InlineData("2.21:07:32")]
@@ -62,7 +58,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("21:07:32 some text")]
         [InlineData("2.21:07:32 some text")]
         [InlineData("333.21:07:32.232 some text")]
@@ -87,7 +83,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("2016-10-05T21:07:32.2082285+03:00")]
         [InlineData("2016-10-05T21:17:32.2082285+01:00")]
         public void CanParseValidDatesTimeOffset(string dt)
@@ -106,7 +102,7 @@ namespace FastTests.Utils
             }
         }
         
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("2016-10-05T")]
         [InlineData("2016-10-05T21:17:32.2082285+01:00,ad")]
         [InlineData("2016-10-05T21:17:3")]
@@ -123,7 +119,7 @@ namespace FastTests.Utils
             }
         }
         
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("1998-02-09", 1998, 2, 9)]
         [InlineData("0001-12-10", 1, 12, 10)]
         [InlineData("2022-02-14", 2022, 2, 14)]
@@ -139,7 +135,7 @@ namespace FastTests.Utils
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("20:59:12.9990000", 20, 59, 12, 999)]
         [InlineData("21:38:32.9120000", 21, 38, 32, 912)]
         [InlineData("23:59:00", 23, 59,0,0)]

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -90,7 +90,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 4077;
+            const int numberToTolerate = 4034;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24425
https://issues.hibernatingrhinos.com/issue/RavenDB-24426

### Additional description

Upgrading of the Blittable Fast Tests.
Depends on: https://github.com/ravendb/ravendb/pull/20775

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
