### PR TITLE
RavenDB-24342 : fixed the problem where Document ID is created with 'null' when using put in the Update Script

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -46,7 +46,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
     protected override long ExecuteCmd(DocumentsOperationContext context)
     {
-        var hashes = new Dictionary<string, (BlittableJsonReaderObject Doc, List<string> Hashes)>();
+        var hashes = new Dictionary<string, (Document Doc, List<string> Hashes)>();
 
         using (_database.Scripts.GetScriptRunner(_patchRequest, readOnly: false, out var runner))
         {
@@ -61,8 +61,10 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                     Document document = GetCurrentDocument(context, item.DocId);
                     if (document is null)
                         continue; // document was probably deleted while we talked to the model, skipping this
-
-                    tuple = (document.Data, []);
+                    using (var old = document)
+                    {
+                        tuple = (document.Clone(context), []);
+                    }
                 }
 
                 tuple.Hashes.Add(item.ContextOutput.AiHash);
@@ -75,9 +77,9 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                 {
                     var documentInstance = (BlittableObjectInstance)runner.Translate(context, tuple.Doc).AsObject();
                     using (var scriptResult = runner.Run(context, context, "execute", item.DocId, [documentInstance, args]))
-                    using (var old = tuple.Doc)
+                    using (var old = tuple.Doc.Data)
                     {
-                        tuple.Doc = scriptResult.TranslateToObject(context);
+                        tuple.Doc.Data = scriptResult.TranslateToObject(context);
                     }
                 }
                 catch (Exception e)
@@ -101,7 +103,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
             if (allHashes.Count is 0)
                 continue;
 
-            UpdateHashesInMetadata(id, doc, _taskIdentifier, allHashes, context);
+            UpdateHashesInMetadata(id, doc.Data, _taskIdentifier, allHashes, context);
         }
 
         return _items.Count;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -61,10 +61,8 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                     Document document = GetCurrentDocument(context, item.DocId);
                     if (document is null)
                         continue; // document was probably deleted while we talked to the model, skipping this
-                    using (var old = document)
-                    {
-                        tuple = (document.Clone(context), []);
-                    }
+
+                    tuple = (document, []);
                 }
 
                 tuple.Hashes.Add(item.ContextOutput.AiHash);

--- a/test/SlowTests/Issues/RavenDB_24342.cs
+++ b/test/SlowTests/Issues/RavenDB_24342.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24342 : RavenTestBase
+    {
+        public RavenDB_24342(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task PutInUpdateScriptShouldUseSourceDocumentIdNotNull(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var etl = Etl.WaitForEtlToComplete(store);
+
+            config.Prompt = "Check if the following blog post comment is spam or not";
+            config.Collection = "Posts";
+            config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam" });
+            config.UpdateScript = @" const newDocument = { ""modelOutput"": $output.Blocked, ""@metadata"": { ""@collection"": ""someNewCollection""} };
+put(id(this) +""/new/"", newDocument);";
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var p = new Post(
+                    [
+                        new Comment("Surefire investment property in caiman islands, win $$$$ for sure, qucik!", "homepage"),
+                        new Comment(
+                            "Probably... That piece of code was written (and never looked at) in 2017, IIRC It wasn't a real issue (since it is cached) except for this particular scenario.",
+                            "Oren Eini")
+                    ],
+                    "I, pencil",
+                    "A B52 pencil...");
+                await session.StoreAsync(p);
+                await session.SaveChangesAsync();
+            }
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+            Assert.True(etl.Wait(TimeSpan.FromSeconds(30)));
+
+            using var verify = store.OpenAsyncSession();
+            var ids = (await verify.Query<Comment>(collectionName: "someNewCollection").Select(x => x.Id).ToListAsync());
+
+            Assert.DoesNotContain(ids, id => id.StartsWith("null/new/"));
+            Assert.Contains(ids, id => id.StartsWith("posts/1-A/new/"));
+        }
+
+        internal record Post(List<Comment> Comments, string Title, string Body);
+
+        internal record Comment
+        {
+            public string Text { get; set; }
+            public string Author { get; set; }
+            public Comment() { }
+
+            public Comment(string text, string author)
+            {
+                Text = text;
+                Author = author;
+            }
+
+            public string Id { get; set; } = Guid.NewGuid().ToString();
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_24342.cs
+++ b/test/SlowTests/Issues/RavenDB_24342.cs
@@ -26,8 +26,6 @@ namespace SlowTests.Issues
             using var store = GetDocumentStore(options);
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-            var etl = Etl.WaitForEtlToComplete(store);
-
             config.Prompt = "Check if the following blog post comment is spam or not";
             config.Collection = "Posts";
             config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam" });
@@ -42,6 +40,9 @@ for(const comment of this.Comments)
 }
 "
             };
+
+            await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+            var etl = Etl.WaitForEtlToComplete(store);
 
             using (var session = store.OpenAsyncSession())
             {
@@ -58,7 +59,6 @@ for(const comment of this.Comments)
                 await session.SaveChangesAsync();
             }
 
-            store.Maintenance.Send(new AddGenAiOperation(config));
             Assert.True(etl.Wait(TimeSpan.FromSeconds(30)));
 
             using var verify = store.OpenAsyncSession();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24342/Gen-AI-Document-ID-is-created-with-null-when-using-put-in-the-Update-Script

### Additional description

Switch from `BlittableJsonReaderObject Doc` to `Document Doc` inside `GenAiBatchPatchCommand`.
Holding the full Document lets us keep its original ID, so `put(id(this)` in the update script no longer turns into null and now creates child docs like `posts/1-A/new/…` instead of `null/new/…`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Test have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
