### PR TITLE
RavenDB-24484 Handle RequestTimeTracker currectly in queries

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -122,9 +122,6 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
                     if (string.IsNullOrWhiteSpace(parameters.Debug) == false)
                     {
                         await HandleDebugAsync(indexQuery, queryContext, context, parameters, existingResultEtag, token);
-                        
-                        tracker.Dispose();
-
                         return;
                     }
 
@@ -193,8 +190,6 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
                         AddQueryTimingsToTrafficWatch(indexQuery);
                     }
-
-                    tracker.Dispose();
                 }
             }
             catch (Exception e)

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
@@ -115,9 +115,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
             var properties = RequestHandler.GetStringValuesQueryString("field", false);
 
             // ReSharper disable once ArgumentsStyleLiteral
-            using (var tracker = GetTimeTracker())
             using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
             using (AllocateContext(out TOperationContext context))
+            using (var tracker = GetTimeTracker())
             {
                 IndexQueryServerSide query;
                 string overrideQuery = null;

--- a/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
+++ b/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
@@ -66,12 +66,10 @@ namespace Raven.Server.NotificationCenter
             catch (Exception e)
             {
                 //precaution - should never arrive here
-                if (_logger.IsInfoEnabled)
-                    _logger.Info(
-                        $"Failed to write request time in response headers. This is not supposed to happen and is probably a bug. The request path was: {_context.Request.Path}",
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations(
+                        $"Failed to write request time in response headers. This is not supposed to happen and is probably a bug. The request path was: {_context.Request.Path}, query: {Query}",
                         e);
-
-                throw;
             }
         }
     }


### PR DESCRIPTION
Custom build
Base - V6.2.6
Additional change:
5d5a4a0 - [RavenDB-24484 Don't throw when RequestTimeTracker.Dispose fails to notify; instead, log an operation message.](https://github.com/ravendb/ravendb/commit/5d5a4a086d19910f127e416c0b4addacda6f531f)
fbfe528 - [RavenDB-24484 - dispose the tracker before we dispose the context](https://github.com/ravendb/ravendb/commit/fbfe528071ac11589e35f094361c3732b9c4b0e1) 
