### PR TITLE
RavenDB-24426: Server Fast Tests Upgrade

### DIFF
--- a/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
+++ b/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.JsonPatch;
@@ -20,27 +20,27 @@ public class BatchCommandWithNoReplyFlagTest : RavenTestBase
     {
     }
         
-    [RavenFact(RavenTestCategory.Patching)]
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
     public async Task BatchWithNoReply_WhenPatch_ShouldNotFail()
     {
         const string user1Id = "users/1";
         const string user1Value = "SomeValue";
-        
+
         var store = GetDocumentStore();
         var requestExecutor = store.GetRequestExecutor();
-        
+
         using (var session = store.OpenSession())
         using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
         {
             session.Store(new TestObj(), user1Id);
             session.SaveChanges();
-                
+
             var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session);
             var patchRequest = new PatchRequest{Script = "this.Name = args.val_0;", Values = new Dictionary<string, object>{{"val_0", user1Value}}};
             result.SessionCommands.Add(new PatchCommandData(user1Id, null, patchRequest));
-            
+
             var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
-            
+
             await requestExecutor.ExecuteAsync(sbc, context);
         }
 
@@ -50,28 +50,28 @@ public class BatchCommandWithNoReplyFlagTest : RavenTestBase
             Assert.Equal(user1Value, user.Name);
         }
     }
-    
-    [RavenFact(RavenTestCategory.Patching)]
+
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
     public async Task BatchWithNoReply_WhenJsonPatch_ShouldNotFail()
     {
         const string user2Id = "users/1";
         const string user2Value = "SomeValue";
-        
+
         var store = GetDocumentStore();
         var requestExecutor = store.GetRequestExecutor();
-        
+
         using (var session = store.OpenSession())
         using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
         {
             session.Store(new TestObj(), user2Id);
             session.SaveChanges();
-                
+
             var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session);
             var jpd = new JsonPatchDocument();
             jpd.Add("/Name", user2Value);
             result.SessionCommands.Add(new JsonPatchCommandData(user2Id, jpd));
             var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
-            
+
             await requestExecutor.ExecuteAsync(sbc, context);
         }
 

--- a/test/FastTests/Client/Changes/BasicChangesDocumentsTests.cs
+++ b/test/FastTests/Client/Changes/BasicChangesDocumentsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Tests.Core.Utils.Entities;
@@ -15,7 +15,7 @@ public class BasicChangesDocumentsTests : RavenTestBase
     {
     }
 
-    [RavenTheory(RavenTestCategory.ChangesApi)]
+    [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task Can_Subscribe_To_Single_Document_Changes(Options options)
     {
@@ -59,7 +59,7 @@ public class BasicChangesDocumentsTests : RavenTestBase
         }
     }
 
-    [RavenTheory(RavenTestCategory.ChangesApi)]
+    [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task Can_Subscribe_To_All_Document_Changes(Options options)
     {
@@ -94,7 +94,7 @@ public class BasicChangesDocumentsTests : RavenTestBase
         }
     }
 
-    [RavenTheory(RavenTestCategory.ChangesApi)]
+    [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task Can_Subscribe_To_Collection_Document_Changes(Options options)
     {
@@ -130,7 +130,7 @@ public class BasicChangesDocumentsTests : RavenTestBase
         }
     }
 
-    [RavenTheory(RavenTestCategory.ChangesApi)]
+    [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task Can_Subscribe_To_Prefix_Document_Changes(Options options)
     {

--- a/test/FastTests/Client/DatabaseChangesTests.cs
+++ b/test/FastTests/Client/DatabaseChangesTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Exceptions.Database;
@@ -18,7 +18,7 @@ namespace FastTests.Client
         {
         }
 
-        [RavenTheory(RavenTestCategory.ChangesApi)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseChanges_WhenRetryAfterCreatingDatabase_ShouldSubscribe(Options options, bool disableTopologyUpdates)
@@ -57,7 +57,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.ChangesApi)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseChanges_WhenTryToReconnectAfterDeletingDatabase_ShouldFailToSubscribe(Options options, bool disableTopologyUpdates)
@@ -90,7 +90,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.ChangesApi)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseChanges_WhenDeleteDatabaseAfterSubscribe_ShouldSetConnectionStateToDatabaseDoesNotExistException(Options options, bool disableTopologyUpdates)
@@ -109,7 +109,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.ChangesApi)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseChanges_WhenDisposeDatabaseChanges_ShouldSetConnectionStateDisposed(Options options, bool disableTopologyUpdates)

--- a/test/FastTests/Client/Queries/InQuery.cs
+++ b/test/FastTests/Client/Queries/InQuery.cs
@@ -14,7 +14,7 @@ namespace FastTests.Client.Queries
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryingUsingInShouldYieldDistinctResults(Options options)
         {
@@ -30,7 +30,7 @@ namespace FastTests.Client.Queries
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task CanQueryNullUsingInQuery(Options options)
         {
@@ -60,7 +60,7 @@ namespace FastTests.Client.Queries
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryDatesViaInQuery(Options options)
         {
@@ -80,7 +80,7 @@ namespace FastTests.Client.Queries
             Assert.Equal(4, query.Count);
         } 
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void InQueryUseAnalyzerDuringQueryBuildingPhase(Options options)
         {

--- a/test/FastTests/Client/Queries/QueryTests.cs
+++ b/test/FastTests/Client/Queries/QueryTests.cs
@@ -41,7 +41,7 @@ namespace FastTests.Client.Queries
             public bool IsDeleted { get; set; }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(true, SearchEngineMode = RavenSearchEngineMode.All)]
         [RavenData(false, SearchEngineMode = RavenSearchEngineMode.All)]
         public  void Query_CreateClausesForQueryDynamicallyWithOnBeforeQueryEvent(Options options, bool useCompression)
@@ -98,7 +98,7 @@ namespace FastTests.Client.Queries
                 }
             }
         }
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task Query_CreateClausesForQueryDynamicallyWhenTheQueryEmpty(Options options)
         {
@@ -141,7 +141,7 @@ namespace FastTests.Client.Queries
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public  void Query_CreateClausesForQueryDynamically(Options options)
         {
@@ -187,7 +187,7 @@ namespace FastTests.Client.Queries
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task Query_CreateClausesForQueryDynamicallyAsyncWithOnBeforeQueryEvent(Options options)
         {
@@ -239,7 +239,7 @@ namespace FastTests.Client.Queries
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
         public async Task Query_WhenCompareObjectWithUlongInWhereClause_ShouldWork(Options options)
         {
@@ -268,7 +268,7 @@ namespace FastTests.Client.Queries
             WaitForUserToContinueTheTest(store);
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
         public async Task Query_DifferentTypesComparison(Options options)
         {
@@ -298,7 +298,7 @@ namespace FastTests.Client.Queries
         }
 
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task Query_WhenUsingDateTimeNowInWhereClause_ShouldSendRequestForEachQuery(Options options)
         {

--- a/test/FastTests/Client/Queries/RegexQueryTests.cs
+++ b/test/FastTests/Client/Queries/RegexQueryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -14,7 +14,7 @@ namespace FastTests.Client.Queries
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueriesWithRegexShouldWork(Options options)
         {
@@ -37,7 +37,7 @@ namespace FastTests.Client.Queries
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueriesWithRegexFromDocumentQuery(Options options)
         {
@@ -84,7 +84,7 @@ namespace FastTests.Client.Queries
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueriesWithRegexFromLinqProvider(Options options)
         {
@@ -110,7 +110,7 @@ namespace FastTests.Client.Queries
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueriesWithRegexFromLinqProvider_QueryExpressionSyntax(Options options)
         {
@@ -136,7 +136,7 @@ namespace FastTests.Client.Queries
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueriesWithRegexAndEscapedCharsShouldWork(Options options)
         {

--- a/test/FastTests/Client/QueriesWithVariables.cs
+++ b/test/FastTests/Client/QueriesWithVariables.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Linq;
 using Raven.Client.Documents.Linq;
 using Tests.Infrastructure;
@@ -13,7 +13,7 @@ namespace FastTests.Client
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Query_With_Simple_Constants(Options options)
         {
@@ -48,7 +48,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Query_With_Simple_Constants_IntoClass(Options options)
         {

--- a/test/FastTests/Client/Query.cs
+++ b/test/FastTests/Client/Query.cs
@@ -39,7 +39,7 @@ namespace FastTests.Client
   
          */
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void RawQuery_with_transformation_function_should_work(Options options)
         {
@@ -122,7 +122,7 @@ namespace FastTests.Client
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void LinqQuery_with_transformation_function_should_work(Options options)
         {
@@ -199,7 +199,7 @@ namespace FastTests.Client
         }
 
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Query_Simple(Options options)
         {
@@ -240,7 +240,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void StringComparisonStringOrdinalWorks(Options options)
         {
@@ -309,7 +309,7 @@ namespace FastTests.Client
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void StringComparisonStringCompareOrdinalWorks(Options options)
         {
@@ -385,7 +385,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryWithWhere_WhenUsingStringEquals_ShouldWork(Options options)
         {
@@ -539,7 +539,7 @@ namespace FastTests.Client
             public string[] StrList { get; set; }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryWithWhere_WhenUsingStringEqualsWhitParameterExpression_ShouldWork(Options options)
         {
@@ -724,7 +724,7 @@ namespace FastTests.Client
             Assert.Equal(queryResult.Count, 1);
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task QueryWithWhere_WhenUsingNotSupportedExpressions_ShouldThrowNotSupported(Options options)
         {
@@ -757,7 +757,7 @@ namespace FastTests.Client
             });
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Query_With_Customize(Options options)
         {
@@ -793,7 +793,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void Query_Long_Request(Options options)
         {
@@ -815,7 +815,7 @@ namespace FastTests.Client
             }
         }
         
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void Query_OverMaxSizeOfTerm(Options options)
         {
@@ -838,7 +838,7 @@ namespace FastTests.Client
         }
 
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void Query_By_Index(Options options)
         {

--- a/test/FastTests/Client/QueryAsync.cs
+++ b/test/FastTests/Client/QueryAsync.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -16,7 +16,7 @@ namespace FastTests.Client
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryAsync_Simple(Options options)
         {
@@ -37,7 +37,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryAsync_With_Where_Clause(Options options)
         {
@@ -64,7 +64,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryAsync_By_Index(Options options)
         {

--- a/test/FastTests/Client/QueryDateTime.cs
+++ b/test/FastTests/Client/QueryDateTime.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -14,7 +14,7 @@ namespace FastTests.Client
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void DynamicQueryingDateTimeShouldWork(Options options)
         {
@@ -40,7 +40,7 @@ namespace FastTests.Client
                     res = session.Query<PersonAndDate>().Where(x => x.Date.Second == 43).ToList();
                     Assert.Equal(1, res.Count);
 
-                    //1902-04-30​T10:40:00.000Z = 600000000000000000L
+                    //1902-04-30T10:40:00.000Z = 600000000000000000L
                     res = session.Query<PersonAndDate>().Where(x => x.Date.Ticks > 600000000000000000L).ToList();
                     Assert.Equal(1, res.Count);
 
@@ -50,7 +50,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void StaticQueryingDateTimeShouldWork(Options options)
         {
@@ -80,7 +80,7 @@ namespace FastTests.Client
                     res = session.Query<PersonAndDate>(index.IndexName).Where(x => x.Date.Second == 43).ToList();
                     Assert.Equal(1, res.Count);
 
-                    //1902-04-30​T10:40:00.000Z = 600000000000000000L
+                    //1902-04-30T10:40:00.000Z = 600000000000000000L
                     res = session.Query<PersonAndDate>(index.IndexName).Where(x => x.Date.Ticks > 600000000000000000L).ToList();
                     Assert.Equal(1, res.Count);
 

--- a/test/FastTests/Client/QueryIntoStream.cs
+++ b/test/FastTests/Client/QueryIntoStream.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -18,7 +18,7 @@ namespace FastTests.Client
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void QueryWithToStream(Options options)
         {
@@ -45,7 +45,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void DocumentQueryWithToStream(Options options)
         {
@@ -72,7 +72,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryWithToStreamAsync(Options options)
         {
@@ -99,7 +99,7 @@ namespace FastTests.Client
             }
         }
 
-        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task DocumentQueryWithToStreamAsync(Options options)
         {

--- a/test/FastTests/Server/Basic/ChangeVectorConflictStatusTests.cs
+++ b/test/FastTests/Server/Basic/ChangeVectorConflictStatusTests.cs
@@ -3,18 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace FastTests.Server.Basic
 {
-    public class ChangeVectorConflictStatusTests : NoDisposalNeeded
+    public class ChangeVectorConflictStatusTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
-        public ChangeVectorConflictStatusTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void EtagShouldNotOverflow()
         {
             var cv1 =
@@ -41,7 +38,7 @@ namespace FastTests.Server.Basic
             var y = ChangeVectorUtils.Distance(cv2, cv1);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void CalculateChangeVectorDistance()
         {
             var cv1 =
@@ -69,7 +66,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(x, -y);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void EtagShouldNotOverflow2()
         {
             var x = ChangeVectorUtils.TryUpdateChangeVector("C", "n0rGjcmUT0u7ctxBXlZZPg", 5554138256, new ChangeVector("C:5554138256-n0rGjcmUT0u7ctxBXlZZPg", null));
@@ -77,7 +74,7 @@ namespace FastTests.Server.Basic
             Assert.False(x.IsValid);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Two_empty_ChangeVectors()
         {
             Assert.Equal(ConflictStatus.AlreadyMerged, ChangeVectorUtils.GetConflictStatus(string.Empty, string.Empty));
@@ -85,19 +82,19 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.AlreadyMerged, ChangeVectorUtils.GetConflictStatus(string.Empty, null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Empty_remote_change_vector_should_generate_already_merged()
         {
             Assert.Equal(ConflictStatus.AlreadyMerged, ChangeVectorUtils.GetConflictStatus(string.Empty, ChangeVector((Guid.NewGuid(), 2, 1), (Guid.NewGuid(), 3, 2))));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Empty_local_change_vector()
         {
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(ChangeVector((Guid.NewGuid(), 2, 1), (Guid.NewGuid(), 3, 2)), string.Empty));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Change_vector_has_negative_etag()
         {
             var changeVectorWithNegatoveEtag = ChangeVector((Guid.NewGuid(), 2, 1), (Guid.NewGuid(), -3, 2));
@@ -110,7 +107,7 @@ namespace FastTests.Server.Basic
                 ChangeVectorUtils.GetConflictStatus(changeVector, changeVectorWithNegatoveEtag));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Remote_has_entries_not_in_local_with_entries_same_order_and_all_remote_etags_large_than_local()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -122,7 +119,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Remote_has_entries_not_in_local_with_entries_not_same_order_and_all_remote_etags_large_than_local()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -134,7 +131,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Remote_has_entries_not_in_local_with_entries_same_order_and_all_local_etags_large_than_remote()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -146,7 +143,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Remote_has_entries_not_in_local_with_entries_not_same_order_and_all_local_etags_large_than_remote()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -158,7 +155,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Remote_has_entries_not_in_local_with_entries_same_order_and_some_local_etags_large_than_remote()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -170,7 +167,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Remote_has_entries_not_in_local_with_entries_not_same_order_and_some_local_etags_large_than_remote()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -182,7 +179,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -211,7 +208,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -243,7 +240,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -275,7 +272,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -307,7 +304,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -339,7 +336,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -369,7 +366,7 @@ namespace FastTests.Server.Basic
         }
 
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -398,7 +395,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.AlreadyMerged, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -427,7 +424,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -460,7 +457,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -493,7 +490,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -525,7 +522,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -558,7 +555,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.AlreadyMerged, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -590,7 +587,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -623,7 +620,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -652,7 +649,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Replication)]
         [InlineData(15)]
         [InlineData(100)]
         [InlineData(1000)]
@@ -681,7 +678,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Different_change_vectors_with_different_prefix_remote_smaller_with_remote_etags_smaller()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -692,7 +689,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.AlreadyMerged, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Different_change_vectors_with_different_prefix_local_smaller_with_remote_etags_smaller()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -703,7 +700,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Different_change_vectors_with_different_prefix_remote_smaller_with_remote_etags_larger()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -714,7 +711,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void Different_change_vectors_with_different_prefix_local_smaller_with_remote_etags_larger()
         {
             var dbIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -725,7 +722,7 @@ namespace FastTests.Server.Basic
             Assert.Equal(ConflictStatus.Update, ChangeVectorUtils.GetConflictStatus(remote, local));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Replication)]
         public void ToChangeVector_should_properly_parse_change_vector()
         {
             var dbIds = new List<string> { DbId(), DbId(), DbId() };

--- a/test/FastTests/Server/Basic/Crud.cs
+++ b/test/FastTests/Server/Basic/Crud.cs
@@ -6,6 +6,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Basic
 {
@@ -15,7 +16,7 @@ namespace FastTests.Server.Basic
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public async Task CanSaveAndLoad()
         {
             using (var store = GetDocumentStore())
@@ -42,7 +43,7 @@ namespace FastTests.Server.Basic
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public void CanOverwriteDocumentWithSmallerValue()
         {
             using (var store = GetDocumentStore())

--- a/test/FastTests/Server/Basic/DatabaseRecordDebugPackageInclusionTest.cs
+++ b/test/FastTests/Server/Basic/DatabaseRecordDebugPackageInclusionTest.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿﻿using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Handlers.Debugging;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Basic
 {
@@ -13,7 +14,7 @@ namespace FastTests.Server.Basic
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Monitoring)]
         public void EnsureIncludedInDatabaseRecordDebugPackage()
         {
             var sensitiveFieldsThatShouldNotBeExposedForDebug = new HashSet<string>()

--- a/test/FastTests/Server/Basic/IdleOperations.cs
+++ b/test/FastTests/Server/Basic/IdleOperations.cs
@@ -5,6 +5,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Basic
 {
@@ -19,7 +20,7 @@ namespace FastTests.Server.Basic
             public string ProductName { get; set; }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task Should_Update_LastIdle()
         {
             using (var store = GetDocumentStore())
@@ -34,7 +35,7 @@ namespace FastTests.Server.Basic
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task Should_Update_LastWork()
         {
             using (var store = GetDocumentStore())
@@ -60,7 +61,7 @@ namespace FastTests.Server.Basic
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task Should_Cleanup_Resources()
         {
             DoNotReuseServer();

--- a/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
+++ b/test/FastTests/Server/Basic/MaxSecondsForTaskToWaitForDatabaseToLoad.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
@@ -12,6 +12,7 @@ using Raven.Server.Config.Settings;
 using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Basic
 {
@@ -21,7 +22,7 @@ namespace FastTests.Server.Basic
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Configuration)]
         public void Should_not_throw_when_there_no_timeout()
         {
             UseNewLocalServer();
@@ -29,7 +30,7 @@ namespace FastTests.Server.Basic
 
             int retries = 3;
             //in case that there is alot of stuff is going on concurrently with this test,
-            //give several chances for the load to pass successfully 
+            //give several chances for the load to pass successfully
             bool didPassAtLeastOnce = false;
             for (int i = 0; i < 3; i++)
             {
@@ -53,7 +54,7 @@ namespace FastTests.Server.Basic
             Assert.True(didPassAtLeastOnce);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Configuration)]
         public async Task Should_throw_when_there_is_timeout()
         {
             UseNewLocalServer();
@@ -63,7 +64,7 @@ namespace FastTests.Server.Basic
             {
                 mre.Set();
                 Thread.Sleep(100);
-            }; // force timeout          
+            }; // force timeout
 
             var url = Server.WebUrl;
             var name = GetDatabaseName();

--- a/test/FastTests/Server/Cluster/VersionValidation.cs
+++ b/test/FastTests/Server/Cluster/VersionValidation.cs
@@ -6,6 +6,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Cluster
 {
@@ -15,7 +16,7 @@ namespace FastTests.Server.Cluster
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Cluster)]
         public void AllClusterCommandsHasVersion()
         {
             List<Exception> exceptions = new List<Exception>();
@@ -44,7 +45,7 @@ namespace FastTests.Server.Cluster
             throw new AggregateException(exceptions);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Cluster)]
         public void AllClusterCommandHasCtor()
         {
             List<Exception> exceptions = new List<Exception>();

--- a/test/FastTests/Server/DatabaseLandlordBugs.cs
+++ b/test/FastTests/Server/DatabaseLandlordBugs.cs
@@ -5,6 +5,7 @@ using Raven.Client.Exceptions;
 using Raven.Server.Config;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server
 {
@@ -14,7 +15,7 @@ namespace FastTests.Server
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task CanCreateAndDeleteDbWithNameBeingPrefix()
         {
             var databaseWithName_2 = CreateDatabaseWithName(true, null, null, "CanCreateAndDeleteDbWithNameBeingPrefix.ctor_2");
@@ -30,7 +31,7 @@ namespace FastTests.Server
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CannotDeleteEntireDbFolder()
         {
             DoNotReuseServer();
@@ -55,7 +56,7 @@ namespace FastTests.Server
             DeleteDatabase("someDB1");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CannotDeleteEntireDbFolder2()
         {
             DoNotReuseServer();

--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -2,6 +2,7 @@
 using Raven.Server.EventListener;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server;
 
@@ -11,7 +12,7 @@ public class DebugMemoryTests : NoDisposalNeeded
     {
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Memory)]
     public void Debug_Events()
     {
         Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCStart == "GCStart_V2",

--- a/test/FastTests/Server/Documents/Collections.cs
+++ b/test/FastTests/Server/Documents/Collections.cs
@@ -17,7 +17,7 @@ namespace FastTests.Server.Documents
         {
         }
 
-        [RavenTheory(RavenTestCategory.None)]
+        [RavenTheory(RavenTestCategory.Core)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void CanSurviveRestart(Options options)
         {

--- a/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
+++ b/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
@@ -22,7 +22,7 @@ namespace FastTests.Server.Documents
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public async Task GetLower_WhenStringAscii_ShouldNotModifyTheValueAcceptToLower()
         {
             using (var store = GetDocumentStore())
@@ -44,7 +44,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public async Task GetSliceFromId_WhenStringAscii_ShouldNotModifyTheValueAcceptToLower()
         {
             using (var store = GetDocumentStore())
@@ -62,7 +62,7 @@ namespace FastTests.Server.Documents
             }
         }
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public void GetSliceFromId_WhenEmptyLazyString_ShouldNotThrow()
         {
             using var ctx = DocumentsOperationContext.ShortTermSingleUse(null);
@@ -74,7 +74,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public async Task GetSliceFromId_WhenStringIsUnicode_ShouldNotModifyTheValueAcceptToLower()
         {
             using (var store = GetDocumentStore())
@@ -92,7 +92,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public async Task GetSliceFromId_WhenDisposing_ShouldFreeMemory()
         {
             using (var store = GetDocumentStore())
@@ -124,7 +124,7 @@ namespace FastTests.Server.Documents
                 ['a' + new string('\r', AbstractPager.MaxKeySize / (JsonParserState.EscapePositionItemSize + 1) - 4)]
             };
 
-        [RavenTheory(RavenTestCategory.Core)]
+        [RavenTheory(RavenTestCategory.Memory)]
         [MemberData(nameof(Ids))]
         public async Task DocumentId_WhenWrite_ShouldBeAbleToRead(string id)
         {
@@ -156,7 +156,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [RavenTheory(RavenTestCategory.Core)]
+        [RavenTheory(RavenTestCategory.Memory)]
         [MemberData(nameof(Ids))]
         public async Task DocumentId_WhenStore_ShouldBeAbleToLoad(string id)
         {

--- a/test/FastTests/Server/Documents/DocumentsCrud.cs
+++ b/test/FastTests/Server/Documents/DocumentsCrud.cs
@@ -9,6 +9,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents
 {
@@ -26,7 +27,7 @@ namespace FastTests.Server.Documents
             _disposeDatabase = CreatePersistentDocumentDatabase(NewDataPath(prefix: "DocumentsCrud"), out _documentDatabase, caller: caller);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("users/1")]
         [InlineData("USERs/1")]
         [InlineData("לכובע שלי שלוש פינות")]
@@ -64,7 +65,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("users/1")]
         [InlineData("USERs/1")]
         [InlineData("לכובע שלי שלוש פינות")]
@@ -105,7 +106,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanQueryByGlobalEtag()
         {
             Initialize();
@@ -167,7 +168,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task EtagsArePersisted()
         {
             Initialize();
@@ -214,7 +215,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task EtagsArePersistedWithDeletes()
         {
             Initialize();
@@ -274,7 +275,7 @@ namespace FastTests.Server.Documents
             _documentDatabase = await GetDatabase(_documentDatabase.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanQueryByPrefix()
         {
             Initialize();
@@ -334,7 +335,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanQueryByCollectionEtag()
         {
             Initialize();
@@ -395,7 +396,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WillVerifyEtags_New()
         {
             Initialize();
@@ -420,7 +421,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WillVerifyEtags_Existing()
         {
             Initialize();
@@ -446,7 +447,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WillVerifyEtags_OnDeleteExisting()
         {
             Initialize();
@@ -472,7 +473,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WillVerifyEtags_OnDeleteNotThere()
         {
             Initialize();
@@ -486,7 +487,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WillVerifyEtags_ShouldBeNew()
         {
             Initialize();
@@ -511,7 +512,7 @@ namespace FastTests.Server.Documents
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void WillVerifyEtags_VerifyNew()
         {
             Initialize();
@@ -537,7 +538,7 @@ namespace FastTests.Server.Documents
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void PutDocumentWithoutId()
         {
             Initialize();

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -36,7 +36,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CheckDispose(RavenTestParameters config)
         {
@@ -80,7 +80,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanPersist(RavenTestParameters config)
         {
@@ -144,7 +144,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanDelete(RavenTestParameters config)
         {
@@ -198,7 +198,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             Assert.Equal(0, indexes.Count);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanReset(RavenTestParameters config)
         {
@@ -254,7 +254,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             Assert.Equal(2, indexes.Count);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void SimpleIndexing(RavenTestParameters config)
         {
@@ -417,7 +417,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void WriteErrors(RavenTestParameters config)
         {
@@ -456,7 +456,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void Errors2(RavenTestParameters config)
         {
@@ -905,7 +905,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void Errors(RavenTestParameters config)
         {
@@ -948,7 +948,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
         public async Task AutoIndexesShouldBeMarkedAsIdleAndDeleted(RavenTestParameters config)
         {
@@ -1312,7 +1312,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task IndexCreationOptions(RavenTestParameters config)
         {
@@ -1337,7 +1337,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task LockMode(RavenTestParameters config)
         {
@@ -1364,7 +1364,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task IndexLoadErrorCreatesFaultyInMemoryIndexFakeAndAddsAlert(RavenTestParameters config)
         {
@@ -1420,7 +1420,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanDeleteFaultyIndex(RavenTestParameters config)
         {

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapReduceIndexing.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -28,7 +28,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanUseSimpleReduction(RavenTestParameters config)
         {
@@ -71,7 +71,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [InlineData(100, new[] { "Poland", "Israel", "USA" })]
         public async Task MultipleReduceKeys(int numberOfUsers, string[] locations)
         {
@@ -118,7 +118,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanDelete(RavenTestParameters config)
         {
@@ -231,7 +231,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Configuration)]
         [RavenExplicitData]
         public async Task DefinitionOfAutoMapReduceIndexIsPersisted(RavenTestParameters config)
         {
@@ -339,7 +339,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanGroupByNestedFieldAndAggregateOnCollection(RavenTestParameters config)
         {
@@ -401,7 +401,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void CanStoreAndReadReduceStats(RavenTestParameters config)
         {
@@ -451,7 +451,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanUpdateByChangingValue(RavenTestParameters config)
         {
@@ -529,7 +529,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanUpdateByChangingReduceKey(RavenTestParameters config)
         {
@@ -610,7 +610,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task GroupByMultipleFields(RavenTestParameters config)
         {

--- a/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
+++ b/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
@@ -26,6 +26,7 @@ using Voron;
 using Xunit;
 using Xunit.Abstractions;
 using Index = Raven.Server.Documents.Indexes.Index;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing
 {
@@ -35,7 +36,7 @@ namespace FastTests.Server.Documents.Indexing
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public async Task CheckAnalyzers()
         {
             using (var store = GetDocumentStore())
@@ -104,7 +105,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public async Task OverrideAnalyzers()
         {
             using (var store = GetDocumentStore())

--- a/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
@@ -5,6 +5,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Threading;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing
 {
@@ -14,7 +15,7 @@ namespace FastTests.Server.Documents.Indexing
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Basic()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
@@ -58,7 +59,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void CanPersist()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
@@ -93,7 +94,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void CheckWritability()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
@@ -138,7 +139,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void CheckReadonly()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
@@ -171,7 +172,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void WillExpand()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
@@ -204,7 +205,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void CannotMixFilters()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
@@ -223,7 +224,7 @@ namespace FastTests.Server.Documents.Indexing
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void WillGetConsumedFromStorage()
         {
             using (var context = new TransactionOperationContext(Env, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LazyStringValueReaderTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LazyStringValueReaderTests.cs
@@ -7,6 +7,7 @@ using Raven.Server.Json;
 using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing.Lucene
 {
@@ -20,7 +21,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             _ctx = JsonOperationContext.ShortTermSingleUse();
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [InlineData("ąęłóżźćń")]
         [InlineData("לכובע שלי שלוש פינות")]
         public void Reads_unicode(string expected)
@@ -35,7 +36,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [InlineData(1024)]
         [InlineData(1500)]
         [InlineData(2048)]
@@ -53,7 +54,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [InlineData(10)]
         [InlineData(1500)]
         [InlineData(2048)]
@@ -67,7 +68,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal(expected.First(), stringResult);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Can_reuse_reader_multiple_times()
         {
             var r = new Random();
@@ -88,7 +89,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public async Task CompareLazyCompressedStringValue()
         {
             using (var context = JsonOperationContext.ShortTermSingleUse())

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Document = Raven.Server.Documents.Document;
 using Index = Raven.Server.Documents.Indexes.Index;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing.Lucene
 {
@@ -55,7 +56,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             _ctx = JsonOperationContext.ShortTermSingleUse();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Returns_null_value_if_property_is_null()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -80,7 +81,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Returns_empty_string_value_if_property_has_empty_string()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -105,7 +106,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_string_value()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -130,7 +131,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Reuses_cached_document_instance()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -164,7 +165,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/2", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_numeric_fields()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new[]
@@ -208,7 +209,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_nested_string_value()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -236,7 +237,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_string_value_nested_inside_collection()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -277,7 +278,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_string_value_nested_inside_double_nested_collections()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -335,7 +336,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("companies/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_complex_value()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -397,7 +398,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_array_value()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]
@@ -427,7 +428,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
             Assert.Equal("users/1", _sut.Document.GetField(Constants.Documents.Indexing.Fields.DocumentIdFieldName).StringValue(null));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Conversion_of_array_having_complex_values()
         {
             _sut = new LuceneDocumentConverter(new FakeIndex(), new IndexField[]

--- a/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/MapReduce/ReduceKeyProcessorTests.cs
@@ -8,6 +8,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Threading;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing.MapReduce
 {
@@ -17,7 +18,7 @@ namespace FastTests.Server.Documents.Indexing.MapReduce
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Memory)]
         public void Can_handle_values_of_different_types()
         {
             using (var bufferPool = new UnmanagedBuffersPoolWithLowMemoryHandling("ReduceKeyProcessorTests"))

--- a/test/FastTests/Server/Documents/Indexing/RavenLinqOptimizerTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/RavenLinqOptimizerTests.cs
@@ -5,6 +5,7 @@ using Raven.Server.Documents.Indexes.Static.Roslyn;
 using Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing
 {
@@ -14,7 +15,7 @@ namespace FastTests.Server.Documents.Indexing
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [InlineData(@"docs.SelectMany(match => match.Teams, (match, team) => new { match = match, team = team })
                           .SelectMany(this0 => this0.team.Series, (this0, serie) => new { this0 = this0, serie = serie })
                           .SelectMany(this1 => this1.serie.Games, (this1, game) => new { Player = game.Player,

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
@@ -28,7 +28,7 @@ namespace FastTests.Server.Documents.Indexing.Static
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task The_easiest_static_index(RavenTestParameters config)
         {
@@ -100,7 +100,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanInheritConfiguration(RavenTestParameters config)
         {
@@ -124,7 +124,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanPersist(RavenTestParameters config)
         {
@@ -191,7 +191,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void IndexDefinitionSerialization()
         {
             var indexDefinition = new IndexDefinition();
@@ -262,7 +262,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void StalenessCalculationShouldWorkForAllDocsIndexes(RavenTestParameters config)
         {
@@ -355,7 +355,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public void NumberOfDocumentsAndTombstonesToProcessShouldBeCalculatedCorrectly(RavenTestParameters config)
         {
@@ -504,7 +504,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [InlineData(200, 1000)]
         [InlineData(1000, 2000)]
         [InlineData(128, 2048)]

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapReduceIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapReduceIndexing.cs
@@ -24,7 +24,7 @@ namespace FastTests.Server.Documents.Indexing.Static
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task The_simpliest_static_map_reduce_index(RavenTestParameters config)
         {
@@ -117,7 +117,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [RavenExplicitData]
         public async Task CanPersist(RavenTestParameters config)
         {

--- a/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/DynamicBlittableJsonTests.cs
@@ -23,7 +23,7 @@ namespace FastTests.Server.Documents.Indexing.Static
             _ctx = JsonOperationContext.ShortTermSingleUse();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void Can_get_simple_values()
         {
             var now = SystemTime.UtcNow;

--- a/test/FastTests/Server/Documents/Indexing/TranslatingLinqQueriesToIndexes.cs
+++ b/test/FastTests/Server/Documents/Indexing/TranslatingLinqQueriesToIndexes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Indexing
 {
@@ -16,7 +17,7 @@ namespace FastTests.Server.Documents.Indexing
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void WillTranslateReferenceToIdTo__document_id()
         {
             Expression<Func<IEnumerable<Nestable>, IEnumerable>> map = nests => from nestable in nests
@@ -25,7 +26,7 @@ namespace FastTests.Server.Documents.Indexing
             Assert.Contains("Id = Id(nestable)", code);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void WillNotTranslateIdTo__document_idIfNotOnRootEntity()
         {
             Expression<Func<IEnumerable<Nestable>, IEnumerable>> map = nests => from nestable in nests
@@ -35,7 +36,7 @@ namespace FastTests.Server.Documents.Indexing
             Assert.Contains("Id = child.Id", code);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void WillTranslateProperlyBothRootAndChild()
         {
             Expression<Func<IEnumerable<Nestable>, IEnumerable>> map = nests => from nestable in nests
@@ -46,7 +47,7 @@ namespace FastTests.Server.Documents.Indexing
             Assert.Contains("Id2 = Id(nestable)", code);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void WillTranslateAnonymousArray()
         {
             Expression<Func<IEnumerable<Nestable>, IEnumerable>> map = nests => from nestable in nests

--- a/test/FastTests/Server/Documents/Operations/BasicOperationsTests.cs
+++ b/test/FastTests/Server/Documents/Operations/BasicOperationsTests.cs
@@ -9,6 +9,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Threading;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Operations
 {
@@ -18,7 +19,7 @@ namespace FastTests.Server.Documents.Operations
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Can_notify_about_operations_progress_and_completion()
         {
             using (var db = CreateDocumentDatabase())
@@ -94,7 +95,7 @@ namespace FastTests.Server.Documents.Operations
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Can_notify_about_exception_in_operation()
         {
             using (var db = CreateDocumentDatabase())
@@ -130,7 +131,7 @@ namespace FastTests.Server.Documents.Operations
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Should_be_able_to_cancel_operation()
         {
             using (var db = CreateDocumentDatabase())
@@ -163,7 +164,7 @@ namespace FastTests.Server.Documents.Operations
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Can_serialize_in_progress_state_to_json()
         {
             var state = new OperationState
@@ -184,7 +185,7 @@ namespace FastTests.Server.Documents.Operations
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Can_serialize_completed_state_to_json()
         {
             var state = new OperationState

--- a/test/FastTests/Server/Documents/Queries/Dynamic/Map/CreationOfAutoMapIndexDefinition.cs
+++ b/test/FastTests/Server/Documents/Queries/Dynamic/Map/CreationOfAutoMapIndexDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿﻿﻿﻿using System;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes;
@@ -7,6 +7,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Dynamic;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Queries.Dynamic.Map
 {
@@ -18,7 +19,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
 
         private DynamicQueryMapping _sut;
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void SpecifyingInvalidParametersWillResultInException()
         {
             var fields = new[] { new AutoIndexField
@@ -35,7 +36,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             new AutoMapIndexDefinition("test", fields);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CanExtractTermsFromRangedQuery()
         {
             create_dynamic_mapping("FROM Users WHERE Term BETWEEN 0 AND 10");
@@ -48,7 +49,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByTerm", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CanExtractTermsFromEqualityQuery()
         {
             create_dynamic_mapping("FROM Users WHERE Term = 'Whatever'");
@@ -62,7 +63,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CanExtractMultipleTermsQuery()
         {
             create_dynamic_mapping("FROM Users WHERE Term = 'Whatever' OR Term2 BETWEEN 0 AND 10");
@@ -77,7 +78,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CanExtractTermsFromComplexQuery()
         {
             create_dynamic_mapping("FROM Users WHERE (Term = 'bar' OR Term2 = 'baz') OR Term3 = 'foo' OR NOT Term4 = 'rob'");
@@ -94,7 +95,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CanExtractMultipleNestedTermsQuery()
         {
             create_dynamic_mapping("FROM Users WHERE Term = 'Whatever' OR (Term2 = 'Whatever' AND Term3 = 'Whatever')");
@@ -109,7 +110,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByTermAndTerm2AndTerm3", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CreateDefinitionSupportsArrayProperties()
         {
             create_dynamic_mapping("FROM Users WHERE Tags[].Name = 'Any'");
@@ -123,7 +124,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CreateDefinitionSupportsNestedProperties()
         {
             create_dynamic_mapping("FROM Users WHERE User.Name = 'Any'");
@@ -136,7 +137,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByUser.Name", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CreateDefinitionForQueryWithSortedFields()
         {
             create_dynamic_mapping("FROM Users WHERE StartsWith(Name, 'a') ORDER BY Age AS long");
@@ -151,7 +152,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             var nameField = definition.MapFields["Name"];
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CreateDefinitionForQueryWithNestedFieldsAndStringSortingSet()
         {
             create_dynamic_mapping("FROM Users WHERE StartsWith(Name, 'a') ORDER BY Address.Country ASC");
@@ -165,7 +166,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByAddress.CountryAndName", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CreateDefinitionForQueryWithNestedFieldsAndNumberSortingSet()
         {
             create_dynamic_mapping("FROM Users WHERE StartsWith(Name, 'a') ORDER BY Address.ZipCode AS double");
@@ -179,7 +180,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByAddress.ZipCodeAndName", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void CreateDefinitionForQueryWithRangeField()
         {
             create_dynamic_mapping("FROM Users WHERE Age BETWEEN 30 AND 40 ORDER BY Age");
@@ -192,7 +193,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByAge", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void ExtendsMappingBasedOnExistingDefinition()
         {
             _sut = DynamicQueryMapping.Create(new IndexQueryServerSide("FROM Users WHERE StartsWith(FirstName, 'a') ORDER BY Count AS long"));
@@ -214,7 +215,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByAgeAndCountAndFirstNameAndLastName", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void DefinitionExtensionWontDuplicateFields()
         {
             _sut = DynamicQueryMapping.Create(new IndexQueryServerSide("FROM Users WHERE StartsWith(FirstName, 'A') AND StartsWith(LastName, 'A') ORDER BY Age AS double, Count AS long"));
@@ -238,7 +239,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByAddressIdAndAgeAndCountAndFirstNameAndLastName", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void OrderingSpecifiedUsing_AS_AfterOrderBy()
         {
             create_dynamic_mapping("FROM Users WHERE Age > 40 ORDER BY Age AS string");
@@ -251,7 +252,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
             Assert.Equal("Auto/Users/ByAge", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void ExtendsIndexingOptionsOfTheSameField()
         {
             _sut = DynamicQueryMapping.Create(new IndexQueryServerSide("FROM Users WHERE FirstName = 'a'"));

--- a/test/FastTests/Server/Documents/Queries/Dynamic/Map/IncludeOrLoadShouldReturnAllDocsEtag.cs
+++ b/test/FastTests/Server/Documents/Queries/Dynamic/Map/IncludeOrLoadShouldReturnAllDocsEtag.cs
@@ -1,6 +1,7 @@
-﻿using Raven.Server.Documents.Queries;
+﻿﻿﻿using Raven.Server.Documents.Queries;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Queries.Dynamic.Map
 {
@@ -10,7 +11,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.Map
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void FunctionWithLoad()
         {
             var query = new IndexQueryServerSide(@"
@@ -28,7 +29,7 @@ select {
             Assert.True(query.Metadata.HasIncludeOrLoad);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void SelectWithLoad()
         {
             var query = new IndexQueryServerSide(@"
@@ -42,7 +43,7 @@ select {
             Assert.True(query.Metadata.HasIncludeOrLoad);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void Load()
         {
             var query = new IndexQueryServerSide(@"
@@ -55,7 +56,7 @@ select c.Name
             Assert.True(query.Metadata.HasIncludeOrLoad);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void Include()
         {
             var query = new IndexQueryServerSide(@"
@@ -68,7 +69,7 @@ include o.Company
             Assert.True(query.Metadata.HasIncludeOrLoad);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void WithoutIncludeOrLoad()
         {
             var query = new IndexQueryServerSide(@"

--- a/test/FastTests/Server/Documents/Queries/Dynamic/MapReduce/CreationOfAutoMapReduceIndexDefinition.cs
+++ b/test/FastTests/Server/Documents/Queries/Dynamic/MapReduce/CreationOfAutoMapReduceIndexDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes;
@@ -8,6 +8,7 @@ using Raven.Server.Documents.Queries.Dynamic;
 using Raven.Server.Documents.Queries.Parser;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
 {
@@ -19,7 +20,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
 
         private DynamicQueryMapping _sut;
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public void SpecifyingInvalidParametersWillResultInException()
         {
             Assert.Throws<ArgumentNullException>(() => new AutoMapReduceIndexDefinition(null, null, null));
@@ -50,7 +51,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
             });
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void Map_all_fields()
         {
             _sut = DynamicQueryMapping.Create(new IndexQueryServerSide("FROM Users GROUP BY Location SELECT Location, count() "));
@@ -63,7 +64,7 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
             Assert.Equal("Auto/Users/ByCountReducedByLocation", definition.Name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void Error_when_no_group_by_field()
         {
             var ex = Assert.Throws<QueryParser.ParseException>(() => new IndexQueryServerSide("FROM Users GROUP BY SELECT count() "));
@@ -71,13 +72,13 @@ namespace FastTests.Server.Documents.Queries.Dynamic.MapReduce
             Assert.Contains("Unable to get field for GROUP BY", ex.Message);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void Can_be_no_aggregation_field_in_dynamic_group_by()
         {
             new IndexQueryServerSide("FROM Users GROUP BY Location");
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void Extends_mapping_based_on_existing_definition_if_group_by_fields_match()
         {
             _sut = DynamicQueryMapping.Create(

--- a/test/FastTests/Server/Documents/Queries/HighlightingQuery.cs
+++ b/test/FastTests/Server/Documents/Queries/HighlightingQuery.cs
@@ -19,7 +19,7 @@ namespace FastTests.Server.Documents.Queries
             public string Name { get; set; }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void HighlightingOnAutomap(Options option)
         {

--- a/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
+++ b/test/FastTests/Server/Documents/Queries/NotModifiedQueryResults.cs
@@ -16,7 +16,7 @@ namespace FastTests.Server.Documents.Queries
         {
         }
         
-        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public async Task Returns_correct_results_from_cache_if_server_response_was_not_modified(Options options)
         {

--- a/test/FastTests/Server/Documents/Queries/Parser/ComplexQueries.cs
+++ b/test/FastTests/Server/Documents/Queries/Parser/ComplexQueries.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Raven.Server.Documents.Queries.AST;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Queries.Parser
 {
@@ -13,7 +14,7 @@ namespace FastTests.Server.Documents.Queries.Parser
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData(@"FROM Users (IsActive =false)", "{\"From\":\"Users\"}")]
         [InlineData(@"FROM Users (IsActive = true)
 GROUP BY Country

--- a/test/FastTests/Server/Documents/Queries/Parser/ParserTests.cs
+++ b/test/FastTests/Server/Documents/Queries/Parser/ParserTests.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿﻿using Newtonsoft.Json;
 using Raven.Server.Documents.Queries.Parser;
 using System;
 using System.IO;
@@ -7,6 +7,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Queries.Parser
 {
@@ -16,7 +17,7 @@ namespace FastTests.Server.Documents.Queries.Parser
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData(@"from Orders
 select ID('not valid argument')", QueryType.Select)]
         [InlineData(@"declare function Name() {
@@ -58,7 +59,7 @@ update {
             Assert.Throws<InvalidQueryException>(() => new QueryMetadata(q, null, 1, queryType: type));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         [InlineData(@"
 declare function Name() {
     var a = ""{{\"""";
@@ -88,7 +89,7 @@ UPDATE {
             parser.Parse(type);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("Name")]
         [InlineData("Address.City")]
         [InlineData("Address.City.Zone")]
@@ -104,7 +105,7 @@ UPDATE {
             Assert.True(parser.Field(out token));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData(" $name ", 4)]
         [InlineData("$age ", 3)]
         public void CanParseParameter(string q, int len)
@@ -116,7 +117,7 @@ UPDATE {
             Assert.Equal(len, token.Length);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("Name = 'Oren'", OperatorType.Equal)]
         [InlineData("Name < 'Oren'", OperatorType.LessThan)]
         [InlineData("Name <= 'Oren'", OperatorType.LessThanEqual)]
@@ -150,7 +151,7 @@ UPDATE {
             Assert.IsType<NegatedExpression>(((BinaryExpression)op).Right);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void CanParseTimeSeriesDeclaration()
         {
             var parser = new QueryParser();
@@ -189,7 +190,7 @@ from Users as u select test(u)
             Assert.Equal(type, op.GetType());
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("Name =     'Oren'", "Name = 'Oren'")]
         [InlineData("Name between \n'Oren' AND 'Phoebe'", "Name BETWEEN 'Oren' AND 'Phoebe'")]
         [InlineData("( Name between 'Oren' AND 'Phoebe' )", "Name BETWEEN 'Oren' AND 'Phoebe'")]
@@ -215,7 +216,7 @@ from Users as u select test(u)
             Assert.Equal(o, output.GetStringBuilder().ToString());
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("State = 2 AND Act = 'Wait'", "{\"Type\":\"And\",\"Left\":{\"Type\":\"Equal\",\"Left\":\"State\",\"Right\":2},\"Right\":{\"Type\":\"Equal\",\"Left\":\"Act\",\"Right\":\"Wait\"}}")]
         [InlineData("( Name between 'Oren' AND 'Phoebe' )", "{\"Between\":{\"Min\":\"Oren\",\"Max\":\"Phoebe\"}}")]
         [InlineData("Name IN ()", "{\"In\":[]}")]

--- a/test/FastTests/Server/Documents/Queries/Parser/ScannerTests.cs
+++ b/test/FastTests/Server/Documents/Queries/Parser/ScannerTests.cs
@@ -3,6 +3,7 @@ using Raven.Server.Documents.Queries.AST;
 using Xunit;
 using Raven.Server.Documents.Queries.Parser;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Queries.Parser
 {
@@ -12,7 +13,7 @@ namespace FastTests.Server.Documents.Queries.Parser
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
@@ -25,7 +26,7 @@ namespace FastTests.Server.Documents.Queries.Parser
             Assert.False(qs.Identifier());
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("hello", 0, 5)]
         [InlineData(" name = ", 1, 4)]
         [InlineData("some_thing ", 0, 10)]
@@ -40,7 +41,7 @@ namespace FastTests.Server.Documents.Queries.Parser
         }
 
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData(" 'hel lo' ", "hel lo")]
         [InlineData(" \"he \"", "he ")]
         [InlineData(" \"he\"\" \" ", "he\" ")]
@@ -55,7 +56,7 @@ namespace FastTests.Server.Documents.Queries.Parser
             Assert.Equal(escape, a.ToString());
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("1", 1L)]
         [InlineData("1.0", 1.0D)]
         [InlineData("1234 ", 1234L)]
@@ -75,7 +76,7 @@ namespace FastTests.Server.Documents.Queries.Parser
                 Assert.Equal((long)expected, long.Parse(qs.Token.Value, CultureInfo.InvariantCulture));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Querying)]
         [InlineData("hello there", 6, 5)]
         public void CanScanConsecutiveIdentifiers(string q, int start, int len)
         {

--- a/test/FastTests/Server/Documents/Queries/WaitingForNonStaleResults.cs
+++ b/test/FastTests/Server/Documents/Queries/WaitingForNonStaleResults.cs
@@ -22,7 +22,7 @@ namespace FastTests.Server.Documents.Queries
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public async Task Cutoff_etag_usage()
         {
             using (var store = GetDocumentStore())

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -1,17 +1,10 @@
-﻿//-----------------------------------------------------------------------
-// <copyright file="RevisionsTests.cs" company="Hibernating Rhinos LTD">
-//     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-// </copyright>
-//-----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Utils;
-using Microsoft.Extensions.Azure;
 using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
@@ -20,7 +13,6 @@ using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Patch;
-using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -32,13 +24,8 @@ using Xunit.Abstractions;
 
 namespace FastTests.Server.Documents.Revisions
 {
-
-    public class RevisionsTests : RavenTestBase
+    public class RevisionsTests(ITestOutputHelper output) : RavenTestBase(output)
     {
-        public RevisionsTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
         [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Revisions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task CanGetNonExistingRevisionsByChangeVectorAsyncLazily(Options options)
@@ -179,7 +166,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task CanGetMetadataForLazily()
         {
             using (var store = GetDocumentStore())
@@ -986,7 +973,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task CanGetNullForNotExistsDocument()
         {
             using (var store = GetDocumentStore())
@@ -1007,7 +994,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task CanGetAllRevisionsFor()
         {
             var company = new Company { Name = "Company Name" };
@@ -1037,7 +1024,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task CanCheckIfDocumentHasRevisions()
         {
             var company = new Company { Name = "Company Name" };
@@ -1180,7 +1167,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task WillCreateRevision()
         {
             var product = new User { Name = "Hibernating" };
@@ -1218,7 +1205,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task WillCreateValidRevisionWhenCompressionDocumentWasSaved()
         {
             var user = new User { Name = new string('1', 4096 * 2) }; // create a string which will be compressed
@@ -1277,7 +1264,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task WillDeleteOldRevisions()
         {
             var company = new Company { Name = "Company #1" };
@@ -1372,7 +1359,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
         public async Task RevisionsOrder()
         {
             using (var store = GetDocumentStore())
@@ -1410,7 +1397,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [RavenFact(RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions | RavenTestCategory.Counters, LicenseRequired = true)]
         public async Task CanGetCountersSnapshotInRevisions()
         {
             using (var store = GetDocumentStore())
@@ -1503,7 +1490,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Revisions)]
         public async Task CanLimitNumberOfRevisionsByAge()
         {
             var revisionsAgeLimit = TimeSpan.FromSeconds(10);
@@ -1861,7 +1848,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions)]
         public async Task CollectionCaseSensitiveTest1()
         {
             using (var store = GetDocumentStore())
@@ -1898,7 +1885,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions)]
         public async Task CollectionCaseSensitiveTest2()
         {
             using (var store = GetDocumentStore())
@@ -1935,7 +1922,7 @@ namespace FastTests.Server.Documents.Revisions
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Configuration)]
         public async Task CollectionCaseSensitiveTest3()
         {
             using (var store = GetDocumentStore())

--- a/test/FastTests/Server/Documents/TimeSeries/TimeSeriesAppendTests.cs
+++ b/test/FastTests/Server/Documents/TimeSeries/TimeSeriesAppendTests.cs
@@ -5,6 +5,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.TimeSeries
 {
@@ -14,7 +15,7 @@ namespace FastTests.Server.Documents.TimeSeries
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.TimeSeries)]
         public void CanAppendMoreThan127Tags()
         {
             using (var db = CreateDocumentDatabase())

--- a/test/FastTests/Server/Documents/TimeSeries/TimeSeriesRangeTests.cs
+++ b/test/FastTests/Server/Documents/TimeSeries/TimeSeriesRangeTests.cs
@@ -7,6 +7,7 @@ using Sparrow.Server;
 using Sparrow.Threading;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.TimeSeries
 {
@@ -17,7 +18,7 @@ namespace FastTests.Server.Documents.TimeSeries
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.TimeSeries)]
         [InlineData("1s", "2019-05-05T06:03:51.1077101Z", "2019-05-05T06:03:51.0000000Z", "2019-05-05T06:03:52.0000000Z")]
         [InlineData("1m", "2019-05-05T06:03:51.1077101Z", "2019-05-05T06:03:00.0000000Z", "2019-05-05T06:04:00.0000000Z")]
         [InlineData("1h", "2019-05-05T06:03:51.1077101Z", "2019-05-05T06:00:00.0000000Z", "2019-05-05T07:00:00.0000000Z")]
@@ -42,7 +43,7 @@ namespace FastTests.Server.Documents.TimeSeries
 
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.TimeSeries)]
         public unsafe void BitBufferCompression()
         {
             using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
@@ -70,7 +71,7 @@ namespace FastTests.Server.Documents.TimeSeries
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.TimeSeries)]
         public void BitBufferCanHandleLargeValuesAndCompression()
         {
             var values = GetFailingValues();

--- a/test/FastTests/Server/Documents/Tombstones/BasicTombstones.cs
+++ b/test/FastTests/Server/Documents/Tombstones/BasicTombstones.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +12,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Documents.Tombstones
 {
@@ -21,7 +22,7 @@ namespace FastTests.Server.Documents.Tombstones
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanCreateAndGetTombstone()
         {
             using (var database = CreateDocumentDatabase())
@@ -71,7 +72,7 @@ namespace FastTests.Server.Documents.Tombstones
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task Cleanup()
         {
             using (var database = CreateDocumentDatabase())
@@ -199,7 +200,7 @@ namespace FastTests.Server.Documents.Tombstones
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task CleanupOfMultiMapIndexWithLoadDocument()
         {
             var indexDefinition = new IndexDefinition()

--- a/test/FastTests/Server/Json/BlittableJsonTraverserTests.cs
+++ b/test/FastTests/Server/Json/BlittableJsonTraverserTests.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿﻿﻿using System.Collections.Generic;
 using System.Linq;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Json
 {
@@ -18,7 +19,7 @@ namespace FastTests.Server.Json
             _ctx = JsonOperationContext.ShortTermSingleUse();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_simple_value()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -31,7 +32,7 @@ namespace FastTests.Server.Json
             Assert.Equal("John Doe", read.ToString());
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_nested_values()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -56,7 +57,7 @@ namespace FastTests.Server.Json
             Assert.Equal(2L, read);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_values_nested_in_array()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -87,7 +88,7 @@ namespace FastTests.Server.Json
             Assert.Equal("John", items[1].ToString());
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_array_values()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -111,7 +112,7 @@ namespace FastTests.Server.Json
             Assert.Equal("John", items[1].ToString());
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_values_nested_in_array_as_objects()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -148,7 +149,7 @@ namespace FastTests.Server.Json
             Assert.Equal("John", items[1].ToString());
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_value_nested_in_object_of_array_of_arrays()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -209,7 +210,7 @@ namespace FastTests.Server.Json
             Assert.Equal("foo/2", items[1].ToString());
             Assert.Equal("foo/3", items[2].ToString());
         }
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_values_of_multidimensional_array()
         {
             var doc = create_doc(new DynamicJsonValue
@@ -287,7 +288,7 @@ namespace FastTests.Server.Json
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Reads_value_nested_in_nested_object_of_array_of_arrays()
         {
             var doc = create_doc(new DynamicJsonValue

--- a/test/FastTests/Server/Routing/TrieTests.cs
+++ b/test/FastTests/Server/Routing/TrieTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Raven.Server.Routing;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server.Routing
 {
@@ -17,7 +18,7 @@ namespace FastTests.Server.Routing
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanQueryTrie()
         {
             var trie = Trie<int>.Build(new[]
@@ -33,7 +34,7 @@ namespace FastTests.Server.Routing
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void CanQueryWithRoot()
         {
             var trie = Trie<int>.Build(new[]
@@ -49,7 +50,7 @@ namespace FastTests.Server.Routing
         }
 
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData("databases/northwind/docs")]
         [InlineData("databases")]
         [InlineData("databases/northwind/indexes/Raven/DocumentsByEntityName")]

--- a/test/FastTests/Server/ServerStore.cs
+++ b/test/FastTests/Server/ServerStore.cs
@@ -9,6 +9,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server
 {
@@ -18,7 +19,7 @@ namespace FastTests.Server
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Admin_databases_endpoint_should_refuse_document_with_lower_etag_with_concurrency_Exception()
         {
             using (var store = GetDocumentStore())
@@ -44,7 +45,7 @@ namespace FastTests.Server
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Admin_databases_endpoint_should_fetch_document_with_etag_in_metadata_property()
         {
             using (var store = GetDocumentStore())

--- a/test/FastTests/Server/ThreadUsageTests.cs
+++ b/test/FastTests/Server/ThreadUsageTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿﻿using System.Linq;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
@@ -16,7 +16,7 @@ namespace FastTests.Server
         {
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.None, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [RavenMultiplatformFact(RavenTestCategory.Monitoring, RavenPlatform.Windows | RavenPlatform.Linux)]
         public void ThreadUsage_WhenThreadsHaveSameCpuUsageAndTotalProcessorTime_ShouldListThemBoth()
         {
             using var database = CreateDocumentDatabase();

--- a/test/FastTests/Server/TrafficWatchConfigurationTests.cs
+++ b/test/FastTests/Server/TrafficWatchConfigurationTests.cs
@@ -5,6 +5,7 @@ using Raven.Client.ServerWide.Operations.TrafficWatch;
 using Sparrow;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Server
 {
@@ -14,7 +15,7 @@ namespace FastTests.Server
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Configuration)]
         public async Task CheckDefaultsAndCanSetAndGetTrafficWatchConfiguration()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24425
https://issues.hibernatingrhinos.com/issue/RavenDB-24426

### Additional description

Upgrading of the Server Fast Tests.
Depends on: https://github.com/ravendb/ravendb/pull/20775

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
