### PR TITLE
RavenDB-23795 Allow to use certificates with only EKU for server auth

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -128,6 +128,9 @@ namespace Raven.Client
 
             public const string Prefix = "certificates/";
             public const int MaxNumberOfCertsWithSameHash = 5;
+            internal const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+            internal const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+            internal const string ServerCertExtensionOid =  CompanyInformation.CompanyOid + ".2.1";
         }
 
         internal class Network
@@ -462,6 +465,7 @@ namespace Raven.Client
                 }
 
                 public const string DatabasesMappingKey = "monitoring/snmp/databases/mapping";
+                public const string SnmpRootOid = CompanyInformation.CompanyOid + ".1.1";
             }
         }
 
@@ -511,6 +515,15 @@ namespace Raven.Client
 
                 public const string ThrowRevisionKeyTooBigFix = "ThrowRevisionKeyTooBigFix";
             }
+        }
+
+        internal class CompanyInformation
+        {
+            private CompanyInformation()
+            {
+            }
+
+            public const string CompanyOid = "1.3.6.1.4.1.45751";
         }
     }
 }

--- a/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
+++ b/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
@@ -150,7 +150,7 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
 
             foreach (var eku in kue.EnhancedKeyUsages)
             {
-                if (eku.Value != "1.3.6.1.5.5.7.3.2")
+                if (eku.Value != Constants.Certificates.ClientAuthenticationOid)
                     continue;
 
                 supported = true;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -49,6 +49,7 @@ namespace Raven.Client.Http
         internal static readonly TimeSpan GlobalHttpClientTimeout = TimeSpan.FromHours(12);
 
         internal static IRavenHttpClientFactory HttpClientFactory = DefaultRavenHttpClientFactory.Instance;
+        internal static Func<X509Certificate2, X509Certificate2> ExtractServerCertificateFromExtension = null;
 
         private static readonly GetStatisticsOperation BackwardCompatibilityFailureCheckOperation = new GetStatisticsOperation(debugTag: "failure=check");
         private static readonly DatabaseHealthCheckOperation FailureCheckOperation = new DatabaseHealthCheckOperation();
@@ -1474,7 +1475,14 @@ namespace Raven.Client.Http
                     }
                     else if (Certificate.HasPrivateKey)
                     {
-                        builder.Append(Certificate.FriendlyName).Append(" does not have permission to access it or is unknown. ");
+                        var extractedCertificate = ExtractServerCertificateFromExtension?.Invoke(Certificate);
+                        builder.Append(Certificate.FriendlyName).Append(" (Thumbprint: ").Append(Certificate.Thumbprint).Append(")");
+                        if (extractedCertificate != null)
+                        {
+                            builder.Append(" with embedded Server Certificate ").Append(extractedCertificate.FriendlyName)
+                                .Append(" (Thumbprint: ").Append(extractedCertificate.Thumbprint).Append(")");
+                        }
+                        builder.Append(" does not have permission to access it or is unknown. ");
                     }
                     else
                     {

--- a/src/Raven.Client/Util/PublicKeyPinningHashHelpers.cs
+++ b/src/Raven.Client/Util/PublicKeyPinningHashHelpers.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Sparrow;
+
+namespace Raven.Client.Util;
+
+internal static class PublicKeyPinningHashHelpers
+{
+    public static string GetPublicKeyPinningHash(this X509Certificate2 cert)
+    {
+        //Get the SubjectPublicKeyInfo member of the certificate
+        var subjectPublicKeyInfo = GetSubjectPublicKeyInfoRaw(cert);
+
+        //Take the SHA2-256 hash of the DER ASN.1 encoded value
+        byte[] digest;
+        using (var sha2 = SHA256.Create())
+        {
+            digest = sha2.ComputeHash(subjectPublicKeyInfo);
+        }
+
+        //Convert hash to base64
+        var hash = Convert.ToBase64String(digest);
+
+        return hash;
+    }
+
+    public static unsafe byte[] GetSubjectPublicKeyInfoRaw(X509Certificate2 cert)
+    {
+        /*
+             Certificate is, by definition:
+
+                Certificate  ::=  SEQUENCE  {
+                    tbsCertificate       TBSCertificate,
+                    signatureAlgorithm   AlgorithmIdentifier,
+                    signatureValue       BIT STRING
+                }
+
+               TBSCertificate  ::=  SEQUENCE  {
+                    version         [0]  EXPLICIT Version DEFAULT v1,
+                    serialNumber         CertificateSerialNumber,
+                    signature            AlgorithmIdentifier,
+                    issuer               Name,
+                    validity             Validity,
+                    subject              Name,
+                    subjectPublicKeyInfo SubjectPublicKeyInfo,
+                    issuerUniqueID  [1]  IMPLICIT UniqueIdentifier OPTIONAL, -- If present, version MUST be v2 or v3
+                    subjectUniqueID [2]  IMPLICIT UniqueIdentifier OPTIONAL, -- If present, version MUST be v2 or v3
+                    extensions      [3]  EXPLICIT Extensions       OPTIONAL  -- If present, version MUST be v3
+                }
+
+            So we walk the ASN.1 DER tree in order to drill down to the SubjectPublicKeyInfo item
+            */
+
+        var rawCert = cert.GetRawCertData();
+        var bufferLength = rawCert.Length;
+
+        fixed (byte* certPtr = rawCert)
+        {
+            var ptr = AsnNext(certPtr, ref bufferLength, true, false);  // unwrap certificate sequence
+            ptr = AsnNext(ptr, ref bufferLength, false, false); // get tbsCertificate
+            ptr = AsnNext(ptr, ref bufferLength, true, false);  // unwrap tbsCertificate sequence
+            ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Version
+            ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.SerialNumber
+            ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Signature
+            ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Issuer
+            ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Validity
+            ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Subject
+            ptr = AsnNext(ptr, ref bufferLength, false, false); // get tbsCertificate.SubjectPublicKeyInfo
+
+            var subjectPublicKeyInfo = new byte[bufferLength];
+            fixed (byte* newPtr = subjectPublicKeyInfo)
+            {
+                Memory.Copy(newPtr, ptr, bufferLength);
+            }
+            return subjectPublicKeyInfo;
+        }
+    }
+
+    private static unsafe byte* AsnNext(byte* buffer, ref int bufferLength, bool unwrap, bool getRemaining)
+    {
+        if (bufferLength < 2)
+        {
+            return buffer;
+        }
+
+        var index = 0;
+        index++;
+
+        int length = buffer[index];
+        index++;
+
+        var lengthBytes = 1;
+        if (length >= 0x80)
+        {
+            lengthBytes = length & 0x0F; //low nibble is number of length bytes to follow
+            length = 0;
+
+            for (var i = 0; i < lengthBytes; i++)
+            {
+                length = (length << 8) + (int)buffer[index + i];
+            }
+            lengthBytes++;
+        }
+
+        int skip;
+        int take;
+        if (unwrap)
+        {
+            skip = 1 + lengthBytes;
+            take = length;
+        }
+        else
+        {
+            skip = 0;
+            take = 1 + lengthBytes + length;
+        }
+
+        if (getRemaining == false)
+        {
+            buffer += skip;
+            bufferLength = take;
+        }
+        else
+        {
+            buffer += skip + take;
+            bufferLength -= (skip + take);
+        }
+
+        return buffer;
+    }
+}

--- a/src/Raven.Client/Util/TcpUtils.cs
+++ b/src/Raven.Client/Util/TcpUtils.cs
@@ -205,7 +205,8 @@ namespace Raven.Client.Util
                 return networkStream;
 
             var expectedCert = CertificateLoaderUtil.CreateCertificate(Convert.FromBase64String(info.Certificate));
-            var sslStream = new SslStream(networkStream, false, (sender, actualCert, chain, errors) => expectedCert.Equals(actualCert));
+            var sslStream = new SslStream(networkStream, false,
+                (sender, actualCert, chain, errors) => expectedCert.Equals(actualCert));
             
             var targetHost = new Uri(info.Url).Host;
             var clientCertificates = new X509CertificateCollection(new X509Certificate[] { storeCertificate });
@@ -230,6 +231,7 @@ namespace Raven.Client.Util
 
             return sslStream;
         }
+
 
         private static TcpClient NewTcpClient(TimeSpan? timeout, bool useIPv6)
         {

--- a/src/Raven.Server/Commercial/CreateSetupPackageParameters.cs
+++ b/src/Raven.Server/Commercial/CreateSetupPackageParameters.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
+﻿using System.Threading;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace Raven.Server.Commercial;
@@ -19,4 +18,5 @@ public class CreateSetupPackageParameters
     public bool RegisterTcpDnsRecords;
     public string AcmeUrl;
     public CancellationToken CancellationToken;
+    public string AcmeProfile;
 }

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Org.BouncyCastle.OpenSsl;
 using Org.BouncyCastle.Pkcs;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
 using Raven.Server.Utils;
 using Sparrow.Server.Platform.Posix;
 
@@ -16,11 +17,11 @@ public class LetsEncryptCertificateUtil
 {
     internal static (byte[] CertBytes, CertificateDefinition CertificateDefinition, X509Certificate2 SelfSignedCertificate) GenerateClientCertificateTask(CertificateUtils.CertificateHolder certificateHolder, string certificateName, SetupInfo setupInfo)
     {
-        if (certificateHolder.Certificate == null)
+        if (certificateHolder.ServerCertificate == null)
             throw new InvalidOperationException($"Cannot generate the client certificate '{certificateName}' because the server certificate is not loaded.");
 
         // this creates a client certificate which is signed by the current server certificate
-        var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(certificateName, certificateHolder, out var certBytes, setupInfo.ClientCertNotAfter ?? DateTime.UtcNow.Date.AddYears(5));
+        var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(certificateName, certificateHolder.ServerCertificate, certificateHolder.PrivateKey.Key, out var certBytes, setupInfo.ClientCertNotAfter ?? DateTime.UtcNow.Date.AddYears(5));
 
         var newCertDef = new CertificateDefinition
         {

--- a/src/Raven.Server/Commercial/LetsEncryptClient.cs
+++ b/src/Raven.Server/Commercial/LetsEncryptClient.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 using Polly;
 using Polly.Retry;
 using Raven.Client;
+using Raven.Server.Commercial.SetupWizard;
 using Raven.Server.Utils;
 using Sparrow.Platform;
 
@@ -282,10 +283,10 @@ namespace Raven.Server.Commercial
             } while (true);
         }
 
-        public async Task<Dictionary<string, string>> NewOrder(string[] hostnames, CancellationToken token = default(CancellationToken))
+        public async Task<Dictionary<string, string>> NewOrder(string[] hostnames, string profile = null, CancellationToken token = default(CancellationToken))
         {
             _challenges.Clear();
-            var (order, response) = await SendAsync<Order>(HttpMethod.Post, _directory.NewOrder, new Order
+            var dto = new Order
             {
                 Expires = DateTime.UtcNow.AddDays(2),
                 Identifiers = hostnames.Select(hostname => new OrderIdentifier
@@ -293,7 +294,13 @@ namespace Raven.Server.Commercial
                     Type = "dns",
                     Value = hostname
                 }).ToArray()
-            }, token);
+            };
+            
+            if (string.IsNullOrEmpty(profile) == false)
+            {
+                dto.Profile = profile;
+            }
+            var (order, response) = await SendAsync<Order>(HttpMethod.Post, _directory.NewOrder, dto, token);
 
             if (order.Status != "pending" && order.Status != "ready")
                 throw new InvalidOperationException("Created new order and expected status 'pending' or 'ready', but got: " + order.Status + Environment.NewLine +
@@ -370,7 +377,7 @@ namespace Raven.Server.Commercial
             }
         }
 
-        public async Task<(X509Certificate2 Cert, RSA PrivateKey)> GetCertificate(RSA existingKey = null, CancellationToken token = default(CancellationToken))
+        public async Task<(X509Certificate2 Cert, RSA PrivateKey)> GetCertificate(RSA existingKey = null, string acmeProfile = null, CancellationToken token = default(CancellationToken))
         {
             var key = existingKey ?? new RSACryptoServiceProvider(4096);
 
@@ -453,8 +460,10 @@ namespace Raven.Server.Commercial
                     blob = rsaCsp.ExportCspBlob(true);
                     break;
             }
+            
+            var cacheCertKey = LetsEncryptSetupUtils.GetCertCacheKey(acmeProfile, _currentOrder.Identifiers[0].Value);
 
-            _cache.CachedCerts[_currentOrder.Identifiers[0].Value] = new CertificateCache
+            _cache.CachedCerts[cacheCertKey] = new CertificateCache
             {
                 Cert = pem,
                 Private = blob
@@ -488,10 +497,10 @@ namespace Raven.Server.Commercial
             }
         }
 
-        public bool TryGetCachedCertificate(string host, out CachedCertificateResult value)
+        public bool TryGetCachedCertificate(string certCacheKey, out CachedCertificateResult value)
         {
             value = null;
-            if (_cache.CachedCerts.TryGetValue(host, out var cache) == false)
+            if (_cache.CachedCerts.TryGetValue(certCacheKey, out var cache) == false)
             {
                 return false;
             }
@@ -521,9 +530,9 @@ namespace Raven.Server.Commercial
             return _directory.Meta.TermsOfService;
         }
 
-        public void ResetCachedCertificate(IEnumerable<string> hostsToRemove)
+        public void ResetCachedCertificate(IEnumerable<string> certCacheKeysToRemove)
         {
-            foreach (var host in hostsToRemove)
+            foreach (var host in certCacheKeysToRemove)
             {
                 _cache.CachedCerts.Remove(host);
             }
@@ -779,6 +788,9 @@ namespace Raven.Server.Commercial
 
             [JsonProperty("certificate")]
             public Uri Certificate { get; set; }
+            
+            [JsonProperty("profile")]
+            public string Profile { get; set; }
         }
 
         private class OrderIdentifier

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -385,7 +385,7 @@ namespace Raven.Server.Commercial
 
         private async Task<Client.ServerWide.Commands.NodeInfo> GetNodeInfo(string nodeUrl, TransactionOperationContext ctx)
         {
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(nodeUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(nodeUrl, _serverStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var infoCmd = new GetNodeInfoCommand(TimeSpan.FromSeconds(15));
 
@@ -1018,11 +1018,11 @@ namespace Raven.Server.Commercial
             DateTime certificateNotBefore = new();
             DateTime certificateNotAfter = new();
             X509Certificate2 certificate = null;
-            if (_serverStore.Server.Certificate.Certificate != null)
+            if (_serverStore.Server.Certificate.ServerCertificate != null)
             {
-                certificateNotBefore  = _serverStore.Server.Certificate.Certificate.NotBefore.ToUniversalTime(); 
-                certificateNotAfter  = _serverStore.Server.Certificate.Certificate.NotAfter.ToUniversalTime(); 
-                certificate = _serverStore.Server.Certificate.Certificate;   
+                certificateNotBefore  = _serverStore.Server.Certificate.ServerCertificate.NotBefore.ToUniversalTime(); 
+                certificateNotAfter  = _serverStore.Server.Certificate.ServerCertificate.NotAfter.ToUniversalTime(); 
+                certificate = _serverStore.Server.Certificate.ServerCertificate;
             }
             
             var clusterSize = GetClusterSize();

--- a/src/Raven.Server/Commercial/SetupInfo.cs
+++ b/src/Raven.Server/Commercial/SetupInfo.cs
@@ -140,7 +140,7 @@ namespace Raven.Server.Commercial
                 }
                 case "lets-encrypt":
                 {
-                    return await LetsEncryptSetupUtils.Setup(parameters.SetupInfo, parameters.Progress, parameters.RegisterTcpDnsRecords, parameters.AcmeUrl, parameters.CancellationToken);
+                    return await LetsEncryptSetupUtils.Setup(parameters.SetupInfo, parameters.Progress, parameters.RegisterTcpDnsRecords, parameters.AcmeUrl, parameters.AcmeProfile, parameters.CancellationToken);
                 }
                 default: throw new InvalidOperationException("Invalid mode provided.");
             }

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Commercial
     public static class SetupManager
     {
         internal static readonly Logger Logger = LoggingSource.Instance.GetLogger<LicenseManager>("Server");
-        
+
         private static string BuildHostName(string nodeTag, string userDomain, string rootDomain)
         {
             return $"{nodeTag}.{userDomain}.{rootDomain}".ToLower();
@@ -56,13 +56,16 @@ namespace Raven.Server.Commercial
             return acmeClient.GetTermsOfServiceUri();
         }
 
-        public static async Task<IOperationResult> SetupUnsecuredTask(Action<IOperationProgress> onProgress, UnsecuredSetupInfo unsecuredSetupInfo,
-            ServerStore serverStore, ClusterOperationContext context, CancellationToken token)
+        public static async Task<IOperationResult> SetupUnsecuredTask(Action<IOperationProgress> onProgress,
+            UnsecuredSetupInfo unsecuredSetupInfo,
+            ServerStore serverStore,
+            ClusterOperationContext context,
+            CancellationToken token)
         {
             var zipOnly = unsecuredSetupInfo.ZipOnly;
             var progress = new SetupProgressAndResult(tuple =>
             {
-                if (Logger is {IsInfoEnabled: true})
+                if (Logger is { IsInfoEnabled: true })
                     Logger.Info(tuple.Message, tuple.Exception);
             });
 
@@ -76,7 +79,7 @@ namespace Raven.Server.Commercial
 
                 try
                 {
-                    unsecuredSetupInfo.ValidateInfo(new CreateSetupPackageParameters {UnsecuredSetupInfo = unsecuredSetupInfo});
+                    unsecuredSetupInfo.ValidateInfo(new CreateSetupPackageParameters { UnsecuredSetupInfo = unsecuredSetupInfo });
                 }
                 catch (Exception e)
                 {
@@ -92,7 +95,6 @@ namespace Raven.Server.Commercial
 
                 try
                 {
-
                     var completeClusterConfigurationResult = await CompleteClusterConfigurationUnsecuredSetup(onProgress,
                         progress,
                         SetupMode.Unsecured,
@@ -114,11 +116,7 @@ namespace Raven.Server.Commercial
                         OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
                         {
                             var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(
-                                new ServerWideStudioConfiguration
-                                {
-                                    Disabled = false,
-                                    Environment = studioEnvironment
-                                },
+                                new ServerWideStudioConfiguration { Disabled = false, Environment = studioEnvironment },
                                 RaftIdGenerator.DontCareId));
                             await serverStore.Cluster.WaitForIndexNotification(res.Index);
                         }
@@ -142,11 +140,14 @@ namespace Raven.Server.Commercial
             return progress;
         }
 
-        public static async Task<IOperationResult> SetupSecuredTask(Action<IOperationProgress> onProgress, SetupInfo setupInfo, ServerStore serverStore, CancellationToken token)
+        public static async Task<IOperationResult> SetupSecuredTask(Action<IOperationProgress> onProgress,
+            SetupInfo setupInfo,
+            ServerStore serverStore,
+            CancellationToken token)
         {
             var progress = new SetupProgressAndResult(tuple =>
             {
-                if (Logger is {IsInfoEnabled: true})
+                if (Logger is { IsInfoEnabled: true })
                     Logger.Info(tuple.Message, tuple.Exception);
             });
 
@@ -176,7 +177,8 @@ namespace Raven.Server.Commercial
 
                 try
                 {
-                    var completeClusterConfigurationResult = await CompleteClusterConfigurationAndGetSettingsZipSecuredSetup(onProgress, progress, SetupMode.Secured, setupInfo, serverStore, token);
+                    var completeClusterConfigurationResult =
+                        await CompleteClusterConfigurationAndGetSettingsZipSecuredSetup(onProgress, progress, SetupMode.Secured, setupInfo, serverStore, token);
 
                     progress.SettingsZipFile = await SettingsZipFileHelper.GetSetupZipFileSecuredSetup(new GetSetupZipFileParameters
                     {
@@ -190,17 +192,15 @@ namespace Raven.Server.Commercial
                         OnWriteSettingsJsonLocally = indentedJson => SettingsZipFileHelper.WriteSettingsJsonLocally(serverStore.Configuration.ConfigPath, indentedJson),
                         OnGetCertificatePath = certificateFileName =>
                         {
-                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ?? Path.Combine(AppContext.BaseDirectory, certificateFileName);
+                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ??
+                                   Path.Combine(AppContext.BaseDirectory, certificateFileName);
                         },
                         OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
                         {
-                            var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(new ServerWideStudioConfiguration
-                            {
-                                Disabled = false,
-                                Environment = studioEnvironment
-                            }, RaftIdGenerator.DontCareId));
+                            var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(
+                                new ServerWideStudioConfiguration { Disabled = false, Environment = studioEnvironment }, RaftIdGenerator.DontCareId));
                             await serverStore.Cluster.WaitForIndexNotification(res.Index);
-                }
+                        }
                     });
                 }
                 catch (Exception e)
@@ -227,13 +227,14 @@ namespace Raven.Server.Commercial
                 Logger.Operations($"Getting challenge(s) from Let's Encrypt. Using e-mail: {setupInfo.Email}.");
 
             var acmeClient = new LetsEncryptClient(serverStore.Configuration.Core.AcmeUrl);
+            var acmeProfile = serverStore.Configuration.Core.AcmeProfile;
             await acmeClient.Init(setupInfo.Email, token);
 
             // here we explicitly want to refresh the cert, so we don't want it cached
-            var cacheKeys = setupInfo.NodeSetupInfos.Select(node => BuildHostName(node.Key, setupInfo.Domain, setupInfo.RootDomain)).ToList();
+            var cacheKeys = setupInfo.NodeSetupInfos.Select(node => LetsEncryptSetupUtils.GetCertCacheKey(acmeProfile, BuildHostName(node.Key, setupInfo.Domain, setupInfo.RootDomain))).ToList();
             acmeClient.ResetCachedCertificate(cacheKeys);
 
-            var challengeResult = await LetsEncryptSetupUtils.InitialLetsEncryptChallenge(setupInfo, acmeClient, token);
+            var challengeResult = await LetsEncryptSetupUtils.InitialLetsEncryptChallenge(setupInfo, acmeClient, acmeProfile, token);
 
             if (Logger.IsOperationsEnabled)
                 Logger.Operations($"Updating DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}.");
@@ -246,7 +247,8 @@ namespace Raven.Server.Commercial
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Failed to update DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}", e);
+                throw new InvalidOperationException($"Failed to update DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}",
+                    e);
             }
 
             if (Logger.IsOperationsEnabled)
@@ -257,15 +259,15 @@ namespace Raven.Server.Commercial
                 {
                     OnValidationSuccessful = () =>
                     {
-                    if (Logger.IsOperationsEnabled)
-                        Logger.Operations("Let's encrypt validation successful, acquiring certificate now...");
-                },
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations("Let's encrypt validation successful, acquiring certificate now...");
+                    },
                     SetupInfo = setupInfo,
                     Client = acmeClient,
                     ChallengeResult = challengeResult,
-                    ExistingPrivateKey = serverStore.Server.Certificate?.Certificate?.GetRSAPrivateKey(),
+                    ExistingPrivateKey = serverStore.Server.Certificate?.ServerCertificate?.GetRSAPrivateKey(),
                     Token = token
-                });
+                }, acmeProfile);
 
             if (Logger.IsOperationsEnabled)
                 Logger.Operations("Successfully acquired certificate from Let's Encrypt.");
@@ -273,18 +275,17 @@ namespace Raven.Server.Commercial
             return cert;
         }
 
-        public static async Task<IOperationResult> ContinueUnsecuredClusterSetupTask(Action<IOperationProgress> onProgress, ContinueSetupInfo continueSetupInfo, ServerStore serverStore, CancellationToken token)
+        public static async Task<IOperationResult> ContinueUnsecuredClusterSetupTask(Action<IOperationProgress> onProgress,
+            ContinueSetupInfo continueSetupInfo,
+            ServerStore serverStore,
+            CancellationToken token)
         {
             var progress = new SetupProgressAndResult(tuple =>
             {
-                if (Logger is {IsInfoEnabled: true})
+                if (Logger is { IsInfoEnabled: true })
                     Logger.Info(tuple.Message, tuple.Exception);
-            })
-            {
-                Processed = 0,
-                Total = 4
-            };
-            
+            }) { Processed = 0, Total = 4 };
+
             try
             {
                 AssertNoClusterDefined(serverStore);
@@ -351,7 +352,8 @@ namespace Raven.Server.Commercial
 
                     try
                     {
-                        await CompleteUnsecuredConfigurationForNewNode(onProgress, progress, continueSetupInfo, settingsJsonObject, serverStore, firstNodeTag, otherNodesUrls, license, context);
+                        await CompleteUnsecuredConfigurationForNewNode(onProgress, progress, continueSetupInfo, settingsJsonObject, serverStore, firstNodeTag,
+                            otherNodesUrls, license, context);
                     }
                     catch (Exception e)
                     {
@@ -374,17 +376,16 @@ namespace Raven.Server.Commercial
             return progress;
         }
 
-        public static async Task<IOperationResult> ContinueClusterSetupTask(Action<IOperationProgress> onProgress, ContinueSetupInfo continueSetupInfo, ServerStore serverStore, CancellationToken token)
+        public static async Task<IOperationResult> ContinueClusterSetupTask(Action<IOperationProgress> onProgress,
+            ContinueSetupInfo continueSetupInfo,
+            ServerStore serverStore,
+            CancellationToken token)
         {
             var progress = new SetupProgressAndResult(tuple =>
             {
-                if (Logger is {IsInfoEnabled: true})
+                if (Logger is { IsInfoEnabled: true })
                     Logger.Info(tuple.Message, tuple.Exception);
-            })
-            {
-                Processed = 0,
-                Total = 4
-            };
+            }) { Processed = 0, Total = 4 };
 
             try
             {
@@ -420,10 +421,10 @@ namespace Raven.Server.Commercial
                     try
                     {
                         settingsJsonObject = ExtractCertificatesAndSettingsJsonFromZip(
-                            zipBytes: zipBytes, 
+                            zipBytes: zipBytes,
                             currentNodeTag: continueSetupInfo.NodeTag,
                             context: context,
-                            certBytes: out serverCertBytes, 
+                            certBytes: out serverCertBytes,
                             serverCert: out serverCert,
                             clientCert: out clientCert,
                             firstNodeTag: out firstNodeTag,
@@ -437,7 +438,7 @@ namespace Raven.Server.Commercial
 
                     progress.Processed++;
                     progress.AddInfo("Starting validation.");
-                    onProgress(progress);     
+                    onProgress(progress);
 
                     try
                     {
@@ -503,7 +504,7 @@ namespace Raven.Server.Commercial
                                                     "Either setup manually by editing the 'settings.json' file or delete the existing cluster, restart the server and try running setup again." +
                                                     Environment.NewLine +
                                                     "Existing cluster nodes " + JsonConvert.SerializeObject(allNodes, Formatting.Indented)
-                                                    );
+                );
             }
         }
 
@@ -513,6 +514,7 @@ namespace Raven.Server.Commercial
             onProgress.Invoke(progress);
             throw new InvalidOperationException(msg, e);
         }
+
         internal static Task ValidateUnsecuredServerCanRunWithSuppliedSettings(UnsecuredSetupInfo unsecuredSetupInfo, ServerStore serverStore, CancellationToken token)
         {
             var localServerIp = unsecuredSetupInfo.NodeSetupInfos.Values.First();
@@ -532,14 +534,14 @@ namespace Raven.Server.Commercial
                     {
                         if (endpoint.Port == node.Port)
                         {
-                            throw new PortInUseException(endpoint.Port, endpoint.Address.ToString() ," Port is already in use");
+                            throw new PortInUseException(endpoint.Port, endpoint.Address.ToString(), " Port is already in use");
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("Failed to validate running the server with the supplied settings: ",ex);
+                throw new InvalidOperationException("Failed to validate running the server with the supplied settings: ", ex);
             }
 
             return Task.CompletedTask;
@@ -588,7 +590,7 @@ namespace Raven.Server.Commercial
                     // In case an external ip was specified, this is the ip we update in the dns records. (not the one we bind to)
                     var ips = localNode.ExternalIpAddress == null
                         ? localIps.ToArray()
-                        : new[] {new IPEndPoint(IPAddress.Parse(localNode.ExternalIpAddress), localNode.ExternalPort)};
+                        : new[] { new IPEndPoint(IPAddress.Parse(localNode.ExternalIpAddress), localNode.ExternalPort) };
 
                     await RavenDnsRecordHelper.AssertDnsUpdatedSuccessfully(localServerUrl, ips, token);
                 }
@@ -604,157 +606,156 @@ namespace Raven.Server.Commercial
             }
         }
 
-    public static async Task<IOperationResult> SetupLetsEncryptTask(Action<IOperationProgress> onProgress, SetupInfo setupInfo, ServerStore serverStore,
-        CancellationToken token)
+        public static async Task<IOperationResult> SetupLetsEncryptTask(Action<IOperationProgress> onProgress,
+            SetupInfo setupInfo,
+            ServerStore serverStore,
+            CancellationToken token)
         {
-        var progress = new SetupProgressAndResult(tuple =>
+            var progress = new SetupProgressAndResult(tuple =>
             {
-            if (Logger is {IsInfoEnabled: true})
-                Logger.Info(tuple.Message, tuple.Exception);
-        })
-                {
-            Processed = 0,
-            Total = 4
-        };
+                if (Logger is { IsInfoEnabled: true })
+                    Logger.Info(tuple.Message, tuple.Exception);
+            }) { Processed = 0, Total = 4 };
 
-        try
-                {
-            var updatedLicense = new Reference<License>();
-            await GetUpdatedLicenseStatus(serverStore, setupInfo.License, updatedLicense).ConfigureAwait(false);
-            setupInfo.License = updatedLicense.Value;
-
-            AssertNoClusterDefined(serverStore);
-            progress.AddInfo("Setting up RavenDB in Let's Encrypt security mode.");
-            onProgress(progress);
             try
             {
-                await LetsEncryptValidationHelper.ValidateSetupInfo(SetupMode.LetsEncrypt, setupInfo, serverStore);
-            }
-            catch (Exception e)
+                var updatedLicense = new Reference<License>();
+                await GetUpdatedLicenseStatus(serverStore, setupInfo.License, updatedLicense).ConfigureAwait(false);
+                setupInfo.License = updatedLicense.Value;
+
+                AssertNoClusterDefined(serverStore);
+                progress.AddInfo("Setting up RavenDB in Let's Encrypt security mode.");
+                onProgress(progress);
+                try
                 {
-                throw new InvalidOperationException("Validation of supplied settings failed.", e);
-            }
-
-            progress.AddInfo($"Getting challenge(s) from Let's Encrypt. Using e-mail: {setupInfo.Email}.");
-            onProgress(progress);
-
-            var acmeClient = new LetsEncryptClient(serverStore.Configuration.Core.AcmeUrl);
-            await acmeClient.Init(setupInfo.Email, token);
-
-            var challengeResult = await LetsEncryptSetupUtils.InitialLetsEncryptChallenge(setupInfo, acmeClient, token);
-
-            progress.Processed++;
-            progress.AddInfo(challengeResult.Challenge != null ? "Successfully received challenge(s) information from Let's Encrypt." : "Using cached Let's Encrypt certificate.");
-
-            progress.AddInfo($"Updating DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}.");
-
-            onProgress(progress);
-
-            try
-        {
-                await RavenDnsRecordHelper.UpdateDnsRecordsTask(new UpdateDnsRecordParameters
-            {
-                    OnProgress = onProgress,
-                    Progress = progress,
-                    Challenge = challengeResult.Challenge,
-                    SetupInfo = setupInfo,
-                    Token = token
-                });
+                    await LetsEncryptValidationHelper.ValidateSetupInfo(SetupMode.LetsEncrypt, setupInfo, serverStore);
                 }
-            catch (Exception e)
-            {
-                throw new InvalidOperationException($"Failed to update DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}", e);
-            }
-
-            progress.Processed++;
-            progress.AddInfo($"Successfully updated DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}");
-            progress.AddInfo("Completing Let's Encrypt challenge(s)...");
-            onProgress(progress);
-
-            await CertificateUtils.CompleteAuthorizationAndGetCertificate(new CompleteAuthorizationAndGetCertificateParameters
-            {
-                OnValidationSuccessful = () =>
+                catch (Exception e)
                 {
-                    progress.AddInfo("Let's Encrypt challenge(s) completed successfully.");
-                    progress.AddInfo("Acquiring certificate.");
-                    onProgress(progress);
-                },
-                SetupInfo = setupInfo,
-                Client = acmeClient,
-                ChallengeResult = challengeResult,
-                ExistingPrivateKey = serverStore.Server.Certificate?.Certificate?.GetRSAPrivateKey(),
-                Token = token
-            });
+                    throw new InvalidOperationException("Validation of supplied settings failed.", e);
+                }
 
+                progress.AddInfo($"Getting challenge(s) from Let's Encrypt. Using e-mail: {setupInfo.Email}.");
+                onProgress(progress);
 
-            progress.Processed++;
-            progress.AddInfo("Successfully acquired certificate from Let's Encrypt.");
-            progress.AddInfo("Starting validation.");
-            onProgress(progress);
+                var acmeClient = new LetsEncryptClient(serverStore.Configuration.Core.AcmeUrl);
+                await acmeClient.Init(setupInfo.Email, token);
+                var acmeProfile = serverStore.Configuration.Core.AcmeProfile;
 
-            try
-            {
-                await ValidateServerCanRunWithSuppliedSettings(setupInfo, serverStore, SetupMode.LetsEncrypt, token);
-            }
-            catch (Exception e)
-            {
-                throw new InvalidOperationException("Validation failed.", e);
-            }
+                var challengeResult = await LetsEncryptSetupUtils.InitialLetsEncryptChallenge(setupInfo, acmeClient, acmeProfile, token);
 
-            progress.Processed++;
-            progress.AddInfo("Validation is successful.");
-            progress.AddInfo("Creating new RavenDB configuration settings.");
+                progress.Processed++;
+                progress.AddInfo(challengeResult.Challenge != null
+                    ? "Successfully received challenge(s) information from Let's Encrypt."
+                    : "Using cached Let's Encrypt certificate.");
 
-            onProgress(progress);
+                progress.AddInfo($"Updating DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}.");
 
-            try
-            {
-                var completeClusterConfigurationResult = await CompleteClusterConfigurationAndGetSettingsZipSecuredSetup(onProgress, progress, SetupMode.LetsEncrypt, setupInfo, serverStore, token);
+                onProgress(progress);
 
-                progress.SettingsZipFile = await SettingsZipFileHelper.GetSetupZipFileSecuredSetup(new GetSetupZipFileParameters
+                try
                 {
-                    CompleteClusterConfigurationResult = completeClusterConfigurationResult,
-                    Progress = progress,
-                    OnProgress = onProgress,
-                    OnSettingsPath = () => serverStore.Configuration.ConfigPath,
+                    await RavenDnsRecordHelper.UpdateDnsRecordsTask(new UpdateDnsRecordParameters
+                    {
+                        OnProgress = onProgress,
+                        Progress = progress,
+                        Challenge = challengeResult.Challenge,
+                        SetupInfo = setupInfo,
+                        Token = token
+                    });
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to update DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}", e);
+                }
+
+                progress.Processed++;
+                progress.AddInfo($"Successfully updated DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}");
+                progress.AddInfo("Completing Let's Encrypt challenge(s)...");
+                onProgress(progress);
+
+                await CertificateUtils.CompleteAuthorizationAndGetCertificate(new CompleteAuthorizationAndGetCertificateParameters
+                {
+                    OnValidationSuccessful = () =>
+                    {
+                        progress.AddInfo("Let's Encrypt challenge(s) completed successfully.");
+                        progress.AddInfo("Acquiring certificate.");
+                        onProgress(progress);
+                    },
                     SetupInfo = setupInfo,
-                    SetupMode = SetupMode.LetsEncrypt,
-                    ZipOnly = true,
-                    OnWriteSettingsJsonLocally = indentedJson => SettingsZipFileHelper.WriteSettingsJsonLocally(serverStore.Configuration.ConfigPath, indentedJson),
-                    OnGetCertificatePath = certificateFileName =>
-            {
-                        return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ??
-                               Path.Combine(AppContext.BaseDirectory, certificateFileName);
-                    },
-                    OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
-                {
-                        var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(new ServerWideStudioConfiguration
-            {
-                            Disabled = false,
-                            Environment = studioEnvironment
-                        }, RaftIdGenerator.DontCareId));
-
-                        await serverStore.Cluster.WaitForIndexNotification(res.Index);
-                    },
+                    Client = acmeClient,
+                    ChallengeResult = challengeResult,
+                    ExistingPrivateKey = serverStore.Server.Certificate?.ServerCertificate?.GetRSAPrivateKey(),
                     Token = token
-                });
+                }, acmeProfile);
+
+                progress.Processed++;
+                progress.AddInfo("Successfully acquired certificate from Let's Encrypt.");
+                progress.AddInfo("Starting validation.");
+                onProgress(progress);
+
+                try
+                {
+                    await ValidateServerCanRunWithSuppliedSettings(setupInfo, serverStore, SetupMode.LetsEncrypt, token);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException("Validation failed.", e);
+                }
+
+                progress.Processed++;
+                progress.AddInfo("Validation is successful.");
+                progress.AddInfo("Creating new RavenDB configuration settings.");
+
+                onProgress(progress);
+
+                try
+                {
+                    var completeClusterConfigurationResult =
+                        await CompleteClusterConfigurationAndGetSettingsZipSecuredSetup(onProgress, progress, SetupMode.LetsEncrypt, setupInfo, serverStore, token);
+
+                    progress.SettingsZipFile = await SettingsZipFileHelper.GetSetupZipFileSecuredSetup(new GetSetupZipFileParameters
+                    {
+                        CompleteClusterConfigurationResult = completeClusterConfigurationResult,
+                        Progress = progress,
+                        OnProgress = onProgress,
+                        OnSettingsPath = () => serverStore.Configuration.ConfigPath,
+                        SetupInfo = setupInfo,
+                        SetupMode = SetupMode.LetsEncrypt,
+                        ZipOnly = true,
+                        OnWriteSettingsJsonLocally = indentedJson => SettingsZipFileHelper.WriteSettingsJsonLocally(serverStore.Configuration.ConfigPath, indentedJson),
+                        OnGetCertificatePath = certificateFileName =>
+                        {
+                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ??
+                                   Path.Combine(AppContext.BaseDirectory, certificateFileName);
+                        },
+                        OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
+                        {
+                            var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(
+                                new ServerWideStudioConfiguration { Disabled = false, Environment = studioEnvironment }, RaftIdGenerator.DontCareId));
+
+                            await serverStore.Cluster.WaitForIndexNotification(res.Index);
+                        },
+                        Token = token
+                    });
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException("Failed to create the configuration settings.", e);
+                }
+
+                progress.Processed++;
+                progress.AddInfo("Configuration settings created.");
+                progress.AddInfo("Setting up RavenDB in Let's Encrypt security mode finished successfully.");
+                onProgress(progress);
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException("Failed to create the configuration settings.", e);
+                LogErrorAndThrow(onProgress, progress, "Setting up RavenDB in Let's Encrypt security mode failed.", e);
             }
 
-            progress.Processed++;
-            progress.AddInfo("Configuration settings created.");
-            progress.AddInfo("Setting up RavenDB in Let's Encrypt security mode finished successfully.");
-            onProgress(progress);
-            }
-        catch (Exception e)
-            {
-            LogErrorAndThrow(onProgress, progress, "Setting up RavenDB in Let's Encrypt security mode failed.", e);
-            }
-
-        return progress;
+            return progress;
         }
 
         private static async Task CompleteSecuredConfigurationForNewNode(
@@ -773,7 +774,8 @@ namespace Raven.Server.Commercial
         {
             try
             {
-                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm,
+                    "During setup wizard, " + "making sure there is no cluster from previous installation.");
             }
             catch (Exception e)
             {
@@ -790,7 +792,7 @@ namespace Raven.Server.Commercial
                 serverCertBytes,
                 certPassword,
                 serverStore.GetLicenseType(),
-                true);
+                validateCertKeyUsages: true);
 
             if (continueSetupInfo.NodeTag.Equals(firstNodeTag))
             {
@@ -833,7 +835,7 @@ namespace Raven.Server.Commercial
                 Permissions = new Dictionary<string, DatabaseAccess>(),
                 SecurityClearance = SecurityClearance.ClusterAdmin,
                 Thumbprint = clientCert.Thumbprint,
-                PublicKeyPinningHash = clientCert.GetPublicKeyPinningHash(),
+                PublicKeyPinningHash = PublicKeyPinningHashHelpers.GetPublicKeyPinningHash(clientCert),
                 NotAfter = clientCert.NotAfter,
                 NotBefore = clientCert.NotBefore
             };
@@ -868,7 +870,8 @@ namespace Raven.Server.Commercial
                 onProgress(progress);
             }
 
-            var certPath = serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ?? Path.Combine(AppContext.BaseDirectory, certificateFileName);
+            var certPath = serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ??
+                           Path.Combine(AppContext.BaseDirectory, certificateFileName);
 
             try
             {
@@ -902,7 +905,7 @@ namespace Raven.Server.Commercial
 
                 if (currentHasKey)
                 {
-                    settingsJsonObject.Modifications = new DynamicJsonValue(settingsJsonObject) {[dataDirKey] = currentDataDir};
+                    settingsJsonObject.Modifications = new DynamicJsonValue(settingsJsonObject) { [dataDirKey] = currentDataDir };
                 }
                 else if (settingsJsonObject.TryGet(dataDirKey, out string _))
                 {
@@ -933,7 +936,8 @@ namespace Raven.Server.Commercial
 
             try
             {
-                progress.Readme = SettingsZipFileHelper.CreateReadmeTextSecured(continueSetupInfo.NodeTag, publicServerUrl, false, continueSetupInfo.RegisterClientCert, false, true);
+                progress.Readme = SettingsZipFileHelper.CreateReadmeTextSecured(continueSetupInfo.NodeTag, publicServerUrl, false, continueSetupInfo.RegisterClientCert,
+                    false, true);
             }
             catch (Exception e)
             {
@@ -941,8 +945,7 @@ namespace Raven.Server.Commercial
             }
         }
 
-        
-          private static async Task CompleteUnsecuredConfigurationForNewNode(
+        private static async Task CompleteUnsecuredConfigurationForNewNode(
             Action<IOperationProgress> onProgress,
             SetupProgressAndResult progress,
             ContinueSetupInfo continueSetupInfo,
@@ -955,7 +958,8 @@ namespace Raven.Server.Commercial
         {
             try
             {
-                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm,
+                    "During setup wizard, " + "making sure there is no cluster from previous installation.");
             }
             catch (Exception e)
             {
@@ -1006,7 +1010,7 @@ namespace Raven.Server.Commercial
 
                 if (currentHasKey)
                 {
-                    settingsJsonObject.Modifications = new DynamicJsonValue(settingsJsonObject) {[dataDirKey] = currentDataDir};
+                    settingsJsonObject.Modifications = new DynamicJsonValue(settingsJsonObject) { [dataDirKey] = currentDataDir };
                 }
                 else if (settingsJsonObject.TryGet(dataDirKey, out string _))
                 {
@@ -1044,7 +1048,7 @@ namespace Raven.Server.Commercial
                 throw new InvalidOperationException("Failed to create the readme text.", e);
             }
         }
-          
+
         private static async Task<CompleteClusterConfigurationResult> CompleteClusterConfigurationUnsecuredSetup(
             Action<IOperationProgress> onProgress,
             SetupProgressAndResult progress,
@@ -1064,11 +1068,7 @@ namespace Raven.Server.Commercial
                 OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
                 {
                     var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(
-                        new ServerWideStudioConfiguration
-                        {
-                            Disabled = false,
-                            Environment = studioEnvironment
-                        },
+                        new ServerWideStudioConfiguration { Disabled = false, Environment = studioEnvironment },
                         RaftIdGenerator.DontCareId));
                     await serverStore.Cluster.WaitForIndexNotification(res.Index);
                 },
@@ -1076,7 +1076,8 @@ namespace Raven.Server.Commercial
                 {
                     try
                     {
-                        serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                        serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm,
+                            "During setup wizard, " + "making sure there is no cluster from previous installation.");
                     }
                     catch (Exception e)
                     {
@@ -1085,7 +1086,7 @@ namespace Raven.Server.Commercial
 
                     if (unsecuredSetupInfo.LocalNodeTag != null)
                         await serverStore.EnsureNotPassiveAsync(publicServerUrl, unsecuredSetupInfo.LocalNodeTag);
-                   
+
                     await DeleteAllExistingCertificates(serverStore);
 
                     serverStore.HasFixedPort = unsecuredSetupInfo.NodeSetupInfos[localNodeTag].Port != 0;
@@ -1104,7 +1105,7 @@ namespace Raven.Server.Commercial
                 },
             });
         }
-                
+
         private static async Task<CompleteClusterConfigurationResult> CompleteClusterConfigurationAndGetSettingsZipSecuredSetup(
             Action<IOperationProgress> onProgress,
             SetupProgressAndResult progress,
@@ -1127,111 +1128,124 @@ namespace Raven.Server.Commercial
                            Path.Combine(AppContext.BaseDirectory, certificateFileName);
                 },
                 OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
-                    {
+                {
                     var res = await serverStore.PutValueInClusterAsync(new PutServerWideStudioConfigurationCommand(
-                        new ServerWideStudioConfiguration {Disabled = false, Environment = studioEnvironment}, RaftIdGenerator.DontCareId));
+                        new ServerWideStudioConfiguration { Disabled = false, Environment = studioEnvironment }, RaftIdGenerator.DontCareId));
 
                     await serverStore.Cluster.WaitForIndexNotification(res.Index);
                 },
                 OnBeforeAddingNodesToCluster = async (publicServerUrl, localNodeTag) =>
-                        {
-                            try
-                            {
-                        serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm, "During setup wizard, " + "making sure there is no cluster from previous installation.");
-                            }
-                            catch (Exception e)
-                            {
-                                throw new InvalidOperationException("Failed to delete previous cluster topology during setup.", e);
-                            }
+                {
+                    try
+                    {
+                        serverStore.Engine.SetNewState(RachisState.Passive, null, serverStore.Engine.CurrentTerm,
+                            "During setup wizard, " + "making sure there is no cluster from previous installation.");
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException("Failed to delete previous cluster topology during setup.", e);
+                    }
 
-                            await serverStore.EnsureNotPassiveAsync(publicServerUrl, setupInfo.LocalNodeTag);
+                    await serverStore.EnsureNotPassiveAsync(publicServerUrl, setupInfo.LocalNodeTag);
 
-                            await DeleteAllExistingCertificates(serverStore);
+                    await DeleteAllExistingCertificates(serverStore);
 
-                            if (setupMode == SetupMode.LetsEncrypt)
-                            {
-                                await serverStore.EnsureNotPassiveAsync(skipLicenseActivation: true);
-                                await serverStore.LicenseManager.ActivateAsync(setupInfo.License, RaftIdGenerator.DontCareId);
-                            }
+                    if (setupMode == SetupMode.LetsEncrypt)
+                    {
+                        await serverStore.EnsureNotPassiveAsync(skipLicenseActivation: true);
+                        await serverStore.LicenseManager.ActivateAsync(setupInfo.License, RaftIdGenerator.DontCareId);
+                    }
 
-                            serverStore.HasFixedPort = setupInfo.NodeSetupInfos[localNodeTag].Port != 0;
+                    serverStore.HasFixedPort = setupInfo.NodeSetupInfos[localNodeTag].Port != 0;
                 },
                 PutCertificateInCluster = async (selfSignedCertificate, newCertDef) =>
-                            {
-                                try
-                                {
-                        var res = await serverStore.PutValueInClusterAsync(new PutCertificateCommand(selfSignedCertificate.Thumbprint, newCertDef, RaftIdGenerator.DontCareId));
+                {
+                    try
+                    {
+                        var res = await serverStore.PutValueInClusterAsync(new PutCertificateCommand(selfSignedCertificate.Thumbprint, newCertDef,
+                            RaftIdGenerator.DontCareId));
                         await serverStore.Cluster.WaitForIndexNotification(res.Index);
-                                }
-                                catch (Exception e)
-                                {
-                        throw new InvalidOperationException($"Failed to to put certificate in cluster. self signed certificate thumbprint'{selfSignedCertificate.Thumbprint}'.", e);
-                                }
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException(
+                            $"Failed to to put certificate in cluster. self signed certificate thumbprint'{selfSignedCertificate.Thumbprint}'.", e);
+                    }
                 },
                 AddNodeToCluster = async nodeTag =>
-                        {
-                        try
-                        {
+                {
+                    try
+                    {
                         await serverStore.AddNodeToClusterAsync(setupInfo.NodeSetupInfos[nodeTag].PublicServerUrl, nodeTag, validateNotInTopology: false, token: token);
-                        }
-                        catch (Exception e)
-                        {
+                    }
+                    catch (Exception e)
+                    {
                         throw new InvalidOperationException($"Failed to add node '{nodeTag}' to the cluster.", e);
-                        }
+                    }
                 },
                 RegisterClientCertInOs = (onProgressCopy, progressCopy, clientCert) => CertificateUtils.RegisterClientCertInOs(onProgressCopy, progressCopy, clientCert)
             });
-                            }
+        }
 
         public static async Task<byte[]> GenerateCertificateTask(string name, ServerStore serverStore, SetupInfo setupInfo)
-                        {
-            if (serverStore.Server.Certificate?.Certificate == null)
+        {
+            if (serverStore.Server.Certificate?.ServerCertificate == null)
                 throw new InvalidOperationException($"Cannot generate the client certificate '{name}' because the server certificate is not loaded.");
 
             // this creates a client certificate which is signed by the current server certificate
-            var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(name, serverStore.Server.Certificate, out var certBytes,
+            var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(name, serverStore.Server.Certificate.ServerCertificate,
+                serverStore.Server.Certificate.PrivateKey.Key,
+                out var certBytes,
                 setupInfo.ClientCertNotAfter ?? DateTime.UtcNow.Date.AddYears(5));
 
             var newCertDef = new CertificateDefinition
-                        {
+            {
                 Name = name,
                 // this does not include the private key, that is only for the client
                 Certificate = Convert.ToBase64String(selfSignedCertificate.Export(X509ContentType.Cert)),
                 Permissions = new Dictionary<string, DatabaseAccess>(),
                 SecurityClearance = SecurityClearance.ClusterAdmin,
                 Thumbprint = selfSignedCertificate.Thumbprint,
-                PublicKeyPinningHash = selfSignedCertificate.GetPublicKeyPinningHash(),
+                PublicKeyPinningHash = PublicKeyPinningHashHelpers.GetPublicKeyPinningHash(selfSignedCertificate),
                 NotAfter = selfSignedCertificate.NotAfter,
                 NotBefore = selfSignedCertificate.NotBefore
             };
 
             var res = await serverStore.PutValueInClusterAsync(new PutCertificateCommand(selfSignedCertificate.Thumbprint, newCertDef, RaftIdGenerator.DontCareId));
-                            await serverStore.Cluster.WaitForIndexNotification(res.Index);
+            await serverStore.Cluster.WaitForIndexNotification(res.Index);
 
             return certBytes;
-                        }
+        }
+
         internal static async Task DeleteAllExistingCertificates(ServerStore serverStore)
-                        {
+        {
             // If a user repeats the setup process, there might be certificate leftovers in the cluster
 
             List<string> existingCertificateKeys;
             using (serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
-                            {
+            {
                 existingCertificateKeys = serverStore.Cluster.GetCertificateThumbprintsFromCluster(context).ToList();
-                            }
+            }
 
             if (existingCertificateKeys.Count == 0)
                 return;
 
-            var res = await serverStore.SendToLeaderAsync(new DeleteCertificateCollectionFromClusterCommand(RaftIdGenerator.NewId()) {Names = existingCertificateKeys});
+            var res = await serverStore.SendToLeaderAsync(new DeleteCertificateCollectionFromClusterCommand(RaftIdGenerator.NewId()) { Names = existingCertificateKeys });
 
             await serverStore.Cluster.WaitForIndexNotification(res.Index);
-                                }
+        }
 
-        public static BlittableJsonReaderObject ExtractCertificatesAndSettingsJsonFromZip(byte[] zipBytes, string currentNodeTag, JsonOperationContext context,
-            out byte[] certBytes, out X509Certificate2 serverCert, out X509Certificate2 clientCert, out string firstNodeTag,
-            out Dictionary<string, string> otherNodesUrls, out License license, bool isSecured = true)
+        public static BlittableJsonReaderObject ExtractCertificatesAndSettingsJsonFromZip(byte[] zipBytes,
+            string currentNodeTag,
+            JsonOperationContext context,
+            out byte[] certBytes,
+            out X509Certificate2 serverCert,
+            out X509Certificate2 clientCert,
+            out string firstNodeTag,
+            out Dictionary<string, string> otherNodesUrls,
+            out License license,
+            bool isSecured = true)
         {
             certBytes = null;
             serverCert = null;
@@ -1245,12 +1259,12 @@ namespace Raven.Server.Commercial
 
             using (var msZip = new MemoryStream(zipBytes))
             using (var archive = new ZipArchive(msZip, ZipArchiveMode.Read, false))
-                                {
+            {
                 foreach (var entry in archive.Entries)
-                            {
+                {
                     // try to find setup.json file first, as we make decisions based on its contents
                     if (entry.Name.Equals("setup.json"))
-                        {
+                    {
                         var json = context.Sync.ReadForMemory(entry.Open(), "license/json");
 
                         SetupSettings setupSettings = JsonDeserializationServer.SetupSettings(json);
@@ -1259,46 +1273,46 @@ namespace Raven.Server.Commercial
                         // Since we allow to customize node tags, we stored information about the order of nodes into setup.json file
                         // The first node is the one in which the cluster should be initialized.
                         // If the file isn't found, it means we are using a zip which was created in the old codebase => first node has the tag 'A'
-                            }
-                        }
+                    }
+                }
 
                 foreach (var entry in archive.Entries)
-        {
+                {
                     if (entry.FullName.StartsWith($"{currentNodeTag}/") && entry.Name.EndsWith(".pfx"))
-        {
+                    {
                         using (var ms = new MemoryStream())
-        {
+                        {
                             entry.Open().CopyTo(ms);
                             certBytes = ms.ToArray();
-                }
-                }
+                        }
+                    }
 
                     if (entry.Name.StartsWith("admin.client.certificate") && entry.Name.EndsWith(".pfx"))
-        {
+                    {
                         using (var ms = new MemoryStream())
-            {
+                        {
                             entry.Open().CopyTo(ms);
                             clientCertBytes = ms.ToArray();
-            }
-            }
+                        }
+                    }
 
                     if (entry.Name.Equals("license.json"))
-            {
+                    {
                         var json = context.Sync.ReadForMemory(entry.Open(), "license/json");
                         license = JsonDeserializationServer.License(json);
-            }
+                    }
 
                     if (entry.Name.Equals("settings.json"))
-        {
+                    {
                         using (var settingsJson = context.Sync.ReadForMemory(entry.Open(), "settings-json-from-zip"))
-            {
+                        {
                             settingsJson.TryGet(RavenConfiguration.GetKey(x => x.Core.PublicServerUrl), out string publicServerUrl);
                             settingsJson.TryGet(RavenConfiguration.GetKey(x => x.Core.ServerUrls), out string serverUrl);
 
                             if (entry.FullName.StartsWith($"{currentNodeTag}/"))
-            {
+                            {
                                 currentNodeSettingsJson = settingsJson.Clone(context);
-            }
+                            }
 
                             // This is for the case where we take the zip file and use it to setup the first node as well.
                             // If this is the first node, we must collect the urls of the other nodes so that
@@ -1325,13 +1339,13 @@ namespace Raven.Server.Commercial
                 if (isSecured)
                 {
                     currentNodeSettingsJson.TryGet(RavenConfiguration.GetKey(x => x.Security.CertificatePassword), out string certPassword);
-                    serverCert = CertificateLoaderUtil.CreateCertificate(certBytes, certPassword, CertificateLoaderUtil.FlagsForPersist);   
+                    serverCert = CertificateLoaderUtil.CreateCertificate(certBytes, certPassword, CertificateLoaderUtil.FlagsForPersist);
                 }
             }
             catch (Exception e)
             {
                 throw new InvalidOperationException($"Unable to load the server certificate of node '{currentNodeTag}'.", e);
-                            }
+            }
 
             try
             {
@@ -1343,9 +1357,9 @@ namespace Raven.Server.Commercial
             catch (Exception e)
             {
                 throw new InvalidOperationException("Unable to load the client certificate.", e);
-                }
+            }
 
             return currentNodeSettingsJson;
-            }
         }
-        }
+    }
+}

--- a/src/Raven.Server/Commercial/SetupWizard/LetsEncryptSetupUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/LetsEncryptSetupUtils.cs
@@ -11,7 +11,12 @@ namespace Raven.Server.Commercial.SetupWizard;
 
 public static class LetsEncryptSetupUtils
 {
-        public static async Task<byte[]> Setup(SetupInfo setupInfo,  SetupProgressAndResult progress, bool registerTcpDnsRecords, string acmeUrl, CancellationToken token)
+        public static async Task<byte[]> Setup(SetupInfo setupInfo,
+            SetupProgressAndResult progress,
+            bool registerTcpDnsRecords,
+            string acmeUrl,
+            string acmeProfile,
+            CancellationToken token)
         {
             progress.Processed++;
             progress?.AddInfo("Setting up RavenDB in Let's Encrypt security mode.");
@@ -29,7 +34,7 @@ public static class LetsEncryptSetupUtils
             (string Challenge, LetsEncryptClient.CachedCertificateResult CachedCertificateResult) challengeResult;
             try
             {
-                challengeResult = await InitialLetsEncryptChallenge(setupInfo, acmeClient, token);
+                challengeResult = await InitialLetsEncryptChallenge(setupInfo, acmeClient, acmeProfile, token);
 
                 progress?.AddInfo(challengeResult.Challenge != null
                     ? "Successfully received challenge(s) information from Let's Encrypt."
@@ -81,7 +86,7 @@ public static class LetsEncryptSetupUtils
             progress?.AddInfo($"Successfully updated DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}");
             progress?.AddInfo("Completing Let's Encrypt challenge(s)...");
 
-           await CertificateUtils.CompleteAuthorizationAndGetCertificate(new CompleteAuthorizationAndGetCertificateParameters
+            await CertificateUtils.CompleteAuthorizationAndGetCertificate(new CompleteAuthorizationAndGetCertificateParameters
             {
                 OnValidationSuccessful = () =>
                 {
@@ -93,7 +98,7 @@ public static class LetsEncryptSetupUtils
                 Client = acmeClient,
                 ChallengeResult = challengeResult,
                 Token = token
-            });
+            }, acmeProfile);
 
             progress.Processed++;
             progress?.AddInfo("Successfully acquired certificate from Let's Encrypt.");
@@ -132,19 +137,20 @@ public static class LetsEncryptSetupUtils
             }
         }
 
-        public static async Task<(string Challenge, LetsEncryptClient.CachedCertificateResult CachedCertificateResult)> InitialLetsEncryptChallenge(
-            SetupInfo setupInfo,
+        public static async Task<(string Challenge, LetsEncryptClient.CachedCertificateResult CachedCertificateResult)> InitialLetsEncryptChallenge(SetupInfo setupInfo,
             LetsEncryptClient client,
+            string profile,
             CancellationToken token)
         {
             try
             {
                 var host = (setupInfo.Domain + "." + setupInfo.RootDomain).ToLowerInvariant();
                 var wildcardHost = "*." + host;
-                if (client.TryGetCachedCertificate(wildcardHost, out var certBytes))
+                var certCacheKey = GetCertCacheKey(profile, wildcardHost);
+                if (client.TryGetCachedCertificate(certCacheKey, out var certBytes))
                     return (null, certBytes);
 
-                var result = await client.NewOrder(new[] {wildcardHost}, token);
+                var result = await client.NewOrder(new[] {wildcardHost}, profile, token);
 
                 result.TryGetValue(host, out var challenge);
                 // we may already be authorized for this?
@@ -154,5 +160,10 @@ public static class LetsEncryptSetupUtils
             {
                 throw new InvalidOperationException("Failed to receive challenge(s) information from Let's Encrypt.", e);
             }
+        }
+        
+        public static string GetCertCacheKey(string profile, string host)
+        {
+            return (string.IsNullOrEmpty(profile) ? string.Empty : (profile + "_")) + host;
         }
 }

--- a/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/SetupWizardUtils.cs
@@ -123,7 +123,7 @@ public static class SetupWizardUtils
                 Domain = domain,
                 CertBytes = certBytes,
                 ServerCertBytes = serverCertBytes,
-                ServerCert = serverCertificateHolder.Certificate,
+                ServerCert = serverCertificateHolder.ServerCertificate,
                 PublicServerUrl = publicServerUrl,
                 ClientCert = clientCert,
                 CertificateDefinition = certificateDefinition

--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -79,6 +79,11 @@ namespace Raven.Server.Config.Categories
         [DefaultValue("https://acme-v02.api.letsencrypt.org/directory")]
         [ConfigurationEntry("AcmeUrl", ConfigurationEntryScope.ServerWideOnly)]
         public string AcmeUrl { get; set; }
+
+        [Description("The profile which the server should use when creating new certificate request to ACME.")]
+        [DefaultValue(null)]
+        [ConfigurationEntry("LetsEncrypt.AcmeProfile", ConfigurationEntryScope.ServerWideOnly)]
+        public string AcmeProfile { get; set; }
         
         [Description("Indicates if we should throw an exception if any index could not be opened")]
         [DefaultValue(false)]

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/QueueBrokerConnectionHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/QueueBrokerConnectionHelper.cs
@@ -47,9 +47,9 @@ public static class QueueBrokerConnectionHelper
 
     public static void SetupKafkaClientConfig(ClientConfig config, KafkaConnectionSettings settings, CertificateUtils.CertificateHolder certificateHolder = null)
     {
-        if (settings.UseRavenCertificate && certificateHolder?.Certificate != null)
+        if (settings.UseRavenCertificate && certificateHolder?.ClientCertificate != null)
         {
-            config.SslCertificatePem = ExportAsPem(new PemObject("CERTIFICATE", certificateHolder.Certificate.RawData));
+            config.SslCertificatePem = ExportAsPem(new PemObject("CERTIFICATE", certificateHolder.ClientCertificate.RawData));
             config.SslKeyPem = ExportAsPem(certificateHolder.PrivateKey.Key);
             config.SecurityProtocol = SecurityProtocol.Ssl;
         }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
         private static RequestExecutor CreateNewRequestExecutor(RavenEtlConfiguration configuration, ServerStore serverStore)
         {
-            var certificate = serverStore.Server.Certificate.Certificate;
+            var certificate = serverStore.Server.Certificate.ClientCertificate;
 
             if (certificate != null && configuration.UsingEncryptedCommunicationChannel() == false && configuration.AllowEtlOnNonEncryptedChannel)
             {

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -14,6 +14,7 @@ using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Extensions;
 using Raven.Server.Json;
@@ -346,7 +347,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             Client.ServerWide.Commands.NodeInfo nodeInfo;
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(nodeUrl, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(nodeUrl, Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 requestExecutor.DefaultTimeout = ServerStore.Engine.OperationTimeout;
 
@@ -452,7 +453,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                         }
 
                         // if it's the same server certificate as our own, we don't want to add it to the cluster
-                        if (certificate.Thumbprint != Server.Certificate.Certificate.Thumbprint)
+                        // also we don't want to add client cert used by server, each node has it's own in local state only 
+                        if (Server.IsServerCertificate(certificate) == false)
                         {
                             using (ctx.OpenReadTransaction())
                             {
@@ -494,7 +496,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                         possibleNode = clusterTopology.TryGetNodeTagByUrl(nodeUrl);
                         nodeTag = possibleNode.HasUrl ? possibleNode.NodeTag : null;
 
-                        if (certificate != null && certificate.Thumbprint != Server.Certificate.Certificate.Thumbprint)
+                        if (certificate != null && Server.IsServerCertificate(certificate) == false)
                         {
                             var modifiedServerCert = JsonDeserializationServer.CertificateDefinition(ServerStore.Cluster.GetCertificateByThumbprint(ctx, certificate.Thumbprint));
 
@@ -729,7 +731,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                         }
 
                         var cmd = new RemoveEntryFromRaftLogCommand(index);
-                        using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(node.Value, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                        using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(node.Value, Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
                         {
                             await requestExecutor.ExecuteAsync(cmd, context);
                             nodeList.AddRange(cmd.Result);

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -231,7 +231,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             try
             {
-                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -144,7 +144,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         private async Task WriteDebugInfoPackageForNodeAsync(JsonOperationContext context, ZipArchive archive, string tag, string url, OperationCancelToken clusterOperationToken, int timeoutInSecPerNode, StringValues databases, DebugInfoPackageContentType contentType)
         {
             //note : theoretically GetDebugInfoFromNodeAsync() can throw, error handling is done at the level of WriteDebugInfoPackageForNodeAsync() calls
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var nextOperationId = new GetNextServerOperationIdCommand();
                 await requestExecutor.ExecuteAsync(nextOperationId, context);

--- a/src/Raven.Server/Documents/Handlers/PullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/PullReplicationHandler.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Handlers
                 {
                     pullReplication = JsonDeserializationClient.PullReplicationDefinition(blittableJson);
 
-                    pullReplication.Validate(ServerStore.Server.Certificate?.Certificate != null);
+                    pullReplication.Validate(ServerStore.Server.Certificate?.ServerCertificate != null);
                     var updatePullReplication = new UpdatePullReplicationAsHubCommand(databaseName, guid)
                     {
                         Definition = pullReplication
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/admin/pull-replication/generate-certificate", "POST", AuthorizationStatus.DatabaseAdmin, DisableOnCpuCreditsExhaustion = true)]
         public async Task GeneratePullReplicationCertificate()
         {
-            if (ServerStore.Server.Certificate?.Certificate == null)
+            if (ServerStore.Server.Certificate?.ServerCertificate == null)
                 throw new BadRequestException("This endpoint requires secured server.");
 
             ServerStore.LicenseManager.AssertCanAddPullReplicationAsHub();

--- a/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SecretKeyHandler.cs
@@ -142,7 +142,7 @@ namespace Raven.Server.Documents.Handlers
 
         private static async Task SendKeyToNodeAsync(string name, string base64, JsonOperationContext ctx, ServerStore server, string node, string url)
         {
-            using (var shortLived = RequestExecutor.CreateForShortTermUse(new string[] { url }, name, server.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var shortLived = RequestExecutor.CreateForShortTermUse(new string[] { url }, name, server.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var command = new PutSecretKeyCommand(name, base64);
                 try

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1721,7 +1721,7 @@ namespace Raven.Server.Documents.Replication
                 case InternalReplication _:
                 case ExternalReplication _:
                     authorizationInfo = null;
-                    return _server.Server.Certificate.Certificate;
+                    return _server.Server.Certificate.ClientCertificate;
 
                 case PullReplicationAsSink sink:
                     authorizationInfo = new TcpConnectionHeaderMessage.AuthorizationInfo
@@ -1737,7 +1737,7 @@ namespace Raven.Server.Documents.Replication
                     };
 
                     if (sink.CertificateWithPrivateKey == null)
-                        return _server.Server.Certificate.Certificate;
+                        return _server.Server.Certificate.ClientCertificate;
 
                     var certBytes = Convert.FromBase64String(sink.CertificateWithPrivateKey);
                     return CertificateLoaderUtil.CreateCertificate(certBytes, sink.CertificatePassword, CertificateLoaderUtil.FlagsForExport);

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -545,7 +545,7 @@ namespace Raven.Server.Documents.TcpHandlers
                                     // check that the subscription exists on AppropriateNode
                                     var clusterTopology = server.GetClusterTopology(ctx);
                                     using (var requester = ClusterRequestExecutor.CreateForShortTermUse(
-                                    clusterTopology.GetUrlFromTag(subscriptionDoesNotBelongException.AppropriateNode), server.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                                    clusterTopology.GetUrlFromTag(subscriptionDoesNotBelongException.AppropriateNode), server.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
                                     {
                                         await requester.ExecuteAsync(new WaitForRaftIndexCommand(subscriptionDoesNotBelongException.Index), ctx);
                                     }

--- a/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
+++ b/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Raven.Client;
+using Raven.Server.ServerWide;
 
 namespace Raven.Server.Https
 {
@@ -20,7 +22,6 @@ namespace Raven.Server.Https
 
         // See http://oid-info.com/get/1.3.6.1.5.5.7.3.1
         // Indicates that a certificate can be used as a SSL server certificate
-        private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
         private readonly X509Certificate2 _originalServerCertificate;
         public HttpsConnectionMiddleware(RavenServer server, KestrelServerOptions options, X509Certificate2 originalServerCertificate)
         {
@@ -66,12 +67,12 @@ namespace Raven.Server.Https
                     if (CipherSuitesPolicy != null)
                         sslServerAuthenticationOptions.CipherSuitesPolicy = CipherSuitesPolicy;
 
-                    if (server.Certificate?.Certificate != null && _originalServerCertificate.Thumbprint != server.Certificate.Certificate.Thumbprint)
+                    if (server.Certificate?.ServerCertificate != null && _originalServerCertificate.Thumbprint != server.Certificate.ServerCertificate.Thumbprint)
                     {
                         // the certificate got changed (refresh) we need to update ssl auth options
 
-                        sslServerAuthenticationOptions.ServerCertificateContext = server.Certificate.CertificateContext;
-                        sslServerAuthenticationOptions.ServerCertificate = server.Certificate.Certificate;
+                        sslServerAuthenticationOptions.ServerCertificateContext = server.Certificate.ServerCertificateContext;
+                        sslServerAuthenticationOptions.ServerCertificate = server.Certificate.ServerCertificate;
                     }
                 };
             });
@@ -86,6 +87,8 @@ namespace Raven.Server.Https
             X509Certificate2 certificate = null;
             if (tlsConnectionFeature != null)
                 certificate = await tlsConnectionFeature.GetClientCertificateAsync(context.ConnectionClosed);
+
+            certificate = RavenServer.GetCertificateForAuthorization(certificate);
 
             var httpConnectionFeature = context.Features.Get<IHttpConnectionFeature>();
             var authenticationStatus = _server.AuthenticateConnectionCertificate(certificate, httpConnectionFeature);
@@ -135,7 +138,7 @@ namespace Raven.Server.Https
                 hasEkuExtension = true;
                 foreach (var oid in extension.EnhancedKeyUsages)
                 {
-                    if (oid.Value.Equals(ServerAuthenticationOid, StringComparison.Ordinal))
+                    if (oid.Value.Equals(Constants.Certificates.ServerAuthenticationOid, StringComparison.Ordinal))
                     {
                         return;
                     }
@@ -144,7 +147,7 @@ namespace Raven.Server.Https
 
             if (hasEkuExtension)
             {
-                throw new InvalidOperationException($"Certificate {certificate.Thumbprint} cannot be used as an SSL server certificate. It has an Extended Key Usage extension but the usages do not include Server Authentication (OID 1.3.6.1.5.5.7.3.1)");
+                throw new InvalidOperationException($"Certificate {certificate.Thumbprint} cannot be used as an SSL server certificate. It has an Extended Key Usage extension but the usages do not include Server Authentication (OID {Constants.Certificates.ServerAuthenticationOid})");
             }
         }
     }

--- a/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgSession.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             if (initialMessage is SSLRequest)
             {
-                if (_serverCertificateHolder.Certificate == null)
+                if (_serverCertificateHolder.ServerCertificate == null)
                 {
                     await writer.WriteAsync(messageBuilder.SSLResponse(false), _token);
                     initialMessage = await messageReader.ReadInitialMessage(reader, _token);
@@ -72,7 +72,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                     await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
                     {
-                        ServerCertificateContext = _serverCertificateHolder.CertificateContext,
+                        ServerCertificateContext = _serverCertificateHolder.ServerCertificateContext,
                         ClientCertificateRequired = false
                     }, _token);
 
@@ -157,7 +157,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 using var transaction = new PgTransaction(database, new MessageReader(), username,this);
 
-                if (_serverCertificateHolder.Certificate != null)
+                if (_serverCertificateHolder.ServerCertificate != null)
                 {
                     // Authentication is required only when running in secured mode
 

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -215,9 +215,9 @@ public class MetricsProvider
     {
         var result = new CertificateMetrics();
         var certificateHolder = _serverStore.Server.Certificate;
-        if (certificateHolder?.Certificate != null)
+        if (certificateHolder?.ServerCertificate != null)
         {
-            var notAfter = certificateHolder.Certificate.NotAfter.ToUniversalTime();
+            var notAfter = certificateHolder.ServerCertificate.NotAfter.ToUniversalTime();
             var timeLeft = notAfter - SystemTime.UtcNow;
             result.ServerCertificateExpirationLeftInSec = (timeLeft.TotalSeconds > 0 ? timeLeft : TimeSpan.Zero).TotalSeconds;
         }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/ServerCertificateExpiration.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/ServerCertificateExpiration.cs
@@ -17,10 +17,10 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override OctetString GetData()
         {
             var holder = _store.Server.Certificate;
-            if (holder == null || holder.Certificate == null)
+            if (holder == null || holder.ServerCertificate == null)
                 return null;
 
-            var notAfter = holder.Certificate.NotAfter.ToUniversalTime();
+            var notAfter = holder.ServerCertificate.NotAfter.ToUniversalTime();
 
             return new OctetString(notAfter.ToString("d", CultureInfo.CurrentCulture));
         }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/ServerCertificateExpirationLeft.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/ServerCertificateExpirationLeft.cs
@@ -18,10 +18,10 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         protected override TimeTicks GetData()
         {
             var holder = _store.Server.Certificate;
-            if (holder == null || holder.Certificate == null)
+            if (holder == null || holder.ServerCertificate == null)
                 return null;
 
-            var notAfter = holder.Certificate.NotAfter;
+            var notAfter = holder.ServerCertificate.NotAfter;
 
             var timeLeft = notAfter - SystemTime.UtcNow;
             return SnmpValuesHelper.TimeSpanToTimeTicks(timeLeft.TotalMilliseconds > 0 ? timeLeft : TimeSpan.Zero);

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reflection;
+using Raven.Client;
 using Raven.Server.Platform.Posix;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -14,7 +15,7 @@ namespace Raven.Server.Monitoring.Snmp
         {
         }
 
-        public const string Root = "1.3.6.1.4.1.45751.1.1.";
+        public const string Root = Constants.Monitoring.Snmp.SnmpRootOid + ".";
 
         public class Server
         {

--- a/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.NotificationCenter.Handlers
 
                         using (var connection = new ProxyWebSocketConnection(webSocket, remoteNodeUrl, $"/admin/cluster-dashboard/remote/watch?thumbprint={currentCert?.Thumbprint}", ServerStore.ContextPool, ServerStore.ServerShutdown))
                         {
-                            await connection.Establish(Server.Certificate?.Certificate);
+                            await connection.Establish(Server.Certificate?.ClientCertificate);
 
                             await connection.RelayData();
                         }

--- a/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Extensions;
+using Raven.Client.Util;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -55,7 +56,8 @@ namespace Raven.Server.NotificationCenter.Handlers
 
                 _remoteWebSocket.Options.ClientCertificates.Add(certificate);
 
-                _remoteWebSocket.Options.RemoteCertificateValidationCallback += (sender, actualCert, chain, errors) => expectedCert.Equals(actualCert);
+                _remoteWebSocket.Options.RemoteCertificateValidationCallback += (sender, actualCert, chain, errors) =>
+                    expectedCert.Equals(actualCert);
             }
 
             return _remoteWebSocket.ConnectAsync(_remoteWebSocketUri, _cts.Token);

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -48,6 +48,8 @@ namespace Raven.Server
             RequestExecutor.HttpClientFactory = useLegacyHttpClientFactory
                 ? DefaultRavenHttpClientFactory.Instance
                 : RavenServerHttpClientFactory.Instance;
+            
+            RequestExecutor.ExtractServerCertificateFromExtension = CertificateUtils.ExtractServerCertificateFromExtension;
 
             NativeMemory.GetCurrentUnmanagedThreadId = () => (ulong)Pal.rvn_get_current_thread_id();
             ZstdLib.CreateDictionaryException = message => new VoronErrorException(message);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -87,7 +87,7 @@ namespace Raven.Server.Rachis
             StateMachine.EnsureNodeRemovalOnDeletion(context, term, nodeTag);
         }
 
-        public override X509Certificate2 ClusterCertificate => _serverStore.Server.Certificate?.Certificate;
+        public override X509Certificate2 ClusterCertificate => _serverStore.Server.Certificate?.ClientCertificate;
         public override ServerStore ServerStore => _serverStore;
 
         public override bool ShouldSnapshot(Slice slice, RootObjectType type)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -25,6 +25,10 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.Replication;
@@ -231,9 +235,9 @@ namespace Raven.Server
 
                     options.ConfigureEndpointDefaults(listenOptions => listenOptions.Protocols = Configuration.Http.Protocols);
 
-                    if (Certificate.Certificate != null)
+                    if (Certificate.ServerCertificate != null)
                     {
-                        _httpsConnectionMiddleware = new HttpsConnectionMiddleware(this, options, Certificate.Certificate);
+                        _httpsConnectionMiddleware = new HttpsConnectionMiddleware(this, options, Certificate.ServerCertificate);
 
                         foreach (var address in ListenEndpoints.Addresses)
                         {
@@ -298,12 +302,25 @@ namespace Raven.Server
 
                 var serverAddressesFeature = _webHost.ServerFeatures.Get<IServerAddressesFeature>();
                 WebUrl = GetWebUrl(serverAddressesFeature.Addresses.First()).TrimEnd('/');
+                
+                _tcpListenerStatus = StartTcpListener(ListenToNewTcpConnection);
 
-                if (Certificate.Certificate != null)
+                try
+                {
+                    ServerStore.Initialize();
+                }
+                catch (Exception e)
+                {
+                    if (Logger.IsOperationsEnabled)
+                        Logger.Operations("Could not open the server store", e);
+                    throw;
+                }
+
+                if (Certificate.ClientCertificate != null)
                 {
                     try
                     {
-                        AssertServerCanContactItselfWhenAuthIsOn(Certificate.Certificate)
+                        AssertServerCanContactItselfWhenAuthIsOn(Certificate.ClientCertificate)
                             .IgnoreUnobservedExceptions()
                             // here we wait a bit, just enough so for normal servers
                             // we'll be successful, but not enough to hang the server
@@ -327,24 +344,11 @@ namespace Raven.Server
                         RedirectsHttpTrafficToHttps();
                     }
 
-                    SecretProtection.AddCertificateChainToTheUserCertificateAuthorityStoreAndCleanExpiredCerts(Certificate.Certificate, Certificate.Certificate.Export(X509ContentType.Cert), Configuration.Security.CertificatePassword);
+                    SecretProtection.AddCertificateChainToTheUserCertificateAuthorityStoreAndCleanExpiredCerts(Certificate.ServerCertificate, Certificate.ServerCertificate.Export(X509ContentType.Cert), Configuration.Security.CertificatePassword);
                 }
 
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Initialized Server... {WebUrl}");
-
-                _tcpListenerStatus = StartTcpListener(ListenToNewTcpConnection);
-
-                try
-                {
-                    ServerStore.Initialize();
-                }
-                catch (Exception e)
-                {
-                    if (Logger.IsOperationsEnabled)
-                        Logger.Operations("Could not open the server store", e);
-                    throw;
-                }
 
                 ServerStore.TriggerDatabases();
 
@@ -404,10 +408,10 @@ namespace Raven.Server
 
         private void UpdateCertificateExpirationAlert()
         {
-            var remainingDays = (Certificate.Certificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
+            var remainingDays = (Certificate.ServerCertificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
             if (remainingDays <= 0)
             {
-                string msg = $"The server certificate has expired on {Certificate.Certificate.NotAfter.ToShortDateString()}.";
+                string msg = $"The server certificate has expired on {Certificate.ServerCertificate.NotAfter.ToShortDateString()}.";
 
                 if (Configuration.Core.SetupMode == SetupMode.LetsEncrypt)
                 {
@@ -421,7 +425,7 @@ namespace Raven.Server
             }
             else if (remainingDays <= 20)
             {
-                string msg = $"The server certificate will expire on {Certificate.Certificate.NotAfter.ToShortDateString()}. There are only {(int)remainingDays} days left for renewal.";
+                string msg = $"The server certificate will expire on {Certificate.ServerCertificate.NotAfter.ToShortDateString()}. There are only {(int)remainingDays} days left for renewal.";
 
                 if (Configuration.Core.SetupMode == SetupMode.LetsEncrypt)
                 {
@@ -457,7 +461,7 @@ namespace Raven.Server
 
             try
             {
-                AssertServerCanContactItselfWhenAuthIsOn(Certificate.Certificate)
+                AssertServerCanContactItselfWhenAuthIsOn(Certificate.ClientCertificate)
                     .IgnoreUnobservedExceptions()
                     // here we wait a bit, just enough so for normal servers
                     // we'll be successful, but not enough to hang the server
@@ -478,7 +482,7 @@ namespace Raven.Server
             catch (Exception exception)
             {
                 if (Logger.IsOperationsEnabled)
-                    Logger.Operations($"Failed to check the expiration date of the new server certificate '{Certificate.Certificate?.Subject} ({Certificate.Certificate?.Thumbprint})'", exception);
+                    Logger.Operations($"Failed to check the expiration date of the new server certificate '{Certificate.ServerCertificate?.GetDisplayName()} ({Certificate.ServerCertificate?.Thumbprint})'", exception);
             }
         }
 
@@ -888,7 +892,7 @@ namespace Raven.Server
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"When setting the certificate, validating that the server can authenticate with itself using {url}.");
 
-                    // Using the server certificate as a client certificate to test if we can talk to ourselves
+                    // Using the client certificate generated from the server certificate to test if we can talk to ourselves
                     httpMessageHandler.ClientCertificates.Add(certificateCertificate);
                     using (var client = new RavenHttpClient(httpMessageHandler)
                     {
@@ -956,7 +960,7 @@ namespace Raven.Server
             var cert2 = HttpsConnectionMiddleware.ConvertToX509Certificate2(cert);
 
             // We trust ourselves
-            if (cert2?.Thumbprint == Certificate?.Certificate?.Thumbprint)
+            if (IsServerCertificate(cert2))
                 return true;
 
             // self-signed is acceptable only if we have the same issuer as the remote certificate
@@ -966,7 +970,7 @@ namespace Raven.Server
                     ? chain.ChainElements[1].Certificate
                     : chain.ChainElements[0].Certificate;
 
-                if (issuer?.Thumbprint == Certificate?.Certificate?.Thumbprint)
+                if (issuer?.Thumbprint == Certificate?.ServerCertificate?.Thumbprint)
                     return true;
             }
 
@@ -1005,7 +1009,7 @@ namespace Raven.Server
             // confirm they got it (or if there are less than 3 days to spare).
 
             var currentCertificate = Certificate;
-            if (currentCertificate.Certificate == null)
+            if (currentCertificate.ServerCertificate == null)
             {
                 return false; // shouldn't happen, but just in case
             }
@@ -1064,9 +1068,9 @@ namespace Raven.Server
                     throw new InvalidOperationException("Tried to load certificate as part of refresh check, but got an error!", e);
                 }
 
-                if (newCertificate.Certificate.Thumbprint != currentCertificate.Certificate.Thumbprint)
+                if (newCertificate.ServerCertificate.Thumbprint != currentCertificate.ServerCertificate.Thumbprint)
                 {
-                    HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(newCertificate.Certificate);
+                    HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(newCertificate.ServerCertificate);
                     
                     if (Interlocked.CompareExchange(ref Certificate, newCertificate, currentCertificate) == currentCertificate)
                         ServerCertificateChanged?.Invoke(this, EventArgs.Empty);
@@ -1078,7 +1082,7 @@ namespace Raven.Server
                     return;
 
                 X509Certificate2 newCert;
-
+                
                 if (Configuration.Core.SetupMode == SetupMode.LetsEncrypt)
                 {
                     newCert = await RefreshViaLetsEncrypt(currentCertificate, forceRenew);
@@ -1128,13 +1132,13 @@ namespace Raven.Server
         {
             try
             {
-                var certHolder = ServerStore.Secrets.LoadCertificateWithExecutable(
+                var (certificate, _) = ServerStore.Secrets.LoadCertificateWithExecutable(
                     Configuration.Security.CertificateRenewExec,
                     Configuration.Security.CertificateRenewExecArguments,
                     ServerStore.GetLicenseType(),
                     ServerStore.Configuration.Security.CertificateValidationKeyUsages);
 
-                return CertificateLoaderUtil.CreateCertificate(certHolder.Certificate.Export(X509ContentType.Pfx), flags: CertificateLoaderUtil.FlagsForPersist);
+                return CertificateLoaderUtil.CreateCertificate(certificate.Export(X509ContentType.Pfx), flags: CertificateLoaderUtil.FlagsForPersist);
             }
             catch (Exception e)
             {
@@ -1197,7 +1201,7 @@ namespace Raven.Server
                 // We don't want an alert here, this happens frequently.
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations(
-                        $"Renew check: still have time left to renew the server certificate with thumbprint `{currentCertificate.Certificate.Thumbprint}`, estimated renewal date: {renewalDate}");
+                        $"Renew check: still have time left to renew the server certificate with thumbprint `{currentCertificate.ServerCertificate.Thumbprint}`, estimated renewal date: {renewalDate}");
                 return null;
             }
 
@@ -1262,13 +1266,13 @@ namespace Raven.Server
             if (forceRenew)
                 return (true, DateTime.UtcNow.Date);
 
-            var remainingDays = (currentCertificate.Certificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
+            var remainingDays = (currentCertificate.ServerCertificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
             if (remainingDays <= 20)
             {
                 return (true, DateTime.UtcNow.Date);
             }
 
-            var firstPossibleDate = currentCertificate.Certificate.NotAfter.ToUniversalTime().AddDays(-30);
+            var firstPossibleDate = currentCertificate.ServerCertificate.NotAfter.ToUniversalTime().AddDays(-30);
 
             // We can do this because saturday is last in the DayOfWeek enum
             var daysUntilSaturday = DayOfWeek.Saturday - firstPossibleDate.DayOfWeek;
@@ -1294,32 +1298,32 @@ namespace Raven.Server
             {
                 SecretProtection.ValidateCertificateBeforeReplacement(newCertificate, password, ServerStore.GetLicenseType(), ServerStore.Configuration.Security.CertificateValidationKeyUsages);
 
-                if (Certificate.Certificate.Thumbprint == newCertificate.Thumbprint)
+                if (Certificate.ServerCertificate.Thumbprint == newCertificate.Thumbprint)
                 {
                     if (Logger.IsOperationsEnabled)
                     {
-                        Logger.Operations($"The new certificate matches the current one. No further steps needed. {Certificate.Certificate.GetBasicCertificateInfo()}");
+                        Logger.Operations($"The new certificate matches the current one. No further steps needed. {Certificate.ServerCertificate.GetBasicCertificateInfo()}");
                     }
                     return;
                 }
                 
                 if (Logger.IsOperationsEnabled)
                 {
-                    Logger.Operations($"Starting certificate replication. current:'{Certificate.Certificate.GetBasicCertificateInfo()}', new:'{newCertificate.GetBasicCertificateInfo()}'");
+                    Logger.Operations($"Starting certificate replication. current:'{Certificate.ServerCertificate.GetBasicCertificateInfo()}', new:'{newCertificate.GetBasicCertificateInfo()}'");
                 }
                 
                 // During replacement of a cluster certificate, we must have both the new and the old server certificates registered in the server store.
                 // This is needed for trust in the case where a node replaced its own certificate while another node still runs with the old certificate.
                 // Since both nodes use different certificates, they will only trust each other if the certs are registered in the server store.
                 // When the certificate replacement is finished throughout the cluster, we will delete both these entries.
-                await ServerStore.PutValueInClusterAsync(new PutCertificateCommand(Certificate.Certificate.Thumbprint,
+                await ServerStore.PutValueInClusterAsync(new PutCertificateCommand(Certificate.ServerCertificate.Thumbprint,
                     new CertificateDefinition
                     {
-                        Certificate = Convert.ToBase64String(Certificate.Certificate.Export(X509ContentType.Cert)),
-                        Thumbprint = Certificate.Certificate.Thumbprint,
-                        PublicKeyPinningHash = Certificate.Certificate.GetPublicKeyPinningHash(),
-                        NotAfter = Certificate.Certificate.NotAfter,
-                        NotBefore = Certificate.Certificate.NotBefore,
+                        Certificate = Convert.ToBase64String(Certificate.ServerCertificate.Export(X509ContentType.Cert)),
+                        Thumbprint = Certificate.ServerCertificate.Thumbprint,
+                        PublicKeyPinningHash = Certificate.ServerCertificate.GetPublicKeyPinningHash(),
+                        NotAfter = Certificate.ServerCertificate.NotAfter,
+                        NotBefore = Certificate.ServerCertificate.NotBefore,
                         Name = "Old Server Certificate - can delete",
                         SecurityClearance = SecurityClearance.ClusterNode
                     }, $"{raftRequestId}/put-old-certificate"));
@@ -1414,7 +1418,7 @@ namespace Raven.Server
                                                     $"but the Security.Certificate.LetsEncrypt.Email configuration setting is: {Configuration.Security.CertificateLetsEncryptEmail}. " +
                                                     "There is a mismatch, therefore cannot automatically renew the Lets Encrypt certificate. Please contact support.");
 
-            var hosts = CertificateUtils.GetCertificateAlternativeNames(existing.Certificate).ToArray();
+            var hosts = CertificateUtils.GetCertificateAlternativeNames(existing.ServerCertificate).ToArray();
 
             // cloud: *.free.iftah.ravendb.cloud => we extract the domain free.iftah
             // normal: *.iftah.development.run => we extract the domain iftah
@@ -1518,20 +1522,25 @@ namespace Raven.Server
                     throw new InvalidOperationException($"Invalid certificate configuration. The configuration property '{RavenConfiguration.GetKey(x => x.Security.CertificateExec)}' has been deprecated since RavenDB 4.2, please use '{RavenConfiguration.GetKey(x => x.Security.CertificateLoadExec)}' along with '{RavenConfiguration.GetKey(x => x.Security.CertificateRenewExec)}' and '{RavenConfiguration.GetKey(x => x.Security.CertificateChangeExec)}'.");
                 }
 
+                X509Certificate2 serverCertificate = null;
+                AsymmetricKeyEntry privateKey = null;
                 if (string.IsNullOrEmpty(Configuration.Security.CertificatePath) == false)
-                    return ServerStore.Secrets.LoadCertificateFromPath(
+                    (serverCertificate, privateKey) = ServerStore.Secrets.LoadCertificateFromPath(
                         Configuration.Security.CertificatePath,
                         Configuration.Security.CertificatePassword,
                         ServerStore.GetLicenseType(),
                         ServerStore.Configuration.Security.CertificateValidationKeyUsages);
                 if (string.IsNullOrEmpty(Configuration.Security.CertificateLoadExec) == false)
-                    return ServerStore.Secrets.LoadCertificateWithExecutable(
+                    (serverCertificate, privateKey) = ServerStore.Secrets.LoadCertificateWithExecutable(
                         Configuration.Security.CertificateLoadExec,
                         Configuration.Security.CertificateLoadExecArguments,
                         ServerStore.GetLicenseType(),
                         ServerStore.Configuration.Security.CertificateValidationKeyUsages);
 
-                return null;
+                if (serverCertificate == null)
+                    return null;
+                
+                return new CertificateUtils.CertificateHolder(serverCertificate, privateKey);
             }
             catch (Exception e)
             {
@@ -1702,7 +1711,7 @@ namespace Raven.Server
             {
                 authenticationStatus.Status = AuthenticationStatus.NotYetValid;
             }
-            else if (certificate.Equals(Certificate.Certificate))
+            else if (IsServerCertificate(certificate))
             {
                 authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
             }
@@ -1719,7 +1728,7 @@ namespace Raven.Server
                     if (AreCertificateSansValid(certificate))
                     {
                         authLogMessage =
-                            $"Connection from {GetRemoteAddress(connectionInfo)} with new certificate '{certificate.Subject} ({certificate.Thumbprint})' which is not registered in the cluster. " +
+                            $"Connection from {GetRemoteAddress(connectionInfo)} with new certificate '{certificate.GetDisplayName()} ({certificate.Thumbprint})' which is not registered in the cluster. " +
                             "Allowing the connection based on the certificate's *issuer* which is trusted by the cluster and valid SAN matching server domain. " +
                             $"Registering the new certificate explicitly based on permissions of existing certificate '{issuer}'. Security Clearance: {AuthenticationStatus.ClusterAdmin}";
                         authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
@@ -2319,7 +2328,7 @@ namespace Raven.Server
                         supported);
                 }
 
-                bool authSuccessful = TryAuthorize(Configuration, tcp.Stream, header, tcpClient, out var err, out TcpConnectionStatus statusResult);
+                bool authSuccessful = TryAuthorize(Configuration, tcp.Stream, tcp.Certificate, header, tcpClient, out var err, out TcpConnectionStatus statusResult);
                 //At this stage the error is not relevant.
 
                 if (header.LicensedFeatures != null)
@@ -2507,6 +2516,8 @@ namespace Raven.Server
             var newCertHolder = SecretProtection.ValidateCertificateAndCreateCertificateHolder("Auto Update", certificate, rawBytes, password, ServerStore.GetLicenseType(), true);
             
             HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(certificate);
+            
+            SecretProtection.AddCertificateChainToTheUserCertificateAuthorityStoreAndCleanExpiredCerts(certificate, rawBytes, password);
 
             if (Interlocked.CompareExchange(ref Certificate, newCertHolder, certificateHolder) == certificateHolder)
             {
@@ -2619,7 +2630,7 @@ namespace Raven.Server
 
         internal async Task<(Stream Stream, X509Certificate2 Certificate)> AuthenticateAsServerIfSslNeeded(Stream stream)
         {
-            if (Certificate.Certificate != null)
+            if (Certificate.ServerCertificate != null)
             {
                 var sslStream = new SslStream(stream, false, (sender, certificate, chain, errors) =>
                         // it is fine that the client doesn't have a cert, we just care that they
@@ -2633,7 +2644,7 @@ namespace Raven.Server
 
                 await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
                 {
-                    ServerCertificateContext = Certificate.CertificateContext,
+                    ServerCertificateContext = Certificate.ServerCertificateContext,
                     ClientCertificateRequired = true,
                     CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
                     EncryptionPolicy = EncryptionPolicy.RequireEncryption,
@@ -2641,13 +2652,35 @@ namespace Raven.Server
                     CipherSuitesPolicy = CipherSuitesPolicy
                 });
 
-                return (sslStream, HttpsConnectionMiddleware.ConvertToX509Certificate2(sslStream.RemoteCertificate));
+                var certificate = HttpsConnectionMiddleware.ConvertToX509Certificate2(sslStream.RemoteCertificate);
+                certificate = GetCertificateForAuthorization(certificate);
+
+                return (sslStream, certificate);
             }
 
             return (stream, null);
         }
 
-        private bool TryAuthorize(RavenConfiguration configuration, Stream stream, TcpConnectionHeaderMessage header, TcpClient tcpClient, out string msg, out TcpConnectionStatus statusResult)
+        internal static X509Certificate2 GetCertificateForAuthorization(X509Certificate2 certificate)
+        {
+            if (certificate == null || SecretProtection.HasCertificateServerAuthEnhancedKeyUsage(certificate))
+                return certificate;
+            
+            var extractedCertificate = CertificateUtils.ExtractServerCertificateFromExtension(certificate);
+
+            if (extractedCertificate != null && extractedCertificate.GetPublicKeyPinningHash() == certificate.GetPublicKeyPinningHash())
+                return extractedCertificate;
+
+            return certificate;
+        }
+
+        private bool TryAuthorize(RavenConfiguration configuration,
+            Stream stream,
+            X509Certificate2 certificate,
+            TcpConnectionHeaderMessage header,
+            TcpClient tcpClient,
+            out string msg,
+            out TcpConnectionStatus statusResult)
         {
             msg = null;
             if (header.ServerId != null && header.ServerId != ServerStore.ServerId.ToString())
@@ -2669,7 +2702,6 @@ namespace Raven.Server
                 return false;
             }
 
-            var certificate = (X509Certificate2)sslStream.RemoteCertificate;
             var auth = AuthenticateConnectionCertificate(certificate, tcpClient);
 
             switch (auth.Status)
@@ -2902,7 +2934,7 @@ namespace Raven.Server
                 ea.Execute(() => ServerMaintenanceTimer?.Dispose());
                 ea.Execute(() => _clusterMaintenanceWorker?.Dispose());
                 ea.Execute(() => _cpuCreditsMonitoring?.Join(int.MaxValue));
-                ea.Execute(() => CpuUsageCalculator.Dispose());
+                ea.Execute(() => CpuUsageCalculator?.Dispose());
 
                 if (SkipCertificateDispose == false)
                     ea.Execute(() => Certificate?.Dispose());
@@ -2997,6 +3029,13 @@ namespace Raven.Server
                 if (socket != null)
                     socket.Close();
             }
+        }
+
+        public bool IsServerCertificate(X509Certificate2 certificate)
+        {
+            var serverCertificate = Certificate?.ServerCertificate;
+            
+            return serverCertificate != null && certificate.Equals(serverCertificate);
         }
 
         public bool CertificateHasWellKnownIssuer(X509Certificate2 cert, out string issuer)

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -504,9 +504,7 @@ namespace Raven.Server.Routing
             }
             else
             {
-                var name = certificate.FriendlyName;
-                if (string.IsNullOrWhiteSpace(name))
-                    name = certificate.Subject;
+                var name = certificate.GetDisplayName();
                 if (string.IsNullOrWhiteSpace(name))
                     name = certificate.ToString(false);
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1105,7 +1105,7 @@ namespace Raven.Server.ServerWide
                     {
                         [nameof(CertificateReplacement.Certificate)] = cert,
                         [nameof(CertificateReplacement.Thumbprint)] = x509Certificate.Thumbprint,
-                        [nameof(CertificateReplacement.OldThumbprint)] = serverStore.Server.Certificate.Certificate.Thumbprint,
+                        [nameof(CertificateReplacement.OldThumbprint)] = serverStore.Server.Certificate.ServerCertificate.Thumbprint,
                         [nameof(CertificateReplacement.Confirmations)] = 0,
                         [nameof(CertificateReplacement.Replaced)] = 0,
                         [nameof(CertificateReplacement.ReplaceImmediately)] = replaceImmediately

--- a/src/Raven.Server/ServerWide/Commands/RegisterReplicationHubAccessCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RegisterReplicationHubAccessCommand.cs
@@ -65,12 +65,12 @@ namespace Raven.Server.ServerWide.Commands
 
             if (certificate != null)
             {
-                CertificatePublicKeyHash = certificate.GetPublicKeyPinningHash();
+                CertificatePublicKeyHash = PublicKeyPinningHashHelpers.GetPublicKeyPinningHash(certificate);
                 CertificateThumbprint = certificate.Thumbprint;
                 NotBefore = certificate.NotBefore;
                 NotAfter = certificate.NotAfter;
                 Issuer = certificate.Issuer;
-                Subject = certificate.Subject;
+                Subject = certificate.GetDisplayName();
             }
 
             UniqueRequestId = uniqueRequestId;

--- a/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
+++ b/src/Raven.Server/ServerWide/DebugInfoPackageUtils.cs
@@ -48,7 +48,7 @@ namespace Raven.Server.ServerWide
 
             foreach (var route in routes)
             {
-                if (server.Certificate.Certificate != null)
+                if (server.Certificate.ServerCertificate != null)
                 {
                     Debug.Assert(feature != null);
                     if (server.Router.CanAccessRoute(route, httpContext, databaseName, feature))

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -271,7 +271,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         using (var timeout = new CancellationTokenSource(tcpTimeout))
                         using (var combined = CancellationTokenSource.CreateLinkedTokenSource(_token, timeout.Token))
                         {
-                            tcpConnection = ReplicationUtils.GetServerTcpInfo(Url, "Supervisor", _parent._server.Server.Certificate.Certificate, combined.Token);
+                            tcpConnection = ReplicationUtils.GetServerTcpInfo(Url, "Supervisor", _parent._server.Server.Certificate.ClientCertificate, combined.Token);
                             if (tcpConnection == null)
                             {
                                 continue;
@@ -492,7 +492,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 {
                     var result = await TcpUtils.ConnectSecuredTcpSocket(
                         tcpConnectionInfo,
-                        _parent._server.Server.Certificate.Certificate,
+                        _parent._server.Server.Certificate.ClientCertificate,
                         _parent._server.Server.CipherSuitesPolicy,
                         TcpConnectionHeaderMessage.OperationTypes.Heartbeats,
                         NegotiateProtocolVersionAsyncForClusterSupervisor,

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -19,6 +19,7 @@ using Org.BouncyCastle.Utilities.Encoders;
 using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 using Raven.Client;
+using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Config.Categories;
 using Raven.Server.Utils;
@@ -362,22 +363,37 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public static CertificateUtils.CertificateHolder ValidateCertificateAndCreateCertificateHolder(string source, X509Certificate2 loadedCertificate, byte[] rawBytes, string password, LicenseType licenseType, bool validateCertKeyUsages, SetupProgressAndResult progress = null)
+        public static CertificateUtils.CertificateHolder ValidateCertificateAndCreateCertificateHolder(string source,
+            X509Certificate2 serverCertificate,
+            byte[] rawBytes,
+            string password,
+            LicenseType licenseType,
+            bool validateCertKeyUsages,
+            SetupProgressAndResult progress = null)
+        {
+            AsymmetricKeyEntry privateKey = ValidateServerCertificate(source, serverCertificate, rawBytes, password, licenseType, validateCertKeyUsages, progress);
+
+            return new CertificateUtils.CertificateHolder(serverCertificate, privateKey);
+        }
+
+        public static AsymmetricKeyEntry ValidateServerCertificate(string source,
+            X509Certificate2 loadedCertificate,
+            byte[] rawBytes,
+            string password,
+            LicenseType licenseType,
+            bool validateCertKeyUsages,
+            SetupProgressAndResult progress = null)
         {
             ValidateExpiration(source, loadedCertificate, licenseType, progress: progress);
 
             ValidatePrivateKey(source, password, rawBytes, out var privateKey, progress);
 
-            ValidateKeyUsages(source, loadedCertificate, validateCertKeyUsages, progress);
-
-            AddCertificateChainToTheUserCertificateAuthorityStoreAndCleanExpiredCerts(loadedCertificate, rawBytes, password, progress);
-
-            return new CertificateUtils.CertificateHolder(loadedCertificate, privateKey, Convert.ToBase64String(loadedCertificate.Export(X509ContentType.Cert)));
+            ValidateServerKeyUsages(source, loadedCertificate, validateCertKeyUsages, progress);
+            return privateKey;
         }
 
-        public static void ValidateKeyUsages(string source, X509Certificate2 loadedCertificate, bool validateKeyUsages, SetupProgressAndResult progress = null)
+        public static void ValidateServerKeyUsages(string source, X509Certificate2 loadedCertificate, bool validateKeyUsages, SetupProgressAndResult progress = null)
         {
-            var clientCert = false;
             var serverCert = false;
             var keyUsages = false;
 
@@ -385,7 +401,7 @@ namespace Raven.Server.ServerWide
             {
                 if (extension is X509KeyUsageExtension kue)
                 {
-                    if (kue.KeyUsages.HasFlag(X509KeyUsageFlags.DigitalSignature) && kue.KeyUsages.HasFlag(X509KeyUsageFlags.KeyEncipherment))
+                    if (kue.KeyUsages.HasFlag(X509KeyUsageFlags.DigitalSignature))
                         keyUsages = true;
                 }
 
@@ -395,10 +411,7 @@ namespace Raven.Server.ServerWide
                     {
                         switch (usage.Value)
                         {
-                            case "1.3.6.1.5.5.7.3.2":
-                                clientCert = true;
-                                break;
-                            case "1.3.6.1.5.5.7.3.1":
+                            case Constants.Certificates.ServerAuthenticationOid:
                                 serverCert = true;
                                 break;
                         }
@@ -406,7 +419,7 @@ namespace Raven.Server.ServerWide
                 }
             }
 
-            var shouldThrow = clientCert == false || serverCert == false;
+            var shouldThrow = serverCert == false;
             if (validateKeyUsages && keyUsages == false)
                 shouldThrow = true;
 
@@ -418,11 +431,9 @@ namespace Raven.Server.ServerWide
             if (validateKeyUsages && keyUsages == false)
             {
                 sb.AppendLine("- Key Usage: DigitalSignature");
-                sb.AppendLine("- Key Usage: KeyEncipherment");
             }
 
-            sb.AppendLine("- Enhanced Key Usage: Client Authentication (Oid 1.3.6.1.5.5.7.3.2)");
-            sb.AppendLine("- Enhanced Key Usage: Server Authentication (Oid 1.3.6.1.5.5.7.3.1)");
+            sb.AppendLine($"- Enhanced Key Usage: Server Authentication (Oid {Constants.Certificates.ServerAuthenticationOid})");
 
             var msg = sb.ToString();
 
@@ -432,11 +443,59 @@ namespace Raven.Server.ServerWide
 
             throw new EncryptionException(msg);
         }
+        
+        public static bool HasCertificateClientAuthEnhancedKeyUsage(X509Certificate2 certificate)
+        {
+            if (certificate == null)
+                return false;
+            
+            foreach (var extension in certificate.Extensions)
+            {
+                if (extension is X509EnhancedKeyUsageExtension ekue) //Enhanced Key Usage extension
+                {
+                    foreach (var usage in ekue.EnhancedKeyUsages)
+                    {
+                        switch (usage.Value)
+                        {
+                            case Constants.Certificates.ClientAuthenticationOid:
+                                return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+        
+        public static bool HasCertificateServerAuthEnhancedKeyUsage(X509Certificate2 certificate)
+        {
+            if (certificate == null)
+                return false;
+            
+            foreach (var extension in certificate.Extensions)
+            {
+                if (extension is X509EnhancedKeyUsageExtension ekue) //Enhanced Key Usage extension
+                {
+                    foreach (var usage in ekue.EnhancedKeyUsages)
+                    {
+                        switch (usage.Value)
+                        {
+                            case Constants.Certificates.ServerAuthenticationOid:
+                                return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
 #if !RVN
 
-
-        public CertificateUtils.CertificateHolder LoadCertificateWithExecutable(string executable, string args, LicenseType licenseType, bool certificateValidationKeyUsages)
+        public (X509Certificate2 Certificate, AsymmetricKeyEntry PrivateKey) LoadCertificateWithExecutable(string executable,
+            string args,
+            LicenseType licenseType,
+            bool certificateValidationKeyUsages)
         {
             Process process;
 
@@ -508,21 +567,20 @@ namespace Raven.Server.ServerWide
 
             var rawData = ms.ToArray();
             X509Certificate2 loadedCertificate;
-            AsymmetricKeyEntry privateKey;
             try
             {
                 // may need to send this over the cluster, so use exportable here
                 loadedCertificate = CertificateLoaderUtil.CreateCertificate(rawData, (string)null, CertificateLoaderUtil.FlagsForExport);
                 ValidateExpiration(executable, loadedCertificate, licenseType, throwOnExpired: false);
-                ValidatePrivateKey(executable, null, rawData, out privateKey);
-                ValidateKeyUsages(executable, loadedCertificate, certificateValidationKeyUsages);
+                ValidatePrivateKey(executable, null, rawData, out var privateKey);
+                ValidateServerKeyUsages(executable, loadedCertificate, certificateValidationKeyUsages);
+                
+                return (loadedCertificate, privateKey);
             }
             catch (Exception e)
             {
                 throw new InvalidOperationException($"Got invalid certificate via {executable} {args}", e);
             }
-
-            return new CertificateUtils.CertificateHolder(loadedCertificate, privateKey, Convert.ToBase64String(loadedCertificate.Export(X509ContentType.Cert)));
         }
 
         public void NotifyExecutableOfCertificateChange(string executable, string args, string newCertificateBase64)
@@ -750,7 +808,10 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public CertificateUtils.CertificateHolder LoadCertificateFromPath(string path, string password, LicenseType licenseType, bool certificateValidationKeyUsages)
+        public (X509Certificate2 Certificate, AsymmetricKeyEntry PrivateKey) LoadCertificateFromPath(string path,
+            string password,
+            LicenseType licenseType,
+            bool certificateValidationKeyUsages)
         {
             try
             {
@@ -764,9 +825,9 @@ namespace Raven.Server.ServerWide
 
                 ValidatePrivateKey(path, password, rawData, out var privateKey);
 
-                ValidateKeyUsages(path, loadedCertificate, certificateValidationKeyUsages);
+                ValidateServerKeyUsages(path, loadedCertificate, certificateValidationKeyUsages);
 
-                return new CertificateUtils.CertificateHolder(loadedCertificate, privateKey, Convert.ToBase64String(loadedCertificate.Export(X509ContentType.Cert)));
+                return (loadedCertificate, privateKey);
             }
             catch (Exception e)
             {
@@ -780,7 +841,7 @@ namespace Raven.Server.ServerWide
 
             ValidatePrivateKey("ValidateCertificateBeforeReplacement", password, certificate.Export(X509ContentType.Pkcs12), out _);
             
-            ValidateKeyUsages("ValidateCertificateBeforeReplacement", certificate, certificateValidationKeyUsages);
+            ValidateServerKeyUsages("ValidateCertificateBeforeReplacement", certificate, certificateValidationKeyUsages);
         }
 
         internal static void ValidatePrivateKey(string source, string certificatePassword, byte[] rawData, out AsymmetricKeyEntry pk, SetupProgressAndResult progress = null)

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -767,15 +768,20 @@ namespace Raven.Server.ServerWide
                 // and it exploded with thousands of certificates. This caused ssl handshakes to fail on that machine, because it would timeout when
                 // trying to match one of these certs to validate the chain.
 
-                if (loadedCertificate.SubjectName.Name == null)
-                    return;
-
-                var cnValue = loadedCertificate.SubjectName.Name.StartsWith("CN=", StringComparison.OrdinalIgnoreCase)
-                    ? loadedCertificate.SubjectName.Name.Substring(3)
-                    : loadedCertificate.SubjectName.Name;
+                IEnumerable<X509Certificate2> existingCerts;
+                if (string.IsNullOrEmpty(loadedCertificate.SubjectName.Name))
+                {
+                    existingCerts = userIntermediateStore.Certificates.Where(x => x.GetDisplayName() == loadedCertificate.GetDisplayName()).ToList();;
+                }
+                else
+                {
+                    var cnValue = loadedCertificate.SubjectName.Name.StartsWith("CN=", StringComparison.OrdinalIgnoreCase)
+                        ? loadedCertificate.SubjectName.Name.Substring(3)
+                        : loadedCertificate.SubjectName.Name;
+                    existingCerts = userIntermediateStore.Certificates.Find(X509FindType.FindBySubjectName, cnValue, false);
+                }
 
                 var utcNow = DateTime.UtcNow;
-                var existingCerts = userIntermediateStore.Certificates.Find(X509FindType.FindBySubjectName, cnValue, false);
                 foreach (var c in existingCerts)
                 {
                     if (c.NotAfter.ToUniversalTime() > utcNow && c.NotBefore.ToUniversalTime() < utcNow)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -33,6 +33,7 @@ using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
@@ -350,9 +351,9 @@ namespace Raven.Server.ServerWide
                                 {
                                     var leaderWsUrl = new Uri($"{leaderUrl.Replace("http", "ws", StringComparison.OrdinalIgnoreCase)}/server/notification-center/watch");
 
-                                    if (Server.Certificate?.Certificate != null)
+                                    if (Server.Certificate?.ServerCertificate != null)
                                     {
-                                        ws.Options.ClientCertificates.Add(Server.Certificate.Certificate);
+                                        ws.Options.ClientCertificates.Add(Server.Certificate.ServerCertificate);
                                     }
 
                                     ws.ConnectAsync(leaderWsUrl, cts.Token).Wait(cts.Token);
@@ -910,7 +911,7 @@ namespace Raven.Server.ServerWide
                 Configuration.Security.AuditLogCompress);
 
             var auditLog = LoggingSource.AuditLog.GetLogger("ServerStartup", "Audit");
-            auditLog.Operations($"Server started up, listening to {string.Join(", ", Configuration.Core.ServerUrls)} with certificate {_server.Certificate?.Certificate?.Subject} ({_server.Certificate?.Certificate?.Thumbprint}), public url: {Configuration.Core.PublicServerUrl}");
+            auditLog.Operations($"Server started up, listening to {string.Join(", ", Configuration.Core.ServerUrls)} with certificate {_server.Certificate?.ServerCertificate?.Subject} ({_server.Certificate?.ServerCertificate?.Thumbprint}), public url: {Configuration.Core.PublicServerUrl}");
         }
 
         private void AssertCanWriteToAuditLogDirectory()
@@ -1375,7 +1376,7 @@ namespace Raven.Server.ServerWide
                         nodesInCluster = GetClusterTopology(context).AllNodes.Count;
                     }
 
-                    if (thumbprint == Server.Certificate?.Certificate?.Thumbprint)
+                    if (thumbprint == Server.Certificate?.ServerCertificate?.Thumbprint)
                     {
                         if (nodesInCluster > replaced)
                         {
@@ -1511,11 +1512,11 @@ namespace Raven.Server.ServerWide
 
                         if (nodesInCluster > confirmations && replaceImmediately == false)
                         {
-                            if (Server.Certificate?.Certificate?.NotAfter != null &&
-                                (Server.Certificate.Certificate.NotAfter - Server.Time.GetUtcNow().ToLocalTime()).Days > 3)
+                            if (Server.Certificate?.ServerCertificate?.NotAfter != null &&
+                                (Server.Certificate.ServerCertificate.NotAfter - Server.Time.GetUtcNow().ToLocalTime()).Days > 3)
                             {
                                 var msg = $"Not all nodes have confirmed the certificate replacement. Confirmation count: {confirmations}. " +
-                                          $"We still have {(Server.Certificate.Certificate.NotAfter - Server.Time.GetUtcNow().ToLocalTime()).Days} days until expiration. " +
+                                          $"We still have {(Server.Certificate.ServerCertificate.NotAfter - Server.Time.GetUtcNow().ToLocalTime()).Days} days until expiration. " +
                                           "The update will happen when all nodes confirm the replacement or we have less than 3 days left for expiration." +
                                           $"If you wish to force replacing the certificate just for the nodes that are up, please set '{nameof(CertificateReplacement.ReplaceImmediately)}' to true.";
 
@@ -1537,7 +1538,7 @@ namespace Raven.Server.ServerWide
                             throw new InvalidOperationException(
                                 $"Invalid 'server/cert' value, expected to get '{nameof(CertificateReplacement.Certificate)}' and '{nameof(CertificateReplacement.Thumbprint)}' properties");
 
-                        if (certThumbprint == Server.Certificate?.Certificate?.Thumbprint)
+                        if (certThumbprint == Server.Certificate?.ServerCertificate?.Thumbprint)
                             return;
 
                         if (cert.TryGet(nameof(CertificateReplacement.OldThumbprint), out oldThumbprint) == false)
@@ -1582,7 +1583,7 @@ namespace Raven.Server.ServerWide
                         catch (Exception e)
                         {
                             if (Logger.IsOperationsEnabled)
-                                Logger.Operations($"Unable to notify executable about the cluster certificate change '{Server.Certificate.Certificate.Thumbprint}'.", e);
+                                Logger.Operations($"Unable to notify executable about the cluster certificate change '{Server.Certificate.ServerCertificate.Thumbprint}'.", e);
                         }
                     }
                     else
@@ -1604,7 +1605,7 @@ namespace Raven.Server.ServerWide
 
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"Replacing the certificate used by the server to: {newClusterCertificate.Thumbprint} ({newClusterCertificate.SubjectName.Name})");
-
+                    
                     Server.SetCertificate(newClusterCertificate, bytesToSave, Configuration.Security.CertificatePassword);
 
                     NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.Certificates_ReplaceError, null));
@@ -2910,7 +2911,8 @@ namespace Raven.Server.ServerWide
                 long? index = null;
                 using (ctx.OpenReadTransaction())
                 {
-                    foreach (var localCertKey in Cluster.GetCertificateThumbprintsFromLocalState(ctx))
+                    var localCertKeys = Cluster.GetCertificateThumbprintsFromLocalState(ctx).ToList();
+                    foreach (var localCertKey in localCertKeys)
                     {
                         // if there are trusted certificates in the local state, we will register them in the cluster now
                         using (var localCertificate = Cluster.GetLocalStateByThumbprint(ctx, localCertKey))
@@ -3008,7 +3010,7 @@ namespace Raven.Server.ServerWide
             {
                 NodeTag = NodeTag,
                 TopologyId = clusterTopology.TopologyId,
-                Certificate = Server.Certificate.CertificateForClients,
+                Certificate = Server.Certificate.ServerCertificateForClients,
                 NumberOfCores = ProcessorInfo.ProcessorCount,
                 InstalledMemoryInGb = memoryInformation.InstalledMemory.GetDoubleValue(SizeUnit.Gigabytes),
                 UsableMemoryInGb = memoryInformation.TotalPhysicalMemory.GetDoubleValue(SizeUnit.Gigabytes),
@@ -3135,7 +3137,7 @@ namespace Raven.Server.ServerWide
         {
             await Cluster.WaitForIndexNotification(index); // first let see if we commit this in the leader
 
-            using (var requester = ClusterRequestExecutor.CreateForShortTermUse(GetClusterTopology().GetUrlFromTag(node), Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requester = ClusterRequestExecutor.CreateForShortTermUse(GetClusterTopology().GetUrlFromTag(node), Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             using (var oct = new OperationCancelToken(cancelAfter: Configuration.Cluster.OperationTimeout.AsTimeSpan, token: ServerShutdown))
                 await requester.ExecuteAsync(new WaitForRaftIndexCommand(index), context, token: oct.Token);
         }
@@ -3147,7 +3149,7 @@ namespace Raven.Server.ServerWide
             if (members == null || members.Count == 0)
                 throw new InvalidOperationException("Cannot wait for execution when there are no nodes to execute on.");
 
-            using (var requestExecutor = ClusterRequestExecutor.Create(GetClusterTopology().Members.Values.ToArray(), Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.Create(GetClusterTopology().Members.Values.ToArray(), Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             using (var oct = new OperationCancelToken(cancelAfter: Configuration.Cluster.OperationTimeout.AsTimeSpan, token: ServerShutdown))
             {
                 List<Exception> exceptions = null;
@@ -3209,7 +3211,7 @@ namespace Raven.Server.ServerWide
 
         private ClusterRequestExecutor CreateNewClusterRequestExecutor(string leaderUrl)
         {
-            var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderUrl, Server.Certificate.Certificate, DocumentConventions.DefaultForServer);
+            var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(leaderUrl, Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer);
             requestExecutor.DefaultTimeout = Engine.OperationTimeout;
 
             return requestExecutor;
@@ -3355,7 +3357,7 @@ namespace Raven.Server.ServerWide
 
                 using (var cts = new CancellationTokenSource(Server.Configuration.Cluster.OperationTimeout.AsTimeSpan))
                 {
-                    connectionInfo = ReplicationUtils.GetDatabaseTcpInfoAsync(GetNodeHttpServerUrl(), url, database, "Test-Connection", Server.Certificate.Certificate,
+                    connectionInfo = ReplicationUtils.GetDatabaseTcpInfoAsync(GetNodeHttpServerUrl(), url, database, "Test-Connection", Server.Certificate.ClientCertificate,
                         cts.Token);
                 }
                 Task timeoutTask = await Task.WhenAny(timeout, connectionInfo);
@@ -3409,7 +3411,7 @@ namespace Raven.Server.ServerWide
             var res = new DynamicJsonValue
             {
                 [nameof(TcpConnectionInfo.Url)] = tcpServerUrl,
-                [nameof(TcpConnectionInfo.Certificate)] = _server.Certificate.CertificateForClients,
+                [nameof(TcpConnectionInfo.Certificate)] = _server.Certificate.ServerCertificateForClients,
                 [nameof(TcpConnectionInfo.NodeTag)] = NodeTag,
                 [nameof(TcpConnectionInfo.ServerId)] = ServerId.ToString()
             };

--- a/src/Raven.Server/Smuggler/Migration/Migrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Smuggler.Migration
             _skipServerCertificateValidation = configuration.SkipServerCertificateValidation;
 
             //because of backward compatibility useCompression == false here
-            var httpClientHandler = DefaultRavenHttpClientFactory.CreateHttpMessageHandler(_serverStore.Server.Certificate.Certificate, setSslProtocols: false, useCompression: false, hasExplicitlySetCompressionUsage: false, DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime, DocumentConventions.DefaultForServer.HttpPooledConnectionIdleTimeout);
+            var httpClientHandler = DefaultRavenHttpClientFactory.CreateHttpMessageHandler(_serverStore.Server.Certificate.ClientCertificate, setSslProtocols: false, useCompression: false, hasExplicitlySetCompressionUsage: false, DocumentConventions.DefaultForServer.HttpPooledConnectionLifetime, DocumentConventions.DefaultForServer.HttpPooledConnectionIdleTimeout);
             httpClientHandler.UseDefaultCredentials = false;
 
             if (configuration.SkipServerCertificateValidation)

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Raven.Client;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -20,10 +20,11 @@ using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 using Raven.Client;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Commercial.SetupWizard;
 using Raven.Server.Config.Categories;
-using Sparrow;
+using Raven.Server.ServerWide;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using BigInteger = Org.BouncyCastle.Math.BigInteger;
@@ -37,14 +38,6 @@ namespace Raven.Server.Utils
 
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger("Server", typeof(CertificateUtils).FullName);
 
-        private static string GetCertificateName(X509Certificate2 certificate)
-        {
-            if (certificate == null)
-                return string.Empty;
-
-            return string.IsNullOrEmpty(certificate.FriendlyName) == false ? certificate.FriendlyName : certificate.Subject;
-        }
-
         private static string GenerateCertificateChainDebugLog(X509Chain chain)
         {
             var stringBuilder = new StringBuilder();
@@ -52,7 +45,7 @@ namespace Raven.Server.Utils
             foreach (var element in chain.ChainElements)
             {
                 var certificate = element.Certificate;
-                stringBuilder.AppendLine($"{GetCertificateName(certificate)} - {certificate.GetPublicKeyPinningHash()}");
+                stringBuilder.AppendLine($"{certificate.GetDisplayName()} - {certificate.GetPublicKeyPinningHash()}");
             }
 
             return stringBuilder.ToString();
@@ -72,14 +65,14 @@ namespace Raven.Server.Utils
             // in order to do that properly it needs to be able to verify the chain by download the certificates
             //knownCertChain.ChainPolicy.DisableCertificateDownloads = true;
 
-            explanations?.Add($"Try building client certificate chain - {GetCertificateName(userCertificate)}.");
+            explanations?.Add($"Try building client certificate chain - {userCertificate.GetDisplayName()}.");
             try
             {
                 userChain.Build(userCertificate);
             }
             catch (Exception e)
             {
-                var message = $"Cannot validate new client certificate '{GetCertificateName(userCertificate)} - ({userCertificate.Thumbprint})'," +
+                var message = $"Cannot validate new client certificate '{userCertificate.GetDisplayName()} - ({userCertificate.Thumbprint})'," +
                               $" failed to build the chain.";
                 explanations?.Add(message);
                 if (Logger.IsInfoEnabled) 
@@ -104,14 +97,14 @@ namespace Raven.Server.Utils
                 return false;
             }
 
-            explanations?.Add($"Try building know certificate chain - {GetCertificateName(knownCertificate)}.");
+            explanations?.Add($"Try building know certificate chain - {knownCertificate.GetDisplayName()}.");
             try
             {
                 knownCertChain.Build(knownCertificate);
             }
             catch (Exception e)
             {
-                var message = $"Cannot validate new client certificate '{GetCertificateName(userCertificate)} {userCertificate.Thumbprint}'." +
+                var message = $"Cannot validate new client certificate '{userCertificate.GetDisplayName()} {userCertificate.Thumbprint}'." +
                               $" Found a known certificate '{knownCertificate.Thumbprint}' with the same hash but failed to build its chain.";
                 explanations?.Add(message);
                 if (Logger.IsInfoEnabled) 
@@ -121,8 +114,8 @@ namespace Raven.Server.Utils
             }
 
             explanations?.Add("Comparing certificates (leafs):\n" +
-                              $"Client certificate - {GetCertificateName(userCertificate)} - {userCertificate.GetPublicKeyPinningHash()}\n" +
-                              $"Known certificate - {GetCertificateName(knownCertificate)} - {knownCertificate.GetPublicKeyPinningHash()}");
+                              $"Client certificate - {userCertificate.GetDisplayName()} - {userCertificate.GetPublicKeyPinningHash()}\n" +
+                              $"Known certificate - {knownCertificate.GetDisplayName()} - {knownCertificate.GetPublicKeyPinningHash()}");
             // client certificates (leafs) Public Key pinning hashes must match
             if (userCertificate.GetPublicKeyPinningHash() != knownCertificate.GetPublicKeyPinningHash())
             {
@@ -165,40 +158,48 @@ namespace Raven.Server.Utils
 
         public class CertificateHolder : IDisposable
         {
-            public readonly string CertificateForClients;
-            public readonly X509Certificate2 Certificate;
-            public readonly SslStreamCertificateContext CertificateContext;
+            public string ServerCertificateForClients { get; private set; }
+            public X509Certificate2 ServerCertificate { get; }
+            public X509Certificate2 ClientCertificate { get; } // this is cert with client EKU and server cert key pair
+            public SslStreamCertificateContext ServerCertificateContext { get; private set; }
             public readonly AsymmetricKeyEntry PrivateKey;
 
             private CertificateHolder()
             {
             }
 
-            public CertificateHolder(X509Certificate2 certificate, AsymmetricKeyEntry privateKey)
-                : this(certificate, privateKey, certificateForClients: null)
+            public CertificateHolder(X509Certificate2 serverCertificate, AsymmetricKeyEntry privateKey)
             {
-            }
-
-            public CertificateHolder(X509Certificate2 certificate, AsymmetricKeyEntry privateKey, string certificateForClients)
-            {
-                Certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
-                CertificateContext = SslStreamCertificateContext.Create(Certificate, additionalCertificates: null);
+                ServerCertificate = serverCertificate ?? throw new ArgumentNullException(nameof(serverCertificate));
                 PrivateKey = privateKey ?? throw new ArgumentNullException(nameof(privateKey));
-                CertificateForClients = certificateForClients;
+                ServerCertificateContext = SslStreamCertificateContext.Create(ServerCertificate, additionalCertificates: null);
+                ServerCertificateForClients = Convert.ToBase64String(ServerCertificate.Export(X509ContentType.Cert));
+
+                if (SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(ServerCertificate))
+                {
+                    ClientCertificate = serverCertificate;
+                }
+                else
+                {
+                    var clientCertificate = CreateClientCertificateFromServerCertificate(serverCertificate, out _);
+                    ClientCertificate = clientCertificate;
+                }
             }
 
             public void Dispose()
             {
-                Certificate?.Dispose();
+                ServerCertificate?.Dispose();
+                ClientCertificate?.Dispose();
             }
 
             public static CertificateHolder CreateEmpty() => new();
         }
-        public static byte[] CreateSelfSignedTestCertificate(string commonNameValue, string issuerName, StringBuilder log = null)
+
+        public static byte[] CreateSelfSignedTestCertificate(string commonNameValue, string issuerName, StringBuilder log = null, bool with2Eku = true)
         {
             // Note this is for tests only!
             CreateCertificateAuthorityCertificate(commonNameValue + " CA", out var ca, out var caSubjectName, log);
-            CreateSelfSignedCertificateBasedOnPrivateKey(commonNameValue, caSubjectName, ca, false, false, DateTime.UtcNow.Date.AddMonths(3), out var certBytes, log: log);
+            CreateSelfSignedCertificateBasedOnPrivateKey(commonNameValue, caSubjectName, ca, false, false, DateTime.UtcNow.Date.AddMonths(3), out var certBytes, log: log, sans: [commonNameValue, "localhost", $"*.{commonNameValue}"], with2Eku: with2Eku);
             var selfSignedCertificateBasedOnPrivateKey = CertificateLoaderUtil.CreateCertificate(certBytes);
             selfSignedCertificateBasedOnPrivateKey.Verify();
 
@@ -214,7 +215,6 @@ namespace Raven.Server.Utils
             CreateCertificateAuthorityCertificate(commonNameValue + " CA", out var ca, out var caSubjectName, log);
 
             var existingKeyPair = GetRsaKey();
-
             CreateSelfSignedCertificateBasedOnPrivateKey(commonNameValue, caSubjectName, ca, false, false, DateTime.UtcNow.Date.AddMonths(3), out var certBytes1, existingKeyPair, log);
             var selfSignedCertificateBasedOnPrivateKey1 = CertificateLoaderUtil.CreateCertificate(certBytes1);
             selfSignedCertificateBasedOnPrivateKey1.Verify();
@@ -264,14 +264,14 @@ namespace Raven.Server.Utils
             }
         }
 
-        public static X509Certificate2 CreateSelfSignedClientCertificate(string commonNameValue, CertificateHolder certificateHolder, out byte[] certBytes, DateTime notAfter)
+        public static X509Certificate2 CreateSelfSignedClientCertificate(string commonNameValue, X509Certificate2 certificate, AsymmetricKeyParameter privateKey, out byte[] certBytes, DateTime notAfter)
         {
-            var serverCertBytes = certificateHolder.Certificate.Export(X509ContentType.Cert);
+            var serverCertBytes = certificate.Export(X509ContentType.Cert);
             var readCertificate = new X509CertificateParser().ReadCertificate(serverCertBytes);
             CreateSelfSignedCertificateBasedOnPrivateKey(
                 commonNameValue,
                 readCertificate.SubjectDN,
-                (certificateHolder.PrivateKey.Key, readCertificate.GetPublicKey()),
+                (privateKey, readCertificate.GetPublicKey()),
                 true,
                 false,
                 notAfter,
@@ -279,12 +279,16 @@ namespace Raven.Server.Utils
 
             ValidateNoPrivateKeyInServerCert(serverCertBytes);
 
+            // create new pfx store
             Pkcs12Store store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
-            var serverCert = DotNetUtilities.FromX509Certificate(certificateHolder.Certificate);
+            var serverCert = DotNetUtilities.FromX509Certificate(certificate);
 
+            // add client certificate to the store
             store.Load(new MemoryStream(certBytes), Array.Empty<char>());
-            store.SetCertificateEntry(serverCert.SubjectDN.ToString(), new X509CertificateEntry(serverCert));
+            // add server certificate to the store
+            store.SetCertificateEntry(certificate.GetDisplayName(), new X509CertificateEntry(serverCert));
 
+            // save pfx store to the memory stream
             var memoryStream = new MemoryStream();
             store.Save(memoryStream, Array.Empty<char>(), GetSeededSecureRandom());
             certBytes = memoryStream.ToArray();
@@ -303,14 +307,14 @@ namespace Raven.Server.Utils
                 throw new InvalidOperationException("After export of CERT, still have private key from signer in certificate, should NEVER happen");
         }
 
-        public static X509Certificate2 CreateSelfSignedExpiredClientCertificate(string commonNameValue, CertificateHolder certificateHolder)
+        public static X509Certificate2 CreateSelfSignedExpiredClientCertificate(string commonNameValue, X509Certificate2 serverCertificate, AsymmetricKeyParameter privateKey)
         {
-            var readCertificate = new X509CertificateParser().ReadCertificate(certificateHolder.Certificate.Export(X509ContentType.Cert));
+            var readCertificate = new X509CertificateParser().ReadCertificate(serverCertificate.Export(X509ContentType.Cert));
 
             CreateSelfSignedCertificateBasedOnPrivateKey(
                 commonNameValue,
                 readCertificate.SubjectDN,
-                (certificateHolder.PrivateKey.Key, readCertificate.GetPublicKey()),
+                (privateKey, readCertificate.GetPublicKey()),
                 true,
                 false,
                 DateTime.UtcNow.Date.AddYears(-1),
@@ -320,14 +324,17 @@ namespace Raven.Server.Utils
         }
 
         public static void CreateSelfSignedCertificateBasedOnPrivateKey(string commonNameValue,
-            X509Name issuer,
+            X509Name issuerCN,
             (AsymmetricKeyParameter PrivateKey, AsymmetricKeyParameter PublicKey) issuerKeyPair,
             bool isClientCertificate,
             bool isCaCertificate,
             DateTime notAfter,
             out byte[] certBytes,
             AsymmetricCipherKeyPair subjectKeyPair = null,
-            StringBuilder log = null)
+            StringBuilder log = null,
+            IEnumerable<string> sans = null,
+            bool with2Eku = false,
+            byte[] issuerCertBytes = null)
         {
             log?.AppendLine("CreateSelfSignedCertificateBasedOnPrivateKey:");
 
@@ -340,14 +347,15 @@ namespace Raven.Server.Utils
             var authorityKeyIdentifier = X509ExtensionUtilities.CreateAuthorityKeyIdentifier(issuerKeyPair.PublicKey);
             certificateGenerator.AddExtension(X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
             certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, true, new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment));
-            if (isClientCertificate)
+            if (with2Eku)
             {
-                certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true, new ExtendedKeyUsage(KeyPurposeID.id_kp_clientAuth));
+                certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true,
+                    new ExtendedKeyUsage(KeyPurposeID.id_kp_clientAuth, KeyPurposeID.id_kp_serverAuth));
             }
             else
             {
                 certificateGenerator.AddExtension(X509Extensions.ExtendedKeyUsage.Id, true,
-                    new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth));
+                    isClientCertificate ? new ExtendedKeyUsage(KeyPurposeID.id_kp_clientAuth) : new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth));
             }
 
             if (isCaCertificate)
@@ -355,6 +363,28 @@ namespace Raven.Server.Utils
                 certificateGenerator.AddExtension(X509Extensions.BasicConstraints.Id, true, new BasicConstraints(0));
                 certificateGenerator.AddExtension(X509Extensions.KeyUsage.Id, false,
                     new X509KeyUsage(X509KeyUsage.KeyCertSign | X509KeyUsage.CrlSign));
+            }
+            
+            var names = new List<GeneralName>();
+            if (sans != null)
+            {
+                names.AddRange(sans.Select(san => new GeneralName(GeneralName.DnsName, san)));
+            }
+            if (names.Count > 0)
+            {
+                var subjectAlternativeNames = new GeneralNames(names.ToArray());
+                certificateGenerator.AddExtension(
+                    X509Extensions.SubjectAlternativeName.Id,
+                    false,
+                    subjectAlternativeNames);
+            }
+            
+            if (issuerCertBytes is { Length: > 0 })
+            {
+                certificateGenerator.AddExtension(
+                    new DerObjectIdentifier(Constants.Certificates.ServerCertExtensionOid),
+                    false,
+                    new DerOctetString(issuerCertBytes));
             }
 
             // Serial Number
@@ -367,16 +397,16 @@ namespace Raven.Server.Utils
             // Issuer and Subject Name
 
             X509Name subjectDN = new X509Name("CN=" + commonNameValue);
-            certificateGenerator.SetIssuerDN(issuer);
+            certificateGenerator.SetIssuerDN(issuerCN);
             certificateGenerator.SetSubjectDN(subjectDN);
-            log?.AppendLine($"issuerDN = {issuer}");
+            log?.AppendLine($"issuerDN = {issuerCN}");
             log?.AppendLine($"subjectDN = {subjectDN}");
 
             // Valid For
             DateTime notBefore = DateTime.UtcNow.Date.AddDays(-7);
 
             certificateGenerator.SetNotBefore(notBefore);
-            certificateGenerator.SetNotAfter(notAfter);
+            certificateGenerator.SetNotAfter(notAfter.ToUniversalTime());
             log?.AppendLine($"notBefore = {notBefore}");
             log?.AppendLine($"notAfter = {notAfter}");
 
@@ -387,14 +417,13 @@ namespace Raven.Server.Utils
 
             X509Certificate certificate = certificateGenerator.Generate(signatureFactory);
             var store = new Pkcs12StoreBuilder().BuildWithoutOracleOids();
-            string friendlyName = certificate.SubjectDN.ToString();
             var certificateEntry = new X509CertificateEntry(certificate);
             var keyEntry = new AsymmetricKeyEntry(subjectKeyPair.Private);
 
             log?.AppendLine($"certificateEntry.Certificate = {certificateEntry.Certificate}");
 
-            store.SetCertificateEntry(friendlyName, certificateEntry);
-            store.SetKeyEntry(friendlyName, keyEntry, new[] { certificateEntry });
+            store.SetCertificateEntry(commonNameValue, certificateEntry);
+            store.SetKeyEntry(commonNameValue, keyEntry, new[] { certificateEntry });
             var stream = new MemoryStream();
             store.Save(stream, new char[0], random);
 
@@ -488,7 +517,56 @@ namespace Raven.Server.Utils
             return new X509Certificate2(stream.ToArray());
         }
 
+        public static X509Certificate2 CreateClientCertificateFromServerCertificate(X509Certificate2 serverCertificate, out byte[] clientCertBytes)
+        {
+            var rsaPrivateKey = serverCertificate.GetRSAPrivateKey();
+            AsymmetricCipherKeyPair kp = DotNetUtilities.GetRsaKeyPair(rsaPrivateKey);
+
+            var subjectName = serverCertificate.GetDisplayName();
+            var serverCertBytes = serverCertificate.Export(X509ContentType.Cert);
+            var readCertificate = new X509CertificateParser().ReadCertificate(serverCertBytes);
+            CreateSelfSignedCertificateBasedOnPrivateKey(
+                $"{subjectName.Replace("CN=", "")}-server-communication",
+                readCertificate.SubjectDN,
+                (kp.Private, kp.Public),
+                true,
+                false,
+                serverCertificate.NotAfter,
+                out clientCertBytes,
+                new AsymmetricCipherKeyPair(readCertificate.GetPublicKey(),kp.Private),
+                issuerCertBytes: serverCertBytes);
+            
+            var clientCertificate = CertificateLoaderUtil.CreateCertificate(clientCertBytes, null, CertificateLoaderUtil.FlagsForPersist);
+            return clientCertificate;
+        }
+        
+        public static X509Certificate2 ExtractServerCertificateFromExtension(X509Certificate2 clientCert)
+        {
+            // The OID used for the server certificate extension
+            const string serverCertExtensionOid = Constants.Certificates.ServerCertExtensionOid;
+    
+            // Look for our custom extension
+            foreach (var extension in clientCert.Extensions)
+            {
+                if (extension.Oid.Value == serverCertExtensionOid)
+                {
+                    // The raw data is a DER encoded octet string containing the certificate
+                    var octetString = Org.BouncyCastle.Asn1.Asn1OctetString.GetInstance(extension.RawData);
+            
+                    // Create a certificate from the raw data
+                    var rawData = octetString.GetOctets();
+                    ValidateNoPrivateKeyInServerCert(rawData);
+                    var certificateFromExtension = CertificateLoaderUtil.CreateCertificate(rawData);
+                    return certificateFromExtension;
+                }
+            }
+    
+            return null; // No server certificate found
+        }
+
+
         // generating this can take a while, so we cache that at the process level, to significantly speed up the tests
+
         private static Lazy<(byte[] Private, byte[] Public)>
             caKeyPair = new Lazy<(byte[] Private, byte[] Public)>(GenerateKey);
 
@@ -610,7 +688,7 @@ namespace Raven.Server.Utils
             }
         }
 
-        public static async Task<X509Certificate2> CompleteAuthorizationAndGetCertificate(CompleteAuthorizationAndGetCertificateParameters parameters)
+        public static async Task<X509Certificate2> CompleteAuthorizationAndGetCertificate(CompleteAuthorizationAndGetCertificateParameters parameters, string acmeProfile)
         {
             if (parameters.ChallengeResult.Challange == null && parameters.ChallengeResult.Cache != null)
             {
@@ -631,7 +709,7 @@ namespace Raven.Server.Utils
             (X509Certificate2 Cert, RSA PrivateKey) result;
             try
             {
-                result = await parameters.Client.GetCertificate(parameters.ExistingPrivateKey, parameters.Token);
+                result = await parameters.Client.GetCertificate(parameters.ExistingPrivateKey, acmeProfile, parameters.Token);
             }
             catch (Exception e)
             {
@@ -685,136 +763,28 @@ namespace Raven.Server.Utils
 
         public static string GetBasicCertificateInfo(this X509Certificate2 certificate)
         {
-            return $"Thumbprint: {certificate.Thumbprint}, Subject: {certificate.Subject}";
+            return $"Thumbprint: {certificate.Thumbprint}, Subject: {certificate.Subject}, Raven Display Name: {certificate.GetDisplayName()}";
+        }
+
+        public static string GetDisplayName(this X509Certificate2 certificate)
+        {
+            if (certificate == null)
+                return "(null)";
+            
+            if (string.IsNullOrEmpty(certificate.Subject) == false)
+                return certificate.Subject;
+            
+            if (string.IsNullOrEmpty(certificate.FriendlyName) == false)
+                return certificate.FriendlyName;
+            
+            var dnsNames = GetCertificateAlternativeNames(certificate).ToList();
+            if (dnsNames.Any())
+                return string.Join(',', dnsNames);
+
+            return string.Empty;
         }
     }
-    public static class PublicKeyPinningHashHelpers
-    {
-        public static string GetPublicKeyPinningHash(this X509Certificate2 cert)
-        {
-            //Get the SubjectPublicKeyInfo member of the certificate
-            var subjectPublicKeyInfo = GetSubjectPublicKeyInfoRaw(cert);
-
-            //Take the SHA2-256 hash of the DER ASN.1 encoded value
-            byte[] digest;
-            using (var sha2 = SHA256.Create())
-            {
-                digest = sha2.ComputeHash(subjectPublicKeyInfo);
-            }
-
-            //Convert hash to base64
-            var hash = Convert.ToBase64String(digest);
-
-            return hash;
-        }
-
-        public static unsafe byte[] GetSubjectPublicKeyInfoRaw(X509Certificate2 cert)
-        {
-            /*
-             Certificate is, by definition:
-
-                Certificate  ::=  SEQUENCE  {
-                    tbsCertificate       TBSCertificate,
-                    signatureAlgorithm   AlgorithmIdentifier,
-                    signatureValue       BIT STRING
-                }
-
-               TBSCertificate  ::=  SEQUENCE  {
-                    version         [0]  EXPLICIT Version DEFAULT v1,
-                    serialNumber         CertificateSerialNumber,
-                    signature            AlgorithmIdentifier,
-                    issuer               Name,
-                    validity             Validity,
-                    subject              Name,
-                    subjectPublicKeyInfo SubjectPublicKeyInfo,
-                    issuerUniqueID  [1]  IMPLICIT UniqueIdentifier OPTIONAL, -- If present, version MUST be v2 or v3
-                    subjectUniqueID [2]  IMPLICIT UniqueIdentifier OPTIONAL, -- If present, version MUST be v2 or v3
-                    extensions      [3]  EXPLICIT Extensions       OPTIONAL  -- If present, version MUST be v3
-                }
-
-            So we walk the ASN.1 DER tree in order to drill down to the SubjectPublicKeyInfo item
-            */
-
-            var rawCert = cert.GetRawCertData();
-            var bufferLength = rawCert.Length;
-
-            fixed (byte* certPtr = rawCert)
-            {
-                var ptr = AsnNext(certPtr, ref bufferLength, true, false);  // unwrap certificate sequence
-                ptr = AsnNext(ptr, ref bufferLength, false, false); // get tbsCertificate
-                ptr = AsnNext(ptr, ref bufferLength, true, false);  // unwrap tbsCertificate sequence
-                ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Version
-                ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.SerialNumber
-                ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Signature
-                ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Issuer
-                ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Validity
-                ptr = AsnNext(ptr, ref bufferLength, false, true);  // skip tbsCertificate.Subject
-                ptr = AsnNext(ptr, ref bufferLength, false, false); // get tbsCertificate.SubjectPublicKeyInfo
-
-                var subjectPublicKeyInfo = new byte[bufferLength];
-                fixed (byte* newPtr = subjectPublicKeyInfo)
-                {
-                    Memory.Copy(newPtr, ptr, bufferLength);
-                }
-                return subjectPublicKeyInfo;
-            }
-        }
-
-        private static unsafe byte* AsnNext(byte* buffer, ref int bufferLength, bool unwrap, bool getRemaining)
-        {
-            if (bufferLength < 2)
-            {
-                return buffer;
-            }
-
-            var index = 0;
-            //var entityType = buffer[index];
-            index++;
-
-            int length = buffer[index];
-            index++;
-
-            var lengthBytes = 1;
-            if (length >= 0x80)
-            {
-                lengthBytes = length & 0x0F; //low nibble is number of length bytes to follow
-                length = 0;
-
-                for (var i = 0; i < lengthBytes; i++)
-                {
-                    length = (length << 8) + (int)buffer[index + i];
-                }
-                lengthBytes++;
-            }
-
-            int skip;
-            int take;
-            if (unwrap)
-            {
-                skip = 1 + lengthBytes;
-                take = length;
-            }
-            else
-            {
-                skip = 0;
-                take = 1 + lengthBytes + length;
-            }
-
-            if (getRemaining == false)
-            {
-                buffer += skip;
-                bufferLength = take;
-            }
-            else
-            {
-                buffer += skip + take;
-                bufferLength -= (skip + take);
-            }
-
-            return buffer;
-        }
-    }
-
+    
     public static class CertificateExtensions
     {
         public static Pkcs12Store BuildWithoutOracleOids(this Pkcs12StoreBuilder builder)

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -626,9 +626,6 @@ namespace Raven.Server.Utils.Cli
             return isOn; // here rc is not an exit code, it is a setter to _experimental
         }
 
-        private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
-        private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
-
         private static bool CommandTrustServerCert(List<string> args, RavenCli cli)
         {
             if (args.Count < 2 || args.Count > 3)
@@ -657,16 +654,16 @@ namespace Raven.Server.Utils.Cli
             {
                 foreach (var oid in extension.EnhancedKeyUsages)
                 {
-                    if (oid.Value.Equals(ServerAuthenticationOid, StringComparison.Ordinal))
+                    if (oid.Value.Equals(Constants.Certificates.ServerAuthenticationOid, StringComparison.Ordinal))
                         serverAuth = true;
-                    if (oid.Value.Equals(ClientAuthenticationOid, StringComparison.Ordinal))
+                    if (oid.Value.Equals(Constants.Certificates.ClientAuthenticationOid, StringComparison.Ordinal))
                         clientAuth = true;
                 }
             }
 
             if (clientAuth == false || serverAuth == false)
             {
-                WriteError($"Certificate {cert.Thumbprint} cannot be a ravendb server certificate. It does not include both Extended Key Usages: Server Authentication ({ServerAuthenticationOid}), Client Authentication ({ClientAuthenticationOid}).", cli);
+                WriteError($"Certificate {cert.Thumbprint} cannot be a ravendb server certificate. It does not include both Extended Key Usages: Server Authentication ({Constants.Certificates.ServerAuthenticationOid}), Client Authentication ({Constants.Certificates.ClientAuthenticationOid}).", cli);
                 return false;
             }
 
@@ -747,14 +744,14 @@ namespace Raven.Server.Utils.Cli
             {
                 foreach (var oid in extension.EnhancedKeyUsages)
                 {
-                    if (oid.Value.Equals(ClientAuthenticationOid, StringComparison.Ordinal))
+                    if (oid.Value.Equals(Constants.Certificates.ClientAuthenticationOid, StringComparison.Ordinal))
                         clientAuth = true;
                 }
             }
 
             if (clientAuth == false)
             {
-                WriteError($"Certificate {cert.Thumbprint} cannot be used as a client certificate. It does not include the Extended Key Usage: Client Authentication ({ClientAuthenticationOid}).", cli);
+                WriteError($"Certificate {cert.Thumbprint} cannot be used as a client certificate. It does not include the Extended Key Usage: Client Authentication ({Constants.Certificates.ClientAuthenticationOid}).", cli);
                 return false;
             }
 

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -649,21 +649,18 @@ namespace Raven.Server.Utils.Cli
             }
 
             var serverAuth = false;
-            var clientAuth = false;
             foreach (var extension in cert.Extensions.OfType<X509EnhancedKeyUsageExtension>())
             {
                 foreach (var oid in extension.EnhancedKeyUsages)
                 {
                     if (oid.Value.Equals(Constants.Certificates.ServerAuthenticationOid, StringComparison.Ordinal))
                         serverAuth = true;
-                    if (oid.Value.Equals(Constants.Certificates.ClientAuthenticationOid, StringComparison.Ordinal))
-                        clientAuth = true;
                 }
             }
 
-            if (clientAuth == false || serverAuth == false)
+            if (serverAuth == false)
             {
-                WriteError($"Certificate {cert.Thumbprint} cannot be a ravendb server certificate. It does not include both Extended Key Usages: Server Authentication ({Constants.Certificates.ServerAuthenticationOid}), Client Authentication ({Constants.Certificates.ClientAuthenticationOid}).", cli);
+                WriteError($"Certificate {cert.Thumbprint} cannot be a ravendb server certificate. It does not include Extended Key Usage: Server Authentication ({Constants.Certificates.ServerAuthenticationOid}).", cli);
                 return false;
             }
 

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -551,6 +551,14 @@ namespace Raven.Server.Web.Authentication
                         writer.WritePropertyName("LoadedServerCert");
                         writer.WriteString(Server.Certificate.ServerCertificate?.Thumbprint);
                         writer.WriteComma();
+
+                        if (IsClientCertificateDifferentFromServerCertificate())
+                        {
+                            writer.WritePropertyName("LoadedServerCertForCommunication");
+                            writer.WriteString(Server.Certificate.ClientCertificate?.Thumbprint);
+                            writer.WriteComma();
+                        }
+
                         writer.WriteArray("WellKnownAdminCerts", wellKnown);
                         writer.WriteComma();
                         writer.WriteArray("WellKnownIssuers", Server.WellKnownIssuers?.Select(x => x.Thumbprint) ?? Array.Empty<string>());

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -906,6 +906,21 @@ namespace Raven.Server.Web.Authentication
 
             await HttpContext.Response.Body.WriteAsync(pfx, 0, pfx.Length);
         }
+        
+        [RavenAction("/admin/certificates/for-communication/export", "GET", AuthorizationStatus.Operator)]
+        public async Task GetServerCertificateForCommunication()
+        {
+            if (Server.Certificate.ClientCertificate == null)
+                return;
+
+            var bytes = Server.Certificate.ClientCertificate.Export(X509ContentType.Cert);
+
+            var contentDisposition = "attachment; filename=ServerCertificateForCommunication.crt";
+            HttpContext.Response.Headers["Content-Disposition"] = contentDisposition;
+            HttpContext.Response.ContentType = "application/octet-stream";
+
+            await HttpContext.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+        }
 
         [RavenAction("/admin/certificates/mode", "GET", AuthorizationStatus.ClusterAdmin)]
         public async Task Mode()

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -127,7 +127,7 @@ namespace Raven.Server.Web.Authentication
         {
             ValidateCertificateDefinition(certificate, serverStore);
 
-            if (serverStore.Server.Certificate?.Certificate == null)
+            if (serverStore.Server.Certificate?.ServerCertificate == null)
             {
                 var keys = new[]
                 {
@@ -141,7 +141,8 @@ namespace Raven.Server.Web.Authentication
             }
 
             // this creates a client certificate which is signed by the current server certificate
-            var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(certificate.Name, serverStore.Server.Certificate, out var clientCertBytes,
+            var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(certificate.Name, serverStore.Server.Certificate.ServerCertificate,
+                serverStore.Server.Certificate.PrivateKey.Key, out var clientCertBytes,
                 certificate.NotAfter ?? DateTime.UtcNow.Date.AddYears(5));
 
             var newCertDef = new CertificateDefinition
@@ -279,16 +280,16 @@ namespace Raven.Server.Web.Authentication
 
             foreach (var x509Certificate in collection)
             {
-                if (serverStore.Server.Certificate.Certificate?.Thumbprint != null && serverStore.Server.Certificate.Certificate.Thumbprint.Equals(x509Certificate.Thumbprint))
+                if (serverStore.Server.Certificate.ServerCertificate?.Thumbprint != null && serverStore.Server.Certificate.ServerCertificate.Thumbprint.Equals(x509Certificate.Thumbprint))
                     throw new InvalidOperationException($"You are trying to import the same server certificate ({x509Certificate.Thumbprint}) as the one which is already loaded. This is not supported.");
 
-                if (x509Certificate.Issuer != x509Certificate.Subject)
+                if (x509Certificate.Issuer != x509Certificate.GetDisplayName())
                     issuers.Add(x509Certificate.Issuer);
             }
 
             foreach (var x509Certificate in collection)
             {
-                if (issuers.Contains(x509Certificate.Subject))
+                if (issuers.Contains(x509Certificate.GetDisplayName()))
                     continue;
 
                 var currentCertDef = new CertificateDefinition
@@ -489,23 +490,44 @@ namespace Raven.Server.Web.Authentication
                     {
                         const string serverCertificateName = "Server Certificate";
                         // The server cert is not part of the local state or the cluster certificates, we add it to the list separately
-                        if ((name == null || name == serverCertificateName) && Server.Certificate.Certificate != null)
+                        if ((name == null || name == serverCertificateName) && Server.Certificate.ServerCertificate != null)
                         {
                             var serverCertDef = new CertificateDefinition
                             {
                                 Name = serverCertificateName,
-                                Certificate = Convert.ToBase64String(Server.Certificate.Certificate.Export(X509ContentType.Cert)),
+                                Certificate = Convert.ToBase64String(Server.Certificate.ServerCertificate.Export(X509ContentType.Cert)),
                                 Permissions = new Dictionary<string, DatabaseAccess>(),
                                 SecurityClearance = SecurityClearance.ClusterNode,
-                                Thumbprint = Server.Certificate.Certificate.Thumbprint,
-                                PublicKeyPinningHash = Server.Certificate.Certificate.GetPublicKeyPinningHash(),
-                                NotAfter = Server.Certificate.Certificate.NotAfter,
-                                NotBefore = Server.Certificate.Certificate.NotBefore
+                                Thumbprint = Server.Certificate.ServerCertificate.Thumbprint,
+                                PublicKeyPinningHash = Server.Certificate.ServerCertificate.GetPublicKeyPinningHash(),
+                                NotAfter = Server.Certificate.ServerCertificate.NotAfter,
+                                NotBefore = Server.Certificate.ServerCertificate.NotBefore
                             };
 
                             var serverCert = context.ReadObject(serverCertDef.ToJson(metadataOnly), "Server/Certificate/Definition");
 
-                            certificateList.TryAdd(Server.Certificate.Certificate?.Thumbprint, serverCert);
+                            certificateList.TryAdd(Server.Certificate.ServerCertificate?.Thumbprint, serverCert);
+
+                            var certificateForCommunication = Server.Certificate.ClientCertificate;
+                            if (IsClientCertificateDifferentFromServerCertificate())
+                            {
+                                var serverCertForCommunicationDef = new CertificateDefinition
+                                {
+                                    Name = "Server Certificate for communication " + ServerStore.NodeTag,
+                                    Certificate = Convert.ToBase64String(certificateForCommunication.Export(X509ContentType.Cert)),
+                                    Permissions = new Dictionary<string, DatabaseAccess>(),
+                                    SecurityClearance = SecurityClearance.ClusterNode,
+                                    Thumbprint = certificateForCommunication.Thumbprint,
+                                    PublicKeyPinningHash = certificateForCommunication.GetPublicKeyPinningHash(),
+                                    NotAfter = certificateForCommunication.NotAfter,
+                                    NotBefore = certificateForCommunication.NotBefore
+                                };
+
+                                var serverCertForCommunication = context.ReadObject(serverCertForCommunicationDef.ToJson(metadataOnly),
+                                    "ServerClient/Certificate/Definition");
+
+                                certificateList.TryAdd(certificateForCommunication.Thumbprint, serverCertForCommunication);
+                            }
                         }
 
                         GetAllRegisteredCertificates(context, certificateList, includeSecondary, name, metadataOnly);
@@ -527,7 +549,7 @@ namespace Raven.Server.Web.Authentication
                         writer.WriteArray(context, "Results", certificateList.ToArray(), (w, c, cert) => c.Write(w, cert.Value));
                         writer.WriteComma();
                         writer.WritePropertyName("LoadedServerCert");
-                        writer.WriteString(Server.Certificate.Certificate?.Thumbprint);
+                        writer.WriteString(Server.Certificate.ServerCertificate?.Thumbprint);
                         writer.WriteComma();
                         writer.WriteArray("WellKnownAdminCerts", wellKnown);
                         writer.WriteComma();
@@ -645,6 +667,8 @@ namespace Raven.Server.Web.Authentication
                 return;
             }
 
+            clientCert = RavenServer.GetCertificateForAuthorization(clientCert);
+
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
@@ -658,23 +682,40 @@ namespace Raven.Server.Web.Authentication
 
                     var wellKnown = ServerStore.Configuration.Security.WellKnownAdminCertificates;
 
-                    if (clientCert.Equals(Server.Certificate.Certificate))
+                    if (Server.IsServerCertificate(clientCert))
                     {
-                        if (Server.Certificate.Certificate != null)
+                        if (Server.Certificate.ServerCertificate != null)
                         {
                             var serverCertDef = new CertificateDefinition
                             {
                                 Name = "Server Certificate",
-                                Certificate = Convert.ToBase64String(Server.Certificate.Certificate.Export(X509ContentType.Cert)),
+                                Certificate = Convert.ToBase64String(Server.Certificate.ServerCertificate.Export(X509ContentType.Cert)),
                                 Permissions = new Dictionary<string, DatabaseAccess>(),
                                 SecurityClearance = SecurityClearance.ClusterNode,
-                                Thumbprint = Server.Certificate.Certificate.Thumbprint,
-                                PublicKeyPinningHash = Server.Certificate.Certificate.GetPublicKeyPinningHash(),
-                                NotAfter = Server.Certificate.Certificate.NotAfter,
-                                NotBefore = Server.Certificate.Certificate.NotBefore
+                                Thumbprint = Server.Certificate.ServerCertificate.Thumbprint,
+                                PublicKeyPinningHash = Server.Certificate.ServerCertificate.GetPublicKeyPinningHash(),
+                                NotAfter = Server.Certificate.ServerCertificate.NotAfter,
+                                NotBefore = Server.Certificate.ServerCertificate.NotBefore
                             };
 
                             certificate = ctx.ReadObject(serverCertDef.ToJson(), "Server/Certificate/Definition");
+                        }
+
+                        if (IsClientCertificateDifferentFromServerCertificate())
+                        {
+                            var serverClientCertDef = new CertificateDefinition
+                            {
+                                Name = "Server Certificate For Communication " + ServerStore.NodeTag,
+                                Certificate = Convert.ToBase64String(Server.Certificate.ClientCertificate.Export(X509ContentType.Cert)),
+                                Permissions = new Dictionary<string, DatabaseAccess>(),
+                                SecurityClearance = SecurityClearance.ClusterNode,
+                                Thumbprint = Server.Certificate.ClientCertificate.Thumbprint,
+                                PublicKeyPinningHash = Server.Certificate.ClientCertificate.GetPublicKeyPinningHash(),
+                                NotAfter = Server.Certificate.ClientCertificate.NotAfter,
+                                NotBefore = Server.Certificate.ClientCertificate.NotBefore
+                            };
+
+                            certificate = ctx.ReadObject(serverClientCertDef.ToJson(), "ServerClient/Certificate/Definition");
                         }
                     }
                     else if (wellKnown != null && wellKnown.Contains(clientCert.Thumbprint, StringComparer.OrdinalIgnoreCase))
@@ -722,6 +763,11 @@ namespace Raven.Server.Web.Authentication
                     ctx.Write(writer, certificateDJV);
                 }
             }
+        }
+
+        private bool IsClientCertificateDifferentFromServerCertificate()
+        {
+            return Server.Certificate.ClientCertificate != null && Server.Certificate.ClientCertificate.Thumbprint != Server.Certificate.ServerCertificate?.Thumbprint;
         }
 
         [RavenAction("/admin/certificates/edit", "POST", AuthorizationStatus.Operator)]
@@ -811,13 +857,14 @@ namespace Raven.Server.Web.Authentication
         [RavenAction("/admin/certificates/export", "GET", AuthorizationStatus.Operator)]
         public async Task GetClusterCertificates()
         {
-            if (Server.Certificate.Certificate == null)
+            if (Server.Certificate.ServerCertificate == null)
                 return;
 
             var collection = new X509Certificate2Collection();
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                CertificateLoaderUtil.Import(collection, Server.Certificate.Certificate.Export(X509ContentType.Cert));
+                // exporting server cert probably because of ETL or Replication so client cert is needed
+                CertificateLoaderUtil.Import(collection, Server.Certificate.ServerCertificate.Export(X509ContentType.Cert));
 
                 if (ServerStore.CurrentRachisState != RachisState.Passive)
                 {
@@ -984,7 +1031,7 @@ namespace Raven.Server.Web.Authentication
             if (ServerStore.Configuration.Core.SetupMode != SetupMode.LetsEncrypt)
                 throw new InvalidOperationException("This server wasn't set up using the Let's Encrypt setup mode.");
 
-            if (Server.Certificate.Certificate == null)
+            if (Server.Certificate.ServerCertificate == null)
                 throw new InvalidOperationException("The server certificate is not loaded.");
 
             var (_, renewalDate) = Server.CalculateRenewalDate(Server.Certificate, false);
@@ -1007,7 +1054,7 @@ namespace Raven.Server.Web.Authentication
                 if (ServerStore.Configuration.Core.SetupMode != SetupMode.LetsEncrypt)
                     throw new InvalidOperationException("Cannot force renew for this server certificate. This server wasn't set up using the Let's Encrypt setup mode.");
 
-                if (Server.Certificate.Certificate == null)
+                if (Server.Certificate.ServerCertificate == null)
                     throw new InvalidOperationException("Cannot force renew this Let's Encrypt server certificate. The server certificate is not loaded.");
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
@@ -1031,7 +1078,7 @@ namespace Raven.Server.Web.Authentication
                 }
                 catch (Exception e)
                 {
-                    throw new InvalidOperationException($"Failed to force renew the Let's Encrypt server certificate for domain: {Server.Certificate.Certificate.GetNameInfo(X509NameType.SimpleName, false)}", e);
+                    throw new InvalidOperationException($"Failed to force renew the Let's Encrypt server certificate for domain: {Server.Certificate.ServerCertificate.GetNameInfo(X509NameType.SimpleName, false)}", e);
                 }
             }
 
@@ -1050,7 +1097,7 @@ namespace Raven.Server.Web.Authentication
 
                 var replaceImmediately = GetBoolValueQueryString("replaceImmediately", required: false) ?? false;
 
-                if (Server.Certificate.Certificate == null)
+                if (Server.Certificate.ServerCertificate == null)
                     throw new InvalidOperationException("Failed to trigger a certificate refresh cycle. The server certificate is not loaded.");
 
                 try
@@ -1235,7 +1282,7 @@ namespace Raven.Server.Web.Authentication
 
                             // In the beginning of 4.0 we had the server certificate stored together with all the other certs (in the local state and in the cluster).
                             // If it's the case now, we make sure not to transfer it to the cluster.
-                            if (certificateDefinition.Thumbprint == ServerStore.Server.Certificate.Certificate.Thumbprint)
+                            if (certificateDefinition.Thumbprint == ServerStore.Server.Certificate.ServerCertificate.Thumbprint)
                                 continue;
 
                             var (newIndex, _) = await ServerStore.PutValueInClusterAsync(new PutCertificateCommand(localStateKey, certificateDefinition, $"{raftRequestId}/{localStateKey}"));

--- a/src/Raven.Server/Web/RequestHandler.Audit.cs
+++ b/src/Raven.Server/Web/RequestHandler.Audit.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Raven.Server.Utils;
 using Sparrow.Logging;
 
 namespace Raven.Server.Web
@@ -41,7 +42,7 @@ namespace Raven.Server.Web
             sb.Append(RequestIp);
             sb.Append(", ");
             if (clientCert != null) 
-                sb.Append($"CN={clientCert.Subject} [{clientCert.Thumbprint}], ");
+                sb.Append($"CN={clientCert.GetDisplayName()} [{clientCert.Thumbprint}], ");
             else
                 sb.Append("no certificate, ");
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -670,7 +670,7 @@ namespace Raven.Server.Web
                     allowedOrigin = requestedOrigin;
                     break;
                 case CorsMode.Cluster:
-                    if (serverStore.Server.Certificate.Certificate == null || IsOriginAllowed(requestedOrigin, serverStore))
+                    if (serverStore.Server.Certificate.ServerCertificate == null || IsOriginAllowed(requestedOrigin, serverStore))
                         allowedOrigin = requestedOrigin;
                     break;
             }

--- a/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
+++ b/src/Raven.Server/Web/Studio/DataDirectoryInfo.cs
@@ -191,7 +191,7 @@ namespace Raven.Server.Web.Studio
             {
                 try
                 {
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(serverUrl, _serverStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(serverUrl, _serverStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
                     using (_serverStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                     {
                         var dataDirectoryInfo = new GetDataDirectoryInfoCommand(_path, _name, _isBackup);

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1411,7 +1411,7 @@ namespace Raven.Server.Web.System
 
             var nodesUrls = topology.AllNodes.Select(clusterTopology.GetUrlFromTag).ToArray();
 
-            using var requestExecutor = RequestExecutor.Create(nodesUrls, databaseName, Server.Certificate.Certificate, DocumentConventions.Default);
+            using var requestExecutor = RequestExecutor.Create(nodesUrls, databaseName, Server.Certificate.ClientCertificate, DocumentConventions.Default);
 
             foreach (var nodeTag in topology.AllNodes)
             {

--- a/src/Raven.Server/Web/System/SetupHandler.cs
+++ b/src/Raven.Server/Web/System/SetupHandler.cs
@@ -459,7 +459,7 @@ namespace Raven.Server.Web.System
 
                 try
                 {
-                    SecretProtection.ValidateKeyUsages("Setup Wizard", certificate, ServerStore.Configuration.Security.CertificateValidationKeyUsages);
+                    SecretProtection.ValidateServerKeyUsages("Setup Wizard", certificate, ServerStore.Configuration.Security.CertificateValidationKeyUsages);
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -391,7 +391,7 @@ namespace Raven.Server.Web.System
             HttpContext.Response.Headers["X-XSS-Protection"] = "1; mode=block";
             HttpContext.Response.Headers["X-Content-Type-Options"] = "nosniff";
 
-            var isSecuredServer = ServerStore.Server.Certificate?.Certificate != null;
+            var isSecuredServer = ServerStore.Server.Certificate?.ServerCertificate != null;
 
             if (isSecuredServer && Server.Configuration.Security.DisableHsts == false)
             {

--- a/src/Raven.Server/Web/System/TestConnectionHandler.cs
+++ b/src/Raven.Server/Web/System/TestConnectionHandler.cs
@@ -40,7 +40,7 @@ namespace Raven.Server.Web.System
                 // test the connection from the remote node to this one
                 if (bidirectional == true && result.Success)
                 {
-                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(url, ServerStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
                     {
                         result = await ServerStore.TestConnectionFromRemote(requestExecutor, context, url);
                     }
@@ -57,7 +57,7 @@ namespace Raven.Server.Web.System
 
             using (server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
             {
-                using var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.Certificate, server.CipherSuitesPolicy,
+                using var tcpSocketResult = await TcpUtils.ConnectSecuredTcpSocket(tcpConnectionInfo, server.Certificate.ClientCertificate, server.CipherSuitesPolicy,
                     TcpConnectionHeaderMessage.OperationTypes.TestConnection,
                     NegotiateWithRemote, ctx, timeout, negLogs, token);
             }

--- a/src/Raven.Studio/typescript/commands/auth/getCertificatesCommand.ts
+++ b/src/Raven.Studio/typescript/commands/auth/getCertificatesCommand.ts
@@ -1,21 +1,37 @@
 import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
 
-class getCertificatesCommand extends commandBase {
+interface Result {
+    Certificates: Array<
+        Raven.Client.ServerWide.Operations.Certificates.CertificateDefinition & { HasTwoFactor: boolean }
+    >;
+    LoadedServerCert: string;
+    LoadedServerCertForCommunication?: string;
+    WellKnownAdminCerts: string[];
+    WellKnownIssuers: string[];
+}
 
+class getCertificatesCommand extends commandBase {
     constructor(private includeSecondary: boolean = false, private metadataOnly: boolean = true) {
         super();
     }
-    
-    execute(): JQueryPromise<{ Certificates: Array<Raven.Client.ServerWide.Operations.Certificates.CertificateDefinition & { HasTwoFactor: boolean; }>, LoadedServerCert: string, WellKnownAdminCerts: string[], WellKnownIssuers: string[] }> {
+
+    execute(): JQueryPromise<Result> {
         const args = {
             secondary: this.includeSecondary,
-            metadataOnly: this.metadataOnly
+            metadataOnly: this.metadataOnly,
         };
         const url = endpoints.global.adminCertificates.adminCertificates + this.urlEncodeArgs(args);
-        
-        return this.query(url, null, null, x => ({ Certificates: x.Results, LoadedServerCert: x.LoadedServerCert, WellKnownAdminCerts: x.WellKnownAdminCerts, WellKnownIssuers: x.WellKnownIssuers }))
-            .fail((response: JQueryXHR) => this.reportError("Unable to get list of certificates", response.responseText, response.statusText));
+
+        return this.query(url, null, null, (x) => ({
+            Certificates: x.Results,
+            LoadedServerCert: x.LoadedServerCert,
+            LoadedServerCertForCommunication: x.LoadedServerCertForCommunication,
+            WellKnownAdminCerts: x.WellKnownAdminCerts,
+            WellKnownIssuers: x.WellKnownIssuers,
+        })).fail((response: JQueryXHR) =>
+            this.reportError("Unable to get list of certificates", response.responseText, response.statusText)
+        );
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
@@ -59,6 +59,7 @@ class certificates extends viewModelBase {
     certificates = ko.observableArray<unifiedCertificateDefinition>();
     
     serverCertificateThumbprint = ko.observable<string>();
+    serverCertificateForCommunicationThumbprint = ko.observable<string>();
     clientCertificateThumbprint = ko.observable<string>();
     
     serverCertificateSetupMode = ko.observable<Raven.Server.Commercial.SetupMode>();
@@ -655,6 +656,7 @@ class certificates extends viewModelBase {
                 });
                 
                 this.serverCertificateThumbprint(certificatesInfo.LoadedServerCert);
+                this.serverCertificateForCommunicationThumbprint(certificatesInfo.LoadedServerCertForCommunication);
                 this.clientCertificateThumbprint(accessManager.clientCertificateThumbprint());
                 
                 secondaryCertificates.forEach(cert => {
@@ -777,7 +779,7 @@ class certificates extends viewModelBase {
     
     canEdit(model: unifiedCertificateDefinition) {
         return ko.pureComputed(() => {
-            if (_.includes(model.Thumbprints, this.serverCertificateThumbprint())) {
+            if (_.includes(model.Thumbprints, this.serverCertificateThumbprint()) || _.includes(model.Thumbprints, this.serverCertificateForCommunicationThumbprint())) {
                 return false;
             }
 
@@ -795,7 +797,7 @@ class certificates extends viewModelBase {
                 return false;
             }
             
-            if (_.includes(model.Thumbprints, this.serverCertificateThumbprint())) {
+            if (_.includes(model.Thumbprints, this.serverCertificateThumbprint()) || _.includes(model.Thumbprints, this.serverCertificateForCommunicationThumbprint())) {
                 return false;
             }
             

--- a/test/BenchmarkTests/BenchmarkTestBase.cs
+++ b/test/BenchmarkTests/BenchmarkTestBase.cs
@@ -78,7 +78,7 @@ namespace BenchmarkTests
             if (Encrypted)
             {
                 var certificates = Certificates.GenerateAndSaveSelfSignedCertificate();
-                adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value,
+                adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value,
                     certificates.ClientCertificate1.Value,
                     new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin,
                     Server);
@@ -136,7 +136,7 @@ namespace BenchmarkTests
             options.ModifyDatabaseRecord = record => record.Settings.Remove(RavenConfiguration.GetKey(x => x.Core.RunInMemory));
 
             if (Encrypted)
-                options.ClientCertificate = Certificates.GenerateAndSaveSelfSignedCertificate().ServerCertificate.Value;
+                options.ClientCertificate = Certificates.GenerateAndSaveSelfSignedCertificate().ServerCertificateForCommunication.Value;
 
             return base.GetDocumentStore(options, caller);
         }

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -37,8 +37,8 @@ namespace FastTests.Client
             if (useSsl)
             {
                 var certificates = Certificates.SetupServerAuthentication();
-                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
                 {
                     [dbName] = DatabaseAccess.ReadWrite
                 });

--- a/test/FastTests/Issues/RavenDB-23795.cs
+++ b/test/FastTests/Issues/RavenDB-23795.cs
@@ -1,0 +1,21 @@
+﻿using Raven.Client;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_23795 : RavenTestBase
+{
+    public RavenDB_23795(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public void CertificateExtensionsOidBase_AndSnmpOidBase_AreDifferent()
+    {
+        var serverCertExtensionOidBase = Constants.Certificates.ServerCertExtensionOid.Substring(0, 19);
+        var snmpOidBase = Constants.Monitoring.Snmp.SnmpRootOid.Substring(0, 19);
+        Assert.NotEqual(serverCertExtensionOidBase, snmpOidBase);
+    }
+}

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -235,7 +235,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -265,7 +265,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -296,7 +296,7 @@ namespace RachisTests
 
             // here we pusblish a wrong PublicServerUrl, but connect to the ServerUrl, so the HTTP connection should be okay, but will when trying to the TCP connection.
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);
@@ -326,7 +326,7 @@ namespace RachisTests
             var dest = raft2.ServerStore.GetNodeHttpServerUrl();
 
             using (raft1.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(source, raft1.ServerStore.Server.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             {
                 var nodeConnectionTest = new TestNodeConnectionCommand(dest, bidirectional: true);
                 await requestExecutor.ExecuteAsync(nodeConnectionTest, context);

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -68,10 +68,11 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task EnsureDocumentsReplication(bool useSsl)
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task EnsureDocumentsReplication(bool useSsl, bool with2Eku)
         {
             var clusterSize = 5;
             var databaseName = GetDatabaseName();
@@ -82,11 +83,11 @@ namespace RachisTests.DatabaseCluster
 
             if (useSsl)
             {
-                var result = await CreateRaftClusterWithSsl(clusterSize, false);
+                var result = await CreateRaftClusterWithSsl(clusterSize, false, with2Eku: with2Eku);
                 leader = result.Leader;
 
-                adminCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificate.Value, result.Certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
-                clientCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificate.Value, result.Certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+                adminCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificateForCommunication.Value, result.Certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
+                clientCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificateForCommunication.Value, result.Certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
                 {
                     [databaseName] = DatabaseAccess.Admin
                 }, server: leader);
@@ -285,10 +286,11 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task EnsureReplicationToWatchers(bool useSsl)
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task EnsureReplicationToWatchers(bool useSsl, bool with2Eku)
         {
             var clusterSize = 3;
             var databaseName = GetDatabaseName();
@@ -298,7 +300,7 @@ namespace RachisTests.DatabaseCluster
 
             if (useSsl)
             {
-                var result = await CreateRaftClusterWithSsl(clusterSize);
+                var result = await CreateRaftClusterWithSsl(clusterSize, with2Eku: with2Eku);
                 leader = result.Leader;
 
                 adminCertificate = Certificates.RegisterClientCertificate(result.Certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
@@ -631,10 +633,11 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task DoNotReplicateBack(bool useSsl)
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task DoNotReplicateBack(bool useSsl, bool with2Eku)
         {
             var clusterSize = 5;
             var databaseName = GetDatabaseName();
@@ -644,7 +647,7 @@ namespace RachisTests.DatabaseCluster
 
             if (useSsl)
             {
-                var result = await CreateRaftClusterWithSsl(clusterSize);
+                var result = await CreateRaftClusterWithSsl(clusterSize, with2Eku: with2Eku);
                 leader = result.Leader;
 
                 adminCertificate = Certificates.RegisterClientCertificate(result.Certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
@@ -703,10 +706,11 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddGlobalChangeVectorToNewDocument(bool useSsl)
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task AddGlobalChangeVectorToNewDocument(bool useSsl, bool with2Eku)
         {
             var clusterSize = 3;
             var databaseName = GetDatabaseName();
@@ -717,11 +721,11 @@ namespace RachisTests.DatabaseCluster
 
             if (useSsl)
             {
-                var result = await CreateRaftClusterWithSsl(clusterSize, true, 0);
+                var result = await CreateRaftClusterWithSsl(clusterSize, true, 0, with2Eku: with2Eku);
                 leader = result.Leader;
 
-                adminCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificate.Value, result.Certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
-                clientCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificate.Value, result.Certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+                adminCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificateForCommunication.Value, result.Certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
+                clientCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificateForCommunication.Value, result.Certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
                 {
                     [databaseName] = DatabaseAccess.Admin
                 }, server: leader);
@@ -744,6 +748,7 @@ namespace RachisTests.DatabaseCluster
                 }
             }.Initialize())
             {
+                WaitForUserToContinueTheTest(Server.WebUrl, true, adminCertificate);
                 var databaseResult = await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(doc, clusterSize));
                 var topology = databaseResult.Topology;
                 Assert.Equal(clusterSize, topology.AllNodes.Count());
@@ -849,13 +854,15 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Fact]
-        public async Task ReplicateToWatcherWithAuth()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReplicateToWatcherWithAuth(bool with2Eku)
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var opCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var opCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
 
             using (var store1 = GetDocumentStore(new Options
             {
@@ -885,14 +892,16 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
-        [Fact]
-        public async Task ReplicateToWatcherWithInvalidAuth()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReplicateToWatcherWithInvalidAuth(bool with2Eku)
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert1 = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
-            var userCert2 = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert1 = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+            var userCert2 = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate3.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName + "otherstuff"] = DatabaseAccess.Admin
             });

--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -46,9 +46,8 @@ namespace SlowTests.Authentication
         {
         }
 
-        public X509Certificate2 CreateAndPutExpiredClientCertificate(string serverCertPath, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance = SecurityClearance.ValidUser)
+        public X509Certificate2 CreateAndPutExpiredClientCertificate(string serverCertPath, X509Certificate2 serverCertificateForCommunication, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance = SecurityClearance.ValidUser)
         {
-            var serverCertificate = new X509Certificate2(serverCertPath, (string)null, X509KeyStorageFlags.MachineKeySet);
             var serverCertificateHolder = new SecretProtection(
                 new SecurityConfiguration()).LoadCertificateFromPath(
                 serverCertPath,
@@ -56,12 +55,12 @@ namespace SlowTests.Authentication
                 Server.ServerStore.GetLicenseType(),
                 Server.ServerStore.Configuration.Security.CertificateValidationKeyUsages);
 
-            var clientCertificate = CertificateUtils.CreateSelfSignedExpiredClientCertificate("expired client cert", serverCertificateHolder);
+            var clientCertificate = CertificateUtils.CreateSelfSignedExpiredClientCertificate("expired client cert", serverCertificateHolder.Certificate, serverCertificateHolder.PrivateKey.Key);
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = serverCertificate,
-                ClientCertificate = serverCertificate
+                AdminCertificate = serverCertificateForCommunication,
+                ClientCertificate = serverCertificateForCommunication
             }))
             {
                 var requestExecutor = store.GetRequestExecutor();
@@ -76,13 +75,15 @@ namespace SlowTests.Authentication
             return clientCertificate;
         }
 
-        [Fact]
-        public void CanGetDocWithValidPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanGetDocWithValidPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });
@@ -104,13 +105,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CanGetAttachmentWithValidPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanGetAttachmentWithValidPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.Read
             });
@@ -137,8 +140,8 @@ namespace SlowTests.Authentication
 
             var certificates = SetupServerAuthentication(Certificates);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });
@@ -161,13 +164,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CanReachOperatorEndpointWithOperatorPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanReachOperatorEndpointWithOperatorPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
 
             using (var store = GetDocumentStore(new Options
             {
@@ -181,13 +186,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CannotReachOperatorEndpointWithoutOperatorPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotReachOperatorEndpointWithoutOperatorPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });
@@ -207,13 +214,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CanReachDatabaseAdminEndpointWithDatabaseAdminPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanReachDatabaseAdminEndpointWithDatabaseAdminPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.Admin
             });
@@ -240,13 +249,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CannotReachDatabaseAdminEndpointWithoutDatabaseAdminPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotReachDatabaseAdminEndpointWithoutDatabaseAdminPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });
@@ -272,16 +283,18 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CanOnlyGetRelevantDbsAccordingToPermissions()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanOnlyGetRelevantDbsAccordingToPermissions(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
             var dbName1 = GetDatabaseName();
             var dbName2 = GetDatabaseName();
 
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.Admin,
                 [dbName1] = DatabaseAccess.ReadWrite
@@ -326,14 +339,16 @@ namespace SlowTests.Authentication
             });
         }
 
-        [Fact]
-        public void CannotGetDocWithInvalidPermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotGetDocWithInvalidPermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
             var otherDbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [otherDbName] = DatabaseAccess.ReadWrite
             });
@@ -364,10 +379,12 @@ namespace SlowTests.Authentication
             });
         }
 
-        [Fact]
-        public void CannotGetCertificateWithInvalidDbNamePermission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotGetCertificateWithInvalidDbNamePermission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
             var e = Assert.Throws<RavenException>(() =>
             {
@@ -380,13 +397,15 @@ namespace SlowTests.Authentication
             Assert.IsType<ArgumentException>(e.InnerException);
         }
 
-        [Fact]
-        public void CannotGetDocWithExpiredCertificate()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotGetDocWithExpiredCertificate(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = CreateAndPutExpiredClientCertificate(certificates.ServerCertificatePath, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = CreateAndPutExpiredClientCertificate(certificates.ServerCertificatePath, certificates.ServerCertificateForCommunication.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });
@@ -446,8 +465,8 @@ namespace SlowTests.Authentication
             const string certificateName = "Client&Certificate 2";
 
             var certificates = SetupServerAuthentication(Certificates);
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, certificateName: "ClientCertificate1");
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, certificateName: "ClientCertificate1");
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 ["SomeName"] = DatabaseAccess.ReadWrite
             }, certificateName: certificateName);
@@ -549,7 +568,7 @@ namespace SlowTests.Authentication
             const string certificateName = "ClientCertificate";
 
             var certificates = SetupServerAuthentication(Certificates);
-            var serverCert = certificates.ServerCertificate.Value;
+            var serverCert = certificates.ServerCertificateForCommunication.Value;
             var permissions = new Dictionary<string, DatabaseAccess>();
 
             var adminCert = Certificates.RegisterClientCertificate(serverCert, certificates.ClientCertificate1.Value, permissions, SecurityClearance.ClusterAdmin, certificateName: certificateName);
@@ -590,13 +609,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CanGetDocWith_Read_Permission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanGetDocWith_Read_Permission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.Read
             });
@@ -636,13 +657,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CannotPutDocWith_Read_Permission_MultiGet()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotPutDocWith_Read_Permission_MultiGet(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.Read
             });
@@ -681,13 +704,15 @@ namespace SlowTests.Authentication
             }
         }
 
-        [Fact]
-        public void CannotPutDocWith_Read_Permission()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CannotPutDocWith_Read_Permission(bool with2Eku)
         {
-            var certificates = SetupServerAuthentication(Certificates);
+            var certificates = SetupServerAuthentication(Certificates, with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.Read
             });
@@ -704,7 +729,7 @@ namespace SlowTests.Authentication
             }
         }
 
-        internal static TestCertificatesHolder SetupServerAuthentication(CertificatesTestBase certificatesBase, Dictionary<string, string> customSettings = null, string serverUrl = null, TestCertificatesHolder certificates = null)
+        internal static TestCertificatesHolder SetupServerAuthentication(CertificatesTestBase certificatesBase, Dictionary<string, string> customSettings = null, string serverUrl = null, TestCertificatesHolder certificates = null, bool with2Eku = true)
         {
             customSettings ??= new Dictionary<string, string>();
 
@@ -712,7 +737,7 @@ namespace SlowTests.Authentication
             customSettings[RavenConfiguration.GetKey(x => x.Licensing.CanForceUpdate)] = "false";
             customSettings[RavenConfiguration.GetKey(x => x.Licensing.CanRenew)] = "false";
 
-            return certificatesBase.SetupServerAuthentication(customSettings, serverUrl, certificates);
+            return certificatesBase.SetupServerAuthentication(customSettings, serverUrl, certificates, with2Eku: with2Eku);
         }
 
         private static void StoreSampleDoc(DocumentStore store, string docName)

--- a/test/SlowTests/Authentication/AuthenticationChangesTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationChangesTests.cs
@@ -6,6 +6,7 @@ using FastTests;
 using Raven.Client.Documents.Changes;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,13 +18,15 @@ namespace SlowTests.Authentication
         {
         }
 
-        [Fact]
-        public async Task ChangesWithAuthentication()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ChangesWithAuthentication(bool with2Eku)
         {
-            var certificates = Certificates.SetupServerAuthentication();
+            var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
             var dbName = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -128,10 +128,10 @@ namespace SlowTests.Authentication
             SecurityClearance securityClearance, string[] shouldContain)
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(),
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(),
                 SecurityClearance.ClusterAdmin);
 
-            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, databaseAccesses, securityClearance);
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, databaseAccesses, securityClearance);
 
             using var store = GetDocumentStore(new Options { AdminCertificate = adminCert, ClientCertificate = userCert, ModifyDatabaseName = s => dbName });
             var requestExecutor = store.GetRequestExecutor(store.Database);
@@ -177,10 +177,10 @@ namespace SlowTests.Authentication
             DoNotReuseServer();
             var databaseName = GetDatabaseName();
             var certs = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certs.ServerCertificate.Value, certs.ClientCertificate1.Value,
+            var adminCert = Certificates.RegisterClientCertificate(certs.ServerCertificateForCommunication.Value, certs.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(),
                 SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certs.ServerCertificate.Value, certs.ClientCertificate2.Value,
+            var userCert = Certificates.RegisterClientCertificate(certs.ServerCertificateForCommunication.Value, certs.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>() { [databaseName] = DatabaseAccess.ReadWrite }, SecurityClearance.Operator);
 
             using (var store = GetDocumentStore(new Options() { ClientCertificate = userCert, AdminCertificate = adminCert, ModifyDatabaseName = _ => databaseName }))
@@ -210,10 +210,10 @@ namespace SlowTests.Authentication
             DoNotReuseServer();
             var databaseName = GetDatabaseName();
             var certs = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certs.ServerCertificate.Value, certs.ClientCertificate1.Value,
+            var adminCert = Certificates.RegisterClientCertificate(certs.ServerCertificateForCommunication.Value, certs.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(),
                 SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certs.ServerCertificate.Value, certs.ClientCertificate2.Value,
+            var userCert = Certificates.RegisterClientCertificate(certs.ServerCertificateForCommunication.Value, certs.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>() { [databaseName] = DatabaseAccess.ReadWrite }, SecurityClearance.ValidUser);
 
             using (var store = GetDocumentStore(new Options()
@@ -242,9 +242,9 @@ namespace SlowTests.Authentication
             DoNotReuseServer();
             var databaseName = GetDatabaseName();
             var certs = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certs.ServerCertificate.Value, certs.ClientCertificate1.Value,
+            var adminCert = Certificates.RegisterClientCertificate(certs.ServerCertificateForCommunication.Value, certs.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var userCert = Certificates.RegisterClientCertificate(certs.ServerCertificate.Value, certs.ClientCertificate2.Value,
+            var userCert = Certificates.RegisterClientCertificate(certs.ServerCertificateForCommunication.Value, certs.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>() { [databaseName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
 
             using (var store = GetDocumentStore(new Options()

--- a/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
@@ -35,8 +35,8 @@ namespace SlowTests.Authentication
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbName,
                 ModifyDatabaseRecord = record => {
                     record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = configuration.SearchEngine.ToString();

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -32,6 +32,7 @@ using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.ServerWide.Context;
 using Raven.Client.Exceptions;
 using Raven.Client.Json;
+using Raven.Server.ServerWide;
 
 namespace SlowTests.Authentication
 {
@@ -41,7 +42,7 @@ namespace SlowTests.Authentication
         {
         }
         
-        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000, Skip = "RavenDB-23795")]
+        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanGetPebbleCertificate()
         {
             var acmeUrl = Environment.GetEnvironmentVariable("RAVEN_PEBBLE_URL") ?? string.Empty;
@@ -57,20 +58,22 @@ namespace SlowTests.Authentication
             Server.Dispose();
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
-        public async Task CanGetLetsEncryptCertificateAndRenewIt()
+        [RetryTheory(delayBetweenRetriesMs: 1000)]
+        [InlineData(null)]
+        [InlineData("tlsserver")]
+        public async Task CanGetLetsEncryptCertificateAndRenewIt(string acmeProfile)
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
             
             SetupLocalServer();
-            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl, acmeProfile);
             // this is needed because we simulate running server inside GetCertificateFromLetsEncrypt
             Server.ForTestingPurposesOnly().OnSimulateRunningServerFinally = port =>
             {
                 setupInfo.Sockets[0] = ReservePort(port).Socket;
             };
             Server._forTestingPurposes.ReservedSockets = new List<Socket> { setupInfo.Sockets[0], setupInfo.Sockets[1] };
-            var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
+            var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl, acmeProfile);
             var firstServerCertThumbprint = serverCert.Thumbprint;
             Server.Dispose();
 
@@ -87,24 +90,28 @@ namespace SlowTests.Authentication
             }
         }
 
-        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000, Skip = "RavenDB-23795")]
+        [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanGetLetsEncryptCertificateAndRenewAfterFailurePebble()
         {
             var acmeUrl = Environment.GetEnvironmentVariable("RAVEN_PEBBLE_URL") ?? string.Empty;
             Assert.NotEmpty(acmeUrl);
 
-            await CanGetLetsEncryptCertificateAndRenewAfterFailure(acmeUrl);
+            await CanGetLetsEncryptCertificateAndRenewAfterFailure_Act(acmeUrl);
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
-        public async Task CanGetLetsEncryptCertificateAndRenewAfterFailure()
+        [RetryTheory(delayBetweenRetriesMs: 1000)]
+        [InlineData(null)]
+        [InlineData("tlsserver")]
+        public async Task CanGetLetsEncryptCertificateAndRenewAfterFailure(string acmeProfile)
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
-            await CanGetLetsEncryptCertificateAndRenewAfterFailure(acmeUrl);
+            await CanGetLetsEncryptCertificateAndRenewAfterFailure_Act(acmeUrl, acmeProfile);
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
-        public async Task ReplaceCertificateWithPrivateKey()
+        [RetryTheory(delayBetweenRetriesMs: 1000)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReplaceCertificateWithPrivateKey(bool with2Eku)
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
             
@@ -122,10 +129,11 @@ namespace SlowTests.Authentication
             var mre = new AsyncManualResetEvent();
             Server.ServerCertificateChanged += (sender, args) => mre.Set();
 
-            var ct = Certificates.GenerateAndSaveSelfSignedCertificate();
-            var first = Server.Certificate.Certificate.Thumbprint;
+            var ct = Certificates.GenerateAndSaveSelfSignedCertificate(with2Eku);
+            var first = Server.Certificate.ServerCertificate.Thumbprint;
+            var certForCommunication = Server.Certificate.ClientCertificate;
 
-            using (var store = GetDocumentStore(new Options { AdminCertificate = serverCert, ClientCertificate = serverCert }))
+            using (var store = GetDocumentStore(new Options { AdminCertificate = certForCommunication, ClientCertificate = certForCommunication }))
             {
                 var bytesWithoutPrivateKey = ct.ServerCertificate.Value.RawData;
                 var op = new ReplaceClusterCertificateOperation(bytesWithoutPrivateKey, replaceImmediately: true);
@@ -138,18 +146,19 @@ namespace SlowTests.Authentication
             }
 
             await mre.WaitAsync(TimeSpan.FromSeconds(15));
-            Assert.NotEqual(first, Server.Certificate.Certificate.Thumbprint);
+            Assert.NotEqual(first, Server.Certificate.ServerCertificate.Thumbprint);
         }
 
-        [RavenFact(RavenTestCategory.Certificates)]
-        public async Task ReplaceCertificateWithPassword()
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReplaceCertificateWithPassword(bool with2Eku)
         {
             const string password = "mysecretpassword";
 
-            var (_, leader, certificates) = await CreateRaftClusterWithSsl(1);
+            var (_, leader, certificates) = await CreateRaftClusterWithSsl(1, with2Eku: with2Eku);
 
-            X509Certificate2 certificateWithPassword;
-            using (var store = GetDocumentStore(new Options { Server = leader, CreateDatabase = false, ClientCertificate = certificates.ServerCertificate.Value }))
+            using (var store = GetDocumentStore(new Options { Server = leader, CreateDatabase = false, ClientCertificate = certificates.ServerCertificateForCommunication.Value }))
             {
                 var rawData = certificates.ServerCertificate.Value.Export(X509ContentType.Pkcs12, password);
                 var certificateDefinition = new CertificateDefinition { Certificate = Convert.ToBase64String(rawData), Password = password };
@@ -164,11 +173,9 @@ namespace SlowTests.Authentication
                     if (response.IsSuccessStatusCode == false)
                         Assert.Fail(await response.Content.ReadAsStringAsync());
                 }
-
-                certificateWithPassword = CertificateLoaderUtil.CreateCertificate(rawData, password);
             }
 
-            using (var store = GetDocumentStore(new Options { Server = leader, CreateDatabase = true, ClientCertificate = certificateWithPassword }))
+            using (var store = GetDocumentStore(new Options { Server = leader, CreateDatabase = true, ClientCertificate = certificates.ServerCertificateForCommunication.Value }))
             {
                 using (var session = store.OpenAsyncSession())
                 {
@@ -178,18 +185,18 @@ namespace SlowTests.Authentication
             }
         }
 
-        private async Task CanGetLetsEncryptCertificateAndRenewAfterFailure(string acmeUrl)
+        private async Task CanGetLetsEncryptCertificateAndRenewAfterFailure_Act(string acmeUrl, string acmeProfile = null)
         {
             RemoveAcmeCache(acmeUrl);
 
             SetupLocalServer();
-            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+            TestingSetupInfo setupInfo = await SetupClusterInfo(acmeUrl, acmeProfile);
             Server.ForTestingPurposesOnly().OnSimulateRunningServerFinally = port =>
             {
                 setupInfo.Sockets[0] = ReservePort(port).Socket;
             };
             Server._forTestingPurposes.ReservedSockets = new List<Socket> { setupInfo.Sockets[0], setupInfo.Sockets[1] };
-            var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
+            var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl, acmeProfile);
             var firstServerCertThumbprint = serverCert.Thumbprint;
             Server.Dispose();
 
@@ -223,7 +230,7 @@ namespace SlowTests.Authentication
             UseNewLocalServer(customConfigPath: settingPath);
         }
 
-        private async Task<X509Certificate2> GetCertificateFromLetsEncrypt(TestingSetupInfo info, string acmeUrl)
+        private async Task<X509Certificate2> GetCertificateFromLetsEncrypt(TestingSetupInfo info, string acmeUrl, string acmeProfile = null)
         {
             X509Certificate2 serverCert;
             using (var store = GetDocumentStoreForServerOnly())
@@ -277,7 +284,8 @@ namespace SlowTests.Authentication
                     [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl,
                     [RavenConfiguration.GetKey(x => x.Core.SetupMode)] = setupMode.ToString(),
                     [RavenConfiguration.GetKey(x => x.Core.ExternalIp)] = externalIp,
-                    [RavenConfiguration.GetKey(x => x.Core.AcmeUrl)] = acmeUrl
+                    [RavenConfiguration.GetKey(x => x.Core.AcmeUrl)] = acmeUrl,
+                    [RavenConfiguration.GetKey(x => x.Core.AcmeProfile)] = acmeProfile
                 };
 
                 DoNotReuseServer(customSettings);
@@ -292,12 +300,16 @@ namespace SlowTests.Authentication
             // It only works because in the TestBase ctor we do:
             // RequestExecutor.ServerCertificateCustomValidationCallback += (msg, cert, chain, errors) => true;
 
-            using (var store = GetDocumentStoreForServerOnly(serverCert))
+            var serverCertificateForCommunication = SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(serverCert)
+                ? serverCert
+                : CertificateUtils.CreateClientCertificateFromServerCertificate(serverCert, out _);
+
+            using (var store = GetDocumentStoreForServerOnly(serverCertificateForCommunication))
             using (var commands = store.Commands())
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 await Server.ServerStore.EnsureNotPassiveAsync();
-                Assert.Equal(firstServerCertThumbprint, Server.Certificate.Certificate.Thumbprint);
+                Assert.Equal(firstServerCertThumbprint, Server.Certificate.ServerCertificate.Thumbprint);
 
                 Server.Time.UtcDateTime = () => DateTime.UtcNow.AddDays(80);
 
@@ -328,7 +340,7 @@ namespace SlowTests.Authentication
 
                 Assert.True(result, "Refresh task didn't complete. Waited too long for the cluster cert to be replaced");
 
-                Assert.NotEqual(firstServerCertThumbprint, Server.Certificate.Certificate.Thumbprint);
+                Assert.NotEqual(firstServerCertThumbprint, Server.Certificate.ServerCertificate.Thumbprint);
 
                 var r = await clusterReplacementConfirmed.WaitAsync(TimeSpan.FromMinutes(2));
                 Assert.True(r, "missing ConfirmServerCertificateReplacedCommand");
@@ -341,10 +353,12 @@ namespace SlowTests.Authentication
             public List<Socket> Sockets;
         }
 
-        private async Task<TestingSetupInfo> SetupClusterInfo(string acmeUrl)
+        private async Task<TestingSetupInfo> SetupClusterInfo(string acmeUrl, string profile = null)
         {
             Server.Configuration.Core.AcmeUrl = acmeUrl;
             Server.ServerStore.Configuration.Core.SetupMode = SetupMode.Initial;
+            if (string.IsNullOrEmpty(profile) == false)
+                Server.Configuration.Core.AcmeProfile = profile;
 
             var domain = "RavenClusterTest" + Environment.MachineName.Replace("-", "");
             string email;

--- a/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Client.Attachments
             {
                 var result = await Encryption.EncryptedServerAsync();
                 dbName = result.DatabaseName;
-                adminCert = result.Certificates.ServerCertificate.Value;
+                adminCert = result.Certificates.ServerCertificateForCommunication.Value;
             }
             else
             {
@@ -87,7 +87,7 @@ namespace SlowTests.Client.Attachments
             {
                 var result = await Encryption.EncryptedServerAsync();
                 dbName = result.DatabaseName;
-                adminCert = result.Certificates.ServerCertificate.Value;
+                adminCert = result.Certificates.ServerCertificateForCommunication.Value;
             }
             else
             {

--- a/test/SlowTests/Client/Subscriptions/CriteriaScript.cs
+++ b/test/SlowTests/Client/Subscriptions/CriteriaScript.cs
@@ -24,18 +24,19 @@ namespace SlowTests.Client.Subscriptions
         private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromSeconds(60 * 10) : TimeSpan.FromSeconds(30);
 
         [RavenTheory(RavenTestCategory.Subscriptions)]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task BasicCriteriaTest(bool useSsl)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task BasicCriteriaTest(bool useSsl, bool with2Eku)
         {
             string dbName = GetDatabaseName();
             X509Certificate2 clientCertificate = null;
             X509Certificate2 adminCertificate = null;
             if (useSsl)
             {
-                var certificates = Certificates.SetupServerAuthentication();
-                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+                var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
+                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
                 {
                     [dbName] = DatabaseAccess.ReadWrite
                 });
@@ -85,18 +86,19 @@ namespace SlowTests.Client.Subscriptions
         }
 
         [RavenTheory(RavenTestCategory.Subscriptions)]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task CriteriaScriptWithTransformation(bool useSsl)
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task CriteriaScriptWithTransformation(bool useSsl, bool with2Eku)
         {
             string dbName = GetDatabaseName();
             X509Certificate2 clientCertificate = null;
             X509Certificate2 adminCertificate = null;
             if (useSsl)
             {
-                var certificates = Certificates.SetupServerAuthentication();
-                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+                var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
+                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
                 {
                     [dbName] = DatabaseAccess.ReadWrite,
                 });

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -358,7 +358,7 @@ exit 0";
             var secrets = Server.ServerStore.Secrets;
             var serverMasterKey = (Lazy<byte[]>)typeof(SecretProtection).GetField("_serverMasterKey", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(secrets);
             Assert.True(serverMasterKey.Value.SequenceEqual(buffer));
-            Assert.True(Server.Certificate.Certificate.Equals(serverCertificate));
+            Assert.True(Server.IsServerCertificate(serverCertificate));
         }
 
         [RavenFact(RavenTestCategory.Certificates)]

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                 Server = leader,
                 ReplicationFactor = 2,
                 ClientCertificate = certificates.ClientCertificate1.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = _ => databaseName,
                 Encrypted = true,
                 RunInMemory = false
@@ -80,7 +80,7 @@ namespace SlowTests.Issues
                 Server = leader,
                 ReplicationFactor = 2,
                 ClientCertificate = certificates.ClientCertificate1.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = _ => databaseName,
                 Encrypted = true,
                 RunInMemory = false
@@ -146,7 +146,7 @@ namespace SlowTests.Issues
                 Server = leader,
                 ReplicationFactor = 2,
                 ClientCertificate = certificates.ClientCertificate1.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = _ => databaseName,
                 Encrypted = true
             };
@@ -196,8 +196,8 @@ namespace SlowTests.Issues
             var options = new Options
             {
                 ModifyDatabaseName = _ => result.DatabaseName,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 Encrypted = true
             };
 
@@ -231,7 +231,7 @@ namespace SlowTests.Issues
                 Server = server,
                 ReplicationFactor = 3,
                 Encrypted = true,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ClientCertificate = certificates.ClientCertificate1.Value,
                 ModifyDatabaseName = _ => databaseName
             };
@@ -270,15 +270,15 @@ namespace SlowTests.Issues
             var databaseName = GetDatabaseName();
             foreach (var node in nodes)
             {
-                Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, userCert, new Dictionary<string, DatabaseAccess>() { [databaseName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser, node);
-                Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, adminClusterCert, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, node);
+                Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, userCert, new Dictionary<string, DatabaseAccess>() { [databaseName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser, node);
+                Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, adminClusterCert, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, node);
             }
 
             using (var store = GetDocumentStore(new Options
             {
                 Server = leader,
                 ReplicationFactor = 3,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ClientCertificate = userCert,
                 ModifyDatabaseName = _ => databaseName,
                 DeleteDatabaseOnDispose = false

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -44,13 +44,13 @@ namespace SlowTests.Issues
             var certificates = Certificates.SetupServerAuthentication();
             using var hooper = GetDocumentStore(new Options
             {
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value
             });
             using var bert = GetDocumentStore(new Options
             {
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value
             });
 
             using (var s = hooper.OpenAsyncSession())
@@ -170,7 +170,7 @@ namespace SlowTests.Issues
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -200,7 +200,7 @@ namespace SlowTests.Issues
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -244,7 +244,7 @@ namespace SlowTests.Issues
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -303,7 +303,7 @@ namespace SlowTests.Issues
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
             var dbNameB = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -456,7 +456,7 @@ namespace SlowTests.Issues
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
             var dbNameB = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -607,7 +607,7 @@ namespace SlowTests.Issues
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
             var dbNameB = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -727,7 +727,7 @@ namespace SlowTests.Issues
         public async Task PickupConfigurationChangesOnTheFly()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var hubStore = GetDocumentStore(new Options
@@ -806,7 +806,7 @@ namespace SlowTests.Issues
         public async Task Sinks_should_not_update_hubs_change_vector()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var hubStore = GetDocumentStore(new Options
@@ -954,7 +954,7 @@ namespace SlowTests.Issues
         public async Task Sinks_should_not_update_hubs_change_vector2()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var hubStore = GetDocumentStore(new Options
@@ -1119,7 +1119,7 @@ namespace SlowTests.Issues
         public async Task Sinks_should_not_update_hubs_change_vector3()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var hubStore = GetDocumentStore(new Options
@@ -1363,7 +1363,7 @@ namespace SlowTests.Issues
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
             var dbNameB = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -1434,7 +1434,7 @@ namespace SlowTests.Issues
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -1469,7 +1469,7 @@ namespace SlowTests.Issues
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbNameA = GetDatabaseName();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var storeA = GetDocumentStore(new Options
@@ -1509,16 +1509,16 @@ namespace SlowTests.Issues
             {
                 Server = hubLeader,
                 ReplicationFactor = 2,
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameA,
                 CreateDatabase = true
             });
 
             using var sink = GetDocumentStore(new Options
             {
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameB
             });
 
@@ -1632,16 +1632,16 @@ namespace SlowTests.Issues
             {
                 Server = hubLeader,
                 ReplicationFactor = 2,
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameA,
                 CreateDatabase = true
             });
 
             using var sink = GetDocumentStore(new Options
             {
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameB
             });
 
@@ -1699,7 +1699,7 @@ namespace SlowTests.Issues
 
             Assert.True(await WaitForDocumentInClusterAsync<User>
                 (hubNodes, dbNameA, usersDocId1, u => u.Name == "Grisha", 
-                    timeout: TimeSpan.FromSeconds(30), certificate: hubCertificates.ServerCertificate.Value));
+                    timeout: TimeSpan.FromSeconds(30), certificate: hubCertificates.ServerCertificateForCommunication.Value));
 
             const int age = 38;
             using (var session = hub.OpenAsyncSession())
@@ -1778,16 +1778,16 @@ namespace SlowTests.Issues
             {
                 Server = hubLeader,
                 ReplicationFactor = 2,
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameA,
                 CreateDatabase = true
             });
 
             using var sink = GetDocumentStore(new Options
             {
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameB
             });
 
@@ -1901,16 +1901,16 @@ namespace SlowTests.Issues
             {
                 Server = hubLeader,
                 ReplicationFactor = 2,
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameA,
                 CreateDatabase = true
             });
 
             using var sink = GetDocumentStore(new Options
             {
-                AdminCertificate = hubCertificates.ServerCertificate.Value,
-                ClientCertificate = hubCertificates.ServerCertificate.Value,
+                AdminCertificate = hubCertificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = hubCertificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbNameB
             });
 

--- a/test/SlowTests/Issues/RDBCL_772.cs
+++ b/test/SlowTests/Issues/RDBCL_772.cs
@@ -25,8 +25,8 @@ namespace SlowTests.Issues
             };
 
             var certificates = Certificates.SetupServerAuthentication(customSettings: customSettings);
-            var adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            var clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            var adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
             {
                 [dbName] = DatabaseAccess.ReadWrite
             });

--- a/test/SlowTests/Issues/RavenDB-15807.cs
+++ b/test/SlowTests/Issues/RavenDB-15807.cs
@@ -13,6 +13,7 @@ using Raven.Client;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,17 +25,19 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
-        public async Task ChangeCertificateTypeInPullReplication()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ChangeCertificateTypeInPullReplication(bool with2Eku)
         {
             var hubSettings = new ConcurrentDictionary<string, string>();
             var sinkSettings = new ConcurrentDictionary<string, string>();
 
             var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate();
-            Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates);
+            Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates, with2Eku: with2Eku);
 
             var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate();
-            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates);
+            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates, with2Eku: with2Eku);
 
             var hubDB = GetDatabaseName();
             var sinkDB = GetDatabaseName();
@@ -48,13 +51,13 @@ namespace SlowTests.Issues
 
             using (var hubStore = GetDocumentStore(new Options
             {
-                ClientCertificate = sinkCerts.ServerCertificate.Value,
+                ClientCertificate = sinkCerts.ServerCertificateForCommunication.Value,
                 Server = hubServer,
                 ModifyDatabaseName = _ => hubDB
             }))
             using (var sinkStore = GetDocumentStore(new Options
             {
-                ClientCertificate = sinkCerts.ServerCertificate.Value,
+                ClientCertificate = sinkCerts.ServerCertificateForCommunication.Value,
                 Server = sinkServer,
                 ModifyDatabaseName = _ => sinkDB
             }))

--- a/test/SlowTests/Issues/RavenDB-16958.cs
+++ b/test/SlowTests/Issues/RavenDB-16958.cs
@@ -62,8 +62,8 @@ namespace SlowTests.Issues
             {
                 var database = GetDatabaseName();
 
-                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.Certificate, Database = database }.Initialize())
-                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.Certificate, Database = database }.Initialize())
+                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.ClientCertificate, Database = database }.Initialize())
+                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.ClientCertificate, Database = database }.Initialize())
                 {
                     storeB.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
                     storeA.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
@@ -109,8 +109,8 @@ namespace SlowTests.Issues
             {
                 var database = GetDatabaseName();
 
-                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.Certificate, Database = database }.Initialize())
-                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.Certificate, Database = database }.Initialize())
+                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.ClientCertificate, Database = database }.Initialize())
+                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.ClientCertificate, Database = database }.Initialize())
                 {
                     storeB.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
                     storeA.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
@@ -158,9 +158,9 @@ namespace SlowTests.Issues
                 var databaseB = GetDatabaseName("DB_B");
                 var databaseC = GetDatabaseName("DB_C");
 
-                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.Certificate, Database = databaseB }.Initialize())
-                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.Certificate, Database = databaseA }.Initialize())
-                using (var storeC = new DocumentStore { Urls = new[] { serverC.WebUrl }, Certificate = serverC.Certificate.Certificate, Database = databaseC }.Initialize())
+                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.ClientCertificate, Database = databaseB }.Initialize())
+                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.ClientCertificate, Database = databaseA }.Initialize())
+                using (var storeC = new DocumentStore { Urls = new[] { serverC.WebUrl }, Certificate = serverC.Certificate.ClientCertificate, Database = databaseC }.Initialize())
                 {
                     storeB.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseB)));
                     storeA.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseA)));
@@ -190,9 +190,9 @@ namespace SlowTests.Issues
             {
                 var database = GetDatabaseName();
 
-                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.Certificate, Database = database }.Initialize())
-                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.Certificate, Database = database }.Initialize())
-                using (var storeC = new DocumentStore { Urls = new[] { serverC.WebUrl }, Certificate = serverC.Certificate.Certificate, Database = database }.Initialize())
+                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.ClientCertificate, Database = database }.Initialize())
+                using (var storeA = new DocumentStore { Urls = new[] { serverA.WebUrl }, Certificate = serverA.Certificate.ClientCertificate, Database = database }.Initialize())
+                using (var storeC = new DocumentStore { Urls = new[] { serverC.WebUrl }, Certificate = serverC.Certificate.ClientCertificate, Database = database }.Initialize())
                 {
                     storeB.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
                     storeA.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
@@ -221,7 +221,7 @@ namespace SlowTests.Issues
             var cluster = await CreateRaftClusterWithSsl(1, watcherCluster: true);
             var serverB = CreateSecuredServer(cluster.Leader.ServerStore.GetNodeTcpServerUrl(), uniqueCerts: false);
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(cluster.Leader.WebUrl, cluster.Leader.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(cluster.Leader.WebUrl, cluster.Leader.Certificate.ClientCertificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
             {
                 string database = GetDatabaseName();
@@ -229,12 +229,12 @@ namespace SlowTests.Issues
                 await requestExecutor.ExecuteAsync(new AddClusterNodeCommand(serverB.WebUrl, serverB.ServerStore.NodeTag), ctx);
 
                 using (var leaderStore =
-                    new DocumentStore { Urls = new[] { cluster.Leader.WebUrl }, Certificate = cluster.Leader.Certificate.Certificate, Database = database }.Initialize())
+                    new DocumentStore { Urls = new[] { cluster.Leader.WebUrl }, Certificate = cluster.Leader.Certificate.ClientCertificate, Database = database }.Initialize())
                 {
                     var res = leaderStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(database)));
                 }
 
-                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.Certificate, Database = database }.Initialize())
+                using (var storeB = new DocumentStore { Urls = new[] { serverB.WebUrl }, Certificate = serverB.Certificate.ClientCertificate, Database = database }.Initialize())
                 {
                     var name = await WaitForValueAsync(() =>
                     {
@@ -252,7 +252,7 @@ namespace SlowTests.Issues
             using (var serverA = CreateSecuredServer())
             using (var serverB = CreateSecuredServer(serverA.ServerStore.GetNodeTcpServerUrl(), false))
             {
-                using (var handler = DefaultRavenHttpClientFactory.CreateHttpMessageHandler(serverA.Certificate.Certificate, true, true))
+                using (var handler = DefaultRavenHttpClientFactory.CreateHttpMessageHandler(serverA.Certificate.ClientCertificate, true, true))
                 using (var client = new HttpClient(handler))
                 {
                     var url = $"{serverA.WebUrl}/admin/debug/node/ping?url={Uri.EscapeDataString(serverB.WebUrl)}";

--- a/test/SlowTests/Issues/RavenDB-18515.cs
+++ b/test/SlowTests/Issues/RavenDB-18515.cs
@@ -40,8 +40,8 @@ namespace SlowTests.Issues
                 Server = hubMentorNode,
                 ReplicationFactor = 1,
                 ModifyDatabaseName = (name) => hubDatabaseName,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseRecord = r =>
                 {
                     r.Topology = new DatabaseTopology();
@@ -54,8 +54,8 @@ namespace SlowTests.Issues
                 Server = leader,
                 ModifyDatabaseName = (name) => sinkDatabaseName,
                 ReplicationFactor = 3,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
             });
 
             var saveResult = await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition

--- a/test/SlowTests/Issues/RavenDB-19101.cs
+++ b/test/SlowTests/Issues/RavenDB-19101.cs
@@ -48,10 +48,12 @@ public class RavenDB_19101: RavenTestBase
         public override bool IsReadRequest => true;
      }
 
-    [Fact]
-    public void CheckIfCertificateNameIsReturned()
+    [RavenTheory(RavenTestCategory.Certificates)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CheckIfCertificateNameIsReturned(bool with2Eku)
     {
-        var certificates = Certificates.SetupServerAuthentication();
+        var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
         var dbName = GetDatabaseName();
         var adminCert = Certificates.RegisterClientCertificate(certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 

--- a/test/SlowTests/Issues/RavenDB-19951.cs
+++ b/test/SlowTests/Issues/RavenDB-19951.cs
@@ -22,10 +22,12 @@ public class RavenDB_19951 : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task CanSetupTOTPWithoutLimits()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanSetupTOTPWithoutLimits(bool wiht2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(wiht2Eku, out DocumentStore store);
         string key = TwoFactorAuthentication.GenerateSecret();
         await store.Maintenance.Server.SendAsync(
             new PutClientCertificateOperation("test",
@@ -52,18 +54,20 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
 
-    private TestCertificatesHolder WithStore(out DocumentStore store)
+    private TestCertificatesHolder WithStore(bool with2Eku, out DocumentStore store)
     {
-        var certificates = Certificates.SetupServerAuthentication();
-        store = GetDocumentStore(new Options {ClientCertificate = certificates.ServerCertificate.Value});
+        var certificates = Certificates.SetupServerAuthentication(with2Eku: with2Eku);
+        store = GetDocumentStore(new Options {ClientCertificate = certificates.ServerCertificateForCommunication.Value});
         Assert.NotNull(store.Certificate);
         return certificates;
     }
 
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task CanSetupTOTPWithLimits()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanSetupTOTPWithLimits(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         await store.Maintenance.Server.SendAsync(
@@ -92,10 +96,12 @@ public class RavenDB_19951 : RavenTestBase
     }
     
     
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task CannotAccessServerAfterLogout()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CannotAccessServerAfterLogout(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         store.Maintenance.Server.Send(
@@ -131,10 +137,12 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task NewOtpOverridesOld()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task NewOtpOverridesOld(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         
@@ -164,10 +172,12 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task Disable2FAWorksProperly()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Disable2FAWorksProperly(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         
@@ -182,10 +192,12 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task DoNotOutputAuthenticationKeyInCertificatesResponse()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task DoNotOutputAuthenticationKeyInCertificatesResponse(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         
@@ -214,10 +226,12 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task CantAccessWhenCodeIsInvalid()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CantAccessWhenCodeIsInvalid(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         
@@ -239,10 +253,12 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Security)]
-    public async Task EditCertificateDoesntOverrideTwoFactorConfig()
+    [RavenTheory(RavenTestCategory.Security)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EditCertificateDoesntOverrideTwoFactorConfig(bool with2Eku)
     {
-        TestCertificatesHolder certificates = WithStore(out DocumentStore store);
+        TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
         
@@ -273,7 +289,7 @@ public class RavenDB_19951 : RavenTestBase
     public async Task CanAccessWhoAmIWithBadCertificate()
     {
         var certificates = Certificates.SetupServerAuthentication();
-        var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+        var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
         var userCert = certificates.ClientCertificate2.Value;
 
         using (var store = GetDocumentStore(new Options

--- a/test/SlowTests/Issues/RavenDB-21535.cs
+++ b/test/SlowTests/Issues/RavenDB-21535.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Issues
             var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
 
             var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
-            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, LocalDomainName, 1, clientKeyPair, []);
+            var client = CertificateGenerator.GenerateSignedClientServerCertificate(ca, caKeyPair, LocalDomainName, 1, clientKeyPair, []);
 
             var server = GetNewServer(new ServerCreationOptions
                 {
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
             var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
 
             var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
-            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [san]);
+            var client = CertificateGenerator.GenerateSignedClientServerCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [san]);
 
             var server = GetNewServer(new ServerCreationOptions
                 {
@@ -84,7 +84,7 @@ namespace SlowTests.Issues
             var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
 
             var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
-            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [san]);
+            var client = CertificateGenerator.GenerateSignedClientServerCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [san]);
 
             var server = GetNewServer(new ServerCreationOptions
                 {
@@ -109,7 +109,7 @@ namespace SlowTests.Issues
             var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
 
             var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
-            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [LocalDomainName]);
+            var client = CertificateGenerator.GenerateSignedClientServerCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [LocalDomainName]);
 
             var server = GetNewServer(new ServerCreationOptions
                 {

--- a/test/SlowTests/Issues/RavenDB-22210.cs
+++ b/test/SlowTests/Issues/RavenDB-22210.cs
@@ -129,9 +129,9 @@ public class RavenDB_22210 : RavenTestBase
         var intermediate2 = CertificateGenerator.GenerateIntermediateCACertificate(ca, caKp, $"{IntermediateName}-{suffix}-2", 2, intermediate2Kp);
 
         var clientKp = CertificateGenerator.GenerateRSAKeyPair();
-        var client = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, $"{ClientName}-{suffix}", 1, clientKp);
+        var client = CertificateGenerator.GenerateSignedClientServerCertificate(intermediate, intermediateKp, $"{ClientName}-{suffix}", 1, clientKp);
 
-        var client2 = CertificateGenerator.GenerateSignedClientCertificate(intermediate2, intermediate2Kp, $"{ClientRenewedName}-{suffix}", 1, clientKp);
+        var client2 = CertificateGenerator.GenerateSignedClientServerCertificate(intermediate2, intermediate2Kp, $"{ClientRenewedName}-{suffix}", 1, clientKp);
 
         return (ca, intermediate, intermediate2, client, client2);
     }
@@ -154,9 +154,9 @@ public class RavenDB_22210 : RavenTestBase
         var intermediate2 = CertificateGenerator.GenerateIntermediateCACertificate(ca2, ca2Kp, $"{IntermediateName}-{suffix}-2", 2, intermediate2Kp);
 
         var clientKp = CertificateGenerator.GenerateRSAKeyPair();
-        var client = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, $"{ClientName}-{suffix}", 1, clientKp);
+        var client = CertificateGenerator.GenerateSignedClientServerCertificate(intermediate, intermediateKp, $"{ClientName}-{suffix}", 1, clientKp);
 
-        var client2 = CertificateGenerator.GenerateSignedClientCertificate(intermediate2, intermediate2Kp, $"{ClientRenewedName}-{suffix}", 1, clientKp);
+        var client2 = CertificateGenerator.GenerateSignedClientServerCertificate(intermediate2, intermediate2Kp, $"{ClientRenewedName}-{suffix}", 1, clientKp);
 
         return (ca, ca2, intermediate, intermediate2, client, client2);
     }
@@ -171,8 +171,8 @@ public class RavenDB_22210 : RavenTestBase
         var intermediate = CertificateGenerator.GenerateIntermediateCACertificate(ca, caKp, $"{IntermediateName}-{suffix}", 2, intermediateKp);
 
         var clientKp = CertificateGenerator.GenerateRSAKeyPair();
-        var client = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, $"{ClientName}-{suffix}", 1, clientKp);
-        var client2 = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, $"{ClientRenewedName}-{suffix}", 1, clientKp);
+        var client = CertificateGenerator.GenerateSignedClientServerCertificate(intermediate, intermediateKp, $"{ClientName}-{suffix}", 1, clientKp);
+        var client2 = CertificateGenerator.GenerateSignedClientServerCertificate(intermediate, intermediateKp, $"{ClientRenewedName}-{suffix}", 1, clientKp);
 
         return (ca, intermediate, client, client2);
     }

--- a/test/SlowTests/Issues/RavenDB-8451.cs
+++ b/test/SlowTests/Issues/RavenDB-8451.cs
@@ -60,8 +60,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options()
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbName,
                 ModifyDatabaseRecord = record =>
                 {
@@ -98,8 +98,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options()
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
             }))
             {
                 var op = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions()

--- a/test/SlowTests/Issues/RavenDB_13972_encrypted.cs
+++ b/test/SlowTests/Issues/RavenDB_13972_encrypted.cs
@@ -29,8 +29,8 @@ namespace SlowTests.Issues
 
             using (var storeToExport = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
@@ -63,8 +63,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
@@ -87,8 +87,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
@@ -110,8 +110,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {

--- a/test/SlowTests/Issues/RavenDB_17006.cs
+++ b/test/SlowTests/Issues/RavenDB_17006.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
 
             RavenServer leader = result.Leader;
 
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificate.Value, result.Certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(result.Certificates.ServerCertificateForCommunication.Value, result.Certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: leader);
 
             var localNode = result.Nodes[0];
             var remoteNode = result.Nodes[1];
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
 
             using (var connection = new ProxyWebSocketConnection(null, remoteNodeUrl, $"/admin/cluster-dashboard/remote/watch?thumbprint={clientCertificate.Thumbprint}", localNode.ServerStore.ContextPool, localNode.ServerStore.ServerShutdown))
             {
-                await connection.Establish(Server.Certificate?.Certificate);
+                await connection.Establish(Server.Certificate?.ClientCertificate);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_17577.cs
+++ b/test/SlowTests/Issues/RavenDB_17577.cs
@@ -25,8 +25,8 @@ public class RavenDB_17577 : RavenTestBase
         });
 
         var dbName = GetDatabaseName();
-        var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-        var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+        var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+        var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
         {
             [dbName] = DatabaseAccess.ReadWrite
         }, SecurityClearance.ValidUser);

--- a/test/SlowTests/Issues/RavenDB_18496.cs
+++ b/test/SlowTests/Issues/RavenDB_18496.cs
@@ -24,11 +24,11 @@ namespace SlowTests.Issues
             using (var encryptedStore = GetDocumentStore(new Options
             {
                 ModifyDatabaseName = _ => result.DatabaseName,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 Encrypted = true
             }))
-            using (var store2 = GetDocumentStore(new Options { ClientCertificate = result.Certificates.ServerCertificate.Value }))
+            using (var store2 = GetDocumentStore(new Options { ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value }))
             {
                 var db = await Databases.GetDocumentDatabaseInstanceFor(encryptedStore);
                 var maxSizeToSend = new Size(16, SizeUnit.Kilobytes);

--- a/test/SlowTests/Issues/RavenDB_19948.cs
+++ b/test/SlowTests/Issues/RavenDB_19948.cs
@@ -37,9 +37,9 @@ namespace SlowTests.Issues
         {
             var dbName = GetDatabaseName();
             var certificates = Certificates.SetupServerAuthentication();
-            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value,
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate3.Value,
                 new Dictionary<string, DatabaseAccess>(), sc);
 
             var path = NewDataPath(forceCreateDir: true);
@@ -78,9 +78,9 @@ namespace SlowTests.Issues
         {
             var dbName = GetDatabaseName();
             var certificates = Certificates.SetupServerAuthentication();
-            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
 
             var path = NewDataPath(forceCreateDir: true);
@@ -128,9 +128,9 @@ namespace SlowTests.Issues
         {
             var dbName = GetDatabaseName();
             var certificates = Certificates.SetupServerAuthentication();
-            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>(), sc);
 
             var path = NewDataPath(forceCreateDir: true);
@@ -174,9 +174,9 @@ namespace SlowTests.Issues
         {
             var dbName = GetDatabaseName();
             var certificates = Certificates.SetupServerAuthentication();
-            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
 
             var path = NewDataPath(forceCreateDir: true);
@@ -225,9 +225,9 @@ namespace SlowTests.Issues
 
             var dbName = GetDatabaseName();
             TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
-            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>(), sc);
 
             var path = NewDataPath(forceCreateDir: true);
@@ -272,9 +272,9 @@ namespace SlowTests.Issues
 
             var dbName = GetDatabaseName();
             TestCertificatesHolder certificates = Certificates.SetupServerAuthentication();
-            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value,
+            X509Certificate2 adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value,
                 new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value,
+            X509Certificate2 clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value,
                 new Dictionary<string, DatabaseAccess>() { [dbName] = DatabaseAccess.Admin }, SecurityClearance.ValidUser);
 
             var path = NewDataPath(forceCreateDir: true);

--- a/test/SlowTests/Issues/RavenDB_22709.cs
+++ b/test/SlowTests/Issues/RavenDB_22709.cs
@@ -332,7 +332,7 @@ namespace SlowTests.Issues
 
         private X509Certificate2 RegisterClientCertificate((List<RavenServer> Nodes, RavenServer Leader, TestCertificatesHolder Certificates) cluster)
         {
-            return Certificates.RegisterClientCertificate(cluster.Certificates.ServerCertificate.Value, cluster.Certificates
+            return Certificates.RegisterClientCertificate(cluster.Certificates.ServerCertificateForCommunication.Value, cluster.Certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: cluster.Leader);
         }
 

--- a/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
@@ -327,7 +327,7 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
         const int clusterSize = 3;
 
         var (hubNodes, hubLeader, hubCertificatesHolder) = await CreateRaftClusterWithSsl(clusterSize, watcherCluster: true, shouldRunInMemory: true);
-        var adminHubClusterCert = hubCertificatesHolder.ServerCertificate.Value;
+        var adminHubClusterCert = hubCertificatesHolder.ServerCertificateForCommunication.Value;
         
         var mentorNodes = hubNodes.Where(s => s.ServerStore.NodeTag != hubLeader.ServerStore.NodeTag).ToList();
        
@@ -422,7 +422,7 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
         const int clusterSize = 3;
     
         var (hubNodes, hubLeader, hubCertificatesHolder) = await CreateRaftClusterWithSsl(clusterSize, watcherCluster: true, shouldRunInMemory: true);
-        var adminHubClusterCert = hubCertificatesHolder.ServerCertificate.Value;
+        var adminHubClusterCert = hubCertificatesHolder.ServerCertificateForCommunication.Value;
         
         var mentorNodes = hubNodes.Where(s => s.ServerStore.NodeTag != hubLeader.ServerStore.NodeTag).ToList();
        

--- a/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         {
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_db_key_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -33,8 +33,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -75,7 +75,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_db_key_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -83,8 +83,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -128,7 +128,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_new_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -136,8 +136,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -181,7 +181,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_db_key_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -189,8 +189,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -232,7 +232,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_db_key_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -240,8 +240,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -286,7 +286,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_new_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -294,8 +294,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -339,7 +339,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_unencrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -347,8 +347,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -387,7 +387,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_unencrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -395,8 +395,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -436,7 +436,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_encrypted_db_and_restore_to_encrypted_DB_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -445,8 +445,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -485,7 +485,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_encrypted_db_and_restore_to_encrypted_DB_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -493,8 +493,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -537,7 +537,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_encrypted_db__with_incremental_and_restore_to_encrypted_DB()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -548,8 +548,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             const string key2 = "users/2";
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -607,7 +607,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_not_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -653,7 +653,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_not_encrypted_db_and_restore_to_not_encrypted_DB_with_not_encrypted_backup_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -693,7 +693,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_not_encrypted_db_and_restore_to_not_encrypted_DB_with_not_encrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -739,7 +739,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task backup_unencrypted_db_and_encrypted_backup_fail_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -769,7 +769,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task can_backup_and_restore_encrypted()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -844,7 +844,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task can_backup_and_restore_sample_data_encrypted()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -925,7 +925,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public unsafe void failed_to_restore_backup_wrong_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -974,7 +974,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public void encryption_settings_validation()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1041,7 +1041,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_encrypted_db_with_new_key_fail()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1049,8 +1049,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -1083,7 +1083,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_unencrypted_db_and_encrypted_backup_fail_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1116,7 +1116,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_unencrypted_db_and_encrypted_backup_fail_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1148,7 +1148,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task snapshot_and_restore_unencrypted_db_and_unencrypted_backup_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1198,8 +1198,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -194,8 +194,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -329,8 +329,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -397,8 +397,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
             var s3Settings = GetS3Settings();
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true
             }))

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             DoNotReuseServer();
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanAddServerWideBackupToNewDatabase()
         {
             using (var store = GetDocumentStore())
@@ -50,7 +50,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanStoreServerWideBackup()
         {
             using (var store = GetDocumentStore())
@@ -126,7 +126,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task UpdateServerWideBackupThroughUpdatePeriodicBackupFails()
         {
             using (var store = GetDocumentStore())
@@ -162,7 +162,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task ToggleDisableServerWideBackupFails()
         {
             using (var store = GetDocumentStore())
@@ -188,7 +188,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task ServerWideBackup_WhenToggleState_ShouldWork()
         {
             using var store = GetDocumentStore();
@@ -223,7 +223,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CreatePeriodicBackupFailsWhenUsingReservedName()
         {
             using (var store = GetDocumentStore())
@@ -333,7 +333,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanCreateMoreThanOneServerWideBackup()
         {
             using (var store = GetDocumentStore())
@@ -386,7 +386,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task DeleteServerWideBackup_WhenDoesntExit_ShouldBeHandledProperly()
         {
             var server = GetNewServer();
@@ -413,7 +413,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             await store.Maintenance.Server.SendAsync(new DeleteServerWideTaskOperation(existentTaskName, OngoingTaskType.Backup));
         }
         
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanDeleteServerWideBackup()
         {
             using (var store = GetDocumentStore())
@@ -468,7 +468,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task SkipExportingTheServerWideBackup1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -546,7 +546,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Theory, Trait("Category", "Smuggler")]
+        [RavenTheory(RavenTestCategory.Smuggler)]
         [InlineData(EncryptionMode.None)]
         [InlineData(EncryptionMode.UseProvidedKey)]
         [InlineData(EncryptionMode.UseDatabaseKey)]
@@ -557,8 +557,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = result.Certificates.ServerCertificate.Value,
-                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = result.Certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
@@ -643,7 +643,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task SkipExportingTheServerWideBackup2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -721,7 +721,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CantCreateServerWideBackupWithExistingNameButCanEdit()
         {
             var backupName = "TestServerWideBackup";
@@ -771,7 +771,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-            [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanExcludeDatabase()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -811,7 +811,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanExcludeForNewDatabase()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -883,7 +883,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task FailToAddNullOrEmptyDatabaseNames()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -930,7 +930,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task CanCreateSnapshotBackupForNonEncryptedDatabase()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1057,7 +1057,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
-        [Fact, Trait("Category", "Smuggler")]
+        [RavenFact(RavenTestCategory.Smuggler)]
         public async Task ServerWideBackup_WhenEditingNameWithOldTaskId_ShouldThrow()
         {
             const string firstName = "FirstName";

--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Server.Replication
         public async Task PreventDeletionsOnHubForAttachments()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var hubDatabase = GetDatabaseName("HUB");
@@ -173,7 +173,7 @@ namespace SlowTests.Server.Replication
         public async Task PreventDeletionOnHubSinkCompromised()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var hubDatabase = GetDatabaseName("HUB");
@@ -301,7 +301,7 @@ namespace SlowTests.Server.Replication
         public async Task DeleteWhenAcceptSinkDeletionsFlagOff()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var hubDatabase = GetDatabaseName("HUB");
@@ -405,7 +405,7 @@ namespace SlowTests.Server.Replication
         public async Task PreventDeletionsOnHub()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var hubDatabase = GetDatabaseName("HUB");
@@ -521,7 +521,7 @@ namespace SlowTests.Server.Replication
         public async Task EnsureArtificialDocsAreSkippedOnReplication_17795(RavenTestParameters config)
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var hubDatabase = GetDatabaseName("HUB");
@@ -640,7 +640,7 @@ namespace SlowTests.Server.Replication
         public async Task MakeSureDeletionsRevisionsDontReplicate()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var hubDatabase = GetDatabaseName("HUB");

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -831,16 +831,16 @@ namespace SlowTests.Server.Replication
                 Server = server,
                 ModifyDatabaseName = s => $"Sink_{s}",
                 RunInMemory = false,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value
             }))
             using (var hub = GetDocumentStore(new Options
             {
                 Server = server,
                 ModifyDatabaseName = s => $"Hub_{s}",
                 RunInMemory = false,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value
             }))
             {
                 await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(name)

--- a/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
+++ b/test/SlowTests/Server/Replication/ReplicationBasicTestsSlow.cs
@@ -37,8 +37,8 @@ namespace SlowTests.Server.Replication
             if (useSsl)
             {
                 var certificates = Certificates.SetupServerAuthentication();
-                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
-                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
+                adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+                clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.Operator);
             }
 
             using (var store1 = GetDocumentStore(new Options

--- a/test/SlowTests/Server/ServerStore.cs
+++ b/test/SlowTests/Server/ServerStore.cs
@@ -6,6 +6,7 @@ using FastTests;
 using Org.BouncyCastle.Crypto.Tls;
 using Raven.Client;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6386;
+            const int numberToTolerate = 6329;
             if (array.Length == numberToTolerate)
                 return;
 

--- a/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
@@ -365,12 +365,13 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
                     Output.WriteLine(tuple.Exception.Message);
                 }
             })
-        {
-            Processed = 0,
-            Total = 4
-        },
+            {
+                Processed = 0,
+                Total = 4
+            },
             false,
             StagingAcmeClientUrl,
+            DefaultAcmeProfile,
             cts.Token);
 
         X509Certificate2 serverCert;
@@ -503,12 +504,13 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
                     Output.WriteLine(tuple.Exception.Message);
                 }
             })
-        {
-            Processed = 0,
-            Total = 4
-        },
+            {
+                Processed = 0,
+                Total = 4
+            },
             false,
             StagingAcmeClientUrl,
+            DefaultAcmeProfile,
             cts.Token);
 
         X509Certificate2 serverCert;
@@ -671,4 +673,5 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
     }
 
     private const string StagingAcmeClientUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
+    private const string DefaultAcmeProfile = "";
 }

--- a/test/StressTests/Issues/FilteredReplicationTestsStress.cs
+++ b/test/StressTests/Issues/FilteredReplicationTestsStress.cs
@@ -39,7 +39,7 @@ namespace StressTests.Issues
         public async Task Sinks_should_not_update_hubs_change_vector_with_conflicts()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var hubStore = GetDocumentStore(new Options
@@ -178,7 +178,7 @@ namespace StressTests.Issues
         public async Task Sinks_should_not_update_hubs_change_vector_with_conflicts2()
         {
             var certificates = Certificates.SetupServerAuthentication();
-            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
                 .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             using var hubStore = GetDocumentStore(new Options

--- a/test/StressTests/Issues/RavenDB-15145.cs
+++ b/test/StressTests/Issues/RavenDB-15145.cs
@@ -6,6 +6,7 @@ using FastTests.Server.Replication;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Exceptions.Security;
 using Raven.Client;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,17 +18,19 @@ namespace StressTests.Issues
         {
         }
 
-        [Fact]
-        public async Task PullReplicationWithoutPrivateKey()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task PullReplicationWithoutPrivateKey(bool with2Eku)
         {
             var hubSettings = new ConcurrentDictionary<string, string>();
             var sinkSettings = new ConcurrentDictionary<string, string>();
 
             var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true);
-            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates);
+            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates, with2Eku: with2Eku);
 
             var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true);
-            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates);
+            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates, with2Eku: with2Eku);
 
             var hubDB = GetDatabaseName();
             var sinkDB = GetDatabaseName();
@@ -42,13 +45,13 @@ namespace StressTests.Issues
 
             using (var hubStore = GetDocumentStore(new Options
             {
-                ClientCertificate = hubCerts.ServerCertificate.Value,
+                ClientCertificate = hubCerts.ServerCertificateForCommunication.Value,
                 Server = hubServer,
                 ModifyDatabaseName = _ => hubDB
             }))
             using (var sinkStore = GetDocumentStore(new Options
             {
-                ClientCertificate = sinkCerts.ServerCertificate.Value,
+                ClientCertificate = sinkCerts.ServerCertificateForCommunication.Value,
                 Server = sinkServer,
                 ModifyDatabaseName = _ => sinkDB
             }))

--- a/test/StressTests/Issues/RavenDB_12151.cs
+++ b/test/StressTests/Issues/RavenDB_12151.cs
@@ -128,8 +128,8 @@ namespace StressTests.Issues
 
             using (var store = GetDocumentStore(new Options()
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
                 ModifyDatabaseName = s => dbName,
                 Path = NewDataPath(),
                 ModifyDatabaseRecord = r =>

--- a/test/StressTests/Server/Encryption/EncryptionStressTests.cs
+++ b/test/StressTests/Server/Encryption/EncryptionStressTests.cs
@@ -41,7 +41,7 @@ namespace StressTests.Server.Encryption
                     Server = leader,
                     ReplicationFactor = 7,
                     ClientCertificate = certificates.ClientCertificate1.Value,
-                    AdminCertificate = certificates.ServerCertificate.Value,
+                    AdminCertificate = certificates.ServerCertificateForCommunication.Value,
                     ModifyDatabaseName = _ => databaseName,
                     Encrypted = true,
                     RunInMemory = false

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,17 +22,19 @@ namespace StressTests.Server.Replication
         {
         }
 
-        [Fact]
-        public async Task PullExternalReplicationWithCertificateShouldWork()
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task PullExternalReplicationWithCertificateShouldWork(bool with2Eku)
         {
             var hubSettings = new ConcurrentDictionary<string, string>();
             var sinkSettings = new ConcurrentDictionary<string, string>();
 
             var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true);
-            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates);
+            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates, with2Eku: with2Eku);
 
             var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: false);
-            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates);
+            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates, with2Eku: with2Eku);
 
             var hubDB = GetDatabaseName();
             var sinkDB = GetDatabaseName();
@@ -46,13 +49,13 @@ namespace StressTests.Server.Replication
 
             using (var hubStore = GetDocumentStore(new Options
             {
-                ClientCertificate = hubCerts.ServerCertificate.Value,
+                ClientCertificate = hubCerts.ServerCertificateForCommunication.Value,
                 Server = hubServer,
                 ModifyDatabaseName = _ => hubDB
             }))
             using (var sinkStore = GetDocumentStore(new Options
             {
-                ClientCertificate = sinkCerts.ServerCertificate.Value,
+                ClientCertificate = sinkCerts.ServerCertificateForCommunication.Value,
                 Server = sinkServer,
                 ModifyDatabaseName = _ => sinkDB
             }))

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -703,7 +703,7 @@ namespace Tests.Infrastructure
             bool useReservedPorts = false,
             [CallerMemberName] string caller = null)
         {
-            var result = await CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: false, customSettings, customSettingsList, watcherCluster, useReservedPorts, caller);
+            var result = await CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: false, commonCustomSettings: customSettings, customSettingsList: customSettingsList, watcherCluster: watcherCluster, useReservedPorts: useReservedPorts, caller: caller);
             return (result.Nodes, result.Leader);
         }
 
@@ -714,9 +714,11 @@ namespace Tests.Infrastructure
             IDictionary<string, string> customSettings = null,
             List<IDictionary<string, string>> customSettingsList = null,
             bool watcherCluster = false,
-            bool useReservedPorts = false)
+            bool useReservedPorts = false,
+            TestCertificatesHolder testCertificatesHolder = null,
+            bool with2Eku = true)
         {
-            return CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: true, customSettings, customSettingsList, watcherCluster, useReservedPorts);
+            return CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: true, commonCustomSettings: customSettings, customSettingsList: customSettingsList, watcherCluster: watcherCluster, useReservedPorts: useReservedPorts, testCertificatesHolder: testCertificatesHolder, with2Eku: with2Eku);
         }
 
         protected async Task<(RavenServer Leader, Dictionary<RavenServer, ProxyServer> Proxies)> CreateRaftClusterWithProxiesAsync(
@@ -801,7 +803,9 @@ namespace Tests.Infrastructure
             List<IDictionary<string, string>> customSettingsList = null,
             bool watcherCluster = false,
             bool useReservedPorts = false,
-            [CallerMemberName] string caller = null)
+            TestCertificatesHolder testCertificatesHolder = null,
+            [CallerMemberName] string caller = null,
+            bool with2Eku = true)
         {
             string[] allowedNodeTags = { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" };
             var actualLeaderIndex = leaderIndex;
@@ -848,7 +852,7 @@ namespace Tests.Infrastructure
                 if (useSsl)
                 {
                     serverUrl = UseFiddlerUrl($"https://127.0.0.1:{port}");
-                    certificates = Certificates.SetupServerAuthentication(customSettings, serverUrl);
+                    certificates = Certificates.SetupServerAuthentication(customSettings, serverUrl, testCertificatesHolder, with2Eku: with2Eku);
                 }
                 else
                 {
@@ -969,14 +973,14 @@ namespace Tests.Infrastructure
             return false;
         }
 
-        protected Dictionary<string, string> GetServerSettingsForPort(bool useSsl, out string serverUrl, out TestCertificatesHolder certificates)
+        protected Dictionary<string, string> GetServerSettingsForPort(bool useSsl, out string serverUrl, out TestCertificatesHolder certificates, bool with2Eku = true)
         {
             var customSettings = new Dictionary<string, string>();
 
             if (useSsl)
             {
                 serverUrl = UseFiddlerUrl("https://127.0.0.1:0");
-                certificates = Certificates.SetupServerAuthentication(customSettings, serverUrl);
+                certificates = Certificates.SetupServerAuthentication(customSettings, serverUrl, with2Eku: with2Eku);
             }
             else
             {

--- a/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
@@ -24,7 +24,8 @@ public partial class RavenTestBase
 
     public class CertificatesTestBase
     {
-        private static TestCertificatesHolder SelfSignedCertificates;
+        private static TestCertificatesHolder SelfSignedCertificates1Eku;
+        private static TestCertificatesHolder SelfSignedCertificates2Eku;
 
         private static int Counter;
 
@@ -37,11 +38,11 @@ public partial class RavenTestBase
 
         public X509Certificate2 RegisterClientCertificate(TestCertificatesHolder certificates, Dictionary<string, DatabaseAccess> permissions, SecurityClearance clearance = SecurityClearance.ValidUser, RavenServer server = null)
         {
-            return RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, permissions, clearance, server);
+            return RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, permissions, clearance, server);
         }
 
         public X509Certificate2 RegisterClientCertificate(
-            X509Certificate2 serverCertificate,
+            X509Certificate2 serverCertificateForCommunication,
             X509Certificate2 clientCertificate,
             Dictionary<string, DatabaseAccess> permissions,
             SecurityClearance clearance = SecurityClearance.ValidUser,
@@ -52,21 +53,25 @@ public partial class RavenTestBase
             {
                 CreateDatabase = false,
                 Server = server,
-                ClientCertificate = serverCertificate,
-                AdminCertificate = serverCertificate,
+                ClientCertificate = serverCertificateForCommunication,
+                AdminCertificate = serverCertificateForCommunication,
                 ModifyDocumentStore = s => s.Conventions = new DocumentConventions { DisableTopologyUpdates = true }
             });
             store.Maintenance.Server.Send(new PutClientCertificateOperation(certificateName, clientCertificate, permissions, clearance));
             return clientCertificate;
         }
 
-        public TestCertificatesHolder SetupServerAuthentication(IDictionary<string, string> customSettings = null, string serverUrl = null, TestCertificatesHolder certificates = null, [CallerMemberName] string caller = null)
+        public TestCertificatesHolder SetupServerAuthentication(IDictionary<string, string> customSettings = null,
+            string serverUrl = null,
+            TestCertificatesHolder certificates = null,
+            [CallerMemberName] string caller = null,
+            bool with2Eku = true)
         {
             if (customSettings == null)
                 customSettings = new ConcurrentDictionary<string, string>();
 
             if (certificates == null)
-                certificates = GenerateAndSaveSelfSignedCertificate(caller: caller);
+                certificates = GenerateAndSaveSelfSignedCertificate(caller: caller, with2Eku: with2Eku);
 
             if (customSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Security.CertificateLoadExec), out var _) == false)
                 customSettings[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certificates.ServerCertificatePath;
@@ -78,20 +83,26 @@ public partial class RavenTestBase
             return certificates;
         }
 
-        public TestCertificatesHolder GenerateAndSaveSelfSignedCertificate(bool createNew = false, [CallerMemberName] string caller = null)
+        public TestCertificatesHolder GenerateAndSaveSelfSignedCertificate(bool createNew = false, [CallerMemberName] string caller = null, bool with2Eku = true)
         {
             if (createNew)
-                return ReturnCertificatesHolder(Generate(caller, Interlocked.Increment(ref Counter)));
+                return ReturnCertificatesHolder(Generate(caller, gen: Interlocked.Increment(ref Counter)));
 
-            var selfSignedCertificates = SelfSignedCertificates;
+            var selfSignedCertificates = with2Eku ? SelfSignedCertificates2Eku : SelfSignedCertificates1Eku;
             if (selfSignedCertificates != null)
                 return ReturnCertificatesHolder(selfSignedCertificates);
 
             lock (typeof(TestBase))
             {
-                selfSignedCertificates = SelfSignedCertificates;
+                selfSignedCertificates = with2Eku ? SelfSignedCertificates2Eku : SelfSignedCertificates1Eku;
                 if (selfSignedCertificates == null)
-                    SelfSignedCertificates = selfSignedCertificates = Generate(caller);
+                {
+                    if (with2Eku)
+                        SelfSignedCertificates2Eku = selfSignedCertificates = Generate(caller);
+                    else
+                        SelfSignedCertificates1Eku = selfSignedCertificates = Generate(caller);
+
+                }
 
                 return ReturnCertificatesHolder(selfSignedCertificates);
             }
@@ -101,19 +112,20 @@ public partial class RavenTestBase
                 return new TestCertificatesHolder(certificates, _parent.GetTempFileName);
             }
 
-            TestCertificatesHolder Generate(string caller, int gen = 0)
+            TestCertificatesHolder Generate(string caller,  int gen = 0)
             {
                 var log = new StringBuilder();
                 byte[] certBytes;
                 string serverCertificatePath = null;
-
-                serverCertificatePath = Path.Combine(Path.GetTempPath(), $"Server-{gen}-{RavenVersionAttribute.Instance.Build}-{DateTime.Today:yyyy-MM-dd}.pfx");
+                string ekuSuffix = with2Eku ? "2eku" : "1eku";
+                
+                serverCertificatePath = Path.Combine(Path.GetTempPath(), $"Server-{gen}-{RavenVersionAttribute.Instance.Build}-{DateTime.Today:yyyy-MM-dd}-{ekuSuffix}.pfx");
 
                 if (File.Exists(serverCertificatePath) == false)
                 {
                     try
                     {
-                        certBytes = CertificateUtils.CreateSelfSignedTestCertificate(Environment.MachineName, "RavenTestsServer", log);
+                        certBytes = CertificateUtils.CreateSelfSignedTestCertificate(Environment.MachineName + "-" + ekuSuffix, "RavenTestsServer", log, with2Eku);
                     }
                     catch (Exception e)
                     {
@@ -142,7 +154,7 @@ public partial class RavenTestBase
                 X509Certificate2 serverCertificate;
                 try
                 {
-                    serverCertificate = new X509Certificate2(certBytes, (string)null, X509KeyStorageFlags.MachineKeySet);
+                    serverCertificate = new X509Certificate2(certBytes, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
                 }
                 catch (Exception e)
                 {
@@ -150,26 +162,64 @@ public partial class RavenTestBase
                 }
 
                 SecretProtection.ValidatePrivateKey(serverCertificatePath, null, certBytes, out var pk);
-                SecretProtection.ValidateKeyUsages(serverCertificatePath, serverCertificate, validateKeyUsages: true);
+                SecretProtection.ValidateServerKeyUsages(serverCertificatePath, serverCertificate, validateKeyUsages: true);
 
-                var clientCertificate1Path = GenerateClientCertificate(1, serverCertificate, pk);
-                var clientCertificate2Path = GenerateClientCertificate(2, serverCertificate, pk);
-                var clientCertificate3Path = GenerateClientCertificate(3, serverCertificate, pk);
+                string serverCertificateForCommunicationPath;
+                if (SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(serverCertificate) == false)
+                {
+                    serverCertificateForCommunicationPath = Path.Combine(Path.GetTempPath(), $"Server-client-{gen}-{RavenVersionAttribute.Instance.Build}-{DateTime.Today:yyyy-MM-dd}-{ekuSuffix}.pfx");
+                    if (File.Exists(serverCertificateForCommunicationPath) == false)
+                    {
+                        byte[] serverClientCertBytes;
+                        try
+                        {
+                            CertificateUtils.CreateClientCertificateFromServerCertificate(serverCertificate, out serverClientCertBytes);
+                        }
+                        catch (Exception e)
+                        {
+                            throw new CryptographicException($"Unable to generate the server certificate for communication for the machine '{Environment.MachineName}'. Log: {log}", e);
+                        }
 
-                return new TestCertificatesHolder(serverCertificatePath, clientCertificate1Path, clientCertificate2Path, clientCertificate3Path);
+                        if (serverClientCertBytes.Length == 0)
+                            throw new CryptographicException($"Test server certificate for communication length is 0 bytes. Machine: '{Environment.MachineName}', Log: {log}");
+
+                        try
+                        {
+                            File.WriteAllBytes(serverCertificateForCommunicationPath, serverClientCertBytes);
+                        }
+                        catch (Exception e)
+                        {
+                            throw new InvalidOperationException("Failed to write the test certificate to a temp file." +
+                                                                $"tempFileName = {serverCertificateForCommunicationPath}" +
+                                                                $"certBytes.Length = {serverClientCertBytes.Length}" +
+                                                                $"MachineName = {Environment.MachineName}.", e);
+                        }
+                    }
+                }
+                else
+                {
+                    serverCertificateForCommunicationPath = serverCertificatePath;
+                }
+                var clientCertificate1Path = GenerateClientCertificate(1, serverCertificate, pk, ekuSuffix);
+                var clientCertificate2Path = GenerateClientCertificate(2, serverCertificate, pk, ekuSuffix);
+                var clientCertificate3Path = GenerateClientCertificate(3, serverCertificate, pk, ekuSuffix);
+
+                return new TestCertificatesHolder(serverCertificatePath, serverCertificateForCommunicationPath, clientCertificate1Path, clientCertificate2Path, clientCertificate3Path);
             }
 
-            string GenerateClientCertificate(int index, X509Certificate2 serverCertificate, Org.BouncyCastle.Pkcs.AsymmetricKeyEntry pk)
+            string GenerateClientCertificate(int index, X509Certificate2 serverCertificate, Org.BouncyCastle.Pkcs.AsymmetricKeyEntry pk, string ekuSuffix)
             {
-                string name = $"{Environment.MachineName}_CC_{RavenVersionAttribute.Instance.Build}_{index}_{DateTime.Today:yyyy-MM-dd}";
+                string name = $"{Environment.MachineName}_CC_{RavenVersionAttribute.Instance.Build}_{index}_{DateTime.Today:yyyy-MM-dd}_{ekuSuffix}";
                 string clientCertificatePath = Path.Combine(Path.GetTempPath(), name + ".pfx");
 
                 if (File.Exists(clientCertificatePath) == false)
                 {
                     CertificateUtils.CreateSelfSignedClientCertificate(
                         name,
-                        new CertificateUtils.CertificateHolder(serverCertificate, pk),
-                        out var certBytes, DateTime.UtcNow.Date.AddYears(5));
+                        serverCertificate,
+                        pk.Key,
+                        out var certBytes, 
+                        DateTime.UtcNow.Date.AddYears(5));
 
                     try
                     {

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -24,6 +24,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Exceptions;
 using Raven.Server.ServerWide.Context;
@@ -61,6 +62,18 @@ namespace FastTests
 
         protected virtual DocumentStore GetDocumentStore(Options options = null, [CallerMemberName] string caller = null)
         {
+            if (options?.ClientCertificate != null && SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(options.ClientCertificate) == false)
+            {
+                throw new InvalidOperationException($"The {nameof(options.ClientCertificate)} must have the Client Authentication Enhanced Key Usage." +
+                                                    " Are you supplying 'Server Certificate' instead of 'Server Certificate for Communication'?");
+            }
+            
+            if (options?.AdminCertificate != null && SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(options.AdminCertificate) == false)
+            {
+                throw new InvalidOperationException($"The {nameof(options.AdminCertificate)} must have the Client Authentication Enhanced Key Usage." +
+                                                    " Are you supplying 'Server Certificate' instead of 'Server Certificate for Communication'?");
+            }
+            
             try
             {
                 lock (_getDocumentStoreSync)

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -157,6 +157,7 @@ namespace FastTests
             }
 
             RequestExecutor.RemoteCertificateValidationCallback += (sender, cert, chain, errors) => true;
+            RequestExecutor.ExtractServerCertificateFromExtension = CertificateUtils.ExtractServerCertificateFromExtension;
 
             TrafficWatchToLog.Instance.UpdateConfiguration(RavenConfiguration.Default.TrafficWatch);
             EventListenerToLog.Instance.UpdateConfiguration(new EventListenerToLog.EventListenerConfiguration

--- a/test/Tests.Infrastructure/TestCertificatesHolder.cs
+++ b/test/Tests.Infrastructure/TestCertificatesHolder.cs
@@ -12,6 +12,8 @@ namespace FastTests
     {
         private readonly Func<string> _getServerCertificatePath;
 
+        private readonly Func<string> _getServerCertificateForCommunicationPath;
+
         private readonly Func<string> _getClientCertificate1Path;
 
         private readonly Func<string> _getClientCertificate2Path;
@@ -20,6 +22,8 @@ namespace FastTests
 
         private string _serverCertificatePath;
 
+        private string _serverCertificateForCommunicationPath;
+
         private string _clientCertificate1Path;
 
         private string _clientCertificate2Path;
@@ -27,6 +31,8 @@ namespace FastTests
         private string _clientCertificate3Path;
 
         public readonly Lazy<TrackingX509Certificate2> ServerCertificate;
+
+        public readonly Lazy<TrackingX509Certificate2> ServerCertificateForCommunication;
 
         public readonly Lazy<TrackingX509Certificate2> ClientCertificate1;
 
@@ -115,6 +121,17 @@ namespace FastTests
                 return _serverCertificatePath;
             }
         }
+        
+        public string ServerCertificateForCommunicationPath
+        {
+            get
+            {
+                if (_serverCertificateForCommunicationPath == null)
+                    _serverCertificateForCommunicationPath = _getServerCertificateForCommunicationPath();
+
+                return _serverCertificateForCommunicationPath;
+            }
+        }
 
         public string ClientCertificate1Path
         {
@@ -149,9 +166,14 @@ namespace FastTests
             }
         }
 
-        public TestCertificatesHolder(string serverCertificatePath, string clientCertificate1Path, string clientCertificate2Path, string clientCertificate3Path)
+        public TestCertificatesHolder(string serverCertificatePath,
+            string serverCertificateForCommunicationPath,
+            string clientCertificate1Path,
+            string clientCertificate2Path,
+            string clientCertificate3Path)
         {
             _getServerCertificatePath = () => serverCertificatePath;
+            _getServerCertificateForCommunicationPath = () => serverCertificateForCommunicationPath;
             _getClientCertificate1Path = () => clientCertificate1Path;
             _getClientCertificate2Path = () => clientCertificate2Path;
             _getClientCertificate3Path = () => clientCertificate3Path;
@@ -168,6 +190,18 @@ namespace FastTests
                 }
             });
 
+            ServerCertificateForCommunication = new Lazy<TrackingX509Certificate2>(() =>
+            {
+                try
+                {
+                    return new TrackingX509Certificate2(ServerCertificateForCommunicationPath, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
+                }
+                catch (CryptographicException e)
+                {
+                    throw new CryptographicException($"Failed to load the test server certificate for communication from {ServerCertificateForCommunicationPath}.", e);
+                }
+            });
+
             ClientCertificate1 = CreateLazy(() => ClientCertificate1Path, 1);
             ClientCertificate2 = CreateLazy(() => ClientCertificate2Path, 2);
             ClientCertificate3 = CreateLazy(() => ClientCertificate3Path, 3);
@@ -179,6 +213,14 @@ namespace FastTests
             {
                 var path = getTemporaryFileName();
                 File.Copy(parent.ServerCertificatePath, path, true);
+
+                return path;
+            };
+            
+            _getServerCertificateForCommunicationPath = () =>
+            {
+                var path = getTemporaryFileName();
+                File.Copy(parent.ServerCertificateForCommunicationPath, path, true);
 
                 return path;
             };
@@ -216,6 +258,18 @@ namespace FastTests
                 catch (CryptographicException e)
                 {
                     throw new CryptographicException($"Failed to load the test server certificate from {ServerCertificatePath}.", e);
+                }
+            });
+            
+            ServerCertificateForCommunication = new Lazy<TrackingX509Certificate2>(() =>
+            {
+                try
+                {
+                    return new TrackingX509Certificate2(ServerCertificateForCommunicationPath, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
+                }
+                catch (CryptographicException e)
+                {
+                    throw new CryptographicException($"Failed to load the test server certificate for communication from {ServerCertificateForCommunicationPath}.", e);
                 }
             });
 

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -11,6 +11,7 @@ using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.X509;
 using Raven.Server.Utils;
+using Raven.Client;
 using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 namespace Tests.Infrastructure.Utils;
@@ -35,11 +36,67 @@ public static class CertificateGenerator
         return GenerateCertificate(subjectName, yearsValid, intermediateKeyPair, signerKeyPair: rootPrivateKey, signerCertificate: rootCertificate, isCa: true);
     }
 
-    public static X509Certificate2 GenerateSignedClientCertificate(X509Certificate2 signerCertificate, AsymmetricCipherKeyPair signerKeyPair, string subjectName,
+    public static X509Certificate2 GenerateSignedClientServerCertificate(X509Certificate2 signerCertificate, AsymmetricCipherKeyPair signerKeyPair, string subjectName,
         int yearsValid, AsymmetricCipherKeyPair clientKeyPair, string[] sans = null)
     {
         var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
-        var extendedKeyUsage = new ExtendedKeyUsage(new[] { KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth });
+        var extendedKeyUsage = new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth, KeyPurposeID.id_kp_clientAuth);
+        GeneralNames subjectAlternativeNames;
+        if (sans == null)
+        {
+            subjectAlternativeNames = new GeneralNames(new GeneralName(GeneralName.DnsName, "localhost"));
+        }
+        else if (sans.Length == 0)
+        {
+            subjectAlternativeNames = null;
+        }
+        else
+        {
+            var names = new List<GeneralName>(sans.Length);
+            foreach (var san in sans)
+            {
+                names.Add(new GeneralName(GeneralName.DnsName, san));
+            }
+
+            subjectAlternativeNames = new GeneralNames(names.ToArray());
+        }
+
+        return GenerateCertificate(subjectName, yearsValid, clientKeyPair, keyUsage, extendedKeyUsage, subjectAlternativeNames, signerCertificate, signerKeyPair);
+    }
+    
+    public static X509Certificate2 GenerateSignedServerOnlyCertificate(X509Certificate2 signerCertificate, AsymmetricCipherKeyPair signerKeyPair, string subjectName,
+        int yearsValid, AsymmetricCipherKeyPair clientKeyPair, string[] sans = null)
+    {
+        var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
+        var extendedKeyUsage = new ExtendedKeyUsage(KeyPurposeID.id_kp_serverAuth);
+        GeneralNames subjectAlternativeNames;
+        if (sans == null)
+        {
+            subjectAlternativeNames = new GeneralNames(new GeneralName(GeneralName.DnsName, "localhost"));
+        }
+        else if (sans.Length == 0)
+        {
+            subjectAlternativeNames = null;
+        }
+        else
+        {
+            var names = new List<GeneralName>(sans.Length);
+            foreach (var san in sans)
+            {
+                names.Add(new GeneralName(GeneralName.DnsName, san));
+            }
+
+            subjectAlternativeNames = new GeneralNames(names.ToArray());
+        }
+
+        return GenerateCertificate(subjectName, yearsValid, clientKeyPair, keyUsage, extendedKeyUsage, subjectAlternativeNames, signerCertificate, signerKeyPair);
+    }
+    
+    public static X509Certificate2 GenerateSignedClientOnlyCertificate(X509Certificate2 signerCertificate, AsymmetricCipherKeyPair signerKeyPair, string subjectName,
+        int yearsValid, AsymmetricCipherKeyPair clientKeyPair, string[] sans = null)
+    {
+        var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
+        var extendedKeyUsage = new ExtendedKeyUsage(KeyPurposeID.id_kp_clientAuth);
         GeneralNames subjectAlternativeNames;
         if (sans == null)
         {
@@ -134,7 +191,7 @@ public static class CertificateGenerator
         store.SetKeyEntry(friendlyName, keyEntry, new[] { certificateEntry });
         var stream = new MemoryStream();
         store.Save(stream, Array.Empty<char>(), random);
-
-        return new X509Certificate2(stream.ToArray());
+        
+        return CertificateLoaderUtil.CreateCertificate(stream.ToArray(), null, CertificateLoaderUtil.FlagsForExport);
     }
 }

--- a/test/Tests.Infrastructure/Utils/DebugPackageHandler.cs
+++ b/test/Tests.Infrastructure/Utils/DebugPackageHandler.cs
@@ -22,7 +22,7 @@ namespace Tests.Infrastructure.Utils
         }
 
         private static IDocumentStore InitDocumentStore(RavenServer ravenServer)
-            => new DocumentStore { Urls = new[] { ravenServer.WebUrl }, Certificate = ravenServer.Certificate?.Certificate }
+            => new DocumentStore { Urls = new[] { ravenServer.WebUrl }, Certificate = ravenServer.Certificate?.ClientCertificate }
                 .Initialize();
 
         private static void SaveDebugPackage(Context testContext, ClusterDebugInfoPackageResult operationResult)

--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -146,6 +146,7 @@ namespace rvn
                 var certPass = ConfigureCertPassword(cmd);
                 var generateHelmValues = ConfigureGenerateValues(cmd);
                 var acmeUrl = ConfigureAcmeUrl(cmd);
+                var acmeProfile = ConfigureAcmeProfile(cmd);
 
                 cmd.OnExecuteAsync(async token =>
                 {
@@ -156,6 +157,7 @@ namespace rvn
                     var certPassTuple = certPass.Value() ?? Environment.GetEnvironmentVariable("RVN_CERT_PASS");
                     var generateHelmValuesVal = generateHelmValues.HasValue() ? generateHelmValues.Value() is null ? "values.yaml": generateHelmValues.Value() : null;
                     var acmeUrlVal = acmeUrl.Value();
+                    var acmeProfileVal = acmeProfile.Value();
 
                     return await CreateSetupPackage(new CreateSetupPackageParameters
                     {
@@ -166,6 +168,7 @@ namespace rvn
                         CertificatePath = certPathVal,
                         CertPassword = certPassTuple,
                         AcmeUrl = acmeUrlVal,
+                        AcmeProfile = acmeProfileVal,
                         HelmValuesOutputPath = generateHelmValuesVal,
                         Progress = new SetupProgressAndResult(tuple =>
                         {
@@ -628,6 +631,13 @@ namespace rvn
         {
             var opt = cmd.Option("--acme-url", "Specify acme url to use (default: 'https://acme-v02.api.letsencrypt.org/directory')", CommandOptionType.SingleValue);
             opt.DefaultValue = "https://acme-v02.api.letsencrypt.org/directory";
+            return opt;
+        }
+        
+        private static CommandOption ConfigureAcmeProfile(CommandLineApplication cmd)
+        {
+            var opt = cmd.Option("--acme-profile", "Specify acme profile to use (default: '')", CommandOptionType.SingleValue);
+            opt.DefaultValue = string.Empty;
             return opt;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23795
https://issues.hibernatingrhinos.com/issue/RavenDB-24910
https://issues.hibernatingrhinos.com/issue/RavenDB-24914
https://issues.hibernatingrhinos.com/issue/RavenDB-24923
https://issues.hibernatingrhinos.com/issue/RavenDB-24925

### Additional description

Due to [Google move](https://community.letsencrypt.org/t/chrome-root-program-v1-6-and-client-certificates/233709) CA are changing certificates - they will no longer have Client Auth EKU. This means that we won't be able to use the server certificate as client cert for communication between nodes.

We are creating new certificate with the same private key as the server certificate and use that for communication between nodes.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
If server certificate contains Client Auth EKU it will be used as it was before.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
Extensive testing in RavenDB features is needed.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
Authentication in ravendb features that use certificates.
- [ ] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
