### PR TITLE
RavenDB-24496 Get cert mode only for ClusterAdmin and ClusterNode [v7.1]

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.spec.tsx
@@ -166,6 +166,7 @@ describe("Certificates", () => {
                         x.Certificates = [serverCert, clientCert];
                         x.Certificates[1].SecurityClearance = "Operator";
                     }}
+                    securityClearance="Operator"
                 />
             );
 
@@ -179,6 +180,7 @@ describe("Certificates", () => {
                         x.Certificates = [serverCert, clientCert];
                         x.Certificates[1].SecurityClearance = "ClusterAdmin";
                     }}
+                    securityClearance="Operator"
                 />
             );
 

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/Certificates.stories.tsx
@@ -3,12 +3,17 @@ import Certificates from "components/pages/resources/manageServer/certificates/C
 import { MockedValue } from "test/mocks/services/AutoMockService";
 import { mockServices } from "test/mocks/services/MockServices";
 import { mockStore } from "test/mocks/store/MockStore";
-import { withStorybookContexts, withBootstrap5 } from "test/storybookTestUtils";
+import {
+    withStorybookContexts,
+    withBootstrap5,
+    securityClearanceArgType,
+    withForceRerender,
+} from "test/storybookTestUtils";
 import { ManageServerStubs } from "test/stubs/ManageServerStubs";
 
 export default {
     title: "Pages/Manage Server/Certificates",
-    decorators: [withStorybookContexts, withBootstrap5],
+    decorators: [withStorybookContexts, withBootstrap5, withForceRerender],
 } satisfies Meta;
 
 interface CertificatesStoryArgs {
@@ -17,6 +22,7 @@ interface CertificatesStoryArgs {
     certificates: MockedValue<CertificatesResponseDto>;
     serverCertSetupMode: MockedValue<Raven.Server.Commercial.SetupMode>;
     serverCertRenewalDate: MockedValue<string>;
+    securityClearance: securityClearance;
 }
 
 export const CertificatesStory: StoryObj<CertificatesStoryArgs> = {
@@ -25,6 +31,7 @@ export const CertificatesStory: StoryObj<CertificatesStoryArgs> = {
         const { manageServerService } = mockServices;
         const { accessManager, databases, cluster, license } = mockStore;
 
+        accessManager.with_securityClearance(args.securityClearance);
         accessManager.with_isServerSecure(args.isSecureServer);
         accessManager.with_clientCertificateThumbprint(ManageServerStubs.certificates().Certificates[1].Thumbprint);
         databases.with_Single();
@@ -43,10 +50,14 @@ export const CertificatesStory: StoryObj<CertificatesStoryArgs> = {
         return <Certificates />;
     },
     args: {
+        securityClearance: "ClusterAdmin",
         isSecureServer: true,
         hasReadOnlyCertificates: true,
         certificates: ManageServerStubs.certificates(),
         serverCertSetupMode: ManageServerStubs.serverCertificateSetupMode(),
         serverCertRenewalDate: ManageServerStubs.serverCertificateRenewalDate(),
+    },
+    argTypes: {
+        securityClearance: securityClearanceArgType,
     },
 };

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
@@ -154,10 +154,14 @@ const fetchData = createAsyncThunk<
     }
 >(certificatesSlice.name + "/fetchData", async (_, { getState }) => {
     const nodeTags = getState().cluster.nodes.ids;
+    const securityClearance = getState().accessManager.securityClearance;
+    const isClusterAdminOrClusterNode = securityClearance === "ClusterAdmin" || securityClearance === "ClusterNode";
 
     const certificatesDto = await services.manageServerService.getCertificates(true);
 
-    const serverCertificateSetupMode = await services.manageServerService.getServerCertificateSetupMode();
+    const serverCertificateSetupMode = isClusterAdminOrClusterNode
+        ? await services.manageServerService.getServerCertificateSetupMode()
+        : null;
 
     const serverCertificateRenewalDate =
         serverCertificateSetupMode === "LetsEncrypt"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24496/admin-certificates-mode-is-called-on-operator-cert

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
