### PR TITLE
RavenDB-24428 Fix description of "Indexing.Static.ArchivedDataProcess…

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -138,21 +138,19 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Auto.DeploymentMode", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public IndexDeploymentMode AutoIndexDeploymentMode { get; protected set; }
-        
-        
-        [Description("The default archived data processing behavior for auto indexes")]
+
+        [Description("The default processing behavior for archived documents in auto indexes.")]
         [DefaultValue(ArchivedDataProcessingBehavior.ExcludeArchived)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.Auto.ArchivedDataProcessingBehavior", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public ArchivedDataProcessingBehavior AutoIndexArchivedDataProcessingBehavior{ get; protected set; }
         
-        
-        [Description("The default archived data processing behavior for static indexes")]
+        [Description("The default processing behavior for archived documents in static indexes that use Documents as their data source." +
+                     "This setting does not apply to indexes based on Time Series or Counters, which default to IncludeArchived.")]
         [DefaultValue(ArchivedDataProcessingBehavior.ExcludeArchived)]
         [IndexUpdateType(IndexUpdateType.None)]
         [ConfigurationEntry("Indexing.Static.ArchivedDataProcessingBehavior", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public ArchivedDataProcessingBehavior StaticIndexArchivedDataProcessingBehavior{ get; protected set; }
-
 
         [Description("Indicate if indexing performance metrics are gathered")]
         [DefaultValue(true)]


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24428/Fix-description-of-Indexing.Static.ArchivedDataProcessingBehavior

### Additional description
Fix description of "Indexing.Static.ArchivedDataProcessingBehavior"

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed => Documentation is handled in:
 https://issues.hibernatingrhinos.com/issue/RDoc-2633/Server-Extensions-Data-archival-Fix-article

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ x No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
