### PR TITLE
RavenDB-24294 Gen AI - Add 'Model type' field to AI Connection string

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
@@ -26,6 +26,8 @@ public sealed class AiConnectionString : ConnectionString
 
     public override ConnectionStringType Type => ConnectionStringType.Ai;
 
+    public AiModelType ModelType { get; set; }
+
     protected override void ValidateImpl(List<string> errors)
     {
         var allSettings = new AbstractAiSettings[]
@@ -73,6 +75,9 @@ public sealed class AiConnectionString : ConnectionString
 
         if (Identifier != newConnectionString.Identifier)
             result |= AiSettingsCompareDifferences.Identifier;
+
+        if (ModelType != newConnectionString.ModelType)
+            result |= AiSettingsCompareDifferences.ModelArchitecture;
 
         var oldProvider = GetActiveProvider();
         var newProvider = newConnectionString.GetActiveProvider();
@@ -151,6 +156,9 @@ public sealed class AiConnectionString : ConnectionString
         if (Identifier != aiConnectionString.Identifier)
             return false;
 
+        if (ModelType != aiConnectionString.ModelType) 
+            return false;
+
         var activeProvider = GetActiveProvider();
         var otherActiveProvider = aiConnectionString.GetActiveProvider();
 
@@ -176,6 +184,7 @@ public sealed class AiConnectionString : ConnectionString
         var json = base.ToJson();
 
         json[nameof(Identifier)] = Identifier;
+        json[nameof(ModelType)] = ModelType;
         json[nameof(OpenAiSettings)] = OpenAiSettings?.ToJson();
         json[nameof(AzureOpenAiSettings)] = AzureOpenAiSettings?.ToJson();
         json[nameof(OllamaSettings)] = OllamaSettings?.ToJson();

--- a/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
@@ -2,6 +2,6 @@
 
 public enum AiModelType
 {
-    Embeddings,
-    LLM
+    TextEmbeddings,
+    Chat
 }

--- a/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Client.Documents.Operations.AI;
+
+public enum AiModelType
+{
+    None,
+    LLM,
+    Embeddings
+}

--- a/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiModelType.cs
@@ -2,7 +2,6 @@
 
 public enum AiModelType
 {
-    None,
-    LLM,
-    Embeddings
+    Embeddings,
+    LLM
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -86,8 +86,8 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         if (validateConnection && TestMode == false)
         {
             Connection.Validate(errors);
-            if (Connection.ModelType != AiModelType.Embeddings)
-                errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.Embeddings)}");
+            if (Connection.ModelType != AiModelType.TextEmbeddings)
+                errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.TextEmbeddings)}");
         }
 
         if (string.IsNullOrEmpty(Collection))

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -84,7 +84,11 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             errors.Add($"{nameof(ConnectionStringName)} cannot be empty");
 
         if (validateConnection && TestMode == false)
+        {
             Connection.Validate(errors);
+            if (Connection.ModelType != AiModelType.Embeddings)
+                errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.Embeddings)}");
+        }
 
         if (string.IsNullOrEmpty(Collection))
             errors.Add($"{nameof(Collection)} must be provided");

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -75,7 +75,11 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             errors.Add($"{nameof(ConnectionStringName)} cannot be empty");
 
         if (validateConnection && TestMode == false)
+        {
             Connection.Validate(errors);
+            if (Connection.ModelType != AiModelType.LLM)
+                errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.LLM)}");
+        }
 
         if (string.IsNullOrEmpty(Collection))
             errors.Add($"{nameof(Collection)} must be provided");

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -77,8 +77,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         if (validateConnection && TestMode == false)
         {
             Connection.Validate(errors);
-            if (Connection.ModelType != AiModelType.LLM)
-                errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.LLM)}");
+            if (Connection.ModelType != AiModelType.Chat)
+                errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.Chat)}");
         }
 
         if (string.IsNullOrEmpty(Collection))

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -31,6 +31,8 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
         if (aiConnectorType == AiConnectorType.None)
             throw new ArgumentException($"AI connector type cannot be '{AiConnectorType.None}'");
 
+        var modelType = RequestHandler.GetEnumQueryString<AiModelType>("modelType");
+
         InMemoryLoggerProvider logger = null;
         try
         {
@@ -39,7 +41,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
             {
                 var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "etl/test/script");
 
-                var aiConnectionString = new AiConnectionString();
+                var aiConnectionString = new AiConnectionString { ModelType = modelType };
 
                 switch (aiConnectorType)
                 {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -84,7 +84,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
 
                 switch (aiConnectionString.ModelType)
                 {
-                    case AiModelType.Embeddings:
+                    case AiModelType.TextEmbeddings:
                         var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
                         (ITextEmbeddingGenerationService service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
                         var embeddings = await service.GenerateEmbeddingsAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
@@ -93,11 +93,11 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                             throw new EmbeddingsMismatchException(
                                 $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
                         break;
-                    case AiModelType.LLM:
+                    case AiModelType.Chat:
                         if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model) == false)
                             throw new InvalidOperationException(
-                                $"Invalid provider settings for {nameof(AiConnectionString)} with model type '{nameof(AiConnectionString.ModelType.LLM)}'. " +
-                                $"Supported providers for '{nameof(AiConnectionString.ModelType.LLM)}' model type are '{nameof(AiConnectorType.OpenAi)}' and '{nameof(AiConnectorType.Ollama)}'");
+                                $"Invalid provider settings for {nameof(AiConnectionString)} with model type '{nameof(AiConnectionString.ModelType.Chat)}'. " +
+                                $"Supported providers for '{nameof(AiConnectionString.ModelType.Chat)}' model type are '{nameof(AiConnectorType.OpenAi)}' and '{nameof(AiConnectorType.Ollama)}'");
                         
                         using (var client = new GenericChatCompletionClientForTesting(uri, model, apiKey, organizationId: null, projectId: null, ServerStore.ContextPool))
                         {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Extensions.AI;
 using Microsoft.SemanticKernel.Embeddings;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI;
@@ -11,6 +12,7 @@ using Raven.Server.Json;
 using Raven.Server.Web.System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+
 #pragma warning disable SKEXP0001
 
 namespace Raven.Server.Documents.ETL.Providers.AI.Handlers.Processors;
@@ -80,30 +82,31 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                         throw new ArgumentOutOfRangeException();
                 }
 
-                try
+                switch (aiConnectionString.ModelType)
                 {
-                    var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
-                    (ITextEmbeddingGenerationService service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
-                    var embeddings = await service.GenerateEmbeddingsAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
+                    case AiModelType.Embeddings:
+                        var aiEtlConfiguration = new EmbeddingsGenerationConfiguration { Connection = aiConnectionString };
+                        (ITextEmbeddingGenerationService service, logger) = AiHelper.CreateEmbeddingServicesForTest(aiEtlConfiguration);
+                        var embeddings = await service.GenerateEmbeddingsAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token.Token);
 
-                    if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
-                        throw new EmbeddingsMismatchException(
-                            $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
-                }
-                // TODO: remove this ugly workaround
-                catch (Exception e) when (e is not EmbeddingsMismatchException)
-                {
-                    if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model))
-                    {
+                        if (embeddings.Count != EmbeddingsHelper.ValuesListToVerifyConnection.Count)
+                            throw new EmbeddingsMismatchException(
+                                $"Failed to generate embeddings for test values. Expected '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' result, but got '{embeddings.Count}'.");
+                        break;
+                    case AiModelType.LLM:
+                        if (aiConnectionString.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model) == false)
+                            throw new InvalidOperationException(
+                                $"Invalid provider settings for {nameof(AiConnectionString)} with model type '{nameof(AiConnectionString.ModelType.LLM)}'. " +
+                                $"Supported providers for '{nameof(AiConnectionString.ModelType.LLM)}' model type are '{nameof(AiConnectorType.OpenAi)}' and '{nameof(AiConnectorType.Ollama)}'");
+                        
                         using (var client = new GenericChatCompletionClientForTesting(uri, model, apiKey, organizationId: null, projectId: null, ServerStore.ContextPool))
                         {
                             await client.CompleteAsync("foo", "bar", HttpContext.RequestAborted);
                         }
-                    }
-                    else
-                    {
-                        throw;
-                    }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Invalid model type: " + aiConnectionString.ModelType);
                 }
 
                 var result = new DynamicJsonValue { [nameof(NodeConnectionTestResult.Success)] = true };

--- a/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ConnectionStrings/PutConnectionStringCommand.cs
@@ -203,8 +203,10 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
                         $"connection string{(identifierConflicts.Length > 1 ? "s" : "")} " +
                         $"'{string.Join("', '", identifierConflicts.Select(x => x.Key))}'");
 
-                var etlsUsingConnection = databaseRecord.EmbeddingsGenerations.Where(x => x.ConnectionStringName == ConnectionString.Name).ToArray();
-                var isConnectionStringInUse = etlsUsingConnection.Length > 0;
+                var embeddingsUsingConnection = databaseRecord.EmbeddingsGenerations.Where(x => x.ConnectionStringName == ConnectionString.Name).ToArray();
+                var genAisUsingConnection = databaseRecord.GenAis.Where(x => x.ConnectionStringName == ConnectionString.Name).ToArray();
+
+                var isConnectionStringInUse = embeddingsUsingConnection.Length > 0 || genAisUsingConnection.Length > 0;
 
                 if (isUpdate == false || isConnectionStringInUse == false)
                     return;
@@ -213,16 +215,19 @@ namespace Raven.Server.ServerWide.Commands.ConnectionStrings
                 if (differences.HasFlag(AiSettingsCompareDifferences.RequiresEmbeddingsRegeneration) == false)
                     return;
 
-                var etlNames = string.Join("', '", etlsUsingConnection.Select(x => x.Name));
+                var embeddingTasks = embeddingsUsingConnection.Select(x => x.Name);
+                var genAiTasks = genAisUsingConnection.Select(x => x.Name);
+                var etlNames = string.Join("', '", embeddingTasks.Concat(genAiTasks));
+
                 throw new RachisApplyException(
                     $"Cannot update connection string '{ConnectionString.Name}' because it contains changes ({differences}) that would affect the structure or creation process of embeddings. " +
                     $"Changes to parameters like model selection, tokenization settings, embedding dimensions, or normalization options require recreating all embeddings to maintain consistency. " +
                     $"To proceed with these changes:{Environment.NewLine}" +
-                    $"1. Delete the existing AI Integration task{(etlsUsingConnection.Length == 1 ? "" : "s")}{Environment.NewLine}" +
-                    $"2. {(etlsUsingConnection.Length == 1 ?
+                    $"1. Delete the existing AI Integration task{(etlNames.Length == 1 ? "" : "s")}{Environment.NewLine}" +
+                    $"2. {(etlNames.Length == 1 ?
                         "After deleting the AI Integration task, you can either update this connection string or create a new one with your desired settings" :
                         $"Create a new connection string with your desired settings, as this connection string is used by AI Integration tasks: '{etlNames}'")}{Environment.NewLine}" +
-                    $"3. Create a new AI Integration task using the {(etlsUsingConnection.Length == 1 ? "updated or new" : "new")} connection string{Environment.NewLine}" +
+                    $"3. Create a new AI Integration task using the {(etlNames.Length == 1 ? "updated or new" : "new")} connection string{Environment.NewLine}" +
                     "This will ensure all documents are processed with consistent settings and maintain data integrity. " +
                     "Note: While you can update non-critical settings like API keys or endpoints without recreating the task, your current changes include critical modifications that affect the embedding process.");
             }

--- a/src/Raven.Studio/typescript/commands/database/cluster/testAiConnectionStringCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/cluster/testAiConnectionStringCommand.ts
@@ -6,6 +6,7 @@ class testAiConnectionStringCommand extends commandBase {
     constructor(
         private db: database | string,
         private type: Raven.Client.Documents.Operations.AI.AiConnectorType,
+        private modelType: Raven.Client.Documents.Operations.AI.AiModelType,
         private settings: Partial<AiConnectionStringsSettings>
     ) {
         super();
@@ -14,6 +15,7 @@ class testAiConnectionStringCommand extends commandBase {
     execute(): JQueryPromise<Raven.Server.Web.System.NodeConnectionTestResult> {
         const args = {
             type: this.type,
+            modelType: this.modelType,
         };
 
         const url = endpoints.databases.aiIntegrationConnection.adminAiTestConnection + this.urlEncodeArgs(args);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
@@ -131,6 +131,7 @@ export interface AiConnection extends ConnectionBase {
         | "embeddedSettings"
         | "openAiSettings"
         | "mistralAiSettings";
+    modelType?: Raven.Client.Documents.Operations.AI.AiModelType;
     azureOpenAiSettings?: {
         apiKey?: string;
         endpoint?: string;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
@@ -20,7 +20,7 @@ import MistralAiSettings from "./aiFields/MistralAiSettings";
 import { useAppUrls } from "components/hooks/useAppUrls";
 import TaskUtils from "components/utils/TaskUtils";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
-import { connectionStringSelectors, ConnectionStringsViewContext } from "../store/connectionStringsSlice";
+import { connectionStringSelectors } from "../store/connectionStringsSlice";
 import { useAppSelector } from "components/store";
 import { ConnectionStringsNameContext, connectionStringsUtils } from "../connectionStringsUtils";
 import { components, OptionProps } from "react-select";
@@ -28,6 +28,7 @@ import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import classNames from "classnames";
 import Form from "react-bootstrap/Form";
+import ModelTypeField from "./aiFields/ModelTypeField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -37,7 +38,6 @@ export interface AiConnectionStringProps extends EditConnectionStringFormProps {
 
 export default function AiConnectionString({ initialConnection, isForNewConnection, onSave }: AiConnectionStringProps) {
     const usedNames = useAppSelector(connectionStringSelectors.connections)["Ai"].map((x) => x.name);
-    const viewContext = useAppSelector(connectionStringSelectors.viewContext);
 
     const form = useForm<FormData>({
         mode: "all",
@@ -59,7 +59,7 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
     const { forCurrentDatabase } = useAppUrls();
 
     const formValues = useWatch({ control });
-    const { connectorType } = formValues;
+    const { connectorType, modelType } = formValues;
 
     const handleGenerateIdentifier = () => {
         setValue("identifier", TaskUtils.getGeneratedIdentifier(formValues.name));
@@ -122,21 +122,21 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
                         }
                     />
                 </div>
+                <ModelTypeField />
                 <div className="mb-2">
                     <FormLabel>Connector</FormLabel>
                     <FormSelect
                         control={control}
                         name="connectorType"
-                        placeholder="Select connector"
-                        options={getConnectorOptions(viewContext)}
-                        isDisabled={isUsedByAnyTask}
+                        placeholder={`Select connector${modelType == null ? " (select model type first)" : ""}`}
+                        options={getConnectorOptions(modelType)}
+                        isDisabled={isUsedByAnyTask || modelType == null}
                         components={{
                             Option: SettingsOptionComponent,
                             SingleValue: SingleValueWithIcon,
                         }}
                     />
                 </div>
-
                 {connectorType === "azureOpenAiSettings" && <AzureOpenAiSettings isUsedByAnyTask={isUsedByAnyTask} />}
                 {connectorType === "googleSettings" && <GoogleSettings isUsedByAnyTask={isUsedByAnyTask} />}
                 {connectorType === "huggingFaceSettings" && <HuggingFaceSettings isUsedByAnyTask={isUsedByAnyTask} />}
@@ -180,9 +180,7 @@ export function SettingsOptionComponent(props: OptionProps<SelectOptionWithIcon>
     );
 }
 
-function getConnectorOptions(
-    viewContext: ConnectionStringsViewContext
-): SelectOptionWithIcon<FormData["connectorType"]>[] {
+function getConnectorOptions(modelType: FormData["modelType"]): SelectOptionWithIcon<FormData["connectorType"]>[] {
     const allOptions: SelectOptionWithIcon<FormData["connectorType"]>[] = [
         { label: "Azure OpenAI", value: "azureOpenAiSettings", icon: "openai" },
         { label: "Google AI", value: "googleSettings", icon: "google-gemini" },
@@ -193,7 +191,7 @@ function getConnectorOptions(
         { label: "Embedded (bge-micro-v2)", value: "embeddedSettings", icon: "onnx" },
     ];
 
-    if (viewContext === "taskGenAi") {
+    if (modelType === "Chat") {
         return [
             ...allOptions.filter(
                 (x) => x.value === "ollamaSettings" || x.value === "openAiSettings" || x.value === "azureOpenAiSettings"
@@ -217,6 +215,7 @@ const schema = yupObjectSchema<FormData>({
             return /^[a-z0-9-]+$/.test(value);
         }),
     connectorType: yup.string<FormData["connectorType"]>().nullable().required(),
+    modelType: yup.string<Raven.Client.Documents.Operations.AI.AiModelType>().nullable().required(),
     azureOpenAiSettings: yup.object({
         apiKey: yup
             .string()
@@ -365,6 +364,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
             name: null,
             identifier: null,
             connectorType: null,
+            modelType: initialConnection?.modelType ?? null,
             azureOpenAiSettings: {
                 apiKey: null,
                 endpoint: null,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
@@ -31,7 +31,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
             return;
         }
 
-        return tasksService.testAiConnectionString(databaseName, "AzureOpenAi", {
+        return tasksService.testAiConnectionString(databaseName, "AzureOpenAi", formValues.modelType, {
             ApiKey: formValues.azureOpenAiSettings.apiKey,
             Endpoint: formValues.azureOpenAiSettings.endpoint,
             Model: formValues.azureOpenAiSettings.model,
@@ -125,29 +125,33 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
                 </FormLabel>
                 <FormInput control={control} name="azureOpenAiSettings.deploymentName" type="text" />
             </div>
-            <div className="mb-2">
-                <FormLabel>
-                    Dimensions <OptionalLabel />
-                    <PopoverWithHoverWrapper
-                        message={
-                            <>
-                                The number of dimensions for the output embeddings.
-                                <br />
-                                Supported only in &quot;text-embedding-3&quot; and later models.
-                            </>
-                        }
-                    >
-                        <Icon icon="info" color="info" id="dimensions" margin="ms-1" />
-                    </PopoverWithHoverWrapper>
-                </FormLabel>
-                <FormInput
-                    control={control}
-                    name="azureOpenAiSettings.dimensions"
-                    type="number"
-                    disabled={isUsedByAnyTask}
-                />
-            </div>
-            <EmbeddingsMaxConcurrentBatches baseName="azureOpenAiSettings" />
+            {formValues.modelType === "TextEmbeddings" && (
+                <div className="mb-2">
+                    <FormLabel>
+                        Dimensions <OptionalLabel />
+                        <PopoverWithHoverWrapper
+                            message={
+                                <>
+                                    The number of dimensions for the output embeddings.
+                                    <br />
+                                    Supported only in &quot;text-embedding-3&quot; and later models.
+                                </>
+                            }
+                        >
+                            <Icon icon="info" color="info" id="dimensions" margin="ms-1" />
+                        </PopoverWithHoverWrapper>
+                    </FormLabel>
+                    <FormInput
+                        control={control}
+                        name="azureOpenAiSettings.dimensions"
+                        type="number"
+                        disabled={isUsedByAnyTask}
+                    />
+                </div>
+            )}
+            {formValues.modelType === "TextEmbeddings" && (
+                <EmbeddingsMaxConcurrentBatches baseName="azureOpenAiSettings" />
+            )}
             <div className="d-flex mb-2">
                 <FlexGrow />
                 <ButtonWithSpinner

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
@@ -33,7 +33,7 @@ export default function GoogleSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
             return;
         }
 
-        return tasksService.testAiConnectionString(databaseName, "Google", {
+        return tasksService.testAiConnectionString(databaseName, "Google", formValues.modelType, {
             AiVersion: formValues.googleSettings.aiVersion,
             ApiKey: formValues.googleSettings.apiKey,
             Model: formValues.googleSettings.model,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/HuggingFaceSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/HuggingFaceSettings.tsx
@@ -31,7 +31,7 @@ export default function HuggingFaceSettings({ isUsedByAnyTask }: { isUsedByAnyTa
             return;
         }
 
-        return tasksService.testAiConnectionString(databaseName, "HuggingFace", {
+        return tasksService.testAiConnectionString(databaseName, "HuggingFace", formValues.modelType, {
             ApiKey: formValues.huggingFaceSettings.apiKey,
             Endpoint: formValues.huggingFaceSettings.endpoint,
             Model: formValues.huggingFaceSettings.model,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/MistralAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/MistralAiSettings.tsx
@@ -31,7 +31,7 @@ export default function MistralAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask
             return;
         }
 
-        return tasksService.testAiConnectionString(databaseName, "MistralAi", {
+        return tasksService.testAiConnectionString(databaseName, "MistralAi", formValues.modelType, {
             ApiKey: formValues.mistralAiSettings.apiKey,
             Endpoint: formValues.mistralAiSettings.endpoint,
             Model: formValues.mistralAiSettings.model,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/ModelTypeField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/ModelTypeField.tsx
@@ -1,0 +1,84 @@
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { useFormContext, useWatch } from "react-hook-form";
+import { Icon } from "components/common/Icon";
+import {
+    ConnectionFormData,
+    AiConnection,
+} from "components/pages/database/settings/connectionStrings/connectionStringsTypes";
+import classNames from "classnames";
+import IconName from "typings/server/icons";
+import { FormLabel } from "components/common/Form";
+
+type FormData = ConnectionFormData<AiConnection>;
+
+export default function ModelTypeField() {
+    const { control, setValue } = useFormContext<FormData>();
+
+    const formValues = useWatch({ control });
+
+    return (
+        <div className="mb-2">
+            <FormLabel>
+                Model type
+                <PopoverWithHoverWrapper message="Select the type of model this connection will target">
+                    <Icon icon="info" color="info" margin="ms-1" />
+                </PopoverWithHoverWrapper>
+            </FormLabel>
+            <div className="d-flex gap-2">
+                <ClickableCard
+                    icon="llm"
+                    title="Chat"
+                    description="Conversational AI and content generation model"
+                    className="w-50"
+                    isSelected={formValues.modelType === "Chat"}
+                    onClick={() => setValue("modelType", "Chat")}
+                />
+                <ClickableCard
+                    icon="document2"
+                    title="Text embeddings"
+                    description="Embedding generation model for vector search and similarity comparison"
+                    className="w-50"
+                    isSelected={formValues.modelType === "TextEmbeddings"}
+                    onClick={() => setValue("modelType", "TextEmbeddings")}
+                />
+            </div>
+        </div>
+    );
+}
+
+interface ClickableCardProps {
+    icon: IconName;
+    title: string;
+    description: string;
+    isSelected: boolean;
+    className?: string;
+    onClick: () => void;
+}
+
+function ClickableCard({ description, icon, onClick, title, isSelected, className }: ClickableCardProps) {
+    return (
+        <div
+            className={classNames(
+                "border rounded p-2 cursor-pointer",
+                {
+                    "bg-faded-primary border-primary": isSelected,
+                },
+                {
+                    "border-secondary": !isSelected,
+                },
+                className
+            )}
+            onClick={onClick}
+        >
+            <div className="text-emphasis hstack gap-2">
+                <div>
+                    <Icon icon={icon} margin="mx-1" />
+                </div>
+                <div className="flex-grow">
+                    <div className="fw-semibold">{title}</div>
+                    <div>{description}</div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
@@ -32,7 +32,7 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
             return;
         }
 
-        return tasksService.testAiConnectionString(databaseName, "Ollama", {
+        return tasksService.testAiConnectionString(databaseName, "Ollama", formValues.modelType, {
             Model: formValues.ollamaSettings.model,
             Uri: formValues.ollamaSettings.uri,
         });
@@ -91,7 +91,7 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     isLoading={asyncGetModelOptions.loading}
                 />
             </div>
-            <EmbeddingsMaxConcurrentBatches baseName="ollamaSettings" />
+            {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="ollamaSettings" />}
             <div className="d-flex mb-2">
                 <FlexGrow />
                 <ButtonWithSpinner

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
@@ -33,7 +33,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
             return;
         }
 
-        return tasksService.testAiConnectionString(databaseName, "OpenAi", {
+        return tasksService.testAiConnectionString(databaseName, "OpenAi", formValues.modelType, {
             ApiKey: formValues.openAiSettings.apiKey,
             Endpoint: formValues.openAiSettings.endpoint,
             Model: formValues.openAiSettings.model,
@@ -173,21 +173,23 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                 </FormLabel>
                 <FormInput control={control} name="openAiSettings.projectId" type="text" />
             </div>
-            <div className="mb-2">
-                <FormLabel>
-                    Dimensions <OptionalLabel />
-                    <PopoverWithHoverWrapper message="The number of dimensions for the output embeddings.">
-                        <Icon icon="info" color="info" id="dimensions" margin="ms-1" />
-                    </PopoverWithHoverWrapper>
-                </FormLabel>
-                <FormInput
-                    control={control}
-                    name="openAiSettings.dimensions"
-                    type="number"
-                    disabled={isUsedByAnyTask}
-                />
-            </div>
-            <EmbeddingsMaxConcurrentBatches baseName="openAiSettings" />
+            {formValues.modelType === "TextEmbeddings" && (
+                <div className="mb-2">
+                    <FormLabel>
+                        Dimensions <OptionalLabel />
+                        <PopoverWithHoverWrapper message="The number of dimensions for the output embeddings.">
+                            <Icon icon="info" color="info" id="dimensions" margin="ms-1" />
+                        </PopoverWithHoverWrapper>
+                    </FormLabel>
+                    <FormInput
+                        control={control}
+                        name="openAiSettings.dimensions"
+                        type="number"
+                        disabled={isUsedByAnyTask}
+                    />
+                </div>
+            )}
+            {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="openAiSettings" />}
             <div className="d-flex mb-2">
                 <FlexGrow />
                 <ButtonWithSpinner

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
@@ -370,6 +370,7 @@ export function mapAiConnectionsFromDto(
                 usedByTasks: getConnectionStringUsedTasks(ongoingTasks, type, connection.Name),
                 identifier: connection.Identifier,
                 connectorType: getConnectorType(connection),
+                modelType: connection.ModelType,
                 azureOpenAiSettings: {
                     apiKey: connection.AzureOpenAiSettings?.ApiKey,
                     endpoint: connection.AzureOpenAiSettings?.Endpoint,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -208,6 +208,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
         Type: "Ai",
         Name: connection.name,
         Identifier: connection.identifier,
+        ModelType: connection.modelType,
         AzureOpenAiSettings:
             connection.connectorType === "azureOpenAiSettings"
                 ? {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
@@ -20,7 +20,7 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import DatabaseUtils from "components/utils/DatabaseUtils";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
-export type ConnectionStringsViewContext = "connectionStrings" | "aiConnectionStrings" | "taskEmbeddings" | "taskGenAi";
+export type ConnectionStringsViewContext = "connectionStrings" | "aiConnectionStrings";
 
 interface ConnectionStringsState {
     loadStatus: loadStatus;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.tsx
@@ -43,7 +43,7 @@ export default function EditGenAiTask({ queryParams }: ReactQueryParamsProps<Que
             dispatch(editGenAiTaskActions.sourceViewSet(queryParams.sourceView));
         }
 
-        dispatch(connectionStringsActions.viewContextSet("taskGenAi"));
+        dispatch(connectionStringsActions.viewContextSet("aiConnectionStrings"));
 
         return () => {
             dispatch(editGenAiTaskActions.reset());

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
@@ -154,7 +154,7 @@ export default function EditGenAiTaskBasicFields() {
                     </InputGroup.Text>
                     {isNewConnectionStringOpen && (
                         <EditConnectionStrings
-                            initialConnection={{ type: "Ai" }}
+                            initialConnection={{ type: "Ai", modelType: "Chat" }}
                             afterSave={handleConnectionStringSave}
                             afterClose={toggleIsNewConnectionStringOpen}
                         />

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
@@ -63,6 +63,7 @@ export function EditGenAiTaskStepBasicFooter() {
             editGenAiTaskActions.testConnectionString({
                 databaseName,
                 connectorType: getConnectorType(connectionString),
+                modelType: connectionString.ModelType,
                 settings: mapAiConnectionStringToSettingsDto(connectionString),
             })
         );

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/store/editGenAiTaskSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/store/editGenAiTaskSlice.ts
@@ -232,11 +232,13 @@ const testConnectionString = createAsyncThunk(
     async (payload: {
         databaseName: string;
         connectorType: Raven.Client.Documents.Operations.AI.AiConnectorType;
+        modelType: Raven.Client.Documents.Operations.AI.AiModelType;
         settings: AiConnectionStringsSettings;
     }): Promise<Raven.Server.Web.System.NodeConnectionTestResult> => {
         return services.tasksService.testAiConnectionString(
             payload.databaseName,
             payload.connectorType,
+            payload.modelType,
             payload.settings
         );
     }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -590,6 +590,7 @@ export class DatabasesStubs {
                     Type: "Ai",
                     Name: "ai-name",
                     Identifier: "some-identifier",
+                    ModelType: "TextEmbeddings",
                     GoogleSettings: {
                         ApiKey: "some-api-key",
                         Model: "some-model",

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -82,7 +82,8 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
             component: EditConnectionStrings.default,
             props: {
                 initialConnection: {
-                    type: "Ai"
+                    type: "Ai",
+                    modelType: "TextEmbeddings"
                 },
                 afterSave: async (name: string) => {
                     await this.getAllConnectionStrings();
@@ -100,7 +101,7 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
         super.activate(args);
         const deferred = $.Deferred<void>();
 
-        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("taskEmbeddings"));
+        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("aiConnectionStrings"));
         this.sourceView(args.sourceView);
         
         this.loadPossibleMentors();

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -72,7 +72,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
     protected static (EmbeddingsGenerationConfiguration AiIntegrationConfiguration, AiConnectionString connectionString) AddEmbeddingsGenerationTask(
         IDocumentStore store, EmbeddingsGenerationConfiguration configuration)
     {
-        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, EmbeddedSettings = new EmbeddedSettings() };
+        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, ModelType = AiModelType.Embeddings, EmbeddedSettings = new EmbeddedSettings() };
 
         connectionString.Identifier = connectionString.GenerateIdentifier();
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -72,7 +72,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
     protected static (EmbeddingsGenerationConfiguration AiIntegrationConfiguration, AiConnectionString connectionString) AddEmbeddingsGenerationTask(
         IDocumentStore store, EmbeddingsGenerationConfiguration configuration)
     {
-        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, ModelType = AiModelType.Embeddings, EmbeddedSettings = new EmbeddedSettings() };
+        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, ModelType = AiModelType.TextEmbeddings, EmbeddedSettings = new EmbeddedSettings() };
 
         connectionString.Identifier = connectionString.GenerateIdentifier();
 

--- a/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
@@ -25,7 +25,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
 
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             AzureOpenAiSettings = new AzureOpenAiSettings(apiKey, endpoint, Model, deploymentName)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
@@ -25,6 +25,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
 
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             AzureOpenAiSettings = new AzureOpenAiSettings(apiKey, endpoint, Model, deploymentName)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
@@ -7,5 +7,5 @@ public class EmbeddedConnectorForTesting : AbstractEmbeddingsConnectorForTesting
 {
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Embedded);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.Embeddings };
+    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.TextEmbeddings };
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
@@ -7,5 +7,5 @@ public class EmbeddedConnectorForTesting : AbstractEmbeddingsConnectorForTesting
 {
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Embedded);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings() };
+    protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.Embeddings };
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
@@ -20,6 +20,7 @@ public class EmbeddingsGoogleConnectorForTesting : AbstractEmbeddingsConnectorFo
         var apiKey = Environment.GetEnvironmentVariable(EnvironmentVariable);
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             GoogleSettings = new GoogleSettings(Model, apiKey)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
@@ -20,7 +20,7 @@ public class EmbeddingsGoogleConnectorForTesting : AbstractEmbeddingsConnectorFo
         var apiKey = Environment.GetEnvironmentVariable(EnvironmentVariable);
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             GoogleSettings = new GoogleSettings(Model, apiKey)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
@@ -20,7 +20,7 @@ public class EmbeddingsHuggingFaceConnectorForTesting : AbstractEmbeddingsConnec
 
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             HuggingFaceSettings = new HuggingFaceSettings(apiKey, Model)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
@@ -20,6 +20,7 @@ public class EmbeddingsHuggingFaceConnectorForTesting : AbstractEmbeddingsConnec
 
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             HuggingFaceSettings = new HuggingFaceSettings(apiKey, Model)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
@@ -21,7 +21,7 @@ public class EmbeddingsMistralAiConnectorForTesting : AbstractEmbeddingsConnecto
 
         return new AiConnectionString
         {
-            ModelType = AiModelType.Embeddings,
+            ModelType = AiModelType.TextEmbeddings,
             MistralAiSettings = new MistralAiSettings(Model, apiKey, Endpoint)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
@@ -21,6 +21,7 @@ public class EmbeddingsMistralAiConnectorForTesting : AbstractEmbeddingsConnecto
 
         return new AiConnectionString
         {
+            ModelType = AiModelType.Embeddings,
             MistralAiSettings = new MistralAiSettings(Model, apiKey, Endpoint)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -37,7 +37,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.TextEmbeddings);
 }
 
 public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOllamaConnectorForTesting>
@@ -50,7 +50,7 @@ public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat);
 }
 
 internal static class OllamaConnectorHelper

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -37,7 +37,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
 }
 
 public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOllamaConnectorForTesting>
@@ -50,19 +50,20 @@ public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
 }
 
 internal static class OllamaConnectorHelper
 {
     public const string EnvironmentVariable = "RAVEN_AI_INTEGRATION_OLLAMA_URI";
 
-    public static AiConnectionString CreateAiConnectionString(string model)
+    public static AiConnectionString CreateAiConnectionString(string model, AiModelType modelType)
     {
         var uri = Environment.GetEnvironmentVariable(EnvironmentVariable);
 
         return new AiConnectionString
         {
+            ModelType = modelType,
             OllamaSettings = new OllamaSettings(uri, model)
         };
     }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsOpenAiConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.TextEmbeddings);
 }
 
 public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOpenAiConnectorForTesting>
@@ -26,7 +26,7 @@ public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat);
     
 }
 

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsOpenAiConnectorForTesting : AbstractEmbeddingsConnectorFo
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Embeddings);
 }
 
 public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOpenAiConnectorForTesting>
@@ -26,7 +26,7 @@ public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<G
     }
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
 
-    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model);
+    protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.LLM);
     
 }
 
@@ -35,11 +35,12 @@ internal static class OpenAiConnectorHelper
     public const string EnvironmentVariable = "RAVEN_AI_INTEGRATION_OPENAI_API_KEY";
     public const string Endpoint = "https://api.openai.com/v1";
 
-    public static AiConnectionString CreateAiConnectionString(string model)
+    public static AiConnectionString CreateAiConnectionString(string model, AiModelType modelType)
     {
         var apiKey = Environment.GetEnvironmentVariable(EnvironmentVariable);
         return new AiConnectionString
         {
+            ModelType = modelType,
             OpenAiSettings = new OpenAiSettings(apiKey, Endpoint, model)
         };
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24294/Gen-AI-Add-Model-type-field-to-AI-Connection-string

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
