### PR TITLE
RavenDB-24484 Handle RequestTimeTracker currectly in queries

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -122,9 +122,6 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
                     if (string.IsNullOrWhiteSpace(parameters.Debug) == false)
                     {
                         await HandleDebugAsync(indexQuery, queryContext, context, parameters, existingResultEtag, token);
-                        
-                        tracker.Dispose();
-
                         return;
                     }
 
@@ -193,8 +190,6 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
                         AddQueryTimingsToTrafficWatch(indexQuery);
                     }
-
-                    tracker.Dispose();
                 }
             }
             catch (Exception e)

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
@@ -115,9 +115,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
             var properties = RequestHandler.GetStringValuesQueryString("field", false);
 
             // ReSharper disable once ArgumentsStyleLiteral
-            using (var tracker = GetTimeTracker())
             using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using (AllocateContext(out TOperationContext context))
+            using (var tracker = GetTimeTracker())
             {
                 IndexQueryServerSide query;
                 string overrideQuery = null;

--- a/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
+++ b/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
@@ -69,12 +69,10 @@ namespace Raven.Server.NotificationCenter
             catch (Exception e)
             {
                 //precaution - should never arrive here
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(
-                        $"Failed to write request time in response headers. This is not supposed to happen and is probably a bug. The request path was: {_context.Request.Path}",
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations(
+                        $"Failed to write request time in response headers. This is not supposed to happen and is probably a bug. The request path was: {_context.Request.Path}, query: {Query}",
                         e);
-
-                throw;
             }
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24484

### Additional description

V6.2 PR for [20820](https://github.com/ravendb/ravendb/pull/20820) and [20826](https://github.com/ravendb/ravendb/pull/20826)

#### [20820](https://github.com/ravendb/ravendb/pull/20820)
The notification failure should not cause the query to fail, so the error is logged instead of thrown.

#### [20826](https://github.com/ravendb/ravendb/pull/20826)
The RequestTimeTracker must be disposed before the QueryOperationContext because it may access QueryParameters (a BlittableJsonReaderObject) during disposal.
If the context is disposed first, it invalidates the underlying memory that QueryParameters references, potentially causing unreadable blittable or an access violation.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
