### PR TITLE
RavenDB-24478: Upgrade tests for SlowTests (Corax, Voron and Blittable)

### DIFF
--- a/test/SlowTests/Blittable/BlittableJsonReaderObjectTest.cs
+++ b/test/SlowTests/Blittable/BlittableJsonReaderObjectTest.cs
@@ -1,6 +1,7 @@
-﻿using FastTests;
+using FastTests;
 using Raven.Client.Documents.Conventions;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,7 +13,7 @@ namespace SlowTests.Blittable
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Clone_WhenContainItemsOfStrings_ShouldBeEqualToOrigin()
         {
             //Arrange
@@ -30,7 +31,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Clone_WhenContainItemsOfIntegers_ShouldBeEqualToOrigin()
         {
             //Arrange
@@ -48,7 +49,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Clone_WhenContainItemsOfDouble_ShouldBeEqualToOrigin()
         {
             //Arrange
@@ -67,7 +68,7 @@ namespace SlowTests.Blittable
         }
 
         //Todo Fixing the clone implementation to support this situation or throw clear error
-        [Fact(Skip = "Should fixing the clone implementation to support this situation or throw clear error")]
+        [RavenFact(RavenTestCategory.Core, Skip = "Should fixing the clone implementation to support this situation or throw clear error")]
         public void Clone_WhenContainItemsOfObjects_AndOriginAndCloneOnSameContext_ShouldBeEqualToOrigin()
         {
             //Arrange
@@ -88,7 +89,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Clone_WhenContainItemsOfObjects_AndOriginAndCloneOnDifferentContext_ShouldBeEqualToOrigin()
         {
             //Arrange
@@ -110,7 +111,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void Clone_WhenContainMixItemTypes_AndOriginAndCloneOnDifferentContext_ShouldBeEqualToOrigin()
         {
             //Arrange

--- a/test/SlowTests/Blittable/BlittableJsonWriterTests/ManualBuilderTestsSlow.cs
+++ b/test/SlowTests/Blittable/BlittableJsonWriterTests/ManualBuilderTestsSlow.cs
@@ -1,7 +1,8 @@
-﻿using System.Globalization;
+using System.Globalization;
 using FastTests;
 using Sparrow.Json;
 using Sparrow.Threading;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,7 +15,7 @@ namespace SlowTests.Blittable.BlittableJsonWriterTests
         }
 
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(byte.MaxValue)]
         [InlineData(short.MaxValue)]
         [InlineData(short.MaxValue + 1)]

--- a/test/SlowTests/Blittable/BlittableJsonWriterTests/VariousPropertyAmountsTests.cs
+++ b/test/SlowTests/Blittable/BlittableJsonWriterTests/VariousPropertyAmountsTests.cs
@@ -1,10 +1,11 @@
-﻿using System.IO;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Server.Documents.Indexes.Static;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,7 +33,7 @@ namespace SlowTests.Blittable.BlittableJsonWriterTests
             return sb.ToString();
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(byte.MaxValue)]
         [InlineData(short.MaxValue)]
         [InlineData(short.MaxValue + 1)]
@@ -55,7 +56,7 @@ namespace SlowTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Core)]
         [InlineData(byte.MaxValue)]
         [InlineData(short.MaxValue)]
         [InlineData(short.MaxValue + 1)]

--- a/test/SlowTests/Blittable/JsonSerializerTests.cs
+++ b/test/SlowTests/Blittable/JsonSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
@@ -9,6 +9,7 @@ using Raven.Server.Json.Converters;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using BlittableJsonConverter = Raven.Server.Json.Converters.BlittableJsonConverter;
@@ -38,7 +39,7 @@ namespace SlowTests.Blittable
             public int GetId() => _id;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonDeserialize_WhenBlittableArrayBlittableObjectAndLazyStringAreNull_ShouldResultInCopy()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext readContext))
@@ -74,7 +75,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonDeserialize_WhenHasBlittableJsonReaderArrayProperty_ShouldResultInCopy()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext readContext))
@@ -113,7 +114,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task JsonDeserialize_WhenHasBlittableObjectPropertyAndWriteAndReadFromStream_ShouldResultInCommandWithTheProperty()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -179,7 +180,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonDeserialize_WhenHasLazyStringProperty_ShouldResultInCopy()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext readContext))
@@ -214,7 +215,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonDeserialize_WhenHasBlittableObjectProperty_ShouldResultInCopy()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext readContext))
@@ -249,7 +250,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonSerialize_WhenLazyStringValueIsProperty_ShouldSerialize()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -275,7 +276,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonSerialize_WhenBlittableObjectIsProperty_ShouldResultInCopy()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -326,7 +327,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public void JsonSerialize_WhenNestedBlittableObjectIsProperty_ShouldSerialize()
         {
             using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))

--- a/test/SlowTests/Blittable/RavenDB-11243.cs
+++ b/test/SlowTests/Blittable/RavenDB-11243.cs
@@ -1,5 +1,6 @@
-﻿
+
 using FastTests;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,7 +12,7 @@ namespace SlowTests.Blittable
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public void CanSerializeStringPropertyOfExactly327666Chars()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
+++ b/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,6 +24,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Processors;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -35,7 +36,7 @@ namespace SlowTests.Blittable
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_PutResolvedConflictsCommand()
         {
             using (var database = CreateDocumentDatabase())
@@ -83,7 +84,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_MergedDeleteAttachmentCommand()
         {
             using (var database = CreateDocumentDatabase())
@@ -127,7 +128,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_MergedPutAttachmentCommand()
         {
             using (var database = CreateDocumentDatabase())
@@ -188,7 +189,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_MergedPutCommandTest()
         {
             using (var database = CreateDocumentDatabase())
@@ -227,7 +228,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_PatchDocumentCommandTest()
         {
             using (var database = CreateDocumentDatabase())
@@ -275,7 +276,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_DeleteDocumentCommandTest()
         {
             using (var database = CreateDocumentDatabase())
@@ -311,7 +312,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_MergedBatchCommandCommandTest()
         {
             using (var database = CreateDocumentDatabase())
@@ -361,7 +362,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_MergedBatchPutCommandTest()
         {
             using (var database = CreateDocumentDatabase())
@@ -413,7 +414,7 @@ namespace SlowTests.Blittable
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core)]
         public async Task SerializeAndDeserialize_MergedInsertBulkCommandTest()
         {
             using (var database = CreateDocumentDatabase())

--- a/test/SlowTests/Corax/CoraxSlowQueryTests.cs
+++ b/test/SlowTests/Corax/CoraxSlowQueryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -205,7 +205,7 @@ public class CoraxSlowQueryTests : RavenTestBase
     }
 
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenExplicitData(searchEngine: RavenSearchEngineMode.Corax)]
     public void CompoundOrderByWithPagination(RavenTestParameters config, int size = 10_000)
     {
@@ -258,7 +258,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         }
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenExplicitData(searchEngine: RavenSearchEngineMode.Corax)]
     public void DistinctBigTestWithPagination(RavenTestParameters config, int size = 100_00)
     {
@@ -307,7 +307,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         }
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void AnalyzerAreApplied(Options options)
     {
@@ -328,7 +328,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         }
     }
     
-    [Theory]
+    [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void NgramSuggestionTest(Options options)
     {
@@ -374,7 +374,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         public string InnerName { get; set; }
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
     public void TestOnDeep(Options options)
     {
@@ -398,7 +398,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         WaitForUserToContinueTheTest(store);
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void Alphanumerical(Options options)
     {
@@ -434,7 +434,7 @@ public class CoraxSlowQueryTests : RavenTestBase
 
     private record SortingData(string data);
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void MaxSuggestionsShouldWork(Options options)
     {
@@ -462,7 +462,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         }
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void OnTermMatchCoraxShouldUseOnlyStandardAnalyzer(Options options)
     {
@@ -498,7 +498,7 @@ public class CoraxSlowQueryTests : RavenTestBase
         }
     }
     
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void CanSearchOnLists(Options options)
     {

--- a/test/SlowTests/Corax/IncludeScoresAndDistancesCorax.cs
+++ b/test/SlowTests/Corax/IncludeScoresAndDistancesCorax.cs
@@ -73,7 +73,7 @@ public class IncludeScoresAndDistancesCorax : RavenTestBase
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Corax)]
     public void DefaultBufferSizeForCoraxHasNotChanged()
     {
         // The tests in this file were designed for a pageSize of 4096. In case the default buffer has changed, please update the number of documents above that limit.

--- a/test/SlowTests/Corax/IndexBackwardCompatibilityAndPersistence.cs
+++ b/test/SlowTests/Corax/IndexBackwardCompatibilityAndPersistence.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -15,6 +15,7 @@ using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -40,7 +41,7 @@ namespace SlowTests.Corax
             _index = new();
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Indexes)]
         [InlineData(SearchEngineType.Corax, SearchEngineType.Lucene)]
         [InlineData(SearchEngineType.Lucene, SearchEngineType.Corax)]
         public async Task AutoPersistIndexConfiguration(SearchEngineType beginType, SearchEngineType endType)
@@ -66,7 +67,7 @@ namespace SlowTests.Corax
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Indexes)]
         public async Task LoadOldIndexWithoutRebuildingForNewIndexingEngine()
         {
             using (var server = GetNewServer(new ServerCreationOptions {DataDirectory = _serverPath, RunInMemory = false}))

--- a/test/SlowTests/Corax/IndexSearcherTestExtended.cs
+++ b/test/SlowTests/Corax/IndexSearcherTestExtended.cs
@@ -10,7 +10,7 @@ public class IndexSearcherTestExtended : NoDisposalNoOutputNeeded
     {
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax)]
     [InlineData(100_000, 1028)]
     [InlineData(100_000, 2048)]
     [InlineData(100_000, 4096)]
@@ -20,7 +20,7 @@ public class IndexSearcherTestExtended : NoDisposalNoOutputNeeded
         testClass.MultiTermMatchWithBinaryOperations(setSize, stackSize);
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax)]
     [InlineData(new object[] {100000, 128})]
     [InlineData(new object[] {100000, 2046})]
     [InlineData(new object[] {11700, 18})]
@@ -31,6 +31,7 @@ public class IndexSearcherTestExtended : NoDisposalNoOutputNeeded
         testClass.AndInStatementAndWhitespaceTokenizer(setSize, stackSize);
     }
 
+    [RavenTheory(RavenTestCategory.Corax)]
     [InlineData(new object[] {100000, 2046})]
     [InlineData(new object[] {11700, 18})]
     [InlineData(new object[] {11859, 18})]
@@ -40,7 +41,7 @@ public class IndexSearcherTestExtended : NoDisposalNoOutputNeeded
         testClass.AndInStatement(setSize, stackSize);
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax)]
     [InlineData(new object[] {100000, 128})]
     [InlineData(new object[] {100000, 18})]
     public void SimpleAndOrForBiggerSet(int setSize, int stackSize)
@@ -49,7 +50,7 @@ public class IndexSearcherTestExtended : NoDisposalNoOutputNeeded
         testClass.SimpleAndOrForBiggerSet(setSize, stackSize);
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Corax)]
     [InlineData(new object[] {100000, 128})]
     [InlineData(new object[] {100000, 2046})]
     [InlineData(new object[] {11700, 18})]

--- a/test/SlowTests/Corax/RavenDB-20923.cs
+++ b/test/SlowTests/Corax/RavenDB-20923.cs
@@ -13,7 +13,7 @@ public class RavenDB_20923 : RavenTestBase
     {
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     public void SortingBigSetReturnsCorrectOrder()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests/Corax/RavenDB-21177.cs
+++ b/test/SlowTests/Corax/RavenDB-21177.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿﻿using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
@@ -13,7 +13,7 @@ public class RavenDB_21177 : RavenTestBase
     {
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     public void CoraxSortingPostingLists()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests/Voron/Backups/Incremental.cs
+++ b/test/SlowTests/Voron/Backups/Incremental.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="IncrementalBackup.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using FastTests.Voron.Backups;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl.Backup;
@@ -32,7 +33,7 @@ namespace SlowTests.Voron.Backups
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void CanBackupAndRestoreOnEmptyStorage()
         {
             RequireFileBasedPager();
@@ -80,7 +81,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void CanDoMultipleIncrementalBackupsAndRestoreOneByOne()
         {
             RequireFileBasedPager();
@@ -157,7 +158,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void IncrementalBackupShouldCopyJustNewPagesSinceLastBackup()
         {
             RequireFileBasedPager();
@@ -227,7 +228,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void IncrementalBackupShouldAcceptEmptyIncrementalBackups()
         {
             RequireFileBasedPager();
@@ -293,7 +294,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2806()
         {
             RequireFileBasedPager();
@@ -355,7 +356,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_2_RavenDB_2806()
         {
             RequireFileBasedPager();
@@ -421,7 +422,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void IncorrectWriteOfOverflowPagesFromJournalsInBackupToDataFile_RavenDB_2891()
         {
             RequireFileBasedPager();
@@ -486,7 +487,7 @@ namespace SlowTests.Voron.Backups
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void IncrementalBackupShouldCreateConsecutiveJournalFiles()
         {
             IOExtensions.DeleteDirectory(DataDir);

--- a/test/SlowTests/Voron/BigValue.cs
+++ b/test/SlowTests/Voron/BigValue.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Xunit;
 using Voron;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron
         }
 
    
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Memory)]
         public void CanStoreInOneTransactionReallyBigValue()
         {
             var random = new Random(43321);

--- a/test/SlowTests/Voron/Bugs/AccessViolationWithIteratorUsage.cs
+++ b/test/SlowTests/Voron/Bugs/AccessViolationWithIteratorUsage.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="AccessViolationWithIteratorUsage.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotThrow()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Bugs/Bugs.cs
+++ b/test/SlowTests/Voron/Bugs/Bugs.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using FastTests.Voron.Tables;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Util.Conversion;
@@ -20,7 +21,7 @@ namespace SlowTests.Voron.Bugs
         public const int Transactions = 10;
         public const string Template = "000000000000000000000000000000000000000000000000000";
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void RavenDB_13840()
         {
             using (var tx = Env.WriteTransaction())
@@ -67,7 +68,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void RepeatedInsertingInTheSameTransaction()
         {
             var schema = new TableSchema()
@@ -123,7 +124,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanInsertThenDeleteBySecondary2()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
+++ b/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="ChecksumMismatchAfterRecovery.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,7 +19,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotThrowChecksumMismatch()
         {
             var random = new Random(1);

--- a/test/SlowTests/Voron/Bugs/DataCorruptionInOverflow.cs
+++ b/test/SlowTests/Voron/Bugs/DataCorruptionInOverflow.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="DataCorruptionInOverflow.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using System;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2585()
         {
             const int testedOverflowSize = 20000;
@@ -66,7 +67,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_2_RavenDB_2585()
         {
             const int testedOverflowSize = 16000;
@@ -118,7 +119,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2806()
         {
             RequireFileBasedPager();
@@ -165,7 +166,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_2_RavenDB_2806()
         {
             RequireFileBasedPager();
@@ -221,7 +222,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void IncorrectWriteOfOverflowPagesFromJournalsToDataFile_RavenDB_2891()
         {
             const int testedOverflowSize = 50000;

--- a/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
+++ b/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
@@ -1,4 +1,4 @@
-﻿
+
 // -----------------------------------------------------------------------
 //  <copyright file="DataInconsistencyRepro.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using FastTests.Voron;
 using SlowTests.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Xunit;
@@ -24,7 +25,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(5000, 10000)]
         [InlineDataWithRandomSeed(1000, 5000)]
         [InlineData(1000, 1500, 1396255086)]

--- a/test/SlowTests/Voron/Bugs/Deletes.cs
+++ b/test/SlowTests/Voron/Bugs/Deletes.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.IO;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void RebalancerIssue()
         {
             const int DocumentCount = 750;

--- a/test/SlowTests/Voron/Bugs/EmptyTree.cs
+++ b/test/SlowTests/Voron/Bugs/EmptyTree.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldBeEmpty()
         {
             using (var tx = Env.WriteTransaction())
@@ -31,7 +32,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SurviveRestart()
         {
             using (var options = StorageEnvironmentOptions.CreateMemoryOnly())

--- a/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
+++ b/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="FlushingToDataFile.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Sparrow;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl;
@@ -29,7 +30,7 @@ namespace SlowTests.Voron.Bugs
             options.MaxLogFileSize = 2 * Constants.Storage.PageSize;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ReadTransactionShouldNotReadFromJournalSnapshotIfJournalWasFlushedInTheMeanwhile()
         {
             var value1 = new byte[4000];
@@ -82,7 +83,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void FlushingOperationShouldHaveOwnScratchPagerStateReference()
         {
             var value1 = new byte[4000];
@@ -148,7 +149,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void OldestActiveTransactionShouldBeCalculatedProperly()
         {
             using (var options = StorageEnvironmentOptions.CreateMemoryOnly())

--- a/test/SlowTests/Voron/Bugs/FreeSpaceAndOverflowPages.cs
+++ b/test/SlowTests/Voron/Bugs/FreeSpaceAndOverflowPages.cs
@@ -1,9 +1,10 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="T1.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +22,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldCorrectlyFindSmallValueMergingByTwoSectionsInFreeSpaceHandling()
         {
             var dataSize = 905048; // never change this

--- a/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
+++ b/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="IndexPointToNotLeafPageTests.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -6,6 +6,7 @@
 
 using System.IO;
 using SlowTests.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,7 +24,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldProperlyMovePositionForNextPageAllocationInScratchBufferPool()
         {
             var sequentialLargeIds = TestDataUtil.ReadData("non-leaf-page-seq-id-large-values.txt");

--- a/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ReadTransactionCanReadJustCommittedValue()
         {
             var options = StorageEnvironmentOptions.CreateMemoryOnly();
@@ -38,7 +39,7 @@ namespace SlowTests.Voron.Bugs
             options.MaxScratchBufferSize *= 2;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void AllScratchPagesShouldBeReleased()
         {
             var options = StorageEnvironmentOptions.CreateMemoryOnly();

--- a/test/SlowTests/Voron/Bugs/Isolation.cs
+++ b/test/SlowTests/Voron/Bugs/Isolation.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MultiTreeIteratorShouldBeIsolated1()
         {
             IOExtensions.DeleteDirectory(DataDir);
@@ -51,7 +52,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MultiTreeIteratorShouldBeIsolated2()
         {
             IOExtensions.DeleteDirectory(DataDir);
@@ -114,7 +115,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ScratchPagesShouldNotBeReleasedUntilNotUsed()
         {
             var options = StorageEnvironmentOptions.ForPath(DataDir);

--- a/test/SlowTests/Voron/Bugs/Iterating.cs
+++ b/test/SlowTests/Voron/Bugs/Iterating.cs
@@ -1,9 +1,10 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="Iterating.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void IterationShouldNotFindAnyRecordsAndShouldNotThrowWhenNumberOfEntriesOnPageIs1AndKeyDoesNotMatch()
         {
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))

--- a/test/SlowTests/Voron/Bugs/MemoryAccess.cs
+++ b/test/SlowTests/Voron/Bugs/MemoryAccess.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,7 +19,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotThrowAccessViolation()
         {
             var trees = CreateTrees(Env, 1, "tree");

--- a/test/SlowTests/Voron/Bugs/MultiAdds.cs
+++ b/test/SlowTests/Voron/Bugs/MultiAdds.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using FastTests;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,7 +28,7 @@ namespace SlowTests.Voron.Bugs
             return builder.ToString();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SplitterIssue()
         {
             const int DocumentCount = 10;
@@ -49,7 +50,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SplitterIssue2()
         {
             var storageEnvironmentOptions = StorageEnvironmentOptions.CreateMemoryOnly();
@@ -129,7 +130,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanAddMultiValuesUnderTheSameKeyToBatch()
         {
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))

--- a/test/SlowTests/Voron/Bugs/MultiReads.cs
+++ b/test/SlowTests/Voron/Bugs/MultiReads.cs
@@ -1,9 +1,10 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="MultiReads.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MultiReadShouldKeepItemOrder()
         {
             foreach (var treeName in CreateTrees(Env, 1, "tree"))
@@ -42,7 +43,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MultiReadShouldKeepItemOrderWhenInsertingLotOfItems()
         {
             var numberOfEntries = 1000;

--- a/test/SlowTests/Voron/Bugs/OverflowsReusage.cs
+++ b/test/SlowTests/Voron/Bugs/OverflowsReusage.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿﻿using System;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(2500, 2400)]
         [InlineData(7000, 5000)]
         [InlineData(9000, 2000)]
@@ -44,7 +45,7 @@ namespace SlowTests.Voron.Bugs
             {
                 var tree = tx.ReadTree("tree");
 
-                tree.Add("key", bytes2); // TryOverwriteOverflowPages will be used under the hood 
+                tree.Add("key", bytes2); // TryOverwriteOverflowPages will be used under the hood
 
                 using (var readTransaction = Env.ReadTransaction())
                 {
@@ -60,7 +61,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(2500, 2400)]
         [InlineData(7000, 5000)]
         [InlineData(9000, 2000)]

--- a/test/SlowTests/Voron/Bugs/PageAllocation.cs
+++ b/test/SlowTests/Voron/Bugs/PageAllocation.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="SomeIssue.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,7 +21,7 @@ namespace SlowTests.Voron.Bugs
         /// <summary>
         /// https://issues.hibernatingrhinos.com/issue/RavenDB-1707
         /// </summary>
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MultipleTxPagesCanPointToOnePageNumberWhichShouldNotBeCausingIssuesDuringFlushing()
         {
             var options = StorageEnvironmentOptions.CreateMemoryOnly();

--- a/test/SlowTests/Voron/Bugs/PageTableIssue.cs
+++ b/test/SlowTests/Voron/Bugs/PageTableIssue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MissingScratchPagesInPageTable()
         {
             var bytes = new byte[1000];

--- a/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
+++ b/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Debugging;
 using Xunit;
@@ -18,7 +19,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CouldNotReadPagesThatWereFilteredOutByJournalApplicator_1()
         {
             var bytes = new byte[1000];
@@ -66,7 +67,7 @@ namespace SlowTests.Voron.Bugs
             }
         } 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CouldNotReadPagesThatWereFilteredOutByJournalApplicator_2()
         {
             var bytes = new byte[1000];

--- a/test/SlowTests/Voron/Bugs/RavenDB_13265.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_13265.cs
@@ -1,4 +1,5 @@
-﻿using FastTests.Voron;
+using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void EnsurePagerStateReferenceMustAdd_Current_PagerStateToCollectionSoWeWillReleaseItsReferenceOnTxDispose()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Bugs/RavenDB_6045.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_6045.cs
@@ -1,4 +1,5 @@
-﻿using Voron;
+﻿using Tests.Infrastructure;
+using Voron;
 using Voron.Global;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void Overflows_overlapping_bug()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Bugs/RavenDB_6748.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_6748.cs
@@ -1,4 +1,5 @@
-﻿using Voron;
+﻿using Tests.Infrastructure;
+using Voron;
 using Voron.Impl;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void Must_not_release_scratch_pages_which_are_visible_for_read_transaction()
         {
             using (var txw = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Bugs/RavenDB_6971.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_6971.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FastTests;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Indexes;
@@ -15,7 +15,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public void Overflow_shrink_needs_to_update_scratch_buffer_page_to_avoid_data_override_after_restart()
         {
             using (var store = GetDocumentStore(new Options
@@ -42,7 +42,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public void Applying_new_diff_requires_to_zero_destination_bytes_first()
         {
             using (var store = GetDocumentStore(new Options

--- a/test/SlowTests/Voron/Bugs/RavenDB_8962.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDB_8962.cs
@@ -1,4 +1,5 @@
-﻿using Voron.Data.BTrees;
+﻿using Tests.Infrastructure;
+using Voron.Data.BTrees;
 using Voron.Global;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_not_throw_if_didnt_find_exact_match_when_looking_for_parent_of_branch()
         {
             var key = "test" + new string('-', 256);

--- a/test/SlowTests/Voron/Bugs/RavenDb_4706.cs
+++ b/test/SlowTests/Voron/Bugs/RavenDb_4706.cs
@@ -1,8 +1,9 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,7 +15,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public async Task SupportRandomOrder()
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
+++ b/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="RecoveryWithManualFlush.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron.Bugs
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldRecoverFromJournalsAfterFlushWhereLastPageOfFlushedTxHadTheSameNumberAsFirstPageOfNextTxNotFlushedJet()
         {
             using (var tx1 = Env.WriteTransaction())
@@ -78,7 +79,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldRecoverTransactionEndPositionsTableAfterRestart()
         {
             using (var tx1 = Env.WriteTransaction())
@@ -124,7 +125,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryAfterFlushingToDataFile()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Bugs/StartsWithSearch.cs
+++ b/test/SlowTests/Voron/Bugs/StartsWithSearch.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="StartsWithSearch.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using FastTests;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,7 +18,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldWork()
         {
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))

--- a/test/SlowTests/Voron/Bugs/TreeRebalancer.cs
+++ b/test/SlowTests/Voron/Bugs/TreeRebalancer.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void TreeRabalancerShouldCopyNodeFlagsWhenMultiValuePageRefIsSet()
         {
             var addedIds = new Dictionary<string, string>();
@@ -115,7 +116,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotThrowThatPageIsFullDuringTreeRebalancing()
         {
             using (var tx = Env.WriteTransaction())
@@ -167,7 +168,7 @@ namespace SlowTests.Voron.Bugs
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void RavenDB_2543_CouldNotEnsureThatWeHaveEnoughSpace_When_MovingLeafNode()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Bugs/UpdateLastItem.cs
+++ b/test/SlowTests/Voron/Bugs/UpdateLastItem.cs
@@ -1,4 +1,5 @@
-﻿using Voron.Data.BTrees;
+﻿using Tests.Infrastructure;
+using Voron.Data.BTrees;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,7 +11,7 @@ namespace SlowTests.Voron.Bugs
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldWork()
         {
             byte* ptr;

--- a/test/SlowTests/Voron/Checksum.cs
+++ b/test/SlowTests/Voron/Checksum.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="StorageCompactionTests.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using FastTests.Utils;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Voron.Impl.Paging;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ValidatePageChecksumShouldDetectDataCorruption()
         {
             // Create some random data

--- a/test/SlowTests/Voron/Compaction/StorageCompactionTestsSlow.cs
+++ b/test/SlowTests/Voron/Compaction/StorageCompactionTestsSlow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,6 +7,7 @@ using FastTests.Voron.FixedSize;
 using FastTests.Voron.Util;
 using Raven.Server.Utils;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl.Compaction;
@@ -26,7 +27,7 @@ namespace SlowTests.Voron.Compaction
             IOExtensions.DeleteDirectory(compactedData);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed()]
         public void ShouldOccupyLessSpace(int seed)
         {
@@ -76,7 +77,7 @@ namespace SlowTests.Voron.Compaction
             Assert.True(newSize < oldSize, string.Format("Old size: {0:#,#;;0} MB, new size {1:#,#;;0} MB", oldSize / 1024 / 1024, newSize / 1024 / 1024));
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed()]
         public void CompactionMustNotLooseAnyData(int seed)
         {
@@ -198,7 +199,7 @@ namespace SlowTests.Voron.Compaction
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(123, 99)]
         [InlineDataWithRandomSeed(1024 * 1024 * 5, 1)]
         public void Streams_RavenDB_6510(int fooSize, int barSize, int seed)
@@ -247,7 +248,7 @@ namespace SlowTests.Voron.Compaction
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(398, 345)]
         [InlineDataWithRandomSeed(217, 701)]
         public void Compressed_tree_RavenDB_6510(int iterationCount, int size, int seed)

--- a/test/SlowTests/Voron/DeletionFromMultiTableWithGlobalIndex.cs
+++ b/test/SlowTests/Voron/DeletionFromMultiTableWithGlobalIndex.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using FastTests.Voron;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
@@ -29,7 +30,7 @@ namespace SlowTests.Voron
         private static readonly Slice Local;
         private static Slice Etag;
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ShouldNotError()
         {
             TableSchema schema = new TableSchema();
@@ -121,7 +122,7 @@ namespace SlowTests.Voron
         }
         
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void SameTransaction()
         {
             TableSchema schema = new TableSchema();

--- a/test/SlowTests/Voron/DuplicatePageUsage.cs
+++ b/test/SlowTests/Voron/DuplicatePageUsage.cs
@@ -1,5 +1,6 @@
-﻿using System.IO;
+using System.IO;
 using FastTests;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Tables;
 using Xunit;
@@ -21,7 +22,7 @@ namespace SlowTests.Voron
                Count = 1
            });
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ShouldNotHappen()
         {
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))

--- a/test/SlowTests/Voron/Issues/RDBCL_1977.cs
+++ b/test/SlowTests/Voron/Issues/RDBCL_1977.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotAllowToCreateWriteTransactionAfterCatastrophicError()
         {
             var exceptionDuringStage3OfCommit = Assert.Throws<InvalidOperationException>(() =>
@@ -53,7 +54,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotAllowToCommitWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
@@ -72,7 +73,7 @@ namespace SlowTests.Voron.Issues
             Assert.Equal("Cannot commit already committed transaction.", ex.Message);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotAllowToCreateWriteTransactionDuringAfterCommitWhenNewTransactionsPrevented()
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>

--- a/test/SlowTests/Voron/Issues/RavenDB-12268.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB-12268.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron;
 using Sparrow;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +22,7 @@ namespace SlowTests.Voron.Issues
             options.MaxScratchBufferSize = new Size(64, SizeUnit.Kilobytes).GetValue(SizeUnit.Bytes);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void UsedScratchBuffersArentDeleted()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Issues/RavenDB-9916.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB-9916.cs
@@ -1,4 +1,5 @@
-﻿using FastTests.Voron;
+using FastTests.Voron;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,7 +11,7 @@ namespace SlowTests.Voron.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void Should_not_corrupt_state_deleting_from_nested_page_right_side()
         {
             using (var tx = Env.WriteTransaction())
@@ -55,7 +56,7 @@ namespace SlowTests.Voron.Issues
                 tx.Commit();
             }
         }
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void Should_not_corrupt_state_deleting_from_nested_page_left_side()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Issues/RavenDB_10225_Voron.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10225_Voron.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Recyclable_journal_files_can_be_deleted_on_storage_cleanup()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_10813.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10813.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
+using System.Linq;
 using FastTests.Voron;
 using Sparrow.Platform;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron.Issues
             options.Encryption.MasterKey = _masterKey.ToArray();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Journal_reader_should_skip_encryption_buffers_overwritten_by_later_allocations_on_db_recovery()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_10825.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10825.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FastTests.Voron;
 using Sparrow;
 using Sparrow.Platform;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Impl;
 using Voron.Impl.Paging;
@@ -25,7 +26,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void Encryption_buffer_of_freed_scratch_page_must_not_affect_another_overflow_allocation_on_tx_commit()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Issues/RavenDB_11865.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_11865.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -20,7 +21,7 @@ namespace SlowTests.Voron.Issues
             options.MaxScratchBufferSize = 2 * Constants.Size.Megabyte;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Scratch_files_on_recyclable_area_should_be_deleted_on_dispose()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_12151_Voron_1.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12151_Voron_1.cs
@@ -1,4 +1,5 @@
-﻿using FastTests.Voron;
+using FastTests.Voron;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,7 +11,7 @@ namespace SlowTests.Voron.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldProperlyReportNumberOfModifiedPagesInTransaction()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Issues/RavenDB_12151_Voron_2.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12151_Voron_2.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl.Scratch;
@@ -26,7 +27,7 @@ namespace SlowTests.Voron.Issues
             options.ScratchSpaceUsage.AddMonitor(_scratchSpaceMonitor);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanTrackScratchSpaceSize()
         {
             RequireFileBasedPager();
@@ -91,7 +92,7 @@ namespace SlowTests.Voron.Issues
             Assert.Equal(0, Env.Options.ScratchSpaceUsage.ScratchSpaceInBytes);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ScratchSpaceSizeMustIncludeDecompressionBuffers()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_12506.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12506.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,7 +13,7 @@ namespace SlowTests.Voron.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Error_on_db_creation_must_not_cause_failure_on_next_db_load()
         {
             var dataDir = DataDir;
@@ -39,7 +40,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Page_locator_must_not_return_true_on_invalid_page_number()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Issues/RavenDB_12524.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12524.cs
@@ -1,5 +1,6 @@
-﻿using FastTests.Voron;
+using FastTests.Voron;
 using Sparrow;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -18,7 +19,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void RecoveryValidationNeedsToTakeIntoAccountOverflows()
         {
             RequireFileBasedPager();
@@ -72,7 +73,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void RecoveryValidationNeedsToTakeIntoAccountFreedPages()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_12543.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12543.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,7 +18,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Must_not_update_PTT_during_stage2_of_commit()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_13130.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13130.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Data.Tables;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,7 +13,7 @@ namespace SlowTests.Voron.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_throw_on_attempt_to_free_page_which_was_not_allocated_by_NewPageAllocator()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Issues/RavenDB_13384.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13384.cs
@@ -5,6 +5,7 @@ using Voron;
 using Voron.Impl.Journal;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Issues
 {
@@ -21,7 +22,7 @@ namespace SlowTests.Voron.Issues
             options.MaxLogFileSize = 4096;
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(true)]
         [InlineData(false)]
         public void Recovery_should_handle_empty_journal_file_and_correctly_set_last_flushed_journal(bool runInMemory)

--- a/test/SlowTests/Voron/Issues/RavenDB_15912.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_15912.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿﻿﻿using System;
 using System.Linq;
 using FastTests.Voron;
 using FastTests.Voron.Tables;
 using Sparrow.Binary;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Tables;
 using Xunit;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void OnDataMoveShouldForgetOldCompressionIds()
         {
             var random = new Random(357);

--- a/test/SlowTests/Voron/Issues/RavenDB_16023.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16023.cs
@@ -1,7 +1,8 @@
-﻿using System.Linq;
+using System.Linq;
 using FastTests.Voron;
 using Sparrow;
 using Sparrow.Platform;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl;
@@ -24,7 +25,7 @@ namespace SlowTests.Voron.Issues
             options.Encryption.MasterKey = _masterKey.ToArray();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void RecoveryOfEncryptedStorageNeedsToTakeIntoAccountFreedOverflowPages()
         {
             RequireFileBasedPager();
@@ -93,7 +94,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void RecoveryOfEncryptedStorageNeedsToTakeIntoAccountFreedPagesThatCouldOverlapAnotherFreedPages()
         {
             RequireFileBasedPager();
@@ -171,7 +172,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void FreeingPageShouldAlsoMarkItsRelatedEncryptionBufferAsNotValidForCommit()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_16105.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16105.cs
@@ -1,7 +1,8 @@
-﻿using System.Linq;
+using System.Linq;
 using FastTests.Voron;
 using Sparrow;
 using Sparrow.Platform;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl;
@@ -25,7 +26,7 @@ namespace SlowTests.Voron.Issues
             options.Encryption.EncryptionBuffersPool = new EncryptionBuffersPool();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void MustNotEncryptBuffersThatWereExtraAllocatedJustToSatisfyPowerOf2Size()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_16507.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16507.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Impl;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.Issues
         {
         }
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void AcquirePagePointerMustNotUseDisposedPagerState()
         {
             RequireFileBasedPager();
@@ -39,7 +40,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustReleaseAllReferencesToPagerState()
         {
             var tempPager = Env.Options.CreateTemporaryBufferPager($"temp-{Guid.NewGuid()}", 16 * 1024);

--- a/test/SlowTests/Voron/Issues/RavenDB_16536.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16536.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +22,7 @@ namespace SlowTests.Voron.Issues
             options.MaxNumberOfPagesInJournalBeforeFlush = 2; // low value to ensure it will flush
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotSayThatThereIsNothingToFlush()
         {
             for (int i = 0; i < 100; i++)

--- a/test/SlowTests/Voron/Issues/RavenDB_16860.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16860.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Impl.Journal;
 using Xunit;
@@ -20,7 +21,7 @@ namespace SlowTests.Voron.Issues
             options.MaxNumberOfRecyclableJournals = 3;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_limit_number_of_recycled_journals()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_17054.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17054.cs
@@ -5,6 +5,7 @@ using Sparrow.Platform;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Issues
 {
@@ -21,7 +22,7 @@ namespace SlowTests.Voron.Issues
             options.Encryption.RegisterForJournalCompressionHandler();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
         public void WeNeedToTakeWriteLockWhenZeroCompressionBufferIsCalled()
         {
             var testingActionWasCalled = false;

--- a/test/SlowTests/Voron/Issues/RavenDB_17088.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17088.cs
@@ -3,6 +3,7 @@ using FastTests.Voron;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Issues
 {
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Issues
             options.MaxScratchBufferSize = 64 * 1024 * 4;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CannotTryToGetPreventNewTransactionsLockRecursivelyDuringFlushing()
         {
             for (int i = 0; i < 100; i++)

--- a/test/SlowTests/Voron/Issues/RavenDB_17194.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17194.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Impl.Journal;
 using Xunit;
@@ -28,7 +29,7 @@ namespace SlowTests.Voron.Issues
             };
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotReadAndProceedWithRecyclableButEffectivelyEmptyJournalOnRecovery()
         {
             RequireFileBasedPager();
@@ -104,7 +105,7 @@ namespace SlowTests.Voron.Issues
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void TheCaseWithTwoEmptyJournalFiles()
         {
             RequireFileBasedPager();
@@ -207,7 +208,7 @@ namespace SlowTests.Voron.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void FirstJournalIsEmptyButContainsDataBecauseWasCreatedFromRecyclable()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_17354.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17354.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using FastTests.Voron;
 using Voron;
 using Voron.Impl.Journal;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Issues
 {
@@ -20,7 +21,7 @@ namespace SlowTests.Voron.Issues
             options.MaxNumberOfRecyclableJournals = 0;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Can_disable_journals_recycling()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_19278.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_19278.cs
@@ -43,7 +43,7 @@ public class RavenDB_19278 : StorageTest
             options.Encryption.MasterKey = _masterKey.ToArray();
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Voron)]
     [InlineData(false)]
     [InlineData(true)]
     public void StopRecoveryAndRaisePartiallyRecoveredAlertAfterGettingInvalidHashOfTransaction(bool encrypted)

--- a/test/SlowTests/Voron/Issues/RavenDB_7097.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_7097.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using System.Threading;
 using FastTests.Voron;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Issues
 {
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Issues
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Recyclable_journal_files_are_deleted_on_dispose()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Issues/RavenDB_7099.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_7099.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using System.Threading;
 using FastTests.Voron;
 using SlowTests.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Impl.Journal;
 using Xunit;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron.Issues
             options.ManualSyncing = true;
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed()]
         public void Do_not_create_recyclable_journal_files_on_db_load(int seed)
         {
@@ -57,7 +58,7 @@ namespace SlowTests.Voron.Issues
             Assert.Equal(0, journalsForReuse.Length);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed()]
         public void Flushed_journals_should_become_recyclable_files_after_sync(int seed)
         {

--- a/test/SlowTests/Voron/LargeFixedSizeTrees.cs
+++ b/test/SlowTests/Voron/LargeFixedSizeTrees.cs
@@ -1,13 +1,8 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="LargeFixedSizeTrees.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections;
 using FastTests.Voron;
 using SlowTests.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Util.Conversion;
 using Xunit;
@@ -21,7 +16,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(8)]
         [InlineData(16)]
         [InlineData(128)]
@@ -68,7 +63,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(8)]
         [InlineData(16)]
         [InlineData(128)]
@@ -113,7 +108,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(8)]
         [InlineData(16)]
         [InlineData(128)]
@@ -163,7 +158,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(8)]
         [InlineData(16)]
         [InlineData(128)]
@@ -238,7 +233,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(8)]
         [InlineData(16)]
         [InlineData(128)]
@@ -293,7 +288,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(250)]
         [InlineDataWithRandomSeed(1000)]
         public void CanDeleteRange_TryToFindABranchNextToLeaf(int count, int seed)
@@ -377,7 +372,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(1000)]
         [InlineDataWithRandomSeed(100000)]
         [InlineDataWithRandomSeed(500000)]
@@ -435,7 +430,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(100)]
         [InlineDataWithRandomSeed(10000)]
         [InlineDataWithRandomSeed(75000)]
@@ -489,7 +484,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(8)]
         [InlineData(12)]
         [InlineData(16)]

--- a/test/SlowTests/Voron/LeafsCompression/RDBS_52.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RDBS_52.cs
@@ -4,6 +4,7 @@ using Voron.Data.BTrees;
 using Voron.Global;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.LeafsCompression
 {
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.LeafsCompression
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
         public unsafe void MustNotCreateEmptyNonCompressedPage()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_12700_Voron.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_12700_Voron.cs
@@ -8,6 +8,7 @@ using Voron;
 using Voron.Data.BTrees;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.LeafsCompression
 {
@@ -17,7 +18,7 @@ namespace SlowTests.Voron.LeafsCompression
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
         public unsafe void Must_split_compressed_page_if_cannot_compress_back_after_decompression()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_15302.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_15302.cs
@@ -3,6 +3,7 @@ using Voron.Data.BTrees;
 using Voron.Data.Compression;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.LeafsCompression
 {
@@ -12,7 +13,7 @@ namespace SlowTests.Voron.LeafsCompression
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
         public void AfterCopyToOriginalDecompressedPageShouldNotBeInCacheIfCompressionWasNotNeeded()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_16363.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_16363.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Data.BTrees;
 using Voron.Debugging;
 using Voron.Global;
@@ -14,7 +15,7 @@ namespace SlowTests.Voron.LeafsCompression
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Compression)]
         public unsafe void MustNotCreateEmptyNonCompressedPageAfterPageSplit()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_17660.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_17660.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using FastTests.Voron;
@@ -6,6 +6,7 @@ using Raven.Client.Extensions.Streams;
 using Raven.Server.Config.Settings;
 using Sparrow;
 using Sparrow.Binary;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Xunit;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.LeafsCompression
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void Must_invalidate_cached_decompressed_page_with_write_usage_after_page_split()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/LeafsCompression/RavenDB_5384.cs
+++ b/test/SlowTests/Voron/LeafsCompression/RavenDB_5384.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
 using FastTests.Voron.FixedSize;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.LeafsCompression
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(777, 2048, false, 1)]
         [InlineData(777, 2048, false, 2019845912)]
         [InlineData(8192, 512, true, 1)]

--- a/test/SlowTests/Voron/LongKeys.cs
+++ b/test/SlowTests/Voron/LongKeys.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="SplittingPageWithPrefixes.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using FastTests.Voron;
 using SlowTests.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +21,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldHaveEnoughSpaceDuringTruncate()
         {
             using (var tx = Env.WriteTransaction())
@@ -78,7 +79,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(1)]
         [InlineData(3)]
         [InlineData(103)]
@@ -144,7 +145,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0)]
         [InlineData(2)]
         [InlineData(4)]

--- a/test/SlowTests/Voron/MemoryMapWithoutBackingPagerTest.cs
+++ b/test/SlowTests/Voron/MemoryMapWithoutBackingPagerTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using FastTests.Voron;
@@ -97,7 +97,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_be_able_to_allocate_new_pages_multiple_times()
         {
             var numberOfPages = PagerInitialSize / Constants.Storage.PageSize;

--- a/test/SlowTests/Voron/MultiAdds.cs
+++ b/test/SlowTests/Voron/MultiAdds.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using FastTests;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,7 +28,7 @@ namespace SlowTests.Voron
             return builder.ToString();
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0500)]
         [InlineData(1000)]
         [InlineData(2000)]

--- a/test/SlowTests/Voron/MutipleScratchBuffersUsage.cs
+++ b/test/SlowTests/Voron/MutipleScratchBuffersUsage.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="MutipleScratchBuffersHandling.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
 
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -25,7 +26,7 @@ namespace SlowTests.Voron
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanAddContinuallyGrowingValue()
         {
             // this test does not have any assertion - we just check here that we don't get ScratchBufferSizeLimitException
@@ -63,7 +64,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanAddContinuallyGrowingValue_ButNotCommitting()
         {
             // this test does not have any assertion - we just check here that we don't get ScratchBufferSizeLimitException

--- a/test/SlowTests/Voron/NativeListTests.cs
+++ b/test/SlowTests/Voron/NativeListTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Util;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,7 +15,7 @@ public class NativeListTests : StorageTest
     {
     }
 
-    [Theory]
+    [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Voron | RavenTestCategory.Memory)]
     [InlineData(16)]
     [InlineData(1 << 10)]
     [InlineData(1 << 15)]

--- a/test/SlowTests/Voron/PageSplitterTests.cs
+++ b/test/SlowTests/Voron/PageSplitterTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -28,7 +29,7 @@ namespace SlowTests.Voron
         }
 
         //Voron must support this in order to support MultiAdd() with values > 2000 characters
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void TreeAdds_WithVeryLargeKey()
         {
             using (var tx = Env.WriteTransaction())
@@ -56,7 +57,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotThrowPageFullExceptionDuringPageSplit()
         {
             using (var tx = Env.WriteTransaction())
@@ -115,7 +116,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotThrowPageFullExceptionDuringPageSplit2()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/PalTest/PalJournalFunctionTests.cs
+++ b/test/SlowTests/Voron/PalTest/PalJournalFunctionTests.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using FastTests;
 using Sparrow.Server.Platform;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -16,7 +17,7 @@ namespace SlowTests.Voron.PalTest
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public unsafe void rvn_get_error_string_WhenCalled_ShouldCreateFile()
         {
             var errBuffer = new byte[256];
@@ -39,7 +40,7 @@ namespace SlowTests.Voron.PalTest
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public void OpenJournal_WhenCalled_ShouldCreateFile()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), $"test_journal.{Guid.NewGuid()}");
@@ -62,7 +63,7 @@ namespace SlowTests.Voron.PalTest
             Assert.Equal(length, actualSize);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public unsafe void WriteJournal_WhenCalled_ShouldWriteOnFile()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), $"test_journal.{Guid.NewGuid()}");
@@ -98,7 +99,7 @@ namespace SlowTests.Voron.PalTest
             Assert.Equal(expected, bytesFromFile);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public unsafe void WriteJournal_WhenOffsetNotOnFileBeginning_ShouldWriteOnFile()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), $"test_journal.{Guid.NewGuid()}");
@@ -134,7 +135,7 @@ namespace SlowTests.Voron.PalTest
             Assert.Equal(expected, bytesFromFile);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public unsafe void ReadJournal_WhenDo_ShouldRead()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), $"test_journal.{Guid.NewGuid()}");
@@ -184,7 +185,7 @@ namespace SlowTests.Voron.PalTest
             Assert.Equal(expected, expected);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public unsafe void ReadJournal_WhenPassingTheEnd_ShouldReadUntilTheEndAndReturnEOF()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), $"test_journal.{Guid.NewGuid()}");
@@ -223,19 +224,19 @@ namespace SlowTests.Voron.PalTest
                 ret = Pal.rvn_open_journal_for_reads(file, out var rHandle, out errno);
                 if (ret != PalFlags.FailCodes.Success)
                     PalHelper.ThrowLastError(ret, errno, "");
-                
+
                 ret = Pal.rvn_read_journal(rHandle, pActual, 1000, offset, out var readActualSize, out errno);
-                
+
                 if (ret != PalFlags.FailCodes.FailEndOfFile)
                     PalHelper.ThrowLastError(ret, errno, "");
-                
+
                 Assert.Equal(500, readActualSize);
             }
 
             Assert.Equal(expected, actual.Take(500));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Pal)]
         public void TruncateJournal_WhenCalled_ShouldTruncate()
         {
             var file = Path.Combine(NewDataPath(forceCreateDir: true), $"test_journal.{Guid.NewGuid()}");

--- a/test/SlowTests/Voron/PalTest/PalMmapFunctionTests.cs
+++ b/test/SlowTests/Voron/PalTest/PalMmapFunctionTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using FastTests;
 using Sparrow.Server.Platform;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,7 +15,7 @@ public class PalMapTests : RavenTestBase
     {
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Pal)]
     public unsafe void MapFile_WhenCalled_ShouldSuccess()
     {
         //TODO To remove when mmap functions are implemented in windows
@@ -36,7 +37,7 @@ public class PalMapTests : RavenTestBase
         handle.Dispose();
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Pal)]
     public unsafe void MapFileAndAllocateMoreSpace_WhenCalled_ShouldSuccess()
     {
         //TODO To remove when mmap functions are implemented in windows

--- a/test/SlowTests/Voron/PostingListTests.cs
+++ b/test/SlowTests/Voron/PostingListTests.cs
@@ -48,7 +48,7 @@ public class PostingListTests : StorageTest
         return l;
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public void CanDeleteRandomLargeNumberOfItemsFromStart()
     {
         using (var wtx = Env.WriteTransaction())
@@ -83,7 +83,7 @@ public class PostingListTests : StorageTest
         }
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public void CanStoreLargeNumberOfItemsInSequentialOrder()
     {
         using (var wtx = Env.WriteTransaction())
@@ -153,7 +153,7 @@ public class PostingListTests : StorageTest
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public void CanDeleteLargeNumberOfItemsFromStart()
     {
         using (var wtx = Env.WriteTransaction())
@@ -188,7 +188,7 @@ public class PostingListTests : StorageTest
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public void CanStoreLargeNumberOfItemsInRandomlyOrder()
     {
         using (var wtx = Env.WriteTransaction())
@@ -212,7 +212,7 @@ public class PostingListTests : StorageTest
         }
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public void CanDeleteLargeNumberOfItems()
     {
         using (var wtx = Env.WriteTransaction())
@@ -247,7 +247,7 @@ public class PostingListTests : StorageTest
         }
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     public void CanDeleteLargeNumberOfItemsFromEnd()
     {
         using (var wtx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/RavenDB-11871.cs
+++ b/test/SlowTests/Voron/RavenDB-11871.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Impl.Journal;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void WillNotRetainJournalsAfterSync()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_12725.cs
+++ b/test/SlowTests/Voron/RavenDB_12725.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using FastTests.Voron;
 using Sparrow.Backups;
@@ -26,7 +26,7 @@ namespace SlowTests.Voron
             options.MaxLogFileSize = 1 * 1024 * 1024;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Recovery_must_not_delete_journals_that_havent_been_synced_yet()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_12725_2.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_2.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using FastTests.Voron;
 using Sparrow.Backups;
@@ -125,7 +125,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Recovery_must_not_throw_missing_journal_if_we_have_synced_everything()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_12725_3.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_3.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿﻿using System.IO;
 using FastTests.Voron;
 using Raven.Server.Config.Settings;
 using Tests.Infrastructure;
@@ -15,7 +15,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Voron_schema_update_will_update_headers_file_and_bump_version_there()
         {
             var dataDir = RavenTestHelper.NewDataPath(nameof(Voron_schema_update_will_update_headers_file_and_bump_version_there), 0, forceCreateDir: true);

--- a/test/SlowTests/Voron/RavenDB_12725_4.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_4.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿﻿﻿using System;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Exceptions;
@@ -24,7 +25,7 @@ namespace SlowTests.Voron
             options.MaxLogFileSize = 1 * 1024 * 1024;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_throw_on_missing_journal_during_recovery()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_12725_5.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_5.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿﻿﻿using System;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl.Journal;
@@ -24,7 +25,7 @@ namespace SlowTests.Voron
             options.IgnoreInvalidJournalErrors = true;
         }
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_recover_if_jounral_is_missing_but_IgnoreInvalidJournalErrors_is_set()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_12725_6.cs
+++ b/test/SlowTests/Voron/RavenDB_12725_6.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl.Journal;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron
             options.IgnoreInvalidJournalErrors = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Can_successfully_sync_journals_after_recovery()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_13940.cs
+++ b/test/SlowTests/Voron/RavenDB_13940.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 using FastTests.Voron;
 using Sparrow.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Exceptions;
 using Voron.Global;
@@ -34,7 +35,7 @@ namespace SlowTests.Voron
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptedSingleTransactionPage_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -116,7 +117,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void CorruptedSingleByteInTransactionPageOfFirstTransaction_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -198,7 +199,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void CorruptionAcrossMultipleTransactions_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -280,7 +281,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptionOfTransactionHeaderLastPageNumber_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -362,7 +363,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ShouldFailBecauseFirstValidTransactionIsTheOneWhichIsNotSynced()
         {
             RequireFileBasedPager();
@@ -425,7 +426,7 @@ namespace SlowTests.Voron
             Assert.Throws<InvalidJournalException>(StartDatabase);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ShouldNotFailBecauseAllCorruptedTransactionsWereSynced()
         {
             // similar test like above but all corrupted transactions were synced so no errors on startup
@@ -512,7 +513,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData("storage-with-reused-journal-and-synced-data.zip")]
         [InlineData("storage-with-reused-journal-and-synced-data-2.zip")]
         public void ShouldNotInvokeIntegrityError(string fileName)

--- a/test/SlowTests/Voron/RavenDB_13940_Encrypted.cs
+++ b/test/SlowTests/Voron/RavenDB_13940_Encrypted.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using FastTests.Voron;
 using Sparrow.Platform;
 using Sparrow.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Exceptions;
 using Voron.Global;
@@ -37,7 +38,7 @@ namespace SlowTests.Voron
             options.Encryption.MasterKey = _masterKey.ToArray();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptedSingleTransactionPage_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -119,7 +120,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void CorruptedSingleByteInTransactionPageOfFirstTransaction_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -201,7 +202,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void CorruptionAcrossMultipleTransactions_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -283,7 +284,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptionOfTransactionHeaderLastPageNumber_WontStopTheRecoveryIfIgnoreErrorsOfSyncedTransactionIsSet()
         {
             RequireFileBasedPager();
@@ -365,7 +366,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void ShouldFailBecauseFirstValidTransactionIsTheOneWhichIsNotSynced()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_16428.cs
+++ b/test/SlowTests/Voron/RavenDB_16428.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,7 +22,7 @@ namespace SlowTests.Voron
             options.ManualSyncing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotThrowObjectDisposedExceptionWhenFreeingPagesOnTxRollback()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_16635.cs
+++ b/test/SlowTests/Voron/RavenDB_16635.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Threading;
 using FastTests.Voron;
 using Sparrow.LowMemory;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Impl;
 using Xunit;
@@ -22,7 +23,7 @@ namespace SlowTests.Voron
             options.MaxScratchBufferSize = 64 * 1024 * 4;
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(false)]
         [InlineData(true)]
         public void MustNotThrowObjectDisposedOnScratchPagerWhenCreatingNewTransaction(bool startWriteTransaction)
@@ -88,7 +89,7 @@ namespace SlowTests.Voron
             Assert.Null(startTransactionException);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotThrowObjectDisposedOnScratchPagerWhenCreatingNewReadTransactionRightAfterDisposingRecycledScratches()
         {
             RequireFileBasedPager();
@@ -176,7 +177,7 @@ namespace SlowTests.Voron
             Assert.Null(startTransactionException);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public unsafe void CannotUsePagerStateOfDisposedPager() // this test is just to verify that we properly throw on such invalid usage
         {
             RequireFileBasedPager();
@@ -203,7 +204,7 @@ namespace SlowTests.Voron
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotThrowObjectDisposedOnScratchPagerWhenCreatingNewReadTransaction()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/RavenDB_2939.cs
+++ b/test/SlowTests/Voron/RavenDB_2939.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="RavenDB_2939.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using FastTests.Voron;
 using FastTests.Voron.Backups;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Voron.Impl.Backup;
@@ -31,7 +32,7 @@ namespace SlowTests.Voron
             options.ManualFlushing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.BackupExportImport)]
         public void ShouldExplicitlyErrorThatTurningOnIncrementalBackupAfterInitializingTheStorageIsntAllowed()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Recovery.cs
+++ b/test/SlowTests/Voron/Recovery.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreNoTransactionsToRecoverFromLog()
         {
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPath(DataDir)))
@@ -28,7 +29,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereSingleTransactionToRecoverFromLog()
         {
 
@@ -69,7 +70,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreCommitedAndUncommitedTransactions()
         {
 
@@ -96,7 +97,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreCommitedAndUncommitedTransactions2()
         {
 
@@ -125,7 +126,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions()
         {
 
@@ -185,7 +186,7 @@ namespace SlowTests.Voron
 
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions2()
         {
 
@@ -245,7 +246,7 @@ namespace SlowTests.Voron
 
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkForSplitTransactions()
         {
             var random = new Random(1234);

--- a/test/SlowTests/Voron/RecoveryMultipleJournals.cs
+++ b/test/SlowTests/Voron/RecoveryMultipleJournals.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron;
 using Sparrow.Utils;
@@ -25,7 +25,7 @@ namespace SlowTests.Voron
             options.MaxScratchBufferSize = 1 * 1024 * 1024 * 1024;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanRecoverAfterRestartWithMultipleFilesInSingleTransaction()
         {
 
@@ -68,7 +68,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanResetLogInfoAfterBigUncommitedTransaction()
         {
             using (var tx = Env.WriteTransaction())
@@ -145,7 +145,7 @@ namespace SlowTests.Voron
             Assert.Equal(currentJournalInfo.CurrentJournal + 1, Env.Journal.GetCurrentJournalInfo().CurrentJournal);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanResetLogInfoAfterBigUncommitedTransactionWithRestart()
         {
             RequireFileBasedPager();
@@ -188,7 +188,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptingOneTransactionWillThrow()
         {
             RequireFileBasedPager();
@@ -221,7 +221,7 @@ namespace SlowTests.Voron
             Assert.Throws<InvalidJournalException>(() => StartDatabase());
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptingAllLastTransactionsConsideredAsEndOfJournal()
         {
             RequireFileBasedPager();
@@ -275,7 +275,7 @@ namespace SlowTests.Voron
 
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CorruptingLastTransactionsInNotLastJournalShouldThrow()
         {
             RequireFileBasedPager();
@@ -348,7 +348,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldThrowIfFirstTransactionIsCorruptedBecauseWeCannotAccessMetadataThen()
         {
             RequireFileBasedPager();

--- a/test/SlowTests/Voron/Snapshots.cs
+++ b/test/SlowTests/Voron/Snapshots.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace SlowTests.Voron
 
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SnapshotIssue()
         {
             const int DocumentCount = 50000;
@@ -70,7 +71,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SnapshotIssue_ExplicitFlushing()
         {
             const int DocumentCount = 50000;

--- a/test/SlowTests/Voron/SplittingVeryBig.cs
+++ b/test/SlowTests/Voron/SplittingVeryBig.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -20,7 +21,7 @@ namespace SlowTests.Voron
             options.MaxLogFileSize = 10 * Constants.Storage.PageSize;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldBeAbleToWriteValuesGreaterThanLogAndReadThem()
         {
             var random = new Random(1234);
@@ -51,7 +52,7 @@ namespace SlowTests.Voron
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldBeAbleToWriteValuesGreaterThanLogAndRecoverThem()
         {
             var random = new Random(1234);

--- a/test/SlowTests/Voron/Storage/BigValue.cs
+++ b/test/SlowTests/Voron/Storage/BigValue.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Sparrow;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Storage
             options.ManualFlushing = true;
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
@@ -161,7 +162,7 @@ namespace SlowTests.Voron.Storage
                 Assert.Equal(0, Memory.Compare(b, c, buffer.Length));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanStoreInOneTransactionManySmallValues()
         {
             var buffers = new List<byte[]>();

--- a/test/SlowTests/Voron/Storage/Files.cs
+++ b/test/SlowTests/Voron/Storage/Files.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="Files.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -6,6 +6,7 @@
 
 using System.IO;
 using Raven.Server.Utils;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Storage
         }
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ByDefaultAllFilesShouldBeStoredInOneDirectory()
         {
             var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir);
@@ -28,7 +29,7 @@ namespace SlowTests.Voron.Storage
             Assert.True(options.TempPath.FullPath.StartsWith(options.BasePath.FullPath));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void TemporaryPathTest()
         {
             var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null);
@@ -37,7 +38,7 @@ namespace SlowTests.Voron.Storage
             Assert.Equal(DataDir + "Temp", options.TempPath.FullPath);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void DefaultScratchLocation()
         {
             var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir);
@@ -48,7 +49,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ScratchLocationWithTemporaryPathSpecified()
         {
             var options = (StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)StorageEnvironmentOptions.ForPath(DataDir, DataDir + "Temp", null, null, null);

--- a/test/SlowTests/Voron/Storage/FreeScratchPages.cs
+++ b/test/SlowTests/Voron/Storage/FreeScratchPages.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+﻿﻿// -----------------------------------------------------------------------
 //  <copyright file="FreeScratchPages.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Tests.Infrastructure;
 using Voron.Impl.Scratch;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,7 +20,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void UncommittedTransactionShouldFreeScratchPagesThatWillBeReusedByNextTransaction()
         {
             var random = new Random();

--- a/test/SlowTests/Voron/Storage/Increments.cs
+++ b/test/SlowTests/Voron/Storage/Increments.cs
@@ -1,9 +1,4 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="Increments.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-
+﻿﻿using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +10,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SimpleIncrementShouldWork()
         {
             CreateTrees(Env, 1, "tree");
@@ -50,8 +45,8 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-    
-        [Fact]
+
+        [RavenFact(RavenTestCategory.Voron)]
         public void SimpleIncrementEntriesCountShouldStayCorrectAfterCommit()
         {
             CreateTrees(Env, 1, "tree");

--- a/test/SlowTests/Voron/Storage/InitialSize.cs
+++ b/test/SlowTests/Voron/Storage/InitialSize.cs
@@ -1,10 +1,5 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="InitialSize.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-
-using System.IO;
+﻿﻿using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -23,7 +18,7 @@ namespace SlowTests.Voron.Storage
             return 64 * 1024;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void WhenInitialFileSizeIsNotSetTheFileSizeForDataFileAndScratchFileShouldBeSetToSystemAllocationGranularity()
         {
             DeleteDataDir();
@@ -41,7 +36,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void WhenInitialFileSizeIsSetTheFileSizeForDataFileAndScratchFileShouldBeSetAccordingly()
         {
             DeleteDataDir();
@@ -59,7 +54,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void WhenInitialFileSizeIsSetTheFileSizeForDataFileAndScratchFileShouldBeSetAccordinglyAndItWillBeRoundedToTheNearestGranularity()
         {
             DeleteDataDir();

--- a/test/SlowTests/Voron/Storage/MemoryMapWithoutBackingPagerTest.cs
+++ b/test/SlowTests/Voron/Storage/MemoryMapWithoutBackingPagerTest.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using FastTests.Voron.Util;
 using Sparrow.Server.Platform.Posix;
 using Sparrow.Server.Platform.Win32;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
 using Xunit;
@@ -35,7 +36,7 @@ namespace SlowTests.Voron.Storage
                 yield return new KeyValuePair<string, string>("Key " + i, "Data:" + dummyData);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_be_able_to_read_and_write_small_values()
         {
             CreatTestSchema();
@@ -52,7 +53,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(2)]
         [InlineData(5)]
         [InlineData(15)]
@@ -72,7 +73,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_be_able_to_allocate_new_pages_multiple_times()
         {
             var numberOfPages = PagerInitialSize / Constants.Storage.PageSize;
@@ -111,7 +112,7 @@ namespace SlowTests.Voron.Storage
             Win32MemoryProtectMethods.VirtualFree(adjacentBlockAddress, UIntPtr.Zero, Win32MemoryProtectMethods.FreeType.MEM_RELEASE);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void Should_be_able_to_allocate_new_pages_with_remapping()
         {
             var pagerSize = PagerInitialSize;

--- a/test/SlowTests/Voron/Storage/MultiTransactions.cs
+++ b/test/SlowTests/Voron/Storage/MultiTransactions.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using FastTests;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldWork()
         {
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnly()))

--- a/test/SlowTests/Voron/Storage/PageHandling.cs
+++ b/test/SlowTests/Voron/Storage/PageHandling.cs
@@ -1,4 +1,5 @@
-﻿using Sparrow;
+﻿﻿using Sparrow;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -10,7 +11,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void AllocateOverflowPages()
         {
             long pageNumber;
@@ -46,7 +47,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ReadModifyReadPagesInSameTransaction()
         {
             using (var tx = Env.WriteTransaction())
@@ -73,7 +74,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void EnsureDataPointerChangesAfterModifyInSameTransaction()
         {
             long pageNumber;

--- a/test/SlowTests/Voron/Storage/Pagers.cs
+++ b/test/SlowTests/Voron/Storage/Pagers.cs
@@ -1,28 +1,34 @@
+﻿using System;
+using System.IO;
+using Tests.Infrastructure;
+using Voron.Impl.Paging;
+using Xunit;
+
 namespace SlowTests.Voron.Storage
 {
     public class Pagers
     {
 #if DEBUG_PAGER_STATE
-//        [Fact]
+//        [RavenFact(RavenTestCategory.Voron)]
 //        public void PureMemoryPagerReleasesPagerState()
 //        {
 //            PagerReleasesPagerState(() => new Win32PureMemoryPager());
 //        }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MemoryMapPagerReleasesPagerState()
         {
             PagerReleasesPagerState(() => new Win32MemoryMapPager("db.voron"));
             File.Delete("db.voron");
         }
 
-        [Fact]	
+        [RavenFact(RavenTestCategory.Voron)]
         public void MemoryMapWithoutBackingReleasePagerState()
         {
             PagerReleasesPagerState(() => new Win32PageFileBackedMemoryMappedPager("test"));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void FilePagerReleasesPagerState()
         {
             PagerReleasesPagerState(() => new FilePager("db.voron"));

--- a/test/SlowTests/Voron/Storage/Quotas.cs
+++ b/test/SlowTests/Voron/Storage/Quotas.cs
@@ -9,6 +9,7 @@ using Voron;
 using Voron.Exceptions;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Storage
 {
@@ -23,7 +24,7 @@ namespace SlowTests.Voron.Storage
             options.MaxStorageSize = 1024 * 1024 * 1; // 1MB
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldThrowQuotaException()
         {
             var quotaEx = Assert.Throws<QuotaException>(() =>

--- a/test/SlowTests/Voron/Storage/Restarts.cs
+++ b/test/SlowTests/Voron/Storage/Restarts.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿﻿using System.IO;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void DataIsKeptAfterRestart_OnDisk()
         {
             using (var pager = StorageEnvironmentOptions.ForPath(DataDir))
@@ -46,7 +47,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void DataIsKeptAfterRestart()
         {
             using (var pureMemoryPager = StorageEnvironmentOptions.CreateMemoryOnly())
@@ -81,7 +82,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void DataIsKeptAfterRestartForSubTrees()
         {
             using (var pureMemoryPager = StorageEnvironmentOptions.CreateMemoryOnly())

--- a/test/SlowTests/Voron/Storage/Snapshots.cs
+++ b/test/SlowTests/Voron/Storage/Snapshots.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Xunit;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace SlowTests.Voron.Storage
 {
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.Storage
 
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void SingleItemBatchTestLowLevel()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
+++ b/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
@@ -1,15 +1,10 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="Stats.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FastTests.Voron.FixedSize;
 using Sparrow;
+using Tests.Infrastructure;
 using Voron.Data.BTrees;
 using Voron.Debugging;
 using Voron.Global;
@@ -26,7 +21,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void AllocatedSpaceOfDataFileEqualsToSumOfSpaceInUseAndFreeSpace()
         {
             using (var tx = Env.ReadTransaction())
@@ -37,7 +32,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(13)]
@@ -87,7 +82,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0)]
         [InlineData(7)]
         [InlineData(14)]
@@ -150,7 +145,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0)]
         [InlineData(7)]
         [InlineData(14)]
@@ -182,7 +177,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(0)]
         [InlineData(7)]
         [InlineData(14)]
@@ -216,7 +211,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(1)]
         [InlineData(5)]
         [InlineData(15)]
@@ -261,7 +256,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(new[] { "key" }, 1000)]
         [InlineData(new[] { "key1", "key2" }, 1000)]
         [InlineData(new[] { "key" }, 1)]
@@ -295,7 +290,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void TreeReportContainsInformationAboutPagesOfChildMultiTrees()
         {
             using (var tx = Env.WriteTransaction())
@@ -315,7 +310,7 @@ namespace SlowTests.Voron.Storage
                 var report = Env.GenerateDetailedReport(tx, includeDetails: true);
 
                 Assert.True(report.Trees[1].MultiValues.PageCount > 0);
-                Assert.Equal(report.Trees[1].MultiValues.PageCount, 
+                Assert.Equal(report.Trees[1].MultiValues.PageCount,
                     report.Trees[1].MultiValues.LeafPages + report.Trees[1].MultiValues.BranchPages + report.Trees[1].MultiValues.OverflowPages);
             }
 
@@ -336,12 +331,12 @@ namespace SlowTests.Voron.Storage
                 var report = Env.GenerateDetailedReport(tx, includeDetails: true);
 
                 Assert.True(report.Trees[1].MultiValues.PageCount == 0);
-                Assert.Equal(report.Trees[1].MultiValues.PageCount, 
+                Assert.Equal(report.Trees[1].MultiValues.PageCount,
                     report.Trees[1].MultiValues.LeafPages + report.Trees[1].MultiValues.BranchPages + report.Trees[1].MultiValues.OverflowPages);
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(1)]
         [InlineDataWithRandomSeed(5)]
         [InlineDataWithRandomSeed(15)]
@@ -392,7 +387,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed(1)]
         [InlineDataWithRandomSeed(5)]
         [InlineDataWithRandomSeed(15)]

--- a/test/SlowTests/Voron/Storage/SyncFlushTimingTest.cs
+++ b/test/SlowTests/Voron/Storage/SyncFlushTimingTest.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using TimeoutException = System.TimeoutException;
@@ -25,14 +26,14 @@ namespace SlowTests.Voron.Storage
             options.ManualSyncing = true;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         // As part of the sync operation, there are stages where the sync operation needs the flush lock
         // and as part of the flush operation, there are stages the flush operation needs transaction write lock
         // this can lead to a situation where the sync is waiting to flush waiting to write transaction
-        // so the sync pass his work that needs the flush lock to the flush operation if the lock is occupied 
+        // so the sync pass his work that needs the flush lock to the flush operation if the lock is occupied
         // and if the flush operation can do it while it waits to write transaction lock
 
-        //In this test, the sync is called while the flush is running and waiting to write transaction so the sync should not be blocked 
+        //In this test, the sync is called while the flush is running and waiting to write transaction so the sync should not be blocked
         public void CanSyncWhileFlushWaiteToWriteTransaction()
         {
             var syncMayFinishedEvent = new AutoResetEvent(false);
@@ -105,7 +106,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact(Timeout = 10 * 1000)]
+        [RavenFact(RavenTestCategory.Voron, Timeout = 10 * 1000)]
         // https://issues.hibernatingrhinos.com/issue/RavenDB-12525
         // The problem was when sync operates while there is no data to sync
         // the sync operation continued with default properties
@@ -141,7 +142,7 @@ namespace SlowTests.Voron.Storage
             return Task.CompletedTask;
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTakenAndNoOneRunTaskIfNotAlreadyRan_ShouldKeepWaiting()
         {
             var tokenSource = new CancellationTokenSource();
@@ -165,7 +166,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTakenAndNoOneRunTaskIfNotAlreadyRanAndCancelToken_ShouldContinueWithoutDoJob()
         {
             var tokenSource = new CancellationTokenSource();
@@ -183,7 +184,7 @@ namespace SlowTests.Voron.Storage
             Assert.Equal(null, worker.Exception);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTakenAndRelease_JobShouldBeDone()
         {
             var tokenSource = new CancellationTokenSource();
@@ -212,7 +213,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTaken_ShouldBeDoneByRunTaskIfNotAlreadyRan()
         {
             var tokenSource = new CancellationTokenSource();
@@ -244,7 +245,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTakenAndJobFailed_ShouldBeDoneByRunTaskIfNotAlreadyRanAndReturnFalse()
         {
             var tokenSource = new CancellationTokenSource();
@@ -279,7 +280,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTakenAndDoneByRunTaskIfNotAlreadyRan_ShouldBeWaitUntilTheJobDone()
         {
             var tokenSource = new CancellationTokenSource();
@@ -326,7 +327,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenTwoThreadsAreWaitingToTaskToBeDone_TheRunThreadShouldRunOnlyOneForCallAndEventuallyCompleteAll()
         {
             var tokenSource = new CancellationTokenSource();
@@ -371,7 +372,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockNotTaken_WorkShouldBeDone()
         {
             var tokenSource = new CancellationTokenSource();
@@ -397,7 +398,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockNotTakenAndJobFailed_WorkShouldReturnFalse()
         {
             var tokenSource = new CancellationTokenSource();
@@ -426,7 +427,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockNotTakenAndWaitTwice_WorkShouldBeDone()
         {
             var tokenSource = new CancellationTokenSource();
@@ -453,7 +454,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenLockTakenAndJobThrow_ShouldThrowToTheWaiter()
         {
             var tokenSource = new CancellationTokenSource();
@@ -490,7 +491,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void LockTaskResponsible_WhenTwoThreadsAreWaitingOneOfThemDoThrowJob_ShouldCompleteTheSecondJob()
         {
             var tokenSource = new CancellationTokenSource();

--- a/test/SlowTests/Voron/Storage/VeryBig.cs
+++ b/test/SlowTests/Voron/Storage/VeryBig.cs
@@ -1,5 +1,6 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,7 +12,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanGrowBeyondInitialSize()
         {
             using (var tx = Env.WriteTransaction())
@@ -37,7 +38,7 @@ namespace SlowTests.Voron.Storage
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanGrowBeyondInitialSize_Root()
         {
             var buffer = new byte[1024 * 512];
@@ -56,7 +57,7 @@ namespace SlowTests.Voron.Storage
                 }
             }
         }
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanGrowBeyondInitialSize_WithAnotherTree()
         {
             using (var tx = Env.WriteTransaction())

--- a/test/SlowTests/Voron/Streams/CanUseStream.cs
+++ b/test/SlowTests/Voron/Streams/CanUseStream.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using FastTests.Voron.FixedSize;
+using Tests.Infrastructure;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace SlowTests.Voron.Streams
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(null, 129)]
         [InlineData(null, 2095)]
         [InlineData("AM4#@dF5Tas", 4096)]
@@ -54,7 +55,7 @@ namespace SlowTests.Voron.Streams
                     Assert.Equal(tag, readTag);
             }
         }
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(129)]
         [InlineData(2095)]
         [InlineData(4096)]
@@ -94,7 +95,7 @@ namespace SlowTests.Voron.Streams
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData("AM4#@dF5Tas", 129)]
         [InlineData(null, 2095)]
         [InlineData(null, 4096)]
@@ -143,7 +144,7 @@ namespace SlowTests.Voron.Streams
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData(null, 50)]
         [InlineData(null, 129)]
         [InlineData(null, 2095)]
@@ -180,7 +181,7 @@ namespace SlowTests.Voron.Streams
             }
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineData("RavenDB", 1546581643)]
         [InlineDataWithRandomSeed(null)]
         [InlineDataWithRandomSeed("RavenDB")]

--- a/test/SlowTests/Voron/Versioning.cs
+++ b/test/SlowTests/Voron/Versioning.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using FastTests.Voron;
 using SlowTests.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,7 +14,7 @@ namespace SlowTests.Voron
         {
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Voron)]
         [InlineDataWithRandomSeed]
         public void SplittersAndRebalancersShouldNotChangeNodeVersion(int seed)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24478

### Additional description

Includes SlowTests directories for Corax, Voron and Blittable.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
