### PR TITLE
RavenDB-23817: Ensure we thrown when rolling back from 8.0 to 7.x

### DIFF
--- a/test/InterversionTests/RavenDB_23817.cs
+++ b/test/InterversionTests/RavenDB_23817.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace InterversionTests
+{
+    public class RavenDB_23817 : InterversionTestBase
+    {
+        public RavenDB_23817(ITestOutputHelper output) : base(output) { }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public async Task UpgradeFrom7To8_ThenRollbackTo7_ShouldFailWhenRollingBack2()
+        {
+            const string version7 = "7.0.2";
+            const string version8 = "8.0.0-nightly-20250603-1852";
+            var dbName = GetDatabaseName(nameof(UpgradeFrom7To8_ThenRollbackTo7_ShouldFailWhenRollingBack2));
+
+            var opts = new InterversionTestOptions
+            {
+                ModifyDatabaseRecord = rec =>
+                {
+                    rec.Settings[RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false";
+                }
+            };
+
+            var node = await GetServerAsync(version7, opts, dbName);
+
+
+            using (var store7 = await GetDocumentStoreAsync(version7, opts, dbName))
+            using (var session = store7.OpenAsyncSession())
+            {
+                await session.StoreAsync(new { Name = "Alice" }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            await UpgradeServerAsync(version8, node);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await UpgradeServerAsync(version7, node);
+            });
+        }
+    }
+}
+

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -286,13 +286,15 @@ namespace Tests.Infrastructure
                 if (readLineTask == null)
                     readLineTask = output.ReadLineAsync();
 
-                var hasResult = await readLineTask.WaitWithTimeout(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                var hasResult = await readLineTask.WaitWithTimeout(TimeSpan.FromSeconds(60)).ConfigureAwait(false);
 
-                //if (startupDuration.Elapsed > options.MaxServerStartupTimeDuration)
-                //    return null;
+                // if (startupDuration.Elapsed > options.MaxServerStartupTimeDuration)
+                //     return null;
 
                 if (hasResult == false)
-                    continue;
+                {
+                    break;
+                }
 
                 var line = await readLineTask;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23817/Ensure-we-thrown-when-rolling-back-from-8.0-to-7.x

### Additional description

Adds RavenDB_23817 inter-version test that:
Spins up 7.0.2 on-disk, writes a doc, upgrades the same node to 8.0, tries to roll back to 7.0.2 again and asserts it fails due to the new metadata format change

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing for linux through WSL
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
