### PR TITLE
RavenDB-24257 - Ai Agent Client

### DIFF
--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Util;
 
@@ -10,33 +11,35 @@ namespace Raven.Client.Documents.AI;
 /// <summary>
 /// Manages AI agents and chat interactions in a specific RavenDB database.
 /// </summary>
-public class DatabaseAiAgents
+public class AiOperations
 {
     private string _databaseName;
     private IDocumentStore _store;
+    private readonly MaintenanceOperationExecutor _executor;
 
     /// <summary>
-    /// Initializes a new instance of <see cref="DatabaseAiAgents"/> for a given document store and optional database name.
+    /// Initializes a new instance of <see cref="AiOperations"/> for a given document store and optional database name.
     /// </summary>
     /// <param name="store">The RavenDB document store.</param>
     /// <param name="databaseName">The name of the database. If null, uses the default database from the store.</param>
-    public DatabaseAiAgents(IDocumentStore store, string databaseName = null)
+    public AiOperations(IDocumentStore store, string databaseName = null)
     {
         _databaseName = databaseName ?? store.Database;
         _store = store;
+        _executor = _store.Maintenance.ForDatabase(_databaseName);
     }
 
     /// <summary>
-    /// Returns a <see cref="DatabaseAiAgents"/> for a different database.
+    /// Returns a <see cref="AiOperations"/> for a different database.
     /// </summary>
     /// <param name="databaseName">The name of the target database.</param>
-    /// <returns>A new or existing <see cref="DatabaseAiAgents"/> instance.</returns>
-    public DatabaseAiAgents ForDatabase(string databaseName)
+    /// <returns>A new or existing <see cref="AiOperations"/> instance.</returns>
+    public AiOperations ForDatabase(string databaseName)
     {
         if (string.Equals(_databaseName, databaseName, StringComparison.OrdinalIgnoreCase))
             return this;
 
-        return new DatabaseAiAgents(_store, databaseName);
+        return new AiOperations(_store, databaseName);
     }
 
     /// <summary>
@@ -48,7 +51,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the creation or update operation.</returns>
     public async Task<AiAgentConfigurationResult> CreateAgentAsync<TSchema>(string agentName, AiAgentConfiguration configuration, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration), token).ConfigureAwait(false);
+        return await _executor.SendAsync(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration), token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -69,12 +72,11 @@ public class DatabaseAiAgents
     /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
     /// <param name="agentName">The name of the AI agent to chat with.</param>
     /// <param name="prompt">The initial user prompt.</param>
-    /// <param name="func">A builder function to define RAG parameters.</param>
+    /// <param name="builder">A builder function to define RAG parameters.</param>
     /// <returns>The result of the chat.</returns>
-    public Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func, CancellationToken token = default) where TSchema : new()
+    public Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> builder, CancellationToken token = default) where TSchema : new()
     {
-        var builder = func.Invoke(new AiAgentParametersBuilder());
-        var parameters = builder.GetParameters();
+        var parameters = builder.Invoke(new AiAgentParametersBuilder()).GetParameters();
         return StartChatAsync<TSchema>(agentName, prompt, parameters, token);
     }
 
@@ -84,11 +86,11 @@ public class DatabaseAiAgents
     /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
     /// <param name="agentName">The name of the AI agent to chat with.</param>
     /// <param name="prompt">The initial user prompt.</param>
-    /// <param name="func">A builder function to define RAG parameters.</param>
+    /// <param name="builder">A builder function to define RAG parameters.</param>
     /// <returns>The result of the chat.</returns>
-    public ChatResult<TSchema> StartChat<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func) where TSchema : new()
+    public ChatResult<TSchema> StartChat<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> builder) where TSchema : new()
     {
-        return AsyncHelpers.RunSync(() => StartChatAsync<TSchema>(agentName, prompt, func));
+        return AsyncHelpers.RunSync(() => StartChatAsync<TSchema>(agentName, prompt, builder));
     }
 
     /// <summary>
@@ -101,7 +103,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the chat.</returns>
     public async Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Dictionary<string, object> parameters = null, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new StartChatOperation<TSchema>(agentName, prompt, parameters), token).ConfigureAwait(false);
+        return await _executor.SendAsync(new StartChatOperation<TSchema>(agentName, prompt, parameters), token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -140,7 +142,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the continued chat.</returns>
     public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, string prompt, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt), token).ConfigureAwait(false);
+        return await _executor.SendAsync(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt), token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -166,7 +168,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the continued chat.</returns>
     public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, List<ToolResponse> toolResponses, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses), token).ConfigureAwait(false);
+        return await _executor.SendAsync(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses), token).ConfigureAwait(false);
     }
 
     public class AiAgentParametersBuilder

--- a/src/Raven.Client/Documents/AI/DatabaseAiAgents.cs
+++ b/src/Raven.Client/Documents/AI/DatabaseAiAgents.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.AI.Agents;
+
+namespace Raven.Client.Documents.AI;
+
+/// <summary>
+/// Manages AI agents and chat interactions in a specific RavenDB database.
+/// </summary>
+public class DatabaseAiAgents
+{
+    private string _databaseName;
+    private IDocumentStore _store;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DatabaseAiAgents"/> for a given document store and optional database name.
+    /// </summary>
+    /// <param name="store">The RavenDB document store.</param>
+    /// <param name="databaseName">The name of the database. If null, uses the default database from the store.</param>
+    public DatabaseAiAgents(IDocumentStore store, string databaseName = null)
+    {
+        _databaseName = databaseName ?? store.Database;
+        _store = store;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="DatabaseAiAgents"/> for a different database.
+    /// </summary>
+    /// <param name="databaseName">The name of the target database.</param>
+    /// <returns>A new or existing <see cref="DatabaseAiAgents"/> instance.</returns>
+    public DatabaseAiAgents ForDatabase(string databaseName)
+    {
+        if (string.Equals(_databaseName, databaseName, StringComparison.OrdinalIgnoreCase))
+            return this;
+
+        return new DatabaseAiAgents(_store, databaseName);
+    }
+
+    /// <summary>
+    /// Asynchronously creates or updates an AI agent configuration (with the given schema) on the database.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type the AI agent should use.</typeparam>
+    /// <param name="agentName">The unique name of the AI agent for create an agent, or name of an existed agent for update an agent.</param>
+    /// <param name="configuration">The configuration to assign to the agent.</param>
+    /// <returns>The result of the creation or update operation.</returns>
+    public async Task<AiAgentConfigurationResult> CreateAgentAsync<TSchema>(string agentName, AiAgentConfiguration configuration) where TSchema : new()
+    {
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Creates or updates an AI agent configuration (with the given schema) on the database.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type the AI agent should use.</typeparam>
+    /// <param name="agentName">The unique name of the AI agent for create an agent, or name of an existed agent for update an agent.</param>
+    /// <param name="configuration">The configuration to assign to the agent.</param>
+    /// <returns>The result of the creation or update operation.</returns>
+    public AiAgentConfigurationResult CreateAgent<TSchema>(string agentName, AiAgentConfiguration configuration) where TSchema : new()
+    {
+        return _store.Maintenance.ForDatabase(_databaseName).Send(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration));
+    }
+
+    /// <summary>
+    /// Asynchronously starts a new chat with an AI agent using a fluent parameter builder.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="agentName">The name of the AI agent to chat with.</param>
+    /// <param name="prompt">The initial user prompt.</param>
+    /// <param name="func">A builder function to define RAG parameters.</param>
+    /// <returns>The result of the chat.</returns>
+    public Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func) where TSchema : new()
+    {
+        var builder = func.Invoke(new AiAgentParametersBuilder());
+        var parameters = builder.GetParameters();
+        return StartChatAsync<TSchema>(agentName, prompt, parameters);
+    }
+
+    /// <summary>
+    /// Starts a new chat with an AI agent using a fluent parameter builder.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="agentName">The name of the AI agent to chat with.</param>
+    /// <param name="prompt">The initial user prompt.</param>
+    /// <param name="func">A builder function to define RAG parameters.</param>
+    /// <returns>The result of the chat.</returns>
+    public ChatResult<TSchema> StartChat<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func) where TSchema : new()
+    {
+        var builder = func.Invoke(new AiAgentParametersBuilder());
+        var parameters = builder.GetParameters();
+        return StartChat<TSchema>(agentName, prompt, parameters);
+    }
+
+    /// <summary>
+    /// Asynchronously starts a new chat with an AI agent using a dictionary of parameters.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="agentName">The name of the AI agent to chat with.</param>
+    /// <param name="prompt">The initial user prompt.</param>
+    /// <param name="parameters">Optional dictionary of chat parameters.</param>
+    /// <returns>The result of the chat.</returns>
+    public async Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Dictionary<string, object> parameters = null) where TSchema : new()
+    {
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new StartChatOperation<TSchema>(agentName, prompt, parameters)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Synchronously starts a new chat with an AI agent using a dictionary of parameters.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="agentName">The name of the AI agent to chat with.</param>
+    /// <param name="prompt">The initial user prompt.</param>
+    /// <param name="parameters">Optional dictionary of chat parameters.</param>
+    /// <returns>The result of the chat.</returns>
+    public ChatResult<TSchema> StartChat<TSchema>(string agentName, string prompt, Dictionary<string, object> parameters = null) where TSchema : new()
+    {
+        return _store.Maintenance.ForDatabase(_databaseName).Send(new StartChatOperation<TSchema>(agentName, prompt, parameters));
+    }
+
+    /// <summary>
+    /// Continues a chat using a fluent parameter builder.
+    /// Also update the chat with the new prompt and response.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="chatId">The ID of the existing chat.</param>
+    /// <param name="prompt">The next user prompt in the conversation.</param>
+    /// <returns>The result of the continued chat.</returns>
+    public ChatResult<TSchema> ContinueChat<TSchema>(string chatId, string prompt) where TSchema : new()
+    {
+        return _store.Maintenance.ForDatabase(_databaseName).Send(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt));
+    }
+
+    /// <summary>
+    /// Asynchronously continues a chat using a fluent parameter builder.
+    /// Also update the chat with the new prompt and response.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="chatId">The ID of the existing chat.</param>
+    /// <param name="prompt">The next user prompt in the conversation.</param>
+    /// <returns>The result of the continued chat.</returns>
+    public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, string prompt) where TSchema : new()
+    {
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt)).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Continues a chat using a fluent parameter builder.
+    /// Also update the chat with the new prompt and response.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="chatId">The ID of the existing chat.</param>
+    /// <param name="toolResponses"> A list of tool responses corresponding to the previous 'ToolActions' requests made by the agent. </param>
+    /// <returns>The result of the continued chat.</returns>
+    public ChatResult<TSchema> ContinueChat<TSchema>(string chatId, List<ToolResponse> toolResponses) where TSchema : new()
+    {
+        return _store.Maintenance.ForDatabase(_databaseName).Send(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses));
+    }
+
+    /// <summary>
+    /// Asynchronously continues a chat using a fluent parameter builder.
+    /// Also update the chat with the new prompt and response.
+    /// </summary>
+    /// <typeparam name="TSchema">The schema type for the chat.</typeparam>
+    /// <param name="chatId">The ID of the existing chat.</param>
+    /// <param name="toolResponses"> A list of tool responses corresponding to the previous 'ToolActions' requests made by the agent. </param>
+    /// <returns>The result of the continued chat.</returns>
+    public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, List<ToolResponse> toolResponses) where TSchema : new()
+    {
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses)).ConfigureAwait(false);
+    }
+
+    public class AiAgentParametersBuilder
+    {
+        private readonly Dictionary<string, object> _parameters = new();
+
+        public AiAgentParametersBuilder AddParameter(string key, string value)
+        {
+            _parameters[key] = value;
+            return this;
+        }
+
+        public Dictionary<string, object> GetParameters() => _parameters.Count == 0 ? null : _parameters;
+    }
+}

--- a/src/Raven.Client/Documents/AI/DatabaseAiAgents.cs
+++ b/src/Raven.Client/Documents/AI/DatabaseAiAgents.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Util;
 
 namespace Raven.Client.Documents.AI;
 
@@ -44,9 +46,9 @@ public class DatabaseAiAgents
     /// <param name="agentName">The unique name of the AI agent for create an agent, or name of an existed agent for update an agent.</param>
     /// <param name="configuration">The configuration to assign to the agent.</param>
     /// <returns>The result of the creation or update operation.</returns>
-    public async Task<AiAgentConfigurationResult> CreateAgentAsync<TSchema>(string agentName, AiAgentConfiguration configuration) where TSchema : new()
+    public async Task<AiAgentConfigurationResult> CreateAgentAsync<TSchema>(string agentName, AiAgentConfiguration configuration, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration)).ConfigureAwait(false);
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration), token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -58,7 +60,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the creation or update operation.</returns>
     public AiAgentConfigurationResult CreateAgent<TSchema>(string agentName, AiAgentConfiguration configuration) where TSchema : new()
     {
-        return _store.Maintenance.ForDatabase(_databaseName).Send(new AddOrUpdateAiAgentOperation<TSchema>(agentName, configuration));
+        return AsyncHelpers.RunSync(() => CreateAgentAsync<TSchema>(agentName, configuration));
     }
 
     /// <summary>
@@ -69,11 +71,11 @@ public class DatabaseAiAgents
     /// <param name="prompt">The initial user prompt.</param>
     /// <param name="func">A builder function to define RAG parameters.</param>
     /// <returns>The result of the chat.</returns>
-    public Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func) where TSchema : new()
+    public Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func, CancellationToken token = default) where TSchema : new()
     {
         var builder = func.Invoke(new AiAgentParametersBuilder());
         var parameters = builder.GetParameters();
-        return StartChatAsync<TSchema>(agentName, prompt, parameters);
+        return StartChatAsync<TSchema>(agentName, prompt, parameters, token);
     }
 
     /// <summary>
@@ -99,9 +101,9 @@ public class DatabaseAiAgents
     /// <param name="prompt">The initial user prompt.</param>
     /// <param name="parameters">Optional dictionary of chat parameters.</param>
     /// <returns>The result of the chat.</returns>
-    public async Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Dictionary<string, object> parameters = null) where TSchema : new()
+    public async Task<ChatResult<TSchema>> StartChatAsync<TSchema>(string agentName, string prompt, Dictionary<string, object> parameters = null, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new StartChatOperation<TSchema>(agentName, prompt, parameters)).ConfigureAwait(false);
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new StartChatOperation<TSchema>(agentName, prompt, parameters), token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -114,7 +116,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the chat.</returns>
     public ChatResult<TSchema> StartChat<TSchema>(string agentName, string prompt, Dictionary<string, object> parameters = null) where TSchema : new()
     {
-        return _store.Maintenance.ForDatabase(_databaseName).Send(new StartChatOperation<TSchema>(agentName, prompt, parameters));
+        return AsyncHelpers.RunSync(() => StartChatAsync<TSchema>(agentName, prompt, parameters));
     }
 
     /// <summary>
@@ -127,7 +129,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the continued chat.</returns>
     public ChatResult<TSchema> ContinueChat<TSchema>(string chatId, string prompt) where TSchema : new()
     {
-        return _store.Maintenance.ForDatabase(_databaseName).Send(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt));
+        return AsyncHelpers.RunSync(() => ContinueChatAsync<TSchema>(chatId, prompt));
     }
 
     /// <summary>
@@ -138,9 +140,9 @@ public class DatabaseAiAgents
     /// <param name="chatId">The ID of the existing chat.</param>
     /// <param name="prompt">The next user prompt in the conversation.</param>
     /// <returns>The result of the continued chat.</returns>
-    public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, string prompt) where TSchema : new()
+    public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, string prompt, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt)).ConfigureAwait(false);
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, userPrompt: prompt), token).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -153,7 +155,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the continued chat.</returns>
     public ChatResult<TSchema> ContinueChat<TSchema>(string chatId, List<ToolResponse> toolResponses) where TSchema : new()
     {
-        return _store.Maintenance.ForDatabase(_databaseName).Send(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses));
+        return AsyncHelpers.RunSync(() => ContinueChatAsync<TSchema>(chatId, toolResponses));
     }
 
     /// <summary>
@@ -164,9 +166,9 @@ public class DatabaseAiAgents
     /// <param name="chatId">The ID of the existing chat.</param>
     /// <param name="toolResponses"> A list of tool responses corresponding to the previous 'ToolActions' requests made by the agent. </param>
     /// <returns>The result of the continued chat.</returns>
-    public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, List<ToolResponse> toolResponses) where TSchema : new()
+    public async Task<ChatResult<TSchema>> ContinueChatAsync<TSchema>(string chatId, List<ToolResponse> toolResponses, CancellationToken token = default) where TSchema : new()
     {
-        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses)).ConfigureAwait(false);
+        return await _store.Maintenance.ForDatabase(_databaseName).SendAsync(new ResumeChatOperation<TSchema>(chatId, toolResponses: toolResponses), token).ConfigureAwait(false);
     }
 
     public class AiAgentParametersBuilder

--- a/src/Raven.Client/Documents/AI/DatabaseAiAgents.cs
+++ b/src/Raven.Client/Documents/AI/DatabaseAiAgents.cs
@@ -88,9 +88,7 @@ public class DatabaseAiAgents
     /// <returns>The result of the chat.</returns>
     public ChatResult<TSchema> StartChat<TSchema>(string agentName, string prompt, Func<AiAgentParametersBuilder, AiAgentParametersBuilder> func) where TSchema : new()
     {
-        var builder = func.Invoke(new AiAgentParametersBuilder());
-        var parameters = builder.GetParameters();
-        return StartChat<TSchema>(agentName, prompt, parameters);
+        return AsyncHelpers.RunSync(() => StartChatAsync<TSchema>(agentName, prompt, func));
     }
 
     /// <summary>

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -47,9 +47,9 @@ namespace Raven.Client.Documents
 
         private string _identifier;
 
-        private DatabaseAiAgents _aiAgents;
+        private AiOperations _ai;
 
-        public override DatabaseAiAgents AiAgents => _aiAgents ??= new DatabaseAiAgents(this);
+        public override AiOperations AI => _ai ??= new AiOperations(this);
 
         public override IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo ?? throw new InvalidOperationException($"Overwriting {nameof(DocumentConventions.AsyncDocumentIdGenerator)} convention does not allow usage of default HiLo generator, you should use your own one.");
 

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.AI;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
@@ -45,6 +46,10 @@ namespace Raven.Client.Documents
         private DatabaseSmuggler _smuggler;
 
         private string _identifier;
+
+        private DatabaseAiAgents _aiAgents;
+
+        public override DatabaseAiAgents AiAgents => _aiAgents ??= new DatabaseAiAgents(this);
 
         public override IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo ?? throw new InvalidOperationException($"Overwriting {nameof(DocumentConventions.AsyncDocumentIdGenerator)} convention does not allow usage of default HiLo generator, you should use your own one.");
 

--- a/src/Raven.Client/Documents/DocumentStoreBase.cs
+++ b/src/Raven.Client/Documents/DocumentStoreBase.cs
@@ -43,7 +43,7 @@ namespace Raven.Client.Documents
         /// </summary>
         public bool WasDisposed { get; protected set; }
 
-        public abstract DatabaseAiAgents AiAgents { get; }
+        public abstract AiOperations AI { get; }
 
         /// <summary>
         /// Subscribe to change notifications from the server

--- a/src/Raven.Client/Documents/DocumentStoreBase.cs
+++ b/src/Raven.Client/Documents/DocumentStoreBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.AI;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
@@ -41,6 +42,8 @@ namespace Raven.Client.Documents
         /// Whether the instance has been disposed
         /// </summary>
         public bool WasDisposed { get; protected set; }
+
+        public abstract DatabaseAiAgents AiAgents { get; }
 
         /// <summary>
         /// Subscribe to change notifications from the server

--- a/src/Raven.Client/Documents/IDocumentStore.cs
+++ b/src/Raven.Client/Documents/IDocumentStore.cs
@@ -255,7 +255,7 @@ namespace Raven.Client.Documents
 
         DatabaseSmuggler Smuggler { get; }
 
-        DatabaseAiAgents AiAgents { get; }
+        AiOperations AI { get; }
 
         IDisposable SetRequestTimeout(TimeSpan timeout, string database = null);
     }

--- a/src/Raven.Client/Documents/IDocumentStore.cs
+++ b/src/Raven.Client/Documents/IDocumentStore.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.AI;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
@@ -253,6 +254,8 @@ namespace Raven.Client.Documents
         OperationExecutor Operations { get; }
 
         DatabaseSmuggler Smuggler { get; }
+
+        DatabaseAiAgents AiAgents { get; }
 
         IDisposable SetRequestTimeout(TimeSpan timeout, string database = null);
     }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
@@ -24,7 +24,7 @@ public class AiAgentConfiguration : IDynamicJson
     /// <summary>
     /// Initializes a new instance of <see cref="AiAgentConfiguration"/> with the specified connection string and system prompt.
     /// </summary>
-    /// <param name="connectionStringName">The name of the connection string to use for the AI integration.</param>
+    /// <param name="connectionStringName">The name of the connection string to use for the AI Agent.</param>
     /// <param name="systemPrompt">The system prompt that defines the agent’s role and behavior.</param>
     public AiAgentConfiguration(string connectionStringName, string systemPrompt)
     {
@@ -61,10 +61,17 @@ public class AiAgentConfiguration : IDynamicJson
     /// </summary>
     public string OutputSchema { get; set; }
 
+    /// <summary>
+    /// Database-side tools: predefined queries that RavenDB executes to fetch data directly during chat.
+    /// The agent decides when to call them based on user input and context.
+    /// When the agent calls them, it gets an actual data from the database based on these queries.
+    /// </summary>
     public List<ToolQuery> Queries { get; set; }= [];
 
     /// <summary>
-    /// A list of actions (tools with parameters) the agent can invoke.
+    /// Model-side tools: callable actions where the AI agent fills parameters and invokes the tool as part of reasoning.
+    /// The agent decides when to call them based on user input and context.
+    /// When the agent calls them, it expects the user to provide "answers" for them.
     /// </summary>
     public List<ToolAction> Actions { get; set; } = [];
 

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
@@ -10,6 +10,10 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.AI.Agents;
 
+/// <summary>
+/// Defines the configuration for an AI agent in RavenDB, including the system prompt,
+/// tools (queries/actions), output schema, persistence settings, and connection string.
+/// </summary>
 public class AiAgentConfiguration : IDynamicJson
 {
     public AiAgentConfiguration()
@@ -17,6 +21,11 @@ public class AiAgentConfiguration : IDynamicJson
         // for serialization purposes
     }
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="AiAgentConfiguration"/> with the specified connection string and system prompt.
+    /// </summary>
+    /// <param name="connectionStringName">The name of the connection string to use for the AI integration.</param>
+    /// <param name="systemPrompt">The system prompt that defines the agent’s role and behavior.</param>
     public AiAgentConfiguration(string connectionStringName, string systemPrompt)
     {
         ValidationMethods.AssertNotNullOrEmpty(connectionStringName, nameof(connectionStringName));
@@ -26,11 +35,42 @@ public class AiAgentConfiguration : IDynamicJson
         SystemPrompt = systemPrompt;
     }
 
+    /// <summary>
+    /// The name of the connection string used to connect to the AI provider.
+    /// </summary>
     public string ConnectionStringName { get; set; }
+
+    /// <summary>
+    /// The prompt that guides the behavior and purpose of the AI agent.
+    /// </summary>
     public string SystemPrompt { get; set; }
+
+    /// <summary>
+    /// A JSON schema (as string) describing the expected structure of the AI agent's output.
+    /// This allows validation and parsing of the AI-generated response according to a known format.
+    ///
+    /// For example:
+    /// <code>
+    /// {
+    ///   "Answer": "Answer to the user question",
+    ///   "Relevant": true,
+    ///   "RelevantOrdersId": ["The order ids relevant to the query or response"],
+    ///   "MatchingProductsId": ["All the product ids referenced either by the user or the system"]
+    /// }
+    /// </code>
+    /// </summary>
     public string OutputSchema { get; set; }
+
     public List<ToolQuery> Queries { get; set; }= [];
+
+    /// <summary>
+    /// A list of actions (tools with parameters) the agent can invoke.
+    /// </summary>
     public List<ToolAction> Actions { get; set; } = [];
+
+    /// <summary>
+    /// Controls persistence behavior of chats - whether the chat history will be persistent or not
+    /// </summary>
     public PersistenceConfiguration Persistence { get; set; }
 
     public class PersistenceConfiguration : IDynamicJson

--- a/src/Raven.Client/Documents/Operations/AI/Agents/ResumeChatOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/ResumeChatOperation.cs
@@ -11,20 +11,17 @@ namespace Raven.Client.Documents.Operations.AI.Agents;
 
 public class ResumeChatOperation<TSchema> : IMaintenanceOperation<ChatResult<TSchema>> where TSchema : new()
 {
-    private readonly string _name;
     private readonly string _chatId;
     private readonly string _userPrompt;
     private readonly List<ToolResponse> _toolResponses;
 
-    public ResumeChatOperation(string agentName, string chatId, string userPrompt = null, List<ToolResponse> toolResponses = null)
+    public ResumeChatOperation(string chatId, string userPrompt = null, List<ToolResponse> toolResponses = null)
     {
-        ValidationMethods.AssertNotNullOrEmpty(agentName, nameof(agentName));
         ValidationMethods.AssertNotNullOrEmpty(chatId, nameof(chatId));
 
         if (string.IsNullOrEmpty(userPrompt) && (toolResponses == null || toolResponses.Count == 0))
             throw new ArgumentException($"Either '{nameof(userPrompt)}' or '{nameof(toolResponses)}' must be provided to resume a chat.");
 
-        _name = agentName;
         _chatId = chatId;
         _userPrompt = userPrompt;
         _toolResponses = toolResponses;
@@ -32,20 +29,18 @@ public class ResumeChatOperation<TSchema> : IMaintenanceOperation<ChatResult<TSc
 
     public RavenCommand<ChatResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new ResumeChatOperationCommand(_name, _chatId, _userPrompt, _toolResponses, conventions);
+        return new ResumeChatOperationCommand(_chatId, _userPrompt, _toolResponses, conventions);
     }
 
     internal sealed class ResumeChatOperationCommand : RavenCommand<ChatResult<TSchema>>
     {
-        private readonly string _name;
         private readonly string _chatId;
         private readonly string _userPrompt;
         private readonly List<ToolResponse> _toolResponses;
         private readonly DocumentConventions _conventions;
 
-        public ResumeChatOperationCommand(string name, string chatId, string userPrompt, List<ToolResponse> toolResponses, DocumentConventions conventions)
+        public ResumeChatOperationCommand(string chatId, string userPrompt, List<ToolResponse> toolResponses, DocumentConventions conventions)
         {
-            _name = name;
             _chatId = chatId;
             _userPrompt = userPrompt;
             _toolResponses = toolResponses;
@@ -54,7 +49,7 @@ public class ResumeChatOperation<TSchema> : IMaintenanceOperation<ChatResult<TSc
         public override bool IsReadRequest => false;
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/databases/{node.Database}/ai/agent/resume?name={Uri.EscapeDataString(_name)}&chatId={Uri.EscapeDataString(_chatId)}";
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/resume?chatId={Uri.EscapeDataString(_chatId)}";
             var body = new ResumeChatBody { ToolResponse = _toolResponses, UserPrompt = _userPrompt};
 
             var request = new HttpRequestMessage

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
@@ -57,12 +57,12 @@ public class AiAgentHandler : DatabaseRequestHandler
         var chat = new ChatDocument(name, body.Parameter);
         
         chat.Initialize(context, configuration.SystemPrompt, body.UserPrompt);
-        var r = await Talk(context, configuration, chat, token);
+        var r = await TalkAsync(context, configuration, chat, token);
 
         string conversationId = null;
         if (configuration.Persistence is not null)
         {
-            MergedPutCommand putCmd = new(r.Docoument, $"{configuration.Persistence.Collection}{Database.IdentityPartsSeparator}", null, Database);
+            MergedPutCommand putCmd = new(r.Document, $"{configuration.Persistence.Collection}{Database.IdentityPartsSeparator}", null, Database);
             await Database.TxMerger.Enqueue(putCmd);
             conversationId = putCmd.PutResult.Id;
         }
@@ -90,12 +90,12 @@ public class AiAgentHandler : DatabaseRequestHandler
 
         AddNewMessages();
 
-        var r = await Talk(context, configuration, chatDocument, token: token);
+        var r = await TalkAsync(context, configuration, chatDocument, token: token);
 
         if (configuration.Persistence is not null)
         {
             // we don't pass change vector here, so last write wins
-            MergedPutCommand putCmd = new(r.Docoument, chatId, changeVector: null, Database);
+            MergedPutCommand putCmd = new(r.Document, chatId, changeVector: null, Database);
             await Database.TxMerger.Enqueue(putCmd);
         }
 
@@ -190,7 +190,7 @@ public class AiAgentHandler : DatabaseRequestHandler
         var chat = new ChatDocument("test", body.Parameter);
         chat.Initialize(context, cfg.SystemPrompt, body.UserPrompt);
 
-        var r = await Talk(context, cfg, chat, token);
+        var r = await TalkAsync(context, cfg, chat, token);
 
         await WriteResponseAsync(context, "test", r);
     }
@@ -215,7 +215,7 @@ public class AiAgentHandler : DatabaseRequestHandler
         return (actionResponse, userPrompt);
     }
 
-    private async Task<(AiUsage Usage, List<ToolRequest> userToolRequests, BlittableJsonReaderObject Response, BlittableJsonReaderObject Docoument)> Talk(JsonOperationContext context, AiAgentConfiguration configuration, ChatDocument document, OperationCancelToken token)
+    private async Task<(AiUsage Usage, List<ToolRequest> userToolRequests, BlittableJsonReaderObject Response, BlittableJsonReaderObject Document)> TalkAsync(JsonOperationContext context, AiAgentConfiguration configuration, ChatDocument document, OperationCancelToken token)
     {
         document.EnsureInitialized();
 
@@ -243,7 +243,7 @@ public class AiAgentHandler : DatabaseRequestHandler
             if (aiResponse.Type is AiResponseType.Result)
                 break;
             
-            await HandleQueryToolCalls(context, configuration, document, aiResponse);
+            await HandleQueryToolCallsAsync(context, configuration, document, aiResponse);
 
             if (TryGetUserTools(configuration, aiResponse, out userToolRequests))
                 break; // we need to return the user tool requests to the client, so we can continue the conversation
@@ -272,7 +272,7 @@ public class AiAgentHandler : DatabaseRequestHandler
         return userTools.Count > 0;
     }
 
-    private async Task HandleQueryToolCalls(JsonOperationContext context, AiAgentConfiguration cfg, ChatDocument document, AiResponse result)
+    private async Task HandleQueryToolCallsAsync(JsonOperationContext context, AiAgentConfiguration cfg, ChatDocument document, AiResponse result)
     {
         // TODO: handle a response that does both query & action
         DynamicJsonArray reqs = [];

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
@@ -62,7 +62,7 @@ public class AiAgentHandler : DatabaseRequestHandler
         string conversationId = null;
         if (configuration.Persistence is not null)
         {
-            MergedPutCommand putCmd = new(r.Dcoument, $"{configuration.Persistence.Collection}{Database.IdentityPartsSeparator}", null, Database);
+            MergedPutCommand putCmd = new(r.Docoument, $"{configuration.Persistence.Collection}{Database.IdentityPartsSeparator}", null, Database);
             await Database.TxMerger.Enqueue(putCmd);
             conversationId = putCmd.PutResult.Id;
         }
@@ -75,9 +75,6 @@ public class AiAgentHandler : DatabaseRequestHandler
     {
         using var token = CreateHttpRequestBoundOperationToken();
         var chatId = GetStringQueryString("chatId", required: true);
-        var name = GetStringQueryString("name", required: true);
-        
-        var configuration = GetAiAgentConfiguration(name);
 
         using var _ = Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
         using var __ = context.OpenReadTransaction();
@@ -86,42 +83,49 @@ public class AiAgentHandler : DatabaseRequestHandler
         if (chat == null)
             throw new DocumentDoesNotExistException(chatId);
 
-        var document = ChatDocument.ToDocument(chatId, chat.Data);
+        var chatDocument = ChatDocument.ToDocument(chatId, chat.Data);
         var body = await ReadResumeChatBodyAsync(context, token.Token);
 
-        if (string.IsNullOrEmpty(body.UserPrompt) == false)
-        {
-            document.AddMessage(context, context.ReadObject(new DynamicJsonValue
-            {
-                ["role"] = "user",
-                ["content"] = body.UserPrompt
-            }, "user/msg"));
-        }
+        var configuration = GetAiAgentConfiguration(chatDocument.Agent);
 
-        if (body.ActionResponse != null)
-        {
-            foreach (BlittableJsonReaderObject tool in body.ActionResponse)
-            {
-                var t = JsonDeserializationClient.ToolResponse(tool);
-                document.Messages.Add(context.ReadObject(new DynamicJsonValue
-                {
-                    ["tool_call_id"] = t.ToolId,
-                    ["role"] = "tool",
-                    ["content"] = t.Content
-                },"user/tool"));
-            }
-        }
+        AddNewMessages();
 
-        var r = await Talk(context, configuration, document, token: token);
+        var r = await Talk(context, configuration, chatDocument, token: token);
 
         if (configuration.Persistence is not null)
         {
             // we don't pass change vector here, so last write wins
-            MergedPutCommand putCmd = new(r.Dcoument, chatId, changeVector: null, Database);
+            MergedPutCommand putCmd = new(r.Docoument, chatId, changeVector: null, Database);
             await Database.TxMerger.Enqueue(putCmd);
         }
 
         await WriteResponseAsync(context, chatId, r);
+
+        void AddNewMessages()
+        {
+            if (string.IsNullOrEmpty(body.UserPrompt) == false)
+            {
+                chatDocument.AddMessage(context, context.ReadObject(new DynamicJsonValue
+                {
+                    ["role"] = "user",
+                    ["content"] = body.UserPrompt
+                }, "user/msg"));
+            }
+
+            if (body.ActionResponse != null)
+            {
+                foreach (BlittableJsonReaderObject tool in body.ActionResponse)
+                {
+                    var t = JsonDeserializationClient.ToolResponse(tool);
+                    chatDocument.Messages.Add(context.ReadObject(new DynamicJsonValue
+                    {
+                        ["tool_call_id"] = t.ToolId,
+                        ["role"] = "tool",
+                        ["content"] = t.Content
+                    }, "user/tool"));
+                }
+            }
+        }
     }
 
     [RavenAction("/databases/*/admin/ai/agent", "GET", AuthorizationStatus.DatabaseAdmin)]
@@ -211,7 +215,7 @@ public class AiAgentHandler : DatabaseRequestHandler
         return (actionResponse, userPrompt);
     }
 
-    private async Task<(AiUsage Usage, List<ToolRequest> userToolRequests, BlittableJsonReaderObject Response, BlittableJsonReaderObject Dcoument)> Talk(JsonOperationContext context, AiAgentConfiguration configuration, ChatDocument document, OperationCancelToken token)
+    private async Task<(AiUsage Usage, List<ToolRequest> userToolRequests, BlittableJsonReaderObject Response, BlittableJsonReaderObject Docoument)> Talk(JsonOperationContext context, AiAgentConfiguration configuration, ChatDocument document, OperationCancelToken token)
     {
         document.EnsureInitialized();
 
@@ -239,7 +243,7 @@ public class AiAgentHandler : DatabaseRequestHandler
             if (aiResponse.Type is AiResponseType.Result)
                 break;
             
-            await HandleToolCalls(context, configuration, document, aiResponse);
+            await HandleQueryToolCalls(context, configuration, document, aiResponse);
 
             if (TryGetUserTools(configuration, aiResponse, out userToolRequests))
                 break; // we need to return the user tool requests to the client, so we can continue the conversation
@@ -268,7 +272,7 @@ public class AiAgentHandler : DatabaseRequestHandler
         return userTools.Count > 0;
     }
 
-    private async Task HandleToolCalls(JsonOperationContext context, AiAgentConfiguration cfg, ChatDocument document, AiResponse result)
+    private async Task HandleQueryToolCalls(JsonOperationContext context, AiAgentConfiguration cfg, ChatDocument document, AiResponse result)
     {
         // TODO: handle a response that does both query & action
         DynamicJsonArray reqs = [];

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -27,7 +27,7 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
 
         var r = await ServerStore.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(RequestHandler.DatabaseName, name, cfg, RequestHandler.GetRaftRequestIdFromQuery()), token.Token);
         
-        RequestHandler.LogTaskToAudit($"Create AI Agent '{name}'", r.Index, options);
+        RequestHandler.LogTaskToAudit($"Add/Update AI Agent '{name}'", r.Index, options);
 
         await RequestHandler.WaitForIndexNotificationAsync(r.Index);
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -129,7 +129,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.NotNull(r.ChatId);
 
 
-            var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>("shopping assistant", r.ChatId,
+            var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>(r.ChatId,
                 userPrompt: "can you give me a cheaper alternative?"));
 
             Assert.NotNull(r2.Response.Answer);
@@ -192,7 +192,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 });
             }
 
-            var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>("shopping assistant", r.ChatId, toolResponses: toolResponse));
+            var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>(r.ChatId, toolResponses: toolResponse));
 
             Assert.NotNull(r2.Response.Answer);
             Assert.NotNull(r2.Usage);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -194,7 +194,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             var r2 = await store.Maintenance.SendAsync(new ResumeChatOperation<OutputSchema>(r.ChatId, toolResponses: toolResponse));
 
-            Assert.NotNull(r2.Response.Answer);
+            Assert.True(r2.Response?.Answer != null || r2.ToolRequests != null);
             Assert.NotNull(r2.Usage);
             Assert.NotNull(r2.ChatId);
         }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -66,9 +66,9 @@ public class AiAgentClientApiBasics : RavenTestBase
                     session.Query<Query.Order>().Where(o => o.Company == "$company").OrderByDescending(o => o.OrderedAt).Take(10))
         ];
 
-        await store.AiAgents.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
+        await store.AI.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
 
-        var r = await store.AiAgents.StartChatAsync<OutputSchema>("shopping assistant", "what goes well with my cheese?",
+        var r = await store.AI.StartChatAsync<OutputSchema>("shopping assistant", "what goes well with my cheese?",
             p => p.AddParameter("company", "companies/90-A"));
 
         Assert.NotNull(r.Response.Answer);
@@ -78,11 +78,11 @@ public class AiAgentClientApiBasics : RavenTestBase
         var chat = await session.LoadAsync<dynamic>(r.ChatId);
         Assert.NotNull(chat);
 
-        var r1 = await store.AiAgents.ContinueChatAsync<OutputSchema>(r.ChatId, "what goes well with my cheese?");
+        var r1 = await store.AI.ContinueChatAsync<OutputSchema>(r.ChatId, "what goes well with my cheese?");
 
         Assert.False(string.IsNullOrEmpty(r1.Response.Answer));
 
-        var r2 = await store.AiAgents.ContinueChatAsync<OutputSchema>(r.ChatId, "what cheese goes well with italian food?");
+        var r2 = await store.AI.ContinueChatAsync<OutputSchema>(r.ChatId, "what cheese goes well with italian food?");
 
         Assert.False(string.IsNullOrEmpty(r2.Response.Answer));
     }
@@ -124,9 +124,9 @@ public class AiAgentClientApiBasics : RavenTestBase
             }
         ];
 
-        await store.AiAgents.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
+        await store.AI.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
 
-        var r = await store.AiAgents.StartChatAsync<OutputSchema>("shopping assistant", "what goes well with my cheese for recent orders?");
+        var r = await store.AI.StartChatAsync<OutputSchema>("shopping assistant", "what goes well with my cheese for recent orders?");
 
         Assert.True(r.ToolRequests.Count > 0);
         Assert.NotNull(r.Usage);
@@ -143,9 +143,9 @@ public class AiAgentClientApiBasics : RavenTestBase
             });
         }
 
-        var r2 = await store.AiAgents.ContinueChatAsync<OutputSchema>(r.ChatId, toolResponses);
+        var r2 = await store.AI.ContinueChatAsync<OutputSchema>(r.ChatId, toolResponses);
 
-        Assert.NotNull(r2.Response.Answer);
+        Assert.True(r2.Response?.Answer != null || r2.ToolRequests != null);
         Assert.NotNull(r2.Usage);
         Assert.NotNull(r2.ChatId);
     }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Client;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class AiAgentClientApiBasics : RavenTestBase
+{
+    public AiAgentClientApiBasics(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public class OutputSchema
+    {
+        public string Answer = "Answer to the user question";
+
+        public bool Relevant = true;
+
+        public List<string> RelevantOrdersId = ["The order ids relevant to the query or response"];
+
+        public List<string> MatchingProductsId = ["All the product ids referenced either by the user or the system"];
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task AiAgentClientApiBasicTest(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        using var session = store.OpenAsyncSession();
+
+        var agent = new AiAgentConfiguration(config.ConnectionStringName,
+            "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+        agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+        {
+            Collection = "Chats",
+            Expires = TimeSpan.FromDays(30)
+        };
+
+        agent.Queries =
+        [
+            AiAgentConfiguration.ToolQuery.Build(
+                    "ProductSearch",
+                    "semantic search the store product catalog",
+                    session.Query<Product>().VectorSearch(v => v.WithText(p => p.Name), v => v.ByText("$query")))
+                ,
+                AiAgentConfiguration.ToolQuery.Build(
+                    "RecentOrder",
+                    "Get the recent orders of the current user",
+                    session.Query<Query.Order>().Where(o => o.Company == "$company").OrderByDescending(o => o.OrderedAt).Take(10))
+        ];
+
+        await store.AiAgents.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
+
+        var r = await store.AiAgents.StartChatAsync<OutputSchema>("shopping assistant", "what goes well with my cheese?",
+            p => p.AddParameter("company", "companies/90-A"));
+
+        Assert.NotNull(r.Response.Answer);
+        Assert.NotNull(r.Usage);
+        Assert.NotNull(r.ChatId);
+
+        var chat = await session.LoadAsync<dynamic>(r.ChatId);
+        Assert.NotNull(chat);
+
+        var r1 = await store.AiAgents.ContinueChatAsync<OutputSchema>(r.ChatId, "what goes well with my cheese?");
+
+        Assert.False(string.IsNullOrEmpty(r1.Response.Answer));
+
+        var r2 = await store.AiAgents.ContinueChatAsync<OutputSchema>(r.ChatId, "what cheese goes well with italian food?");
+
+        Assert.False(string.IsNullOrEmpty(r2.Response.Answer));
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task AiAgentClientApiAnswerActionTool(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        using var session = store.OpenAsyncSession();
+
+        var agent = new AiAgentConfiguration(config.ConnectionStringName,
+            "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+        agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+        {
+            Collection = "Chats",
+            Expires = TimeSpan.FromDays(30)
+        };
+
+        agent.Actions =
+        [
+            new AiAgentConfiguration.ToolAction
+            {
+                Name = "ProductSearch",
+                Description =  "semantic search the store product catalog",
+                ParametersSchema = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            }
+            ,
+            new AiAgentConfiguration.ToolAction
+            {
+                Name = "RecentOrder",
+                Description = "Get the recent orders of the current user",
+                ParametersSchema = "{}"
+            }
+        ];
+
+        await store.AiAgents.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
+
+        var r = await store.AiAgents.StartChatAsync<OutputSchema>("shopping assistant", "what goes well with my cheese for recent orders?");
+
+        Assert.True(r.ToolRequests.Count > 0);
+        Assert.NotNull(r.Usage);
+        Assert.NotNull(r.ChatId);
+
+        var toolResponses = new List<ToolResponse>();
+        for (int i = 0; i < r.ToolRequests.Count; i++)
+        {
+            var request = r.ToolRequests[i];
+            toolResponses.Add(new ToolResponse
+            {
+                ToolId = request.ToolId,
+                Content = "{}"
+            });
+        }
+
+        var r2 = await store.AiAgents.ContinueChatAsync<OutputSchema>(r.ChatId, toolResponses);
+
+        Assert.NotNull(r2.Response.Answer);
+        Assert.NotNull(r2.Usage);
+        Assert.NotNull(r2.ChatId);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24257/AI-Agent-Client-API-Design-the-API

### Additional description

Create client api (in raven client) for ai agents communication:
Create\update agent config
Start Chat - with parameters dict\builder
continue chat - with or without action\query tools

Also make "resume" (continue chat) ep use the agent name from the chat doc, instead of getting it on URL query (it isn't needed, that's why you have the agent name on the chat doc).

1. Implement Client API for AI Agent Communication in Raven Client:
  * Create\update agent config
  * Start Chat - with parameters dict\builder
  * continue chat - with or without associated action\query tools
2. Refactor the "Resume Chat" EP to extract the agent name from the chat document instead of requiring it as a query parameter, since it's already stored within the chat.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes - Refactor the "Resume Chat" EP to extract the agent name from the chat document instead of requiring it as a query parameter, since it's already stored within the chat.
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
