### PR TITLE
RavenDB-24294 : Gen AI - Add 'Model type' field to AI Connection string

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
@@ -26,6 +26,8 @@ public sealed class AiConnectionString : ConnectionString
 
     public override ConnectionStringType Type => ConnectionStringType.Ai;
 
+    public AiModelType ModelType { get; set; }
+
     protected override void ValidateImpl(List<string> errors)
     {
         var allSettings = new AbstractAiSettings[]
@@ -73,6 +75,9 @@ public sealed class AiConnectionString : ConnectionString
 
         if (Identifier != newConnectionString.Identifier)
             result |= AiSettingsCompareDifferences.Identifier;
+
+        if (ModelType != newConnectionString.ModelType)
+            result |= AiSettingsCompareDifferences.ModelArchitecture;
 
         var oldProvider = GetActiveProvider();
         var newProvider = newConnectionString.GetActiveProvider();
@@ -151,6 +156,9 @@ public sealed class AiConnectionString : ConnectionString
         if (Identifier != aiConnectionString.Identifier)
             return false;
 
+        if (ModelType != aiConnectionString.ModelType) 
+            return false;
+
         var activeProvider = GetActiveProvider();
         var otherActiveProvider = aiConnectionString.GetActiveProvider();
 
@@ -176,6 +184,7 @@ public sealed class AiConnectionString : ConnectionString
         var json = base.ToJson();
 
         json[nameof(Identifier)] = Identifier;
+        json[nameof(ModelType)] = ModelType;
         json[nameof(OpenAiSettings)] = OpenAiSettings?.ToJson();
         json[nameof(AzureOpenAiSettings)] = AzureOpenAiSettings?.ToJson();
         json[nameof(OllamaSettings)] = OllamaSettings?.ToJson();

--- a/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
@@ -2,6 +2,6 @@
 
 public enum AiModelType
 {
-    Embeddings,
-    LLM
+    TextEmbeddings,
+    Chat
 }

--- a/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Client.Documents.Operations.AI;
+
+public enum AiModelType
+{
+    None,
+    LLM,
+    Embeddings
+}

--- a/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
@@ -2,7 +2,6 @@
 
 public enum AiModelType
 {
-    None,
-    LLM,
-    Embeddings
+    Embeddings,
+    LLM
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -86,8 +86,8 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         if (validateConnection && TestMode == false)
         {
             Connection.Validate(errors);
-            if (Connection.ModelType != AiModelType.Embeddings)
-                errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.Embeddings)}");
+            if (Connection.ModelType != AiModelType.TextEmbeddings)
+                errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.TextEmbeddings)}");
         }
 
         if (string.IsNullOrEmpty(Collection))

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -84,7 +84,11 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             errors.Add($"{nameof(ConnectionStringName)} cannot be empty");
 
         if (validateConnection && TestMode == false)
+        {
             Connection.Validate(errors);
+            if (Connection.ModelType != AiModelType.Embeddings)
+                errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.Embeddings)}");
+        }
 
         if (string.IsNullOrEmpty(Collection))
             errors.Add($"{nameof(Collection)} must be provided");

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -75,7 +75,11 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             errors.Add($"{nameof(ConnectionStringName)} cannot be empty");
 
         if (validateConnection && TestMode == false)
+        {
             Connection.Validate(errors);
+            if (Connection.ModelType != AiModelType.LLM)
+                errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.LLM)}");
+        }
 
         if (string.IsNullOrEmpty(Collection))
             errors.Add($"{nameof(Collection)} must be provided");

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -77,8 +77,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         if (validateConnection && TestMode == false)
         {
             Connection.Validate(errors);
-            if (Connection.ModelType != AiModelType.LLM)
-                errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.LLM)}");
+            if (Connection.ModelType != AiModelType.Chat)
+                errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.Chat)}");
         }
 
         if (string.IsNullOrEmpty(Collection))

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.AI;
-using Microsoft.SemanticKernel.Embeddings;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.Embeddings;
@@ -12,6 +11,7 @@ using Raven.Server.Json;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+
 #pragma warning disable SKEXP0001
 
 namespace Raven.Server.Documents.ETL.Providers.AI.Handlers.Processors;
@@ -81,30 +81,31 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                         throw new ArgumentOutOfRangeException();
                 }
 
-                try
+                switch (aiConnectionString.ModelType)
                 {
-                    var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
-                    (IEmbeddingGenerator<string, Embedding<float>> service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
-                    var embeddings = await service.GenerateAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
+                    case AiModelType.Embeddings:
+                        var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
+                        (IEmbeddingGenerator<string, Embedding<float>> service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
+                        var embeddings = await service.GenerateAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
 
-                    if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
-                        throw new EmbeddingsMismatchException(
-                            $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
-                }
-                // TODO: remove this ugly workaround
-                catch (Exception e) when (e is not EmbeddingsMismatchException)
-                {
-                    if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model))
-                    {
+                        if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
+                            throw new EmbeddingsMismatchException(
+                                $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
+                        break;
+                    case AiModelType.LLM:
+                        if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model) == false)
+                            throw new InvalidOperationException(
+                                $"Invalid provider settings for {nameof(AiConnectionString)} with model type '{nameof(AiConnectionString.ModelType.LLM)}'. " +
+                                $"Supported providers for '{nameof(AiConnectionString.ModelType.LLM)}' model type are '{nameof(AiConnectorType.OpenAi)}' and '{nameof(AiConnectorType.Ollama)}'");
+                        
                         using (var client = new GenericChatCompletionClientForTesting(uri, model, apiKey, organizationId: null, projectId: null, ServerStore.ContextPool))
                         {
                             await client.CompleteAsync("foo", "bar", HttpContext.RequestAborted);
                         }
-                    }
-                    else
-                    {
-                        throw;
-                    }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Invalid model type: " + aiConnectionString.ModelType);
                 }
 
                 var result = new DynamicJsonValue { [nameof(NodeConnectionTestResult.Success)] = true };

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -83,7 +83,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
 
                 switch (aiConnectionString.ModelType)
                 {
-                    case AiModelType.Embeddings:
+                    case AiModelType.TextEmbeddings:
                         var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
                         (IEmbeddingGenerator<string, Embedding<float>> service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
                         var embeddings = await service.GenerateAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
@@ -92,11 +92,11 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                             throw new EmbeddingsMismatchException(
                                 $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
                         break;
-                    case AiModelType.LLM:
+                    case AiModelType.Chat:
                         if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model) == false)
                             throw new InvalidOperationException(
-                                $"Invalid provider settings for {nameof(AiConnectionString)} with model type '{nameof(AiConnectionString.ModelType.LLM)}'. " +
-                                $"Supported providers for '{nameof(AiConnectionString.ModelType.LLM)}' model type are '{nameof(AiConnectorType.OpenAi)}' and '{nameof(AiConnectorType.Ollama)}'");
+                                $"Invalid provider settings for {nameof(AiConnectionString)} with model type '{nameof(AiConnectionString.ModelType.Chat)}'. " +
+                                $"Supported providers for '{nameof(AiConnectionString.ModelType.Chat)}' model type are '{nameof(AiConnectorType.OpenAi)}' and '{nameof(AiConnectorType.Ollama)}'");
                         
                         using (var client = new GenericChatCompletionClientForTesting(uri, model, apiKey, organizationId: null, projectId: null, ServerStore.ContextPool))
                         {

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -203,8 +203,10 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
                         $"connection string{(identifierConflicts.Length > 1 ? "s" : "")} " +
                         $"'{string.Join("', '", identifierConflicts.Select(x => x.Key))}'");
 
-                var etlsUsingConnection = databaseRecord.EmbeddingsGenerations.Where(x => x.ConnectionStringName == ConnectionString.Name).ToArray();
-                var isConnectionStringInUse = etlsUsingConnection.Length > 0;
+                var embeddingsUsingConnection = databaseRecord.EmbeddingsGenerations.Where(x => x.ConnectionStringName == ConnectionString.Name).ToArray();
+                var genAisUsingConnection = databaseRecord.GenAis.Where(x => x.ConnectionStringName == ConnectionString.Name).ToArray();
+
+                var isConnectionStringInUse = embeddingsUsingConnection.Length > 0 || genAisUsingConnection.Length > 0;
 
                 if (isUpdate == false || isConnectionStringInUse == false)
                     return;
@@ -213,16 +215,19 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
                 if (differences.HasFlag(AiSettingsCompareDifferences.RequiresEmbeddingsRegeneration) == false)
                     return;
 
-                var etlNames = string.Join("', '", etlsUsingConnection.Select(x => x.Name));
+                var embeddingTasks = embeddingsUsingConnection.Select(x => x.Name);
+                var genAiTasks = genAisUsingConnection.Select(x => x.Name);
+                var etlNames = string.Join("', '", embeddingTasks.Concat(genAiTasks));
+
                 throw new RachisApplyException(
                     $"Cannot update connection string '{ConnectionString.Name}' because it contains changes ({differences}) that would affect the structure or creation process of embeddings. " +
                     $"Changes to parameters like model selection, tokenization settings, embedding dimensions, or normalization options require recreating all embeddings to maintain consistency. " +
                     $"To proceed with these changes:{Environment.NewLine}" +
-                    $"1. Delete the existing AI Integration task{(etlsUsingConnection.Length == 1 ? "" : "s")}{Environment.NewLine}" +
-                    $"2. {(etlsUsingConnection.Length == 1 ?
+                    $"1. Delete the existing AI Integration task{(etlNames.Length == 1 ? "" : "s")}{Environment.NewLine}" +
+                    $"2. {(etlNames.Length == 1 ?
                         "After deleting the AI Integration task, you can either update this connection string or create a new one with your desired settings" :
                         $"Create a new connection string with your desired settings, as this connection string is used by AI Integration tasks: '{etlNames}'")}{Environment.NewLine}" +
-                    $"3. Create a new AI Integration task using the {(etlsUsingConnection.Length == 1 ? "updated or new" : "new")} connection string{Environment.NewLine}" +
+                    $"3. Create a new AI Integration task using the {(etlNames.Length == 1 ? "updated or new" : "new")} connection string{Environment.NewLine}" +
                     "This will ensure all documents are processed with consistent settings and maintain data integrity. " +
                     "Note: While you can update non-critical settings like API keys or endpoints without recreating the task, your current changes include critical modifications that affect the embedding process.");
             }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -72,7 +72,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
     protected static (EmbeddingsGenerationConfiguration AiIntegrationConfiguration, AiConnectionString connectionString) AddEmbeddingsGenerationTask(
         IDocumentStore store, EmbeddingsGenerationConfiguration configuration)
     {
-        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, EmbeddedSettings = new EmbeddedSettings() };
+        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, ModelType = AiModelType.Embeddings, EmbeddedSettings = new EmbeddedSettings() };
 
         connectionString.Identifier = connectionString.GenerateIdentifier();
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -72,7 +72,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
     protected static (EmbeddingsGenerationConfiguration AiIntegrationConfiguration, AiConnectionString connectionString) AddEmbeddingsGenerationTask(
         IDocumentStore store, EmbeddingsGenerationConfiguration configuration)
     {
-        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, ModelType = AiModelType.Embeddings, EmbeddedSettings = new EmbeddedSettings() };
+        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, ModelType = AiModelType.TextEmbeddings, EmbeddedSettings = new EmbeddedSettings() };
 
         connectionString.Identifier = connectionString.GenerateIdentifier();
 

--- a/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
@@ -25,7 +25,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
 
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             AzureOpenAiSettings = new AzureOpenAiSettings(apiKey, endpoint, Model, deploymentName)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
@@ -25,6 +25,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
 
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             AzureOpenAiSettings = new AzureOpenAiSettings(apiKey, endpoint, Model, deploymentName)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
@@ -7,5 +7,5 @@ public class EmbeddedConnectorForTesting : AbstractEmbeddingsConnectorForTesting
 {
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Embedded);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.Embeddings };
+    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.TextEmbeddings };
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
@@ -7,5 +7,5 @@ public class EmbeddedConnectorForTesting : AbstractEmbeddingsConnectorForTesting
 {
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Embedded);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings() };
+    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.Embeddings };
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
@@ -20,6 +20,7 @@ public class EmbeddingsGoogleConnectorForTesting : AbstractEmbeddingsConnectorFo
         var apiKey = Environment.GetEnvironmentVariable(EnvironmentVariable);
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             GoogleSettings = new GoogleSettings(Model, apiKey)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
@@ -20,7 +20,7 @@ public class EmbeddingsGoogleConnectorForTesting : AbstractEmbeddingsConnectorFo
         var apiKey = Environment.GetEnvironmentVariable(EnvironmentVariable);
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             GoogleSettings = new GoogleSettings(Model, apiKey)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
@@ -20,7 +20,7 @@ public class EmbeddingsHuggingFaceConnectorForTesting : AbstractEmbeddingsConnec
 
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             HuggingFaceSettings = new HuggingFaceSettings(apiKey, Model)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
@@ -20,6 +20,7 @@ public class EmbeddingsHuggingFaceConnectorForTesting : AbstractEmbeddingsConnec
 
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             HuggingFaceSettings = new HuggingFaceSettings(apiKey, Model)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
@@ -21,7 +21,7 @@ public class EmbeddingsMistralAiConnectorForTesting : AbstractEmbeddingsConnecto
 
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             MistralAiSettings = new MistralAiSettings(Model, apiKey, Endpoint)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
@@ -21,6 +21,7 @@ public class EmbeddingsMistralAiConnectorForTesting : AbstractEmbeddingsConnecto
 
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             MistralAiSettings = new MistralAiSettings(Model, apiKey, Endpoint)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -37,7 +37,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.TextEmbeddings);
 }
 
 public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOllamaConnectorForTesting>
@@ -50,7 +50,7 @@ public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat);
 }
 
 internal static class OllamaConnectorHelper

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -37,7 +37,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
 }
 
 public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOllamaConnectorForTesting>
@@ -50,19 +50,20 @@ public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
 }
 
 internal static class OllamaConnectorHelper
 {
     public const string EnvironmentVariable = "RAVEN_AI_INTEGRATION_OLLAMA_URI";
 
-    public static AiConnectionString CreateAiConnectionString(string model)
+    public static AiConnectionString CreateAiConnectionString(string model, AiModelType modelType)
     {
         var uri = Environment.GetEnvironmentVariable(EnvironmentVariable);
 
         return new AiConnectionString
         {
+            ModelType = modelType,
             OllamaSettings = new OllamaSettings(uri, model)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsOpenAiConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.TextEmbeddings);
 }
 
 public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOpenAiConnectorForTesting>
@@ -26,7 +26,7 @@ public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat);
     
 }
 

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsOpenAiConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
 }
 
 public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOpenAiConnectorForTesting>
@@ -26,7 +26,7 @@ public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
     
 }
 
@@ -35,11 +35,12 @@ internal static class OpenAiConnectorHelper
     public const string EnvironmentVariable = "RAVEN_AI_INTEGRATION_OPENAI_API_KEY";
     public const string Endpoint = "https://api.openai.com/v1";
 
-    public static AiConnectionString CreateAiConnectionString(string model)
+    public static AiConnectionString CreateAiConnectionString(string model, AiModelType modelType)
     {
         var apiKey = Environment.GetEnvironmentVariable(EnvironmentVariable);
         return new AiConnectionString
         {
+            ModelType = modelType,
             OpenAiSettings = new OpenAiSettings(apiKey, Endpoint, model)
         };
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24294/Gen-AI-Add-Model-type-field-to-AI-Connection-string

### Additional description

- add Model Type (`LLM`, `Embeddings`) property to AI ConnectionString
- when validating GenAI/Embeddings configuration, validate that the connection string that we're using is targeting the right model type

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
