### PR TITLE
RavenDB-24077 create indexes should not throw when list of indexes is empty

### DIFF
--- a/src/Raven.Client/Documents/DocumentStoreBase.cs
+++ b/src/Raven.Client/Documents/DocumentStoreBase.cs
@@ -112,7 +112,9 @@ namespace Raven.Client.Documents
             database = this.GetDatabase(database);
             
             var indexesToAdd = IndexCreation.CreateIndexesToAdd(tasks, conventions);
-
+            if (indexesToAdd == null || indexesToAdd.Length == 0)
+                return Task.CompletedTask;
+            
             return Maintenance.ForDatabase(database).SendAsync(new PutIndexesOperation(indexesToAdd), token);
         }
 

--- a/test/FastTests/Issues/RavenDB_24077.cs
+++ b/test/FastTests/Issues/RavenDB_24077.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_24077 : RavenTestBase
+{
+    public RavenDB_24077(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Indexes)]
+    public async Task CreateIndexes_Should_Not_Throw_When_Indexes_List_Is_Empty()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await IndexCreation.CreateIndexesAsync(typeof(string).Assembly, store);
+
+            await store.ExecuteIndexesAsync([]);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24077

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
