### PR TITLE
RavenDB-24352 Change colors & icons for certificates database permissions

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
@@ -275,8 +275,8 @@ function PermissionsBadge({ certificate }: { certificate: CertificateItem }) {
         SecurityClearance === "Operator"
     ) {
         return (
-            <Badge bg="faded-success" pill>
-                <Icon icon="user" />
+            <Badge bg="faded-success" title="Cluster admin access" pill>
+                <Icon icon="cluster" />
                 All
             </Badge>
         );
@@ -297,7 +297,7 @@ function PermissionsBadge({ certificate }: { certificate: CertificateItem }) {
     return (
         <div className="hstack gap-1">
             {dbAccessArray.map(({ databaseName, accessLevel }) => (
-                <Badge key={databaseName} bg={getAccessColor(accessLevel)} pill>
+                <Badge key={databaseName} bg={getAccessColor(accessLevel)} title={getAccessTitle(accessLevel)} pill>
                     <Icon icon={getAccessIcon(accessLevel)} />
                     {databaseName}
                 </Badge>
@@ -306,10 +306,23 @@ function PermissionsBadge({ certificate }: { certificate: CertificateItem }) {
     );
 }
 
+function getAccessTitle(access: Raven.Client.ServerWide.Operations.Certificates.DatabaseAccess) {
+    switch (access) {
+        case "Admin":
+            return "Admin access";
+        case "Read":
+            return "Read access";
+        case "ReadWrite":
+            return "Read/write access";
+        default:
+            assertUnreachable(access);
+    }
+}
+
 function getAccessIcon(access: Raven.Client.ServerWide.Operations.Certificates.DatabaseAccess): IconName {
     switch (access) {
         case "Admin":
-            return "access-admin";
+            return "hammer-driver";
         case "Read":
             return "access-read";
         case "ReadWrite":
@@ -322,9 +335,9 @@ function getAccessIcon(access: Raven.Client.ServerWide.Operations.Certificates.D
 function getAccessColor(access: Raven.Client.ServerWide.Operations.Certificates.DatabaseAccess): `faded-${ThemeColor}` {
     switch (access) {
         case "Admin":
-            return "faded-success";
-        case "Read":
             return "faded-danger";
+        case "Read":
+            return "faded-info";
         case "ReadWrite":
             return "faded-warning";
         default:


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24352

### Additional description

Changed colors & icons for database permissions badges to make them more effectively show the restrictions

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
