### PR TITLE
RavenDB-24480 Cluster dashboard / traffic by db - sorting by requests does not work

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/databaseIndexingWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/databaseIndexingWidget.ts
@@ -39,17 +39,20 @@ class databaseIndexingWidget extends abstractDatabaseAndNodeAwareTableWidget<Rav
         return [
             new textColumn<indexingSpeedItem>(grid, x => x.hideDatabaseName && !grid.sortEnabled() ? "" : DatabaseUtils.default.formatName(x.database), "Database", "35%"),
             new nodeTagColumn<indexingSpeedItem>(grid, item => this.prepareUrl(item, "Indexing Performance View")),
-            new textColumn<indexingSpeedItem>(grid, x => widget.formatNumber(x.indexedPerSecond), "Indexed/s", "15%", {
+            new textColumn<indexingSpeedItem>(grid, x => x.indexedPerSecond, "Indexed/s", "15%", {
                 headerTitle: "Indexed items per second",
-                sortable: "number"
+                sortable: "number",
+                transformValue: (x: number) => widget.formatNumber(x)
             }),
-            new textColumn<indexingSpeedItem>(grid, x => widget.formatNumber(x.mappedPerSecond), "Mapped/s", "15%", {
+            new textColumn<indexingSpeedItem>(grid, x => x.mappedPerSecond, "Mapped/s", "15%", {
                 headerTitle: "Mapped items per second",
-                sortable: "number"
+                sortable: "number",
+                transformValue: (x: number) => widget.formatNumber(x)
             }),
-            new textColumn<indexingSpeedItem>(grid, x => widget.formatNumber(x.reducedPerSecond), "Reduced/s", "15%", {
+            new textColumn<indexingSpeedItem>(grid, x => x.reducedPerSecond, "Reduced/s", "15%", {
                 headerTitle: "Reduced mapped entries per second",
-                sortable: "number"
+                sortable: "number",
+                transformValue: (x: number) => widget.formatNumber(x)
             })
         ];
     }

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/databaseTrafficWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/databaseTrafficWidget.ts
@@ -41,21 +41,26 @@ class databaseTrafficWidget extends abstractDatabaseAndNodeAwareTableWidget<Rave
         return [
             new textColumn<trafficWatchItem>(grid, x => x.hideDatabaseName && !grid.sortEnabled() ? "" : DatabaseUtils.default.formatName(x.database), "Database", "30%"),
             new nodeTagColumn<trafficWatchItem>(grid, item => this.prepareUrl(item, "Traffic Watch View")),
-            new textColumn<trafficWatchItem>(grid, x => widget.formatNumber(x.requestsPerSecond), "Requests/s", "12%", {
+            new textColumn<trafficWatchItem>(grid, x => x.requestsPerSecond, "Requests/s", "12%", {
                 headerTitle: "Requests made to node per second",
                 sortable: "number",
+                transformValue: (x: number) => widget.formatNumber(x)
             }),
-            new textColumn<trafficWatchItem>(grid, x => widget.formatNumber(x.writesPerSecond), "Writes/s", "12%", {
+            new textColumn<trafficWatchItem>(grid, x => x.writesPerSecond, "Writes/s", "12%", {
                 headerTitle: "Items written by node per second",
                 sortable: "number",
+                transformValue: (x: number) => widget.formatNumber(x)
             }),
-            new textColumn<trafficWatchItem>(grid, x => x.noData ? "-" : generalUtils.formatBytesToSize(x.dataWritesPerSecond), "Data written/s", "12%", {
+            new textColumn<trafficWatchItem>(grid, x => x.noData ? -1 : x.dataWritesPerSecond, "Data written/s", "12%", {
                 headerTitle: "Bytes written by node per second",
                 sortable: "number",
+                transformValue: (x: number) => x === -1 ? "-" : generalUtils.formatBytesToSize(x)
+
             }),
-            new textColumn<trafficWatchItem>(grid, x => x.noData ? "-" : Math.round(x.averageDuration).toLocaleString() + " ms", "Avg Req Time", "12%", {
+            new textColumn<trafficWatchItem>(grid, x => x.noData ? -1 : Math.round(x.averageDuration) + " ms", "Avg Req Time", "12%", {
                 headerTitle: "Average request time",
                 sortable: "number",
+                transformValue: (x: number) => x === -1 ? "-" : x.toLocaleString()
             }),
         ];
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24480/Cluster-dashboard-traffic-by-db-sorting-by-requests-does-not-work

### Additional description

Sorting was performed on the sting values, not number

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
