### PR TITLE
RavenDB-22335 Fixing test RavenDB_20922.DisableAutoMapIndexClusterWideAndEnableAutoMapIndexClusterWide

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20922.cs
+++ b/test/SlowTests/Issues/RavenDB-20922.cs
@@ -101,6 +101,13 @@ namespace SlowTests.Issues
             await EnableIndexClusterWide(store, index[0].Name);
 
             var documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+            await WaitForValueAsync(async () =>
+            {
+                documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                return documentDatabase.IndexStore.GetIndex(index[0].Name).Status;
+            }, IndexRunningStatus.Running);
+
             var autoIndex = documentDatabase.IndexStore.GetIndex(index[0].Name);
             Assert.Equal(IndexState.Normal, autoIndex.State);
             Assert.Equal(IndexRunningStatus.Running, autoIndex.Status);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22335/SlowTests.Issues.RavenDB20922.DisableAutoMapIndexClusterWideAndEnableAutoMapIndexClusterWide

### Additional description

Applying the same fix as in https://github.com/ravendb/ravendb/pull/17778

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
