### PR TITLE
RavenDB-24517 - Add Read / Write pages metrics

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/PagingStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/PagingStatsHandler.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Routing;
+using Raven.Server.Utils;
+using Raven.Server.Web;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Debugging;
+
+public class PagingStatsHandler : ServerRequestHandler
+{
+    [RavenAction("/debug/paging-statistics", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
+    public async Task PagingStatistics()
+    {
+        using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+        {
+            var t = Voron.Impl.Paging.PagingStatistics.GetTotals();
+            context.Write(writer, new DynamicJsonValue
+            {
+                [nameof(t.TotalReads)] = t.TotalReads,
+                [nameof(t.TotalWrites)] = t.TotalWrites
+            });
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Debugging/PagingStatsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/PagingStatsHandler.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Handlers.Debugging;
 
 public class PagingStatsHandler : ServerRequestHandler
 {
-    [RavenAction("/debug/paging-statistics", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
+    [RavenAction("/debug/storage/paging/stats", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
     public async Task PagingStatistics()
     {
         using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.5/TotalPagesRead.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.5/TotalPagesRead.cs
@@ -1,0 +1,15 @@
+using Lextm.SharpSnmpLib;
+using Raven.Server.Monitoring.OpenTelemetry;
+using Voron.Impl.Paging;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server;
+
+public sealed class TotalPagesRead() : ScalarObjectBase<Counter64>(SnmpOids.Server.TotalPagesRead), IMetricInstrument<long>
+{
+    protected override Counter64 GetData()
+    {
+        return new Counter64((ulong)PagingStatistics.GetTotals().TotalReads);
+    }
+
+    public long GetCurrentMeasurement() => PagingStatistics.GetTotals().TotalReads;
+}

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.5/TotalPagesWritten.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.5/TotalPagesWritten.cs
@@ -1,0 +1,15 @@
+using Lextm.SharpSnmpLib;
+using Raven.Server.Monitoring.OpenTelemetry;
+using Voron.Impl.Paging;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server;
+
+public sealed class TotalPagesWritten() : ScalarObjectBase<Counter64>(SnmpOids.Server.TotalPagesRead), IMetricInstrument<long>
+{
+    protected override Counter64 GetData()
+    {
+        return new Counter64((ulong)PagingStatistics.GetTotals().TotalWrites);
+    }
+
+    public long GetCurrentMeasurement() => PagingStatistics.GetTotals().TotalWrites;
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpMibWriter.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpMibWriter.cs
@@ -88,6 +88,9 @@ public class SnmpMibWriter : IAsyncDisposable
             case SnmpType.TimeTicks:
                 await _writer.WriteLineAsync("   SYNTAX TimeTicks");
                 break;
+            case SnmpType.Counter64:
+                await _writer.WriteLineAsync("   SYNTAX Counter64");
+                break; 
             default:
                 throw new ArgumentOutOfRangeException(nameof(typeCode), typeCode, null);
         }

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -102,6 +102,14 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("IO wait in %")]
             public const string MachineIoWait = "1.5.4";
 
+            [SnmpDataType(SnmpType.Counter64)]
+            [Description("Total number of pages read by the server since last start (across all databases & indexes)")]
+            public const string TotalPagesRead = "1.5.5.1";
+            
+            [SnmpDataType(SnmpType.Counter64)]
+            [Description("Total number of pages written by the server since last start (across all databases & indexes)")]
+            public const string TotalPagesWritten = "1.5.5.2";
+            
             [SnmpDataType(SnmpType.Gauge32)]
             [Description("Server allocated memory in MB")]
             public const string TotalMemory = "1.6.1";

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -388,6 +388,9 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new ProcessCpu(server.MetricCacher, server.CpuUsageCalculator));
             store.Add(new MachineCpu(server.MetricCacher, server.CpuUsageCalculator));
             store.Add(new IoWait(server.MetricCacher, server.CpuUsageCalculator));
+            
+            store.Add(new TotalPagesRead());
+            store.Add(new TotalPagesWritten());
 
             store.Add(new CpuCreditsBase(server.CpuCreditsBalance));
             store.Add(new CpuCreditsMax(server.CpuCreditsBalance));

--- a/src/Voron/Impl/Journal/JournalFile.cs
+++ b/src/Voron/Impl/Journal/JournalFile.cs
@@ -14,6 +14,7 @@ using Sparrow.Logging;
 using System.Threading;
 using Sparrow.Collections;
 using Sparrow.Server;
+using Voron.Impl.Paging;
 using Voron.Util;
 using Constants = Voron.Global.Constants;
 
@@ -139,6 +140,7 @@ namespace Voron.Impl.Journal
         /// </summary>
         public void Write(long posBy4Kb, byte* p, int numberOf4Kbs)
         {
+            PagingStatistics.MarkWrite(numberOf4Kbs / 2 + numberOf4Kbs % 2);
             int posBy4Kbs = 0;
             while (posBy4Kbs < numberOf4Kbs)
             {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -807,6 +807,7 @@ namespace Voron.Impl
 #if VALIDATE
             VerifyNoDuplicateScratchPages();
 #endif
+                PagingStatistics.MarkWrite(numberOfPages);
                 var pageFromScratchBuffer = _env.ScratchBufferPool.Allocate(this, numberOfPages);
                 pageFromScratchBuffer.PreviousVersion = previousVersion;
                 _transactionPages.Add(pageFromScratchBuffer);

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -805,6 +805,8 @@ namespace Voron.Impl.Paging
 
         public void Write(long posBy4Kbs, int numberOf4Kbs, byte* source)
         {
+            PagingStatistics.MarkWrite(numberOf4Kbs / 2 + numberOf4Kbs % 2);
+            
             const int pageSizeTo4KbRatio = (Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte));
             var pageNumber = posBy4Kbs / pageSizeTo4KbRatio;
             var offsetBy4Kb = posBy4Kbs % pageSizeTo4KbRatio;

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -344,12 +344,16 @@ namespace Voron.Impl.Paging
 
         public virtual byte* AcquirePagePointer(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null)
         {
-            return AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            byte* p = AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            PagingStatistics.MarkRead(VirtualPagerLegacyExtensions.GetNumberOfPages((PageHeader*)p));
+            return p;
         }
 
         public virtual byte* AcquirePagePointerForNewPage(IPagerLevelTransactionState tx, long pageNumber, int numberOfPages, PagerState pagerState = null)
         {
-            return AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            byte* p = AcquirePagePointerInternal(tx, pageNumber, pagerState);
+            PagingStatistics.MarkRead(numberOfPages);
+            return p;
         }
         
         public virtual T AcquirePagePointerHeader<T>(IPagerLevelTransactionState tx, long pageNumber, PagerState pagerState = null) where T : unmanaged

--- a/src/Voron/Impl/Paging/PagingStatistics.cs
+++ b/src/Voron/Impl/Paging/PagingStatistics.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Sparrow.Binary;
+
+namespace Voron.Impl.Paging;
+
+public static class PagingStatistics
+{
+    [StructLayout(LayoutKind.Explicit, Size = 64)] // Cache line alignment (64 bytes)
+    private struct Counter
+    {
+        [FieldOffset(0)]
+        public long PageReads;
+        [FieldOffset(8)]
+        public long PageWrites;
+    }
+
+    private static readonly Counter[] Counters;
+    private static readonly int CoreCountMask;
+
+    static PagingStatistics()
+    {
+        int coreCount = Bits.PowerOf2(Environment.ProcessorCount);
+        Counters = new Counter[coreCount];
+        CoreCountMask = coreCount - 1;
+    }
+
+    public static void MarkRead(long l)
+    {
+        int coreId = Thread.GetCurrentProcessorId() & CoreCountMask;
+        Interlocked.Add(ref Counters[coreId].PageReads, l);
+    }
+
+    public static void MarkWrite(long l)
+    {
+        int coreId = Thread.GetCurrentProcessorId() & CoreCountMask;
+        Interlocked.Add(ref Counters[coreId].PageWrites, l);
+    }
+
+    public static (long TotalReads, long TotalWrites) GetTotals()
+    {
+        long totalReads = 0, totalWrites = 0;
+        for (int i = 0; i < Counters.Length; i++)
+        {
+            totalReads += Interlocked.Read(ref Counters[i].PageReads);
+            totalWrites += Interlocked.Read(ref Counters[i].PageWrites);
+        }
+        return (totalReads, totalWrites);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24517 

### Additional description

- Added tracking for how many pages we read & write at the pager level for the whole process.
- Exposed that via debug endpoint + SNMP

Using structs whose size match the cache line size to ensure that different processes will not compete for the same cache line to reduce contention

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No
