### PR TITLE
RavenDB-24208 implement resume and user actions

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Session;
 using Raven.Client.Util;
@@ -80,7 +82,6 @@ public class AiAgentConfiguration : IDynamicJson
         public string Name { get; set; }
         public string Description { get; set; }
         public string Query { get; set; }
-        
         public string ParametersSchema { get; set; }
         public DynamicJsonValue ToJson()
         {

--- a/src/Raven.Client/Documents/Operations/AI/Agents/ResumeChatOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/ResumeChatOperation.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.AI.Agents;
+
+public class ResumeChatOperation<TSchema> : IMaintenanceOperation<ChatResult<TSchema>> where TSchema : new()
+{
+    private readonly string _name;
+    private readonly string _chatId;
+    private readonly string _userPrompt;
+    private readonly List<ToolResponse> _toolResponses;
+
+    public ResumeChatOperation(string agentName, string chatId, string userPrompt = null, List<ToolResponse> toolResponses = null)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(agentName, nameof(agentName));
+        ValidationMethods.AssertNotNullOrEmpty(chatId, nameof(chatId));
+
+        if (string.IsNullOrEmpty(userPrompt) && (toolResponses == null || toolResponses.Count == 0))
+            throw new ArgumentException($"Either '{nameof(userPrompt)}' or '{nameof(toolResponses)}' must be provided to resume a chat.");
+
+        _name = agentName;
+        _chatId = chatId;
+        _userPrompt = userPrompt;
+        _toolResponses = toolResponses;
+    }
+
+    public RavenCommand<ChatResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new ResumeChatOperationCommand(_name, _chatId, _userPrompt, _toolResponses, conventions);
+    }
+
+    internal sealed class ResumeChatOperationCommand : RavenCommand<ChatResult<TSchema>>
+    {
+        private readonly string _name;
+        private readonly string _chatId;
+        private readonly string _userPrompt;
+        private readonly List<ToolResponse> _toolResponses;
+        private readonly DocumentConventions _conventions;
+
+        public ResumeChatOperationCommand(string name, string chatId, string userPrompt, List<ToolResponse> toolResponses, DocumentConventions conventions)
+        {
+            _name = name;
+            _chatId = chatId;
+            _userPrompt = userPrompt;
+            _toolResponses = toolResponses;
+            _conventions = conventions;
+        }
+        public override bool IsReadRequest => false;
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/resume?name={Uri.EscapeDataString(_name)}&chatId={Uri.EscapeDataString(_chatId)}";
+            var body = new ResumeChatBody { ToolResponse = _toolResponses, UserPrompt = _userPrompt};
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await ctx.WriteAsync(stream, ctx.ReadObject(body.ToJson(),"resume-chat-params")).ConfigureAwait(false);
+                }, _conventions)
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = ChatResult<TSchema>.Convert(response, _conventions);
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/Agents/StartChatOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/StartChatOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
@@ -69,16 +70,7 @@ public class StartChatOperation<TSchema> : IMaintenanceOperation<ChatResult<TSch
             if (response == null)
                 ThrowInvalidResponse();
 
-            response.TryGet(nameof(ChatResult<TSchema>.Usage), out BlittableJsonReaderObject usage);
-            response.TryGet(nameof(ChatResult<TSchema>.Response), out BlittableJsonReaderObject result);
-            response.TryGet(nameof(ChatResult<TSchema>.ChatId), out string chatId);
-
-            Result = new ChatResult<TSchema>
-            {
-                ChatId = chatId,
-                Usage = JsonDeserializationClient.AiUsage(usage),
-                Response = _conventions.Serialization.DefaultConverter.FromBlittable<TSchema>(result, chatId)
-            };
+            Result = ChatResult<TSchema>.Convert(response, _conventions);
         }
     }
 }
@@ -97,11 +89,82 @@ internal class StartChatBody : IDynamicJson
     }
 }
 
-public class ChatResult<T>
+internal class ResumeChatBody : IDynamicJson
+{
+    public List<ToolResponse> ToolResponse { get; set; }
+    public string UserPrompt { get; set; }
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(ToolResponse)] = ToolResponse == null ? null : new DynamicJsonArray(ToolResponse.Select(r => r.ToJson())), 
+            [nameof(UserPrompt)] = UserPrompt,
+        };
+    }
+}
+
+public class ChatResult<TSchema>
 {
     public string ChatId { get; set; }
-    public T Response { get; set; }
+    public TSchema Response { get; set; }
     public AiUsage Usage { get; set; }
+    public List<ToolRequest> ToolRequests { get; set; }
+
+    internal static ChatResult<TSchema> Convert(BlittableJsonReaderObject response, DocumentConventions conventions)
+    {
+        response.TryGet(nameof(Usage), out BlittableJsonReaderObject usage);
+        response.TryGet(nameof(Response), out BlittableJsonReaderObject result);
+        response.TryGet(nameof(ChatId), out string chatId);
+
+        List<ToolRequest> requests = null;
+        if (response.TryGet(nameof(ToolRequests), out BlittableJsonReaderArray toolRequests) && toolRequests != null)
+        {
+            requests = [];
+            foreach (BlittableJsonReaderObject toolRequest in toolRequests)
+            {
+                var r = JsonDeserializationClient.ToolRequest(toolRequest);
+                requests.Add(r);
+            }
+        }
+
+        return new ChatResult<TSchema>
+        {
+            ChatId = chatId,
+            ToolRequests = requests,
+            Usage = JsonDeserializationClient.AiUsage(usage),
+            Response = result == null ? default : conventions.Serialization.DefaultConverter.FromBlittable<TSchema>(result, chatId)
+        };
+    }
+}
+
+public class ToolRequest : IDynamicJson
+{
+    public string Name;
+    public string ToolId;
+    public string Arguments;
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(Name)] = Name,
+            [nameof(ToolId)] = ToolId,
+            [nameof(Arguments)] = Arguments
+        };
+    }
+}
+
+public class ToolResponse : IDynamicJson
+{
+    public string ToolId;
+    public string Content;
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(ToolId)] = ToolId,
+            [nameof(Content)] = Content
+        };
+    }
 }
 
 public class AiUsage : IDynamicJsonValueConvertible

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -342,5 +342,9 @@ namespace Raven.Client.Json.Serialization
         public static readonly Func<BlittableJsonReaderObject, AiAgentConfigurationResult> AiAgentConfigurationResult = GenerateJsonDeserializationRoutine<AiAgentConfigurationResult>();
         
         public static readonly Func<BlittableJsonReaderObject, AiUsage> AiUsage = GenerateJsonDeserializationRoutine<AiUsage>();
+
+        public static readonly Func<BlittableJsonReaderObject, ToolRequest> ToolRequest = GenerateJsonDeserializationRoutine<ToolRequest>();
+
+        public static readonly Func<BlittableJsonReaderObject, ToolResponse> ToolResponse = GenerateJsonDeserializationRoutine<ToolResponse>();
     }
 }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -236,7 +236,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
     {
         var content = new BlittableJsonContent(async stream =>
         {
-            using var bodyJson = ctx.ReadObject(body, "ai-rag/request");
+            using var bodyJson = ctx.ReadObject(body, "ai-agent/request");
             await using var writer = new AsyncBlittableJsonTextWriter(ctx, stream);
             writer.WriteObject(bodyJson);
         }, ConventionsToUse);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.AiGen;
@@ -47,18 +50,14 @@ public class AiAgentHandler : DatabaseRequestHandler
         using var token = CreateHttpRequestBoundOperationToken();
         var name = GetStringQueryString("name", required: true);
 
-        AiAgentConfiguration configuration;
-        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
-        using (ctx.OpenReadTransaction())
-        using (var record = ServerStore.Cluster.ReadRawDatabaseRecord(ctx, DatabaseName))
-        {
-            if (record.TryGetAiAgent(name, out configuration) == false)
-                throw new ArgumentException($"AI Agent '{name}' doesn't exists");
-        }
+        var configuration = GetAiAgentConfiguration(name);
 
         using var _ = ContextPool.AllocateOperationContext(out JsonOperationContext context);
-        var body = await ReadBodyAsync(context, token.Token);
-        var r = await Talk(context, configuration, body.UserPrompt, body.Parameter, token: token);
+        var body = await ReadStartChatBodyAsync(context, token.Token);
+        var chat = new ChatDocument(name, body.Parameter);
+        
+        chat.Initialize(context, configuration.SystemPrompt, body.UserPrompt);
+        var r = await Talk(context, configuration, chat, token);
 
         string conversationId = null;
         if (configuration.Persistence is not null)
@@ -68,27 +67,61 @@ public class AiAgentHandler : DatabaseRequestHandler
             conversationId = putCmd.PutResult.Id;
         }
 
-        await using var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream());
-        writer.WriteStartObject();
-        writer.WritePropertyName("Response");
-        writer.WriteObject(r.Response.Result);
-        writer.WriteComma();
-        writer.WritePropertyName("Usage");
-        r.Usage.Write(writer);
-        writer.WriteComma();
-        writer.WritePropertyName("ChatId");
-        writer.WriteString(conversationId);
-        writer.WriteEndObject();
+        await WriteResponseAsync(context, conversationId, r);
     }
-
-
 
     [RavenAction("/databases/*/ai/agent/resume", "POST", AuthorizationStatus.ValidUser, EndpointType.Write)]
     public async Task ResumeChat()
     {
         using var token = CreateHttpRequestBoundOperationToken();
         var chatId = GetStringQueryString("chatId", required: true);
-        throw new NotImplementedException();
+        var name = GetStringQueryString("name", required: true);
+        
+        var configuration = GetAiAgentConfiguration(name);
+
+        using var _ = Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
+        using var __ = context.OpenReadTransaction();
+
+        var chat = Database.DocumentsStorage.Get(context, chatId);
+        if (chat == null)
+            throw new DocumentDoesNotExistException(chatId);
+
+        var document = ChatDocument.ToDocument(chatId, chat.Data);
+        var body = await ReadResumeChatBodyAsync(context, token.Token);
+
+        if (string.IsNullOrEmpty(body.UserPrompt) == false)
+        {
+            document.AddMessage(context, context.ReadObject(new DynamicJsonValue
+            {
+                ["role"] = "user",
+                ["content"] = body.UserPrompt
+            }, "user/msg"));
+        }
+
+        if (body.ActionResponse != null)
+        {
+            foreach (BlittableJsonReaderObject tool in body.ActionResponse)
+            {
+                var t = JsonDeserializationClient.ToolResponse(tool);
+                document.Messages.Add(context.ReadObject(new DynamicJsonValue
+                {
+                    ["tool_call_id"] = t.ToolId,
+                    ["role"] = "tool",
+                    ["content"] = t.Content
+                },"user/tool"));
+            }
+        }
+
+        var r = await Talk(context, configuration, document, token: token);
+
+        if (configuration.Persistence is not null)
+        {
+            // we don't pass change vector here, so last write wins
+            MergedPutCommand putCmd = new(r.Dcoument, chatId, changeVector: null, Database);
+            await Database.TxMerger.Enqueue(putCmd);
+        }
+
+        await WriteResponseAsync(context, chatId, r);
     }
 
     [RavenAction("/databases/*/admin/ai/agent", "GET", AuthorizationStatus.DatabaseAdmin)]
@@ -149,148 +182,94 @@ public class AiAgentHandler : DatabaseRequestHandler
         var options = await context.ReadForMemoryAsync(RequestBodyStream(), "ai-agent", token.Token);
         var cfg = JsonDeserializationClient.AiAgentConfiguration(options);
 
-        var body = await ReadBodyAsync(context, token.Token);
-        var r = await Talk(context, cfg, body.UserPrompt, body.Parameter, token);
+        var body = await ReadStartChatBodyAsync(context, token.Token);
+        var chat = new ChatDocument("test", body.Parameter);
+        chat.Initialize(context, cfg.SystemPrompt, body.UserPrompt);
 
-        await using var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream());
-        writer.WriteStartObject();
-        writer.WritePropertyName("Result");
-        writer.WriteObject(r.Response.Result);
-        writer.WriteComma();
-        writer.WritePropertyName("Usage");
-        r.Usage.Write(writer);
-        writer.WriteEndObject();
+        var r = await Talk(context, cfg, chat, token);
+
+        await WriteResponseAsync(context, "test", r);
     }
-    private async Task<(BlittableJsonReaderObject Parameter, string UserPrompt)> ReadBodyAsync(JsonOperationContext context, CancellationToken token)
+    private async Task<(BlittableJsonReaderObject Parameter, string UserPrompt)> ReadStartChatBodyAsync(JsonOperationContext context, CancellationToken token)
     {
         var body = await context.ReadForMemoryAsync(RequestBodyStream(), "ai-agent", token);
-        body.TryGet(nameof(StartChatBody.Parameters), out BlittableJsonReaderObject parameters);
+        if (body.TryGet(nameof(StartChatBody.Parameters), out BlittableJsonReaderObject parameters) == false)
+            throw new ArgumentException(nameof(StartChatBody.Parameters));
         if (body.TryGet(nameof(StartChatBody.Prompt), out string userPrompt) == false)
             throw new ArgumentException($"User prompt is missing");
 
         return (parameters, userPrompt);
     }
 
-    private async Task<(AiUsage Usage, AiResponse Response, BlittableJsonReaderObject Dcoument)> Talk(JsonOperationContext context, AiAgentConfiguration cfg,
-        string userPrompt, BlittableJsonReaderObject parameters, OperationCancelToken token)
+    private async Task<(BlittableJsonReaderArray ActionResponse, string UserPrompt)> ReadResumeChatBodyAsync(JsonOperationContext context, CancellationToken token)
     {
-        var conStr = GetAiConnectionString(cfg.ConnectionStringName);
+        var body = await context.ReadForMemoryAsync(RequestBodyStream(), "ai-agent", token);
+        if (body.TryGet(nameof(ResumeChatBody.ToolResponse), out BlittableJsonReaderArray actionResponse) == false)
+            throw new ArgumentException(nameof(ResumeChatBody.ToolResponse));
+        if (body.TryGet(nameof(ResumeChatBody.UserPrompt), out string userPrompt) == false)
+            throw new ArgumentException($"User prompt is missing");
 
-        string schemaOrSampleObject = cfg.OutputSchema ?? throw new InvalidOperationException("Missing output schema in configuration");
+        return (actionResponse, userPrompt);
+    }
+
+    private async Task<(AiUsage Usage, List<ToolRequest> userToolRequests, BlittableJsonReaderObject Response, BlittableJsonReaderObject Dcoument)> Talk(JsonOperationContext context, AiAgentConfiguration configuration, ChatDocument document, OperationCancelToken token)
+    {
+        document.EnsureInitialized();
+
+        var conStr = GetAiConnectionString(configuration.ConnectionStringName);
+
+        string schemaOrSampleObject = configuration.OutputSchema ?? throw new InvalidOperationException("Missing output schema in configuration");
         string schema = ChatCompletionClient.GetSchemaFor(schemaOrSampleObject);
         using var client = ChatCompletionClient.CreateChatCompletionClient(Database.ServerStore.ContextPool, conStr, schema);
 
-        List<BlittableJsonReaderObject> msgs =
-        [
-            context.ReadObject(new DynamicJsonValue
-            {
-                ["role"] = "system",
-                ["content"] = cfg.SystemPrompt
-            }, "system/msg"),
-            context.ReadObject(new DynamicJsonValue
-            {
-                ["role"] = "user",
-                ["content"] = userPrompt
-            }, "user/msg"),
-        ];
-        var tools = GenerateTools(cfg, context);
+        var tools = document.GenerateTools(context, configuration);
 
         AiUsage usage = new();
-        AiResponse result;
+        AiResponse aiResponse;
+        List<ToolRequest> userToolRequests = null;
+
         while (true)
         {
-            result = await client.CompleteAsync2(
+            aiResponse = await client.CompleteAsync2(
                 context,
-                msgs,
+                document.Messages,
                 tools,
                 usage,
                 token.Token
             );
-            if (result.Type is AiResponseType.Result)
+            if (aiResponse.Type is AiResponseType.Result)
                 break;
             
-            await HandleToolCalls(context, msgs, result, cfg, parameters);
+            await HandleToolCalls(context, configuration, document, aiResponse);
+
+            if (TryGetUserTools(configuration, aiResponse, out userToolRequests))
+                break; // we need to return the user tool requests to the client, so we can continue the conversation
         }
 
-        BlittableJsonReaderObject docJson = CreateDocument(context, cfg, msgs);
-
-        return (usage, result, docJson);
+        document.UpdateUsage(usage);
+        return (usage, userToolRequests, aiResponse.Result,document.ToBlittable(context, configuration));
     }
 
-    private static BlittableJsonReaderObject CreateDocument(JsonOperationContext context, AiAgentConfiguration cfg, List<BlittableJsonReaderObject> msgs)
+    private bool TryGetUserTools(AiAgentConfiguration configuration, AiResponse result, out List<ToolRequest> userTools)
     {
-        var metadata = new DynamicJsonValue
+        userTools = [];
+        foreach (var call in result.ToolCalls)
         {
-            ["@collection"] = cfg.Persistence.Collection,
-        };
-        if (cfg.Persistence.Expires is { } expire)
-        {
-            metadata["@expires"] = DateTime.UtcNow.Add(expire);
-        }
-
-        foreach (var msg in msgs)
-        {
-            if(msg.TryGet("role", out string role) is false)
+            if (configuration.FindAction(call.Name) == null)
                 continue;
-            switch (role)
+
+            userTools ??= [];
+            userTools.Add(new ToolRequest
             {
-                case "tool":
-                { // TODO: assuming an array only here. 
-                    if(msg.TryGet("content", out string content) is false)
-                        continue;
-                    var array = context.ParseBufferToArray(content, "tool-response", BlittableJsonDocumentBuilder.UsageMode.None);
-                    msg.Modifications = new DynamicJsonValue(msg)
-                    {
-                        ["content"] = array
-                    };
-                    break;
-                }
-                case "assistant":
-                {
-                    if (msg.TryGet("content", out string content) && content is not null)
-                    {
-                        //TODO: assuming an object only here
-                        var obj = context.Sync.ReadForMemory(content, "assistant-response");
-                        msg.Modifications = new DynamicJsonValue(msg)
-                        {
-                            ["content"] = obj
-                        };
-                    }
-
-                    if (msg.TryGet("tool_calls", out BlittableJsonReaderArray toolCalls) && toolCalls is not null)
-                    {
-                        foreach (BlittableJsonReaderObject call in toolCalls)
-                        {
-                            if (call.TryGet("function", out BlittableJsonReaderObject function) && function is not null)
-                            {
-                                if (function.TryGet("arguments", out string args) && args is not null)
-                                {
-                                    var obj = context.Sync.ReadForMemory(args, "tool-arguments");
-                                    function.Modifications = new DynamicJsonValue(function)
-                                    {
-                                        ["arguments"] = obj
-                                    };          
-                                }
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
+                ToolId = call.Id,
+                Name = call.Name,
+                Arguments = call.Arguments
+            });
         }
-
-        var conversation = new DynamicJsonValue
-        {
-            ["Agent"] = cfg.ToJson(),
-            ["Messages"] = msgs,
-            ["@metadata"] = metadata,
-        };
-            
-        return context.ReadObject(conversation, "create-conversion");
+        return userTools.Count > 0;
     }
 
-    private async Task HandleToolCalls(JsonOperationContext context, List<BlittableJsonReaderObject> messages, AiResponse result, AiAgentConfiguration cfg,
-        BlittableJsonReaderObject parameters)
+    private async Task HandleToolCalls(JsonOperationContext context, AiAgentConfiguration cfg, ChatDocument document, AiResponse result)
     {
         // TODO: handle a response that does both query & action
         DynamicJsonArray reqs = [];
@@ -312,12 +291,12 @@ public class AiAgentHandler : DatabaseRequestHandler
                 {
                     ["Query"] = q.Query,
                     // TODO: need to dispose this? Or maybe use a dedicated context per each tool call to avoid high memory?
-                    ["QueryParameters"] = CreateParameters(context, call, parameters)
+                    ["QueryParameters"] = CreateParameters(context, call, document.Parameters)
                 }
             });
         }
 
-        using var reqsBlittable = context.ReadObject(new DynamicJsonValue { ["Requests"] = reqs }, "ai-rag/multi-query");
+        using var reqsBlittable = context.ReadObject(new DynamicJsonValue { ["Requests"] = reqs }, "ai-agent/multi-query");
         using MultiGetHandlerProcessorForPost handler = new(this);
         using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
@@ -341,7 +320,7 @@ public class AiAgentHandler : DatabaseRequestHandler
                 if (queryResponseResult.TryGet("Results", out BlittableJsonReaderArray queryResult) is false)
                     throw new InvalidOperationException("Missing Results from query output"); // TODO: shouldn't happen, but add error handling
 
-                messages.Add(context.ReadObject(new DynamicJsonValue
+                document.Messages.Add(context.ReadObject(new DynamicJsonValue
                 {
                     ["tool_call_id"] = toolCallsIds[i],
                     ["role"] = "tool",
@@ -349,6 +328,20 @@ public class AiAgentHandler : DatabaseRequestHandler
                 },"tool-call/response"));
             }
         }
+    }
+
+    private async Task WriteResponseAsync(JsonOperationContext context, string conversationId, (AiUsage Usage, List<ToolRequest> UserToolRequests, BlittableJsonReaderObject Response, BlittableJsonReaderObject Dcoument) r)
+    {
+        var output = new DynamicJsonValue
+        {
+            [nameof(ChatResult<object>.ChatId)] = conversationId,
+            [nameof(ChatResult<object>.Response)] = r.Response,
+            [nameof(ChatResult<object>.ToolRequests)] = r.UserToolRequests == null ? null : new DynamicJsonArray(r.UserToolRequests.Select(t => t.ToJson())),
+            [nameof(ChatResult<object>.Usage)] = r.Usage.ToJson()
+        };
+
+        await using var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream());
+        context.Write(writer, output);
     }
 
     private static BlittableJsonReaderObject CreateParameters(JsonOperationContext context, AiToolCall call, BlittableJsonReaderObject parameters)
@@ -368,45 +361,18 @@ public class AiAgentHandler : DatabaseRequestHandler
         }
         return args;
     }
-
-    private static BlittableJsonReaderArray GenerateTools(AiAgentConfiguration cfg, JsonOperationContext context)
+    
+    private AiAgentConfiguration GetAiAgentConfiguration(string name)
     {
-        DynamicJsonArray tools = [];
-        foreach (var q in cfg.Queries ?? [])
+        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        using (var record = ServerStore.Cluster.ReadRawDatabaseRecord(ctx, DatabaseName))
         {
-            string paramsSchema = ChatCompletionClient.GenerateJsonObjectFromSampleObject(q.ParametersSchema);
-            tools.Add(new DynamicJsonValue
-            {
-                ["type"] = "function",
-                ["function"] = new DynamicJsonValue
-                {
-                    ["name"] = q.Name,
-                    ["description"] = q.Description,
-                    ["parameters"] = context.Sync.ReadForMemory(paramsSchema, "params/schema")
-                },
-                ["strict"] = true
-            });
-        }
-        foreach (var a in cfg.Actions ?? [])
-        {
-            string paramsSchema = ChatCompletionClient.GenerateJsonObjectFromSampleObject(a.ParametersSchema);
-            tools.Add(new DynamicJsonValue
-            {
-                ["type"] = "function",
-                ["function"] = new DynamicJsonValue
-                {
-                    ["name"] = a.Name,
-                    ["description"] = a.Description,
-                    ["parameters"] = context.Sync.ReadForMemory(paramsSchema, "params/schema")
-                },
-                ["strict"] = true
-            });
-        }
+            if (record.TryGetAiAgent(name, out var configuration) == false)
+                throw new ArgumentException($"AI Agent '{name}' doesn't exists");
 
-        var obj = context.ReadObject(new DynamicJsonValue { ["_"] = tools }, "ai-rag/tools");
-        BlittableJsonReaderObject.PropertyDetails prop = default;
-        obj.GetPropertyByIndex(0, ref prop);
-        return (BlittableJsonReaderArray)prop.Value;
+            return configuration;
+        }
     }
 
     private AiConnectionString GetAiConnectionString(string name)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ChatDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ChatDocument.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.AI;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Json.Sync;
+using Sparrow.Utils;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+public class ChatDocument(string agent, BlittableJsonReaderObject parameters)
+{
+    public string Agent = agent ?? throw new ArgumentNullException(nameof(agent));
+    
+    public BlittableJsonReaderObject Parameters = parameters ;
+    public List<BlittableJsonReaderObject> Messages = [];
+    public AiUsage TotalUsage;
+    public void Initialize(JsonOperationContext context, string systemPrompt, string userPrompt)
+    {
+        if (Messages.Count > 0)
+            throw new InvalidOperationException("Chat document is already initialized. Cannot re-initialize.");
+
+        AddMessage(context, context.ReadObject(new DynamicJsonValue
+        {
+            ["role"] = "system",
+            ["content"] = systemPrompt
+        }, "system/msg"));
+
+        AddMessage(context, context.ReadObject(new DynamicJsonValue
+        {
+            ["role"] = "user",
+            ["content"] = userPrompt
+        }, "user/msg"));
+    }
+
+    public void EnsureInitialized()
+    {
+        if (Messages.Count == 0)
+            throw new InvalidOperationException("Chat document is not initialized. Call Initialize() first.");
+    }
+
+    public BlittableJsonReaderObject ToBlittable(JsonOperationContext context, AiAgentConfiguration configuration)
+    {
+        var metadata = new DynamicJsonValue
+        {
+            ["@collection"] = configuration.Persistence.Collection,
+        };
+        if (configuration.Persistence.Expires is { } expire)
+        {
+            metadata["@expires"] = DateTime.UtcNow.Add(expire);
+        }
+
+        var conversation = new DynamicJsonValue
+        {
+            [nameof(Agent)] = Agent,
+            [nameof(Parameters)] = Parameters,
+            [nameof(Messages)] = Messages,
+            [nameof(TotalUsage)] = TotalUsage.ToJson(),
+            ["@metadata"] = metadata,
+        };
+            
+        return context.ReadObject(conversation, "create-conversion");
+    }
+
+    public void AddMessage(JsonOperationContext context, BlittableJsonReaderObject msg)
+    {
+        if (msg.TryGet("role", out string role) is false)
+            return;
+
+        switch (role)
+        {
+            case "system":
+            case "user":
+                break;
+            case "tool":
+            {
+                // TODO: assuming an array only here. 
+                if (msg.TryGet("content", out string content) is false)
+                    return;
+
+                var array = context.ParseBufferToArray(content, "tool-response", BlittableJsonDocumentBuilder.UsageMode.None);
+                msg.Modifications = new DynamicJsonValue(msg) { ["content"] = array };
+                break;
+            }
+            case "assistant":
+            {
+                if (msg.TryGet("content", out string content) && content is not null)
+                {
+                    //TODO: assuming an object only here
+                    var obj = context.Sync.ReadForMemory(content, "assistant-response");
+                    msg.Modifications = new DynamicJsonValue(msg) { ["content"] = obj };
+                }
+
+                if (msg.TryGet("tool_calls", out BlittableJsonReaderArray toolCalls) && toolCalls is not null)
+                {
+                    foreach (BlittableJsonReaderObject call in toolCalls)
+                    {
+                        if (call.TryGet("function", out BlittableJsonReaderObject function) && function is not null)
+                        {
+                            if (function.TryGet("arguments", out string args) && args is not null)
+                            {
+                                var obj = context.Sync.ReadForMemory(args, "tool-arguments");
+                                function.Modifications = new DynamicJsonValue(function) { ["arguments"] = obj };
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+        }
+
+        Messages.Add(msg);
+    }
+
+    public static ChatDocument ToDocument(string id, BlittableJsonReaderObject document)
+    {
+        if (document.TryGet(nameof(Agent), out string agent) == false)
+            throw new ArgumentException($"Missing Agent in '{id}' chat document");
+        if (document.TryGet(nameof(Parameters), out BlittableJsonReaderObject parameters) == false)
+            throw new ArgumentException($"Missing Parameters in '{id}' chat document");
+        if (document.TryGet(nameof(Messages), out BlittableJsonReaderArray messages) == false)
+            throw new ArgumentException($"Missing Messages in '{id}' chat document");
+        if (document.TryGet(nameof(TotalUsage), out BlittableJsonReaderObject usage) == false)
+            throw new ArgumentException($"AI Usage in '{id}' chat document");
+
+
+        DevelopmentHelper.ToDo(DevelopmentHelper.Feature.AI, DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "make messages IEnumerable?");
+
+        return new ChatDocument(agent, parameters)
+        {
+            Messages = messages.Items.Select(m=>(BlittableJsonReaderObject)m).ToList(),
+            TotalUsage = JsonDeserializationClient.AiUsage(usage)
+        };
+    }
+
+    public BlittableJsonReaderArray GenerateTools(JsonOperationContext context, AiAgentConfiguration configuration)
+    {
+        DynamicJsonArray tools = [];
+        foreach (var q in configuration.Queries ?? [])
+        {
+            string paramsSchema = ChatCompletionClient.GenerateJsonObjectFromSampleObject(q.ParametersSchema);
+            tools.Add(new DynamicJsonValue
+            {
+                ["type"] = "function",
+                ["function"] = new DynamicJsonValue
+                {
+                    ["name"] = q.Name,
+                    ["description"] = q.Description,
+                    ["parameters"] = context.Sync.ReadForMemory(paramsSchema, "params/schema")
+                },
+                ["strict"] = true
+            });
+        }
+        foreach (var a in configuration.Actions ?? [])
+        {
+            string paramsSchema = ChatCompletionClient.GenerateJsonObjectFromSampleObject(a.ParametersSchema);
+            tools.Add(new DynamicJsonValue
+            {
+                ["type"] = "function",
+                ["function"] = new DynamicJsonValue
+                {
+                    ["name"] = a.Name,
+                    ["description"] = a.Description,
+                    ["parameters"] = context.Sync.ReadForMemory(paramsSchema, "params/schema")
+                },
+                ["strict"] = true
+            });
+        }
+
+        var obj = context.ReadObject(new DynamicJsonValue { ["_"] = tools }, "ai-rag/tools");
+        BlittableJsonReaderObject.PropertyDetails prop = default;
+        obj.GetPropertyByIndex(0, ref prop);
+        return (BlittableJsonReaderArray)prop.Value;
+    }
+
+    public void UpdateUsage(AiUsage usage)
+    {
+        if (TotalUsage is null)
+        {
+            TotalUsage = usage;
+            return;
+        }
+
+        TotalUsage.TotalTokens += usage.TotalTokens;
+        TotalUsage.PromptTokens += usage.PromptTokens;
+        TotalUsage.CompletionTokens += usage.CompletionTokens;
+        TotalUsage.CachedTokens += usage.CachedTokens;
+    }
+}

--- a/src/Sparrow/Utils/DevelopmentHelper.cs
+++ b/src/Sparrow/Utils/DevelopmentHelper.cs
@@ -16,7 +16,8 @@ internal static class DevelopmentHelper
     internal enum Feature
     {
         Sharding,
-        Cluster
+        Cluster,
+        AI
     }
 
     internal enum TeamMember

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -73,7 +73,7 @@ namespace FastTests.Client
                 "AdoptOrphanedRevisionsCommand",
                 "AddPrefixedShardingSettingCommand", "DeletePrefixedShardingSettingCommand", "UpdatePrefixedShardingSettingCommand", "RevertRevisionsByIdCommand",
                 "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand",
-                "GetCollectionRevisionsStatisticsCommand","AddOrUpdateAiAgentOperationCommand","DeleteAiAgentOperationCommand","StartChatOperationCommand"
+                "GetCollectionRevisionsStatisticsCommand","AddOrUpdateAiAgentOperationCommand","DeleteAiAgentOperationCommand","StartChatOperationCommand","ResumeChatOperationCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -2,10 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Client;
-using Orders;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -55,15 +51,21 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             agent.Queries =
             [
-                AiAgentConfiguration.ToolQuery.Build(
-                    "ProductSearch", 
-                    "semantic search the store product catalog",
-                    session.Query<Product>().VectorSearch(v => v.WithText(p => p.Name), v => v.ByText("$query")))
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSchema = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
                 ,
-                AiAgentConfiguration.ToolQuery.Build(
-                    "RecentOrder", 
-                    "Get the recent orders of the current user",
-                    session.Query<Query.Order>().Where(o => o.Company == "$company").OrderByDescending(o => o.OrderedAt).Take(10))
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSchema = "{}"
+                }
             ];
 
             await store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<OutputSchema>("shopping assistant", agent));
@@ -76,6 +78,124 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             var chat = await session.LoadAsync<dynamic>(r.ChatId);
             Assert.NotNull(chat);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task CanResumeConversation(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration(config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+            {
+                Collection = "Chats",
+                Expires = TimeSpan.FromDays(30)
+            };
+
+            agent.Queries =
+            [
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSchema = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+                ,
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSchema = "{}"
+                }
+            ];
+
+            await store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<OutputSchema>("shopping assistant", agent));
+            var r = await store.Maintenance.SendAsync(new StartChatOperation<OutputSchema>("shopping assistant", "what goes well with my cheese for recent orders?",
+                new Dictionary<string, object> { ["company"] = "companies/90-A" }));
+
+            Assert.NotNull(r.Response.Answer);
+            Assert.NotNull(r.Usage);
+            Assert.NotNull(r.ChatId);
+
+
+            var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>("shopping assistant", r.ChatId,
+                userPrompt: "can you give me a cheaper alternative?"));
+
+            Assert.NotNull(r2.Response.Answer);
+            Assert.NotNull(r2.Usage);
+            Assert.NotNull(r2.ChatId);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task AnswerActionToolRequest(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration(config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+            {
+                Collection = "Chats",
+                Expires = TimeSpan.FromDays(30)
+            };
+
+            agent.Actions =
+            [
+                new AiAgentConfiguration.ToolAction
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    ParametersSchema = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+                ,
+                new AiAgentConfiguration.ToolAction
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    ParametersSchema = "{}"
+                }
+            ];
+
+            await store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<OutputSchema>("shopping assistant", agent));
+            var r = await store.Maintenance.SendAsync(new StartChatOperation<OutputSchema>("shopping assistant", "what goes well with my cheese for recent orders?"));
+
+            Assert.True(r.ToolRequests.Count > 0);
+            Assert.NotNull(r.Usage);
+            Assert.NotNull(r.ChatId);
+
+            var toolResponse = new List<ToolResponse>();
+            for (int i = 0; i < r.ToolRequests.Count; i++)
+            {
+                var request = r.ToolRequests[i];
+                toolResponse.Add(new ToolResponse
+                {
+                    ToolId = request.ToolId,
+                    Content = "{}"
+                });
+            }
+
+            var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>("shopping assistant", r.ChatId, toolResponses: toolResponse));
+
+            Assert.NotNull(r2.Response.Answer);
+            Assert.NotNull(r2.Usage);
+            Assert.NotNull(r2.ChatId);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24208 

### Additional description

Implement the EP and client API to resume the chat with the AI agent. Either by providing a new prompt to it, or by answering the user tool request.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
