### PR TITLE
[6.2] - RavenDB-24453 - Reduce string allocations when logging is disabled

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -94,9 +94,9 @@ public sealed class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDat
         return result;
     }
 
-    protected override SubscriptionBatchItem ShouldSend(Document item, out string reason)
+    protected override SubscriptionBatchItem ShouldSend(Document item)
     {
-        if (IsUnderActiveMigration(item.Id, _sharding, _allocator, _database.ShardNumber, Fetcher.FetchingFrom, out reason, out var isActiveMigration))
+        if (IsUnderActiveMigration(item.Id, _sharding, _allocator, _database.ShardNumber, Fetcher.FetchingFrom, out var isActiveMigration))
         {
             return new SubscriptionBatchItem
             {
@@ -106,23 +106,28 @@ public sealed class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDat
             };
         }
 
-        return base.ShouldSend(item, out reason);
+        return base.ShouldSend(item);
     }
   
-    public static bool IsUnderActiveMigration(string id, ShardingConfiguration sharding, ByteStringContext allocator, int shardNumber, FetchingOrigin fetchingFrom, out string reason, out bool isActiveMigration)
+    public bool IsUnderActiveMigration(string id, ShardingConfiguration sharding, ByteStringContext allocator, int shardNumber, FetchingOrigin fetchingFrom, out bool isActiveMigration)
     {
-        reason = null;
         isActiveMigration = false;
         var bucket = ShardHelper.GetBucketFor(sharding, allocator, id);
         var shard = ShardHelper.GetShardNumberFor(sharding, bucket);
         if (sharding.BucketMigrations.TryGetValue(bucket, out var migration) && migration.IsActive)
         {
-            reason = $"The document '{id}' from bucket '{bucket}' is under active migration and fetched from '{fetchingFrom}'.";
             if (fetchingFrom == FetchingOrigin.Storage || shard == shardNumber)
             {
-                reason += " Will set IsActiveMigration to true.";
                 // we pulled doc with active migration from storage or from resend list (when it belongs to us)
                 isActiveMigration = true;
+            }
+
+            if (Logger.IsInfoEnabled)
+            {
+                var reason = $"The document '{id}' from bucket '{bucket}' is under active migration and fetched from '{fetchingFrom}'.";
+                if (isActiveMigration)
+                    reason += " Will set IsActiveMigration to true.";
+                Logger.Info(reason);
             }
 
             return true;
@@ -130,11 +135,17 @@ public sealed class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDat
 
         if (shard != shardNumber)
         {
-            reason = $"The owner of '{id}' document is shard '{shard}' (current shard number: '{shardNumber}') and fetched from '{fetchingFrom}'.";
             if (fetchingFrom == FetchingOrigin.Storage)
             {
-                reason += " Will set IsActiveMigration to true.";
                 isActiveMigration = true;
+            }
+
+            if (Logger.IsInfoEnabled)
+            {
+                var reason = $"The owner of '{id}' document is shard '{shard}' (current shard number: '{shardNumber}') and fetched from '{fetchingFrom}'.";
+                if (isActiveMigration)
+                    reason += " Will set IsActiveMigration to true.";
+                Logger.Info(reason);
             }
 
             // current shard fetched an entry from resend list that belongs to another shard
@@ -162,24 +173,26 @@ public sealed class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDat
         return false;
     }
 
-    protected override bool ShouldFetchFromResend(DocumentsOperationContext context, string id, Document item, string currentChangeVector, out string reason)
+    protected override bool ShouldFetchFromResend(DocumentsOperationContext context, string id, Document item, string currentChangeVector)
     {
-        reason = null;
         if (item == null)
         {
             // the document was delete while it was processed by the client
             ItemsToRemoveFromResend.Add(id);
-            reason = $"document '{id}' removed and skipped from resend";
+
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"document '{id}' removed and skipped from resend");
+            
             return false;
         }
 
         var cv = context.GetChangeVector(item.ChangeVector);
         if (cv.IsSingle)
-            return base.ShouldFetchFromResend(context, id, item, currentChangeVector, out reason);
+            return base.ShouldFetchFromResend(context, id, item, currentChangeVector);
 
         item.ChangeVector = context.GetChangeVector(cv.Version, cv.Order.RemoveId(_sharding.DatabaseId, context));
 
-        return base.ShouldFetchFromResend(context, id, item, currentChangeVector, out reason);
+        return base.ShouldFetchFromResend(context, id, item, currentChangeVector);
     }
 
     public HashSet<string> Skipped;

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedRevisionsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedRevisionsDatabaseSubscriptionProcessor.cs
@@ -28,14 +28,16 @@ public sealed class ShardedRevisionsDatabaseSubscriptionProcessor : RevisionsDat
         return base.CreateFetcher();
     }
 
-    protected override SubscriptionBatchItem ShouldSend((Document Previous, Document Current) item, out string reason)
+    protected override SubscriptionBatchItem ShouldSend((Document Previous, Document Current) item)
     {
         DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Egor, DevelopmentHelper.Severity.Normal, "https://issues.hibernatingrhinos.com/issue/RavenDB-18881/Sharding-Subscription-Revisions");
         
         var shard = ShardHelper.GetShardNumberFor(_sharding, _allocator, item.Current.Id);
         if (shard != _database.ShardNumber)
         {
-            reason = $"The owner of {item.Current.Id} is shard {shard} ({_database.ShardNumber})";
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"The owner of {item.Current.Id} is shard {shard} ({_database.ShardNumber})");
+
             return new SubscriptionBatchItem
             {
                 Document = item.Current,
@@ -44,7 +46,7 @@ public sealed class ShardedRevisionsDatabaseSubscriptionProcessor : RevisionsDat
             };
         }
 
-        return base.ShouldSend(item, out reason);
+        return base.ShouldSend(item);
     }
 
     public override void Dispose()

--- a/src/Raven.Server/Documents/Subscriptions/Processor/DatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DatabaseSubscriptionProcessor.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
         protected override SubscriptionBatchItem GetBatchItem(T item)
         {
-            var batchItem = ShouldSend(item, out var reason);
+            var batchItem = ShouldSend(item);
 
             if (batchItem.Status == SubscriptionBatchItemStatus.Send)
             {
@@ -87,9 +87,6 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
                 return batchItem;
             }
-
-            if (Logger.IsInfoEnabled)
-                Logger.Info(reason, batchItem.Exception);
 
             if (batchItem.Status  == SubscriptionBatchItemStatus.Exception)
             {
@@ -104,7 +101,7 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
         protected abstract SubscriptionFetcher<T> CreateFetcher();
 
-        protected abstract SubscriptionBatchItem ShouldSend(T item, out string reason);
+        protected abstract SubscriptionBatchItem ShouldSend(T item);
     }
 
     public abstract class DatabaseSubscriptionProcessorBase<TItem> : AbstractSubscriptionProcessor<DatabaseIncludesCommandImpl, TItem>, IDatabaseSubscriptionProcessor

--- a/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -120,9 +120,8 @@ namespace Raven.Server.Documents.Subscriptions.Processor
             return new DocumentSubscriptionFetcher(Database, SubscriptionConnectionsState, Collection);
         }
 
-        protected override SubscriptionBatchItem ShouldSend(Document item, out string reason)
+        protected override SubscriptionBatchItem ShouldSend(Document item)
         {
-            reason = null;
             string id = item.Id; // we convert the Id to string since item might get disposed
             var result = new SubscriptionBatchItem
             {
@@ -136,14 +135,18 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {
-                    reason = $"{id} is already merged";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{id} is already merged");
+
                     result.Status = SubscriptionBatchItemStatus.Skip;
                     return result;
                 }
 
                 if (SubscriptionConnectionsState.IsDocumentInActiveBatch(ClusterContext, id, Active))
                 {
-                    reason = $"{id} exists in an active batch";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{id} exists in an active batch");
+
                     result.Status = SubscriptionBatchItemStatus.Skip;
                     return result;
                 }
@@ -152,7 +155,7 @@ namespace Raven.Server.Documents.Subscriptions.Processor
             if (Fetcher.FetchingFrom == SubscriptionFetcher.FetchingOrigin.Resend)
             {
                 var current = Database.DocumentsStorage.Get(DocsContext, id, throwOnConflict: false);
-                if (ShouldFetchFromResend(DocsContext, id, current, item.ChangeVector, out reason) == false)
+                if (ShouldFetchFromResend(DocsContext, id, current, item.ChangeVector) == false)
                 {
                     result.Document.ChangeVector = string.Empty;
                     current?.Dispose();
@@ -175,14 +178,18 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
             if (result.Document.Flags.Contain(DocumentFlags.Archived) && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ExcludeArchived)
             {
-                reason = $"{id} is archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"{id} is archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'");
+
                 result.Status = SubscriptionBatchItemStatus.Skip;
                 return result;
             }
             
             if (result.Document.Flags.Contain(DocumentFlags.Archived) == false && SubscriptionState.ArchivedDataProcessingBehavior == ArchivedDataProcessingBehavior.ArchivedOnly)
             {
-                reason = $"{id} is not archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'";
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"{id} is not archived, while the archived data processing behavior is '{SubscriptionState.ArchivedDataProcessingBehavior}'");
+
                 result.Status = SubscriptionBatchItemStatus.Skip;
                 return result;
             }
@@ -206,7 +213,9 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                         ItemsToRemoveFromResend.Add(id);
                     }
 
-                    reason = $"{id} filtered out by criteria";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{id} filtered out by criteria");
+
                     result.Status = SubscriptionBatchItemStatus.Skip;
                     return result;
                 }
@@ -216,21 +225,25 @@ namespace Raven.Server.Documents.Subscriptions.Processor
             }
             catch (Exception ex)
             {
-                reason = $"Criteria script threw exception for document id {id}";
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Criteria script threw exception for document id {id}", ex);
+                
                 result.Exception = ex;
                 result.Status = SubscriptionBatchItemStatus.Exception;
                 return result;
             }
         }
 
-        protected virtual bool ShouldFetchFromResend(DocumentsOperationContext context, string id, Document item, string currentChangeVector, out string reason)
+        protected virtual bool ShouldFetchFromResend(DocumentsOperationContext context, string id, Document item, string currentChangeVector)
         {
-            reason = null;
             if (item == null)
             {
                 // the document was delete while it was processed by the client
                 ItemsToRemoveFromResend.Add(id);
-                reason = $"document '{id}' removed and skipped from resend";
+
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"document '{id}' removed and skipped from resend");
+                
                 return false;
             }
 
@@ -244,28 +257,35 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                     {
                         // we can clear it from resend list, and it will processed as regular document
                         ItemsToRemoveFromResend.Add(id);
-                        reason = $"document '{id}' was updated ({item.ChangeVector}), but the subscription went too far and skipped from resend (sub progress: {SubscriptionConnectionsState.LastChangeVectorSent})";
+
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"document '{id}' was updated ({item.ChangeVector}), but the subscription went too far and skipped from resend (sub progress: {SubscriptionConnectionsState.LastChangeVectorSent})");
+
                         return false;
                     }
 
                     // We need to resend it
                     var fetch = resendStatus == ConflictStatus.AlreadyMerged;
-                    if (fetch == false)
-                        reason = $"document '{id}' is in status {resendStatus} (local: {item.ChangeVector}) with the subscription progress (sub progress: {SubscriptionConnectionsState.LastChangeVectorSent})";
+                    if (fetch == false && Logger.IsInfoEnabled)
+                        Logger.Info($"document '{id}' is in status {resendStatus} (local: {item.ChangeVector}) with the subscription progress (sub progress: {SubscriptionConnectionsState.LastChangeVectorSent})");
 
                     return fetch;
 
                 case ConflictStatus.AlreadyMerged:
                     if (CheckIfNewerInResendList(context, item.Id, item.ChangeVector, currentChangeVector))
                     {
-                        reason = $"document '{id}' is older in storage (cv: '{item.ChangeVector}') then in resend list (cv: '{currentChangeVector}'), probably there is a active migration. sub progress: {SubscriptionConnectionsState.LastChangeVectorSent}";
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info($"document '{id}' is older in storage (cv: '{item.ChangeVector}') then in resend list (cv: '{currentChangeVector}'), probably there is a active migration. sub progress: {SubscriptionConnectionsState.LastChangeVectorSent}");
+
                         return false;
                     }
 
                     return true;
 
                 case ConflictStatus.Conflict:
-                    reason = $"document '{id}' is in conflict, CV in storage '{item.ChangeVector}' CV in resend list '{currentChangeVector}' (sub progress: {SubscriptionConnectionsState.LastChangeVectorSent})";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"document '{id}' is in conflict, CV in storage '{item.ChangeVector}' CV in resend list '{currentChangeVector}' (sub progress: {SubscriptionConnectionsState.LastChangeVectorSent})");
+                    
                     return false;
 
                 default:

--- a/src/Raven.Server/Documents/Subscriptions/Processor/RevisionsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/RevisionsDatabaseSubscriptionProcessor.cs
@@ -110,9 +110,8 @@ namespace Raven.Server.Documents.Subscriptions.Processor
             return new RevisionSubscriptionFetcher(Database, SubscriptionConnectionsState, Collection);
         }
 
-        protected override SubscriptionBatchItem ShouldSend((Document Previous, Document Current) item, out string reason)
+        protected override SubscriptionBatchItem ShouldSend((Document Previous, Document Current) item)
         {
-            reason = null;
             var result = new SubscriptionBatchItem
             {
                 Document = item.Current.CloneWith(DocsContext, newData: null),
@@ -125,14 +124,18 @@ namespace Raven.Server.Documents.Subscriptions.Processor
 
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                 {
-                    reason = $"{item.Current.Id} is already merged";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{item.Current.Id} is already merged");
+
                     result.Status = SubscriptionBatchItemStatus.Skip;
                     return result;
                 }
 
                 if (SubscriptionConnectionsState.IsRevisionInActiveBatch(ClusterContext, item.Current, Active))
                 {
-                    reason = $"{item.Current.Id} is in active batch";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{item.Current.Id} is in active batch");
+
                     result.Status = SubscriptionBatchItemStatus.Skip;
                     return result;
                 }
@@ -164,7 +167,9 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                 var match = Patch.MatchCriteria(Run, DocsContext, transformResult, ProjectionMetadataModifier.Instance, ref result.Document.Data);
                 if (match == false)
                 {
-                    reason = $"{item.Current.Id} filtered by criteria";
+                    if (Logger.IsInfoEnabled)
+                        Logger.Info($"{item.Current.Id} filtered by criteria");
+
                     transformResult.Dispose();
                     result.Document.Data?.Dispose();
                     result.Document.Data = null;
@@ -183,7 +188,9 @@ namespace Raven.Server.Documents.Subscriptions.Processor
             }
             catch (Exception ex)
             {
-                reason = $"Criteria script threw exception for revision id {item.Current.Id} with change vector current: {item.Current.ChangeVector}, previous: {item.Previous?.ChangeVector}";
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Criteria script threw exception for revision id {item.Current.Id} with change vector current: {item.Current.ChangeVector}, previous: {item.Previous?.ChangeVector}", ex);
+
                 result.Exception = ex;
                 result.Status = SubscriptionBatchItemStatus.Exception;
                 return result;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24453/Subscription-with-filtering-generates-excessive-string-allocations

### Additional description

Reduce string allocations when logging is disabled.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
