### PR TITLE
RavenDB-24209 - Add EmbeddingsGenerations and AiConnectionStrings to DefaultOperateOnDatabaseRecordTypes

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -51,6 +51,8 @@ namespace Raven.Client.Documents.Smuggler
                                                                                   DatabaseRecordItemType.QueueSinks |
                                                                                   DatabaseRecordItemType.SnowflakeEtls |
                                                                                   DatabaseRecordItemType.SnowflakeConnectionStrings |
+                                                                                  DatabaseRecordItemType.EmbeddingsGenerations |
+                                                                                  DatabaseRecordItemType.AiConnectionStrings |
                                                                                   DatabaseRecordItemType.GenAiEtls;
 
         internal const DatabaseItemType OperateOnFirstShardOnly = DatabaseItemType.Indexes |


### PR DESCRIPTION
Cherry-picked: https://github.com/ravendb/ravendb/pull/20835