### PR TITLE
RavenDB-24056 Add pause/resume indexing to List of Indexes view

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -989,6 +989,9 @@ namespace Raven.Server.Documents.Indexes
                 return;
             }
 
+            if (Status == IndexRunningStatus.Running)
+                return;
+            
             using (DrainRunningQueries())
             {
                 StartIndexingThread();

--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -623,7 +623,7 @@ class genUtils {
         
         while (element != currentTarget) {
             
-            const tag = element.tagName.toLocaleLowerCase();
+            const tag = element.tagName?.toLocaleLowerCase();
             
             if (tag === "a" || tag === "button" || tag === "input") {
                 return false;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -31,6 +31,10 @@ import { ConditionalPopover } from "components/common/ConditionalPopover";
 import Dropdown from "react-bootstrap/Dropdown";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import { CustomDropdownToggle } from "components/common/Dropdown";
+import useBoolean from "components/hooks/useBoolean";
+import { GlobalPauseIndexingConfirm } from "components/pages/resources/databases/partials/GlobalPauseIndexingConfirm";
+import { GlobalResumeIndexingConfirm } from "components/pages/resources/databases/partials/GlobalResumeIndexingConfirm";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 
 interface IndexesPageProps {
     stale?: boolean;
@@ -79,6 +83,9 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,
+        asyncPauseGlobalIndexing,
+        asyncResumeGlobalIndexing,
+        globalStatusList,
     } = useIndexesPage(queryParams?.stale, queryParams?.isImportOpen);
 
     const deleteSelectedIndexes = () => {
@@ -95,6 +102,14 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
             mode
         );
     };
+
+    console.log("kalczur globalStatusList", globalStatusList);
+
+    const canPauseGlobalIndexing = globalStatusList?.some((x) => x.status === "Running");
+    const canResumeGlobalIndexing = globalStatusList?.some((x) => x.status === "Paused");
+
+    const { value: isGlobalPauseIndexingOpen, toggle: toggleIsGlobalPauseIndexingOpen } = useBoolean(false);
+    const { value: isGlobalResumeIndexingOpen, toggle: toggleIsGlobalResumeIndexingOpen } = useBoolean(false);
 
     const allActionContexts = ActionContextUtils.getContexts(DatabaseUtils.getLocations(db));
 
@@ -172,7 +187,7 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
             {stats.indexes.length > 0 && (
                 <StickyHeader>
                     <Row>
-                        <Col className="hstack">
+                        <Col className="hstack gap-2">
                             {hasDatabaseWriteAccess && (
                                 <ConditionalPopover
                                     conditions={{
@@ -227,6 +242,46 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
                                         </Dropdown.Menu>
                                     </Dropdown>
                                 </ConditionalPopover>
+                            )}
+                            {canResumeGlobalIndexing && (
+                                <>
+                                    <ButtonWithSpinner
+                                        variant="success"
+                                        className="rounded-pill"
+                                        onClick={toggleIsGlobalResumeIndexingOpen}
+                                        isSpinning={asyncResumeGlobalIndexing.loading}
+                                        icon="play"
+                                    >
+                                        Resume indexing
+                                    </ButtonWithSpinner>
+                                    {isGlobalResumeIndexingOpen && (
+                                        <GlobalResumeIndexingConfirm
+                                            toggle={toggleIsGlobalResumeIndexingOpen}
+                                            onConfirm={asyncResumeGlobalIndexing.execute}
+                                            allActionContexts={allActionContexts}
+                                        />
+                                    )}
+                                </>
+                            )}
+                            {canPauseGlobalIndexing && (
+                                <>
+                                    <ButtonWithSpinner
+                                        variant="secondary"
+                                        className="rounded-pill"
+                                        onClick={toggleIsGlobalPauseIndexingOpen}
+                                        isSpinning={asyncPauseGlobalIndexing.loading}
+                                        icon="pause"
+                                    >
+                                        Pause indexing
+                                    </ButtonWithSpinner>
+                                    {isGlobalPauseIndexingOpen && (
+                                        <GlobalPauseIndexingConfirm
+                                            toggle={toggleIsGlobalPauseIndexingOpen}
+                                            onConfirm={asyncPauseGlobalIndexing.execute}
+                                            allActionContexts={allActionContexts}
+                                        />
+                                    )}
+                                </>
                             )}
                         </Col>
                         <Col xs="auto">

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -103,8 +103,6 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         );
     };
 
-    console.log("kalczur globalStatusList", globalStatusList);
-
     const canPauseGlobalIndexing = globalStatusList?.some((x) => x.status === "Running");
     const canResumeGlobalIndexing = globalStatusList?.some((x) => x.status === "Paused");
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -78,6 +78,16 @@ interface ActionLocationsLoaded {
     type: "LocationsLoaded";
 }
 
+export interface GlobalIndexStatus {
+    location: databaseLocationSpecifier;
+    status: Raven.Client.Documents.Indexes.IndexRunningStatus;
+}
+
+interface ActionGlobalStatusLoaded {
+    statusList: GlobalIndexStatus[];
+    type: "GlobalStatusLoaded";
+}
+
 type IndexesStatsReducerAction =
     | ActionDeleteIndexes
     | ActionStatsLoaded
@@ -90,16 +100,14 @@ type IndexesStatsReducerAction =
     | ActionResetIndex
     | ActionDisableIndexing
     | ActionEnableIndexing
-    | ActionLocationsLoaded;
+    | ActionLocationsLoaded
+    | ActionGlobalStatusLoaded;
 
 interface IndexesStatsState {
     indexes: IndexSharedInfo[];
     locations: databaseLocationSpecifier[];
     resetInProgress: string[];
-    globalStatus: {
-        location: databaseLocationSpecifier;
-        status: Raven.Client.Documents.Indexes.IndexRunningStatus;
-    }[];
+    globalStatusList: GlobalIndexStatus[];
 }
 
 function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
@@ -393,6 +401,10 @@ export const indexesStatsReducer: Reducer<IndexesStatsState, IndexesStatsReducer
                     }
                 }
             });
+        case "GlobalStatusLoaded":
+            return produce(state, (draft) => {
+                draft.globalStatusList = action.statusList;
+            });
         default:
             console.warn("Unhandled action: ", action);
             return state;
@@ -404,6 +416,6 @@ export const indexesStatsReducerInitializer = (locations: databaseLocationSpecif
         indexes: [],
         locations,
         resetInProgress: [],
-        globalStatus: [],
+        globalStatusList: [],
     };
 };

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -96,6 +96,10 @@ interface IndexesStatsState {
     indexes: IndexSharedInfo[];
     locations: databaseLocationSpecifier[];
     resetInProgress: string[];
+    globalStatus: {
+        location: databaseLocationSpecifier;
+        status: Raven.Client.Documents.Indexes.IndexRunningStatus;
+    }[];
 }
 
 function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
@@ -400,5 +404,6 @@ export const indexesStatsReducerInitializer = (locations: databaseLocationSpecif
         indexes: [],
         locations,
         resetInProgress: [],
+        globalStatus: [],
     };
 };

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -260,7 +260,7 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
     const asyncGetGlobalStatus = useAsync(async () => {
         const statusList: GlobalIndexStatus[] = [];
 
-        for (const { tag: nodeTag } of db.nodes) {
+        for (const { tag: nodeTag } of db?.nodes ?? []) {
             try {
                 const status = await databasesService.getDatabasesState(nodeTag);
 
@@ -281,7 +281,7 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
             type: "GlobalStatusLoaded",
             statusList,
         });
-    }, [db]);
+    }, []);
 
     const asyncPauseGlobalIndexing = useAsyncCallback(async (contexts: DatabaseActionContexts[]) => {
         let tasks: Promise<void>[] = [];

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -9,6 +9,7 @@ import {
     IndexType,
 } from "components/models/indexes";
 import {
+    GlobalIndexStatus,
     indexesStatsReducer,
     indexesStatsReducerInitializer,
 } from "components/pages/database/indexes/list/IndexesStatsReducer";
@@ -25,7 +26,7 @@ import IndexRunningStatus = Raven.Client.Documents.Indexes.IndexRunningStatus;
 import collection from "models/database/documents/collection";
 import IndexLockMode = Raven.Client.Documents.Indexes.IndexLockMode;
 import IndexPriority = Raven.Client.Documents.Indexes.IndexPriority;
-import { useAsync } from "react-async-hook";
+import { useAsync, useAsyncCallback } from "react-async-hook";
 import { InputItem, InputItemLimit } from "components/models/common";
 import { DatabaseActionContexts } from "components/common/MultipleDatabaseLocationSelector";
 import ActionContextUtils from "components/utils/actionContextUtils";
@@ -78,7 +79,7 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         onConfirm: (contextPoints: DatabaseActionContexts[]) => void;
     }>();
 
-    const { indexesService } = useServices();
+    const { indexesService, databasesService } = useServices();
     const eventsCollector = useEventsCollector();
     const { databaseChangesApi, serverNotifications } = useChanges();
 
@@ -255,6 +256,64 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
             };
         }
     }, [databaseChangesApi, handleDatabaseChanges, serverNotifications]);
+
+    const asyncGetGlobalStatus = useAsync(async () => {
+        const statusList: GlobalIndexStatus[] = [];
+
+        for (const { tag: nodeTag } of db.nodes) {
+            try {
+                const status = await databasesService.getDatabasesState(nodeTag);
+
+                for (const dbStatus of status.Databases) {
+                    if (DatabaseUtils.shardGroupKey(dbStatus.Name) === db.name) {
+                        statusList.push({
+                            location: { nodeTag, shardNumber: DatabaseUtils.shardNumber(dbStatus.Name) },
+                            status: dbStatus.IndexingStatus,
+                        });
+                    }
+                }
+            } catch {
+                messagePublisher.reportError("Failed to load global indexing status for node " + nodeTag);
+            }
+        }
+
+        dispatch({
+            type: "GlobalStatusLoaded",
+            statusList,
+        });
+    }, [db]);
+
+    const asyncPauseGlobalIndexing = useAsyncCallback(async (contexts: DatabaseActionContexts[]) => {
+        let tasks: Promise<void>[] = [];
+
+        for (const { nodeTag, shardNumbers } of contexts) {
+            const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
+
+            tasks = locations.map(async (location) => {
+                await indexesService.pauseAllIndexes(db.name, location);
+            });
+        }
+
+        await Promise.all(tasks);
+        await asyncGetGlobalStatus.execute();
+        throttledRefresh.current();
+    });
+
+    const asyncResumeGlobalIndexing = useAsyncCallback(async (contexts: DatabaseActionContexts[]) => {
+        let tasks: Promise<void>[] = [];
+
+        for (const { nodeTag, shardNumbers } of contexts) {
+            const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
+
+            tasks = locations.map(async (location) => {
+                await indexesService.resumeAllIndexes(db.name, location);
+            });
+        }
+
+        await Promise.all(tasks);
+        await asyncGetGlobalStatus.execute();
+        throttledRefresh.current();
+    });
 
     const highlightUsed = useRef<boolean>(false);
 
@@ -773,6 +832,9 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,
+        asyncPauseGlobalIndexing,
+        asyncResumeGlobalIndexing,
+        globalStatusList: stats.globalStatusList,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -383,20 +383,6 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                     </ButtonGroup>
 
                                     <Dropdown.Menu data-testid="database-actions-dropdown-menu">
-                                        {canPauseAnyIndexing && (
-                                            <>
-                                                <Dropdown.Item onClick={toggleIsGlobalPauseIndexingOpen}>
-                                                    <Icon icon="pause" /> Pause indexing until restart
-                                                </Dropdown.Item>
-                                                {isGlobalPauseIndexingOpen && (
-                                                    <GlobalPauseIndexingConfirm
-                                                        toggle={toggleIsGlobalPauseIndexingOpen}
-                                                        onConfirm={handleGlobalPauseIndexing}
-                                                        allActionContexts={allActionContexts}
-                                                    />
-                                                )}
-                                            </>
-                                        )}
                                         {canResumeAnyPausedIndexing && (
                                             <>
                                                 <Dropdown.Item onClick={toggleIsGlobalResumeIndexingOpen}>
@@ -406,6 +392,20 @@ export function DatabasePanel(props: DatabasePanelProps) {
                                                     <GlobalResumeIndexingConfirm
                                                         toggle={toggleIsGlobalResumeIndexingOpen}
                                                         onConfirm={handleGlobalResumeIndexing}
+                                                        allActionContexts={allActionContexts}
+                                                    />
+                                                )}
+                                            </>
+                                        )}
+                                        {canPauseAnyIndexing && (
+                                            <>
+                                                <Dropdown.Item onClick={toggleIsGlobalPauseIndexingOpen}>
+                                                    <Icon icon="pause" /> Pause indexing until restart
+                                                </Dropdown.Item>
+                                                {isGlobalPauseIndexingOpen && (
+                                                    <GlobalPauseIndexingConfirm
+                                                        toggle={toggleIsGlobalPauseIndexingOpen}
+                                                        onConfirm={handleGlobalPauseIndexing}
                                                         allActionContexts={allActionContexts}
                                                     />
                                                 )}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -1,4 +1,4 @@
-﻿import React, { MouseEvent, useState } from "react";
+﻿import React, { MouseEvent, useMemo, useState } from "react";
 import { DatabaseLocalInfo, DatabaseSharedInfo } from "components/models/databases";
 import classNames from "classnames";
 import { useAppUrls } from "hooks/useAppUrls";
@@ -51,6 +51,8 @@ import useConfirm from "components/common/ConfirmDialog";
 import Dropdown from "react-bootstrap/Dropdown";
 import changesContext = require("common/changesContext");
 import DatabaseLockMode = Raven.Client.ServerWide.DatabaseLockMode;
+import { GlobalPauseIndexingConfirm } from "./GlobalPauseIndexingConfirm";
+import { GlobalResumeIndexingConfirm } from "./GlobalResumeIndexingConfirm";
 
 interface DatabasePanelProps {
     databaseName: string;
@@ -99,6 +101,9 @@ export function DatabasePanel(props: DatabasePanelProps) {
     const dispatch = useAppDispatch();
     const { databasesService } = useServices();
     const confirm = useConfirm();
+
+    const locations = useMemo(() => DatabaseUtils.getLocations(db), [db]);
+    const allActionContexts = useMemo(() => ActionContextUtils.getContexts(locations), [locations]);
 
     //TODO: show commands errors!
 
@@ -175,22 +180,28 @@ export function DatabasePanel(props: DatabasePanelProps) {
         }
     };
 
-    const onTogglePauseIndexing = async (pause: boolean) => {
+    const { value: isGlobalPauseIndexingOpen, toggle: toggleIsGlobalPauseIndexingOpen } = useBoolean(false);
+    const { value: isGlobalResumeIndexingOpen, toggle: toggleIsGlobalResumeIndexingOpen } = useBoolean(false);
+
+    const handleGlobalPauseIndexing = async (contexts: DatabaseActionContexts[]) => {
         reportEvent("databases", "pause-indexing");
 
-        const isConfirmed = await confirm({
-            icon: pause ? "pause" : "play",
-            title: `Do you want to ${pause ? "pause" : "resume"} indexing?`,
-            actionColor: pause ? "warning" : "success",
-        });
+        try {
+            setInProgressAction("Pausing indexing");
+            await dispatch(togglePauseIndexing(db, true, contexts));
+        } finally {
+            setInProgressAction(null);
+        }
+    };
 
-        if (isConfirmed) {
-            try {
-                setInProgressAction(pause ? "Pausing indexing" : "Resume indexing");
-                await dispatch(togglePauseIndexing(db, pause));
-            } finally {
-                setInProgressAction(null);
-            }
+    const handleGlobalResumeIndexing = async (contexts: DatabaseActionContexts[]) => {
+        reportEvent("databases", "resume-indexing");
+
+        try {
+            setInProgressAction("Resuming indexing");
+            await dispatch(togglePauseIndexing(db, false, contexts));
+        } finally {
+            setInProgressAction(null);
         }
     };
 
@@ -373,14 +384,32 @@ export function DatabasePanel(props: DatabasePanelProps) {
 
                                     <Dropdown.Menu data-testid="database-actions-dropdown-menu">
                                         {canPauseAnyIndexing && (
-                                            <Dropdown.Item onClick={() => onTogglePauseIndexing(true)}>
-                                                <Icon icon="pause" /> Pause indexing until restart
-                                            </Dropdown.Item>
+                                            <>
+                                                <Dropdown.Item onClick={toggleIsGlobalPauseIndexingOpen}>
+                                                    <Icon icon="pause" /> Pause indexing until restart
+                                                </Dropdown.Item>
+                                                {isGlobalPauseIndexingOpen && (
+                                                    <GlobalPauseIndexingConfirm
+                                                        toggle={toggleIsGlobalPauseIndexingOpen}
+                                                        onConfirm={handleGlobalPauseIndexing}
+                                                        allActionContexts={allActionContexts}
+                                                    />
+                                                )}
+                                            </>
                                         )}
                                         {canResumeAnyPausedIndexing && (
-                                            <Dropdown.Item onClick={() => onTogglePauseIndexing(false)}>
-                                                <Icon icon="play" /> Resume indexing
-                                            </Dropdown.Item>
+                                            <>
+                                                <Dropdown.Item onClick={toggleIsGlobalResumeIndexingOpen}>
+                                                    <Icon icon="play" /> Resume indexing
+                                                </Dropdown.Item>
+                                                {isGlobalResumeIndexingOpen && (
+                                                    <GlobalResumeIndexingConfirm
+                                                        toggle={toggleIsGlobalResumeIndexingOpen}
+                                                        onConfirm={handleGlobalResumeIndexing}
+                                                        allActionContexts={allActionContexts}
+                                                    />
+                                                )}
+                                            </>
                                         )}
                                         {canDisableIndexing && (
                                             <Dropdown.Item onClick={() => onToggleDisableIndexing(true)}>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/GlobalPauseIndexingConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/GlobalPauseIndexingConfirm.tsx
@@ -1,0 +1,61 @@
+import Modal from "components/common/Modal";
+import {
+    DatabaseActionContexts,
+    MultipleDatabaseLocationSelector,
+} from "components/common/MultipleDatabaseLocationSelector";
+import ActionContextUtils from "components/utils/actionContextUtils";
+import { Icon } from "components/common/Icon";
+import { useState } from "react";
+import Button from "react-bootstrap/Button";
+
+interface GlobalPauseIndexingConfirmProps {
+    toggle: () => void;
+    onConfirm: (contextPoints: DatabaseActionContexts[]) => void;
+    allActionContexts: DatabaseActionContexts[];
+}
+
+export function GlobalPauseIndexingConfirm(props: GlobalPauseIndexingConfirmProps) {
+    const { allActionContexts, toggle, onConfirm } = props;
+
+    const [selectedActionContexts, setSelectedActionContexts] = useState<DatabaseActionContexts[]>(allActionContexts);
+
+    const handlePause = () => {
+        onConfirm(selectedActionContexts);
+        toggle();
+    };
+
+    return (
+        <Modal show scrollable onHide={toggle} contentClassName="modal-border bulge-warning">
+            <Modal.Header className="vstack gap-4" onCloseClick={toggle}>
+                <div className="text-center">
+                    <Icon icon="index" color="warning" addon="pause" className="fs-1" margin="m-0" />
+                </div>
+                <div className="text-center lead">You&apos;re about to pause indexing until restart</div>
+            </Modal.Header>
+            <Modal.Body className="vstack gap-4">
+                <p>
+                    Are you sure you want to pause indexing until the server restarts? This will affect both existing
+                    indexes and any new indexes created in this database during that time.
+                </p>
+                {ActionContextUtils.showContextSelector(allActionContexts) && (
+                    <div>
+                        <h4>Select context</h4>
+                        <MultipleDatabaseLocationSelector
+                            allActionContexts={allActionContexts}
+                            selectedActionContexts={selectedActionContexts}
+                            setSelectedActionContexts={setSelectedActionContexts}
+                        />
+                    </div>
+                )}
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="link" onClick={toggle} className="link-muted">
+                    Cancel
+                </Button>
+                <Button variant="warning" onClick={handlePause} className="rounded-pill">
+                    <Icon icon="pause" /> Pause
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/GlobalResumeIndexingConfirm.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/GlobalResumeIndexingConfirm.tsx
@@ -1,0 +1,57 @@
+import Modal from "components/common/Modal";
+import {
+    DatabaseActionContexts,
+    MultipleDatabaseLocationSelector,
+} from "components/common/MultipleDatabaseLocationSelector";
+import ActionContextUtils from "components/utils/actionContextUtils";
+import { Icon } from "components/common/Icon";
+import { useState } from "react";
+import Button from "react-bootstrap/Button";
+
+interface GlobalResumeIndexingConfirmProps {
+    toggle: () => void;
+    onConfirm: (contextPoints: DatabaseActionContexts[]) => void;
+    allActionContexts: DatabaseActionContexts[];
+}
+
+export function GlobalResumeIndexingConfirm(props: GlobalResumeIndexingConfirmProps) {
+    const { allActionContexts, toggle, onConfirm } = props;
+
+    const [selectedActionContexts, setSelectedActionContexts] = useState<DatabaseActionContexts[]>(allActionContexts);
+
+    const handleResume = () => {
+        onConfirm(selectedActionContexts);
+        toggle();
+    };
+
+    return (
+        <Modal show scrollable onHide={toggle} contentClassName="modal-border bulge-success">
+            <Modal.Header className="vstack gap-4" onCloseClick={toggle}>
+                <div className="text-center">
+                    <Icon icon="index" color="success" addon="play" className="fs-1" margin="m-0" />
+                </div>
+                <div className="text-center lead">You&apos;re about to resume indexing</div>
+            </Modal.Header>
+            <Modal.Body className="vstack gap-4">
+                {ActionContextUtils.showContextSelector(allActionContexts) && (
+                    <div>
+                        <h4>Select context</h4>
+                        <MultipleDatabaseLocationSelector
+                            allActionContexts={allActionContexts}
+                            selectedActionContexts={selectedActionContexts}
+                            setSelectedActionContexts={setSelectedActionContexts}
+                        />
+                    </div>
+                )}
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="link" onClick={toggle} className="link-muted">
+                    Cancel
+                </Button>
+                <Button variant="success" onClick={handleResume} className="rounded-pill">
+                    <Icon icon="play" /> Resume
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
@@ -6,7 +6,6 @@ import {
 } from "components/pages/resources/databases/store/databasesViewSlice";
 import databasesManager from "common/shell/databasesManager";
 import notificationCenter from "common/notifications/notificationCenter";
-import DatabaseUtils from "components/utils/DatabaseUtils";
 import { UnsubscribeListener } from "@reduxjs/toolkit";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
 import app from "durandal/app";
@@ -18,6 +17,8 @@ import DatabaseLockMode = Raven.Client.ServerWide.DatabaseLockMode;
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { addAppListener } from "components/storeUtils";
 import { databasesSlice } from "components/common/shell/databasesSlice";
+import { DatabaseActionContexts } from "components/common/MultipleDatabaseLocationSelector";
+import ActionContextUtils from "components/utils/actionContextUtils";
 
 export const toggleIndexing =
     (db: DatabaseSharedInfo, disable: boolean): AppAsyncThunk =>
@@ -52,24 +53,29 @@ export const openNotificationCenterForDatabase =
     };
 
 export const togglePauseIndexing =
-    (db: DatabaseSharedInfo, pause: boolean): AppAsyncThunk =>
-    async (dispatch, getState, getServices) => {
+    (db: DatabaseSharedInfo, pause: boolean, contexts: DatabaseActionContexts[]): AppAsyncThunk =>
+    async (dispatch, _, getServices) => {
         const { indexesService } = getServices();
-        const locations = DatabaseUtils.getLocations(db);
 
-        if (pause) {
-            const tasks = locations.map(async (l) => {
-                await indexesService.pauseAllIndexes(db.name, l);
-                dispatch(databasesViewSlice.actions.pausedIndexing(db.name, l));
-            });
-            await Promise.all(tasks);
-        } else {
-            const tasks = locations.map(async (l) => {
-                await indexesService.resumeAllIndexes(db.name, l);
-                dispatch(databasesViewSlice.actions.resumedIndexing(db.name, l));
-            });
-            await Promise.all(tasks);
+        let tasks: Promise<void>[] = [];
+
+        for (const { nodeTag, shardNumbers } of contexts) {
+            const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
+
+            if (pause) {
+                tasks = locations.map(async (location) => {
+                    await indexesService.pauseAllIndexes(db.name, location);
+                    dispatch(databasesViewSlice.actions.pausedIndexing(db.name, location));
+                });
+            } else {
+                tasks = locations.map(async (location) => {
+                    await indexesService.resumeAllIndexes(db.name, location);
+                    dispatch(databasesViewSlice.actions.resumedIndexing(db.name, location));
+                });
+            }
         }
+
+        await Promise.all(tasks);
     };
 
 export const syncDatabaseDetails = (): AppThunk<UnsubscribeListener> => (dispatch) => {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24056/Add-pause-resume-indexing-to-List-of-Indexes-view

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
