### PR TITLE
RavenDB-24377 switched to string because PathSetting by default checks path access and those configuration options are not representing the path, just a name

### DIFF
--- a/src/Raven.Server/Config/Categories/LogsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LogsConfiguration.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Config.Categories
         [Description("The name of the log file.")]
         [DefaultValue("server.log")]
         [ConfigurationEntry("Logs.FileName", ConfigurationEntryScope.ServerWideOnly)]
-        public PathSetting FileName { get; set; }
+        public string FileName { get; set; }
 
         [Description("Determines the minimum logging level.")]
         [DefaultValue(LogLevel.Info)]

--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Config.Categories
         [Description("The name of the audit log file.")]
         [DefaultValue("server.audit.log")]
         [ConfigurationEntry("Security.AuditLog.FileName", ConfigurationEntryScope.ServerWideOnly)]
-        public PathSetting AuditLogFileName { get; set; }
+        public string AuditLogFileName { get; set; }
 
         [Description("The largest size (in megabytes) that an audit log file may reach " +
                      "before it is archived and logging is directed to a new file.")]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24377

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
