### PR TITLE
RavenDB-24512 Fix description of subscription configuration

### DIFF
--- a/src/Raven.Server/Config/Categories/SubscriptionsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SubscriptionsConfiguration.cs
@@ -9,12 +9,12 @@ namespace Raven.Server.Config.Categories
     {
         [DefaultValue(1000)]
         [ConfigurationEntry("Subscriptions.MaxNumberOfConcurrentConnections", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        [Description("Amount of concurrent subscription connections per database")]
+        [Description("The maximum number of concurrent subscription connections allowed per database.")]
         public int MaxNumberOfConcurrentConnections { get; set; }
         
         [DefaultValue(ArchivedDataProcessingBehavior.ExcludeArchived)]
         [ConfigurationEntry("Subscriptions.ArchivedDataProcessingBehavior", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        [Description("The default subscriptions archived data processing behavior per database")]
+        [Description("The default processing behavior for archived documents in a subscription query.")]
         public ArchivedDataProcessingBehavior ArchivedDataProcessingBehavior { get; set; }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24512/Fix-description-of-subscription-configuration

### Additional description
* Amount of concurrent subscription connections per database
=> The maximum number of concurrent subscription connections allowed per database.
* The default subscriptions archived data processing behavior per database
=> The default processing behavior for archived documents in a subscription query.

### Type of change
- [x] Bug fix - usability/cosmetics
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
