### PR TITLE
[5.4] - RavenDB-24484 - Reorder disposal of RequestTimeTracker to occur before QueryOperationContext disposal

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -47,50 +47,51 @@ namespace Raven.Server.Documents.Handlers
 
         public async Task HandleQuery(HttpMethod httpMethod)
         {
-            RequestTimeTracker tracker = null;
-
-            try
+            using (var queryContext = QueryOperationContext.Allocate(Database))
+            using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "Query"))
             {
-                using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
-                using (var queryContext = QueryOperationContext.Allocate(Database))
+                try
                 {
-                    tracker = new RequestTimeTracker(HttpContext, Logger, Database, "Query");
-                    var debug = GetStringQueryString("debug", required: false);
-                    if (string.IsNullOrWhiteSpace(debug) == false)
+                    using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
                     {
-                        await Debug(queryContext, debug, token, tracker, httpMethod);
-                        return;
-                    }
+                        var debug = GetStringQueryString("debug", required: false);
+                        if (string.IsNullOrWhiteSpace(debug) == false)
+                        {
+                            await Debug(queryContext, debug, token, tracker, httpMethod);
+                            
+                            tracker.Dispose();
+                            
+                            return;
+                        }
 
-                    await Query(queryContext, token, tracker, httpMethod);
+                        await Query(queryContext, token, tracker, httpMethod);
+                        
+                        tracker.Dispose();
+                    }
                 }
-            }
-            catch (Exception e)
-            {
-                if (tracker != null && tracker.Query == null)
+                catch (Exception e)
                 {
-                    string errorMessage;
-                    if (e is EndOfStreamException || e is ArgumentException)
+                    if (tracker.Query == null)
                     {
-                        errorMessage = "Failed: " + e.Message;
-                    }
-                    else
-                    {
-                        errorMessage = "Failed: " +
-                                       HttpContext.Request.Path.Value +
-                                       e.ToString();
+                        string errorMessage;
+                        if (e is EndOfStreamException || e is ArgumentException)
+                        {
+                            errorMessage = "Failed: " + e.Message;
+                        }
+                        else
+                        {
+                            errorMessage = "Failed: " +
+                                           HttpContext.Request.Path.Value +
+                                           e.ToString();
+                        }
+
+                        tracker.Query = errorMessage;
+                        if (TrafficWatchManager.HasRegisteredClients)
+                            AddStringToHttpContext(errorMessage, TrafficWatchChangeType.Queries);
                     }
 
-                    tracker.Query = errorMessage;
-                    if (TrafficWatchManager.HasRegisteredClients)
-                        AddStringToHttpContext(errorMessage, TrafficWatchChangeType.Queries);
+                    throw;
                 }
-
-                throw;
-            }
-            finally
-            {
-                tracker?.Dispose();
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -58,15 +58,10 @@ namespace Raven.Server.Documents.Handlers
                         if (string.IsNullOrWhiteSpace(debug) == false)
                         {
                             await Debug(queryContext, debug, token, tracker, httpMethod);
-                            
-                            tracker.Dispose();
-                            
                             return;
                         }
 
                         await Query(queryContext, token, tracker, httpMethod);
-                        
-                        tracker.Dispose();
                     }
                 }
                 catch (Exception e)

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -47,51 +47,50 @@ namespace Raven.Server.Documents.Handlers
 
         public async Task HandleQuery(HttpMethod httpMethod)
         {
-            using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "Query"))
+            RequestTimeTracker tracker = null;
+
+            try
             {
-                try
+                using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
+                using (var queryContext = QueryOperationContext.Allocate(Database))
                 {
-                    using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
-                    using (var queryContext = QueryOperationContext.Allocate(Database))
+                    tracker = new RequestTimeTracker(HttpContext, Logger, Database, "Query");
+                    var debug = GetStringQueryString("debug", required: false);
+                    if (string.IsNullOrWhiteSpace(debug) == false)
                     {
-                        var debug = GetStringQueryString("debug", required: false);
-                        if (string.IsNullOrWhiteSpace(debug) == false)
-                        {
-                            await Debug(queryContext, debug, token, tracker, httpMethod);
-                            
-                            tracker.Dispose();
-                            
-                            return;
-                        }
-
-                        await Query(queryContext, token, tracker, httpMethod);
-                        
-                        tracker.Dispose();
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (tracker.Query == null)
-                    {
-                        string errorMessage;
-                        if (e is EndOfStreamException || e is ArgumentException)
-                        {
-                            errorMessage = "Failed: " + e.Message;
-                        }
-                        else
-                        {
-                            errorMessage = "Failed: " +
-                                           HttpContext.Request.Path.Value +
-                                           e.ToString();
-                        }
-
-                        tracker.Query = errorMessage;
-                        if (TrafficWatchManager.HasRegisteredClients)
-                            AddStringToHttpContext(errorMessage, TrafficWatchChangeType.Queries);
+                        await Debug(queryContext, debug, token, tracker, httpMethod);
+                        return;
                     }
 
-                    throw;
+                    await Query(queryContext, token, tracker, httpMethod);
                 }
+            }
+            catch (Exception e)
+            {
+                if (tracker != null && tracker.Query == null)
+                {
+                    string errorMessage;
+                    if (e is EndOfStreamException || e is ArgumentException)
+                    {
+                        errorMessage = "Failed: " + e.Message;
+                    }
+                    else
+                    {
+                        errorMessage = "Failed: " +
+                                       HttpContext.Request.Path.Value +
+                                       e.ToString();
+                    }
+
+                    tracker.Query = errorMessage;
+                    if (TrafficWatchManager.HasRegisteredClients)
+                        AddStringToHttpContext(errorMessage, TrafficWatchChangeType.Queries);
+                }
+
+                throw;
+            }
+            finally
+            {
+                tracker?.Dispose();
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -137,9 +137,9 @@ namespace Raven.Server.Documents.Handlers.Streaming
         public async Task StreamQueryGet()
         {
             // ReSharper disable once ArgumentsStyleLiteral
-            using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
             using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using (var queryContext = QueryOperationContext.Allocate(Database))
+            using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
             {
                 var documentId = GetStringQueryString("fromDocument", false);
                 string overrideQuery = null;
@@ -234,9 +234,9 @@ namespace Raven.Server.Documents.Handlers.Streaming
         public async Task StreamQueryPost()
         {
             // ReSharper disable once ArgumentsStyleLiteral
-            using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
             using (var token = CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using (var queryContext = QueryOperationContext.Allocate(Database))
+            using (var tracker = new RequestTimeTracker(HttpContext, Logger, Database, "StreamQuery", doPerformanceHintIfTooLong: false))
             {
                 var stream = TryGetRequestFromStream("ExportOptions") ?? RequestBodyStream();
                 var queryJson = await queryContext.Documents.ReadForMemoryAsync(stream, "index/query");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24484/RequestTimeTracker-throws-and-disrupts-the-query

### Additional description

The `RequestTimeTracker` must be disposed before the `QueryOperationContext` because it may access `QueryParameters` (a `BlittableJsonReaderObject`) during disposal. 
If the context is disposed first, it invalidates the underlying memory that `QueryParameters` references, potentially causing unreadable blittable or an access violation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
