### PR TITLE
RavenDB-24446 - WindowsDiskStatsGetter is flooding the logs

### DIFF
--- a/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
@@ -117,7 +117,18 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"{nameof(DiskCounters)} was created for \"{drive}\" (requested for path \"{path}\").");
 
-                    counter = _countersPerDisk[path] = new DiskCounters(name);
+                    try
+                    {
+                        counter = _countersPerDisk[path] = new DiskCounters(name);
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        if (Logger.IsOperationsEnabled)
+                            Logger.Operations($"Couldn't create disk counters instance in {DiskCategory} for \"{drive}\" (requested for path \"{path}\").");
+
+                        _countersPerDisk[path] = null;
+                    }
+
                     break;
                 }
 

--- a/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
@@ -127,6 +127,7 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
                             Logger.Operations($"Couldn't create disk counters instance in {DiskCategory} for \"{drive}\" (requested for path \"{path}\").");
 
                         _countersPerDisk[path] = null;
+                        return null;
                     }
 
                     break;

--- a/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
@@ -101,7 +101,7 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
     private class CountersPerDisk : IDisposable
     {
         private readonly PerformanceCounterCategory _category = new PerformanceCounterCategory(DiskCategory);
-        private readonly ConcurrentDictionary<string, DiskCounters> _countersPerDisk = new ConcurrentDictionary<string, DiskCounters>();
+        private readonly ConcurrentDictionary<string, Lazy<DiskCounters>> _countersPerDisk = new ConcurrentDictionary<string, Lazy<DiskCounters>>();
 
         public DiskCounters Get(string path)
         {
@@ -119,7 +119,7 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
 
                     try
                     {
-                        counter = _countersPerDisk[path] = new DiskCounters(name);
+                        counter = _countersPerDisk[path] = new Lazy<DiskCounters>(() => new DiskCounters(name));
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -141,14 +141,14 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
                 }
             }
 
-            return counter;
+            return counter?.Value;
         }
 
         public void Dispose()
         {
             foreach (var (_, value) in _countersPerDisk)
             {
-                value.Dispose();
+                value?.Value.Dispose();
             }
         }
     }

--- a/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
@@ -119,7 +119,8 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
 
                     try
                     {
-                        counter = _countersPerDisk[path] = new Lazy<DiskCounters>(() => new DiskCounters(name));
+                        counter = _countersPerDisk.GetOrAdd(path, new Lazy<DiskCounters>(() => new DiskCounters(name)));
+                        return counter?.Value;
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -129,17 +130,12 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
                         _countersPerDisk[path] = null;
                         return null;
                     }
-
-                    break;
                 }
 
-                if (counter == null)
-                {
-                    if (Logger.IsOperationsEnabled)
-                        Logger.Operations($"Couldn't find instance in {DiskCategory} for \"{drive}\" (requested for path \"{path}\").");
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations($"Couldn't find instance in {DiskCategory} for \"{drive}\" (requested for path \"{path}\").");
 
-                    _countersPerDisk[path] = null;
-                }
+                _countersPerDisk[path] = null;
             }
 
             return counter?.Value;

--- a/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/WindowsDiskStatsGetter.cs
@@ -117,19 +117,23 @@ internal class WindowsDiskStatsGetter : DiskStatsGetter<WindowsDiskStatsRawResul
                     if (Logger.IsOperationsEnabled)
                         Logger.Operations($"{nameof(DiskCounters)} was created for \"{drive}\" (requested for path \"{path}\").");
 
-                    try
+                    counter = _countersPerDisk.GetOrAdd(path, new Lazy<DiskCounters>(() =>
                     {
-                        counter = _countersPerDisk.GetOrAdd(path, new Lazy<DiskCounters>(() => new DiskCounters(name)));
-                        return counter?.Value;
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        if (Logger.IsOperationsEnabled)
-                            Logger.Operations($"Couldn't create disk counters instance in {DiskCategory} for \"{drive}\" (requested for path \"{path}\").");
+                        try
+                        {
+                            return new DiskCounters(name);
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            if (Logger.IsOperationsEnabled)
+                                Logger.Operations($"Couldn't create disk counters instance in {DiskCategory} for \"{drive}\" (requested for path \"{path}\").");
 
-                        _countersPerDisk[path] = null;
-                        return null;
-                    }
+                            _countersPerDisk[path] = null;
+                            return null;
+                        }
+                    }));
+
+                    return counter?.Value;
                 }
 
                 if (Logger.IsOperationsEnabled)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24446/WindowsDiskStatsGetter-is-flooding-the-logs

### Additional description
- Add exception handling for UnauthorizedAccessException when creating disk performance counters.
- Avoid duplicate DiskCounters instantiation in concurrent scenarios.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
