### PR TITLE
RavenDB-24435 we need to escape database name in the Database-Missing…

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1026,7 +1026,7 @@ namespace Raven.Client.Http
                             {
                                 var name = databaseMissing.FirstOrDefault();
                                 if (name != null)
-                                    DatabaseDoesNotExistException.Throw(name);
+                                    DatabaseDoesNotExistException.Throw(Uri.UnescapeDataString(name));
                             }
 
                             ThrowFailedToContactAllNodes(command, request);

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractHandlerProcessorForGetDatabaseRecord.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractHandlerProcessorForGetDatabaseRecord.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client;
@@ -43,7 +44,7 @@ internal abstract class AbstractHandlerProcessorForGetDatabaseRecord<TRequestHan
                 if (dbDoc == null)
                 {
                     RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                    RequestHandler.HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = name;
+                    RequestHandler.HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = Uri.EscapeDataString(name);
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                     {
                         context.Write(writer,

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -127,7 +127,7 @@ namespace Raven.Server.Web.System
                         // here we return 503 so clients will try to failover to another server
                         // if this is a newly created db that we haven't been notified about it yet
                         HttpContext.Response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
-                        HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = name;
+                        HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = Uri.EscapeDataString(name);
                         await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                         {
                             context.Write(writer,
@@ -150,7 +150,7 @@ namespace Raven.Server.Web.System
                     {
                         // The database at deletion progress from all nodes
                         HttpContext.Response.StatusCode = (int)HttpStatusCode.ServiceUnavailable;
-                        HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = name;
+                        HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = Uri.EscapeDataString(name);
                         await using (var writer = new AsyncBlittableJsonTextWriter(context, HttpContext.Response.Body))
                         {
                             context.Write(writer, new DynamicJsonValue { ["Type"] = "Error", ["Message"] = "Database " + name + " was deleted" });

--- a/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
@@ -62,7 +62,7 @@ internal sealed class DatabasesHandlerProcessorForGet : AbstractDatabasesHandler
             if (items.Count == 0 && name != null)
             {
                 await RequestHandler.NoContent(HttpStatusCode.NotFound);
-                HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = name;
+                HttpContext.Response.Headers[Constants.Headers.DatabaseMissing] = Uri.EscapeDataString(name);
                 return;
             }
 

--- a/test/FastTests/Issues/RavenDB_24435.cs
+++ b/test/FastTests/Issues/RavenDB_24435.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Raven.Client;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_24435 : RavenTestBase
+    {
+        public RavenDB_24435(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task GetDatabaseRecord_Should_Return_URL_Encoded_DatabaseName_In_Header_When_Database_Is_Missing()
+        {
+            var databaseName = $"database-møøse-{Guid.NewGuid()}";
+
+            using var httpClient = new HttpClient();
+            var requestUri = $"{Server.WebUrl}/admin/databases?name={Uri.EscapeDataString(databaseName)}";
+
+            await AssertDatabaseMissingHeaderValueAsync(httpClient, requestUri, databaseName);
+            
+            requestUri = $"{Server.WebUrl}/topology?name={Uri.EscapeDataString(databaseName)}";
+            
+            await AssertDatabaseMissingHeaderValueAsync(httpClient, requestUri, databaseName);
+        }
+        
+        private async Task AssertDatabaseMissingHeaderValueAsync(HttpClient httpClient, string requestUri, string expectedDatabaseName)
+        {
+            var response = await httpClient.GetAsync(requestUri);
+            
+            Assert.True(response.Headers.Contains(Constants.Headers.DatabaseMissing));
+            var headerValues = response.Headers.GetValues(Constants.Headers.DatabaseMissing);
+            var headerValue = Assert.Single(headerValues);
+
+            var decodedName = Uri.UnescapeDataString(headerValue);
+            Assert.Equal(expectedDatabaseName, decodedName);
+        }
+    }
+}


### PR DESCRIPTION
… header because it might contain not allowed in header characters

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24435

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
