### PR TITLE
RavenDB-24138 Removed obsolete test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -157,41 +157,6 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public async Task EmbeddingsMustBeGeneratedOnlyOnceInSameBatch()
-    {
-        using (var store = GetDocumentStore())
-        {
-            var dto1 = new Dto { Name = "Name1" };
-            var dto2 = new Dto { Name = "Name1" };
-
-            using (var session = store.OpenAsyncSession())
-            {
-                await session.StoreAsync(dto1);
-                await session.StoreAsync(dto2);
-                await session.SaveChangesAsync();
-            }
-
-            var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }]);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
-            var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
-            var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
-
-            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["Name1"], dto1.Id);
-            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["Name1"], dto2.Id);
-
-            var db = await GetDatabase(store.Database);
-            var etlProcess = (EmbeddingsGenerationTask)db.EtlLoader.Processes.First();
-            var stats = etlProcess.GetPerformanceStats();
-
-            Assert.Equal(2, stats.Length);
-            Assert.Equal(2, stats[0].NumberOfLoadedItems);
-            Assert.Equal("No more items to process", stats[1].BatchTransformationCompleteReason);
-        }
-    }
-
-    [RavenFact(RavenTestCategory.Ai)]
     public void EmbeddingsMustBeGeneratedOnlyOnceInDifferentBatches()
     {
         using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24138/SlowTests.Server.Documents.AI.Embeddings.GenerateEmbeddingsTests.EmbeddingsMustBeGeneratedOnlyOnceInSameBatch

### Additional description

We don't have a check that prevents from generating embeddings from duplicated textual values in the same batch

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
