### PR TITLE
[5.4] - RavenDB-24453 - Reduce string allocations when logging is disabled

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsSubscriptionProcessor.cs
@@ -117,10 +117,9 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             return new DocumentSubscriptionFetcher(Database, SubscriptionConnectionsState, Collection);
         }
 
-        protected override bool ShouldSend(Document item, out string reason, out Exception exception, out Document result)
+        protected override bool ShouldSend(Document item, out Exception exception, out Document result)
         {
             exception = null;
-            reason = null;
             result = item;
             string id = item.Id; // we convert the Id to string since item might get disposed
 
@@ -129,16 +128,18 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
                 var conflictStatus = ChangeVectorUtils.GetConflictStatus(
                     remoteAsString: item.ChangeVector,
                     localAsString: SubscriptionState.ChangeVectorForNextBatchStartingPoint);
-
+                
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {
-                    reason = $"{id} is already merged";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{id} is already merged");
                     return false;
                 }
 
                 if (SubscriptionConnectionsState.IsDocumentInActiveBatch(ClusterContext, id, Active))
                 {
-                    reason = $"{id} exists in an active batch";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{id} exists in an active batch");
                     return false;
                 }
             }
@@ -151,7 +152,10 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
                     item.ChangeVector = string.Empty;
                     current.Document?.Dispose();
                     current.Tombstone?.Dispose();
-                    reason = $"Skip {id} from resend";
+
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"Skip {id} from resend");
+
                     return false;
                 }
 
@@ -182,7 +186,10 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
                         ItemsToRemoveFromResend.Add(id);
 
                     result.Data = null;
-                    reason = $"{id} filtered out by criteria";
+
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{id} filtered out by criteria");
+
                     return false;
                 }
                 
@@ -191,7 +198,10 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             catch (Exception ex)
             {
                 exception = ex;
-                reason = $"Criteria script threw exception for document id {id}";
+
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Criteria script threw exception for document id {id}", exception);
+
                 return false;
             }
         }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsSubscriptionProcessor.cs
@@ -105,10 +105,9 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             return new RevisionSubscriptionFetcher(Database, SubscriptionConnectionsState, Collection);
         }
 
-        protected override bool ShouldSend((Document Previous, Document Current) item, out string reason, out Exception exception, out Document result)
+        protected override bool ShouldSend((Document Previous, Document Current) item, out Exception exception, out Document result)
         {
             exception = null;
-            reason = null;
             result = item.Current;
 
             if (Fetcher.FetchingFrom == SubscriptionFetcher.FetchingOrigin.Storage)
@@ -119,13 +118,15 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {
-                    reason = $"{item.Current.Id} is already merged";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{item.Current.Id} is already merged");
                     return false;
                 }
 
                 if (SubscriptionConnectionsState.IsRevisionInActiveBatch(ClusterContext, item.Current.ChangeVector, Active))
                 {
-                    reason = $"{item.Current.Id} is in active batch";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{item.Current.Id} is in active batch");
                     return false;
                 }
             }
@@ -156,7 +157,10 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
                     transformResult.Dispose();
                     result.Data?.Dispose();
                     result.Data = null;
-                    reason = $"{item.Current.Id} filtered by criteria";
+
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{item.Current.Id} filtered by criteria");
+
                     return false;
                 }
 
@@ -170,7 +174,9 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             }
             catch (Exception ex)
             {
-                reason = $"Criteria script threw exception for revision id {item.Current.Id} with change vector current: {item.Current.ChangeVector}, previous: {item.Previous?.ChangeVector}";
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Criteria script threw exception for revision id {item.Current.Id} with change vector current: {item.Current.ChangeVector}, previous: {item.Previous?.ChangeVector}", exception);
+
                 exception = ex;
                 return false;
             }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/SubscriptionProcessor.cs
@@ -39,11 +39,11 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
             Fetcher.Initialize(clusterContext, docsContext, Active);
         }
 
-        protected abstract bool ShouldSend(T item, out string reason, out Exception exception, out Document result);
+        protected abstract bool ShouldSend(T item, out Exception exception, out Document result);
 
         protected (Document Doc, Exception Exception) GetBatchItem(T item)
         {
-            if (ShouldSend(item, out var reason, out var exception, out var result))
+            if (ShouldSend(item, out var exception, out var result))
             {
                 if (IncludesCmd != null && Run != null)
                     IncludesCmd.AddRange(Run.Includes, result.Id);
@@ -53,9 +53,6 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
 
                 return (result, null);
             }
-
-            if (Logger.IsInfoEnabled) 
-                Logger.Info(reason, exception);
 
             if (exception != null)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24453/Subscription-with-filtering-generates-excessive-string-allocations

### Additional description

Reduce string allocations when logging is disabled.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
