### PR TITLE
[6.2] RavenDB-24530 - Apply client configuration properties based on enabled flags

### DIFF
--- a/src/Raven.Studio/typescript/components/common/clientConfiguration/ClientConfigurationUtils.ts
+++ b/src/Raven.Studio/typescript/components/common/clientConfiguration/ClientConfigurationUtils.ts
@@ -90,11 +90,11 @@ export default class ClientConfigurationUtils {
         }
 
         return {
-            IdentityPartsSeparator: formData.identityPartsSeparatorValue,
-            LoadBalanceBehavior: formData.loadBalancerValue,
+            IdentityPartsSeparator: formData.identityPartsSeparatorEnabled ? formData.identityPartsSeparatorValue : null,
+            LoadBalanceBehavior: formData.loadBalancerEnabled ? formData.loadBalancerValue : null,
             LoadBalancerContextSeed: formData.loadBalancerSeedEnabled ? formData.loadBalancerSeedValue : null,
-            ReadBalanceBehavior: formData.readBalanceBehaviorValue,
-            MaxNumberOfRequestsPerSession: formData.maximumNumberOfRequestsValue,
+            ReadBalanceBehavior: formData.readBalanceBehaviorEnabled ? formData.readBalanceBehaviorValue : null,
+            MaxNumberOfRequestsPerSession: formData.maximumNumberOfRequestsEnabled ? formData.maximumNumberOfRequestsValue : null,
             Disabled: !formData.overrideConfig,
             Etag: undefined,
         };

--- a/src/Raven.Studio/typescript/components/common/clientConfiguration/ClientConfigurationUtils.ts
+++ b/src/Raven.Studio/typescript/components/common/clientConfiguration/ClientConfigurationUtils.ts
@@ -90,11 +90,15 @@ export default class ClientConfigurationUtils {
         }
 
         return {
-            IdentityPartsSeparator: formData.identityPartsSeparatorEnabled ? formData.identityPartsSeparatorValue : null,
+            IdentityPartsSeparator: formData.identityPartsSeparatorEnabled
+                ? formData.identityPartsSeparatorValue
+                : null,
             LoadBalanceBehavior: formData.loadBalancerEnabled ? formData.loadBalancerValue : null,
             LoadBalancerContextSeed: formData.loadBalancerSeedEnabled ? formData.loadBalancerSeedValue : null,
             ReadBalanceBehavior: formData.readBalanceBehaviorEnabled ? formData.readBalanceBehaviorValue : null,
-            MaxNumberOfRequestsPerSession: formData.maximumNumberOfRequestsEnabled ? formData.maximumNumberOfRequestsValue : null,
+            MaxNumberOfRequestsPerSession: formData.maximumNumberOfRequestsEnabled
+                ? formData.maximumNumberOfRequestsValue
+                : null,
             Disabled: !formData.overrideConfig,
             Etag: undefined,
         };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24530/Client-configuration-properties-should-conditionally-apply-based-on-enabled-flags

### Additional description

Client configuration properties like `IdentityPartsSeparator`, `LoadBalanceBehavior`, `ReadBalanceBehavior`, and `MaxNumberOfRequestsPerSession` are always set to their form values, even when users may not want to override the default RavenDB conventions.
Now, these properties are only set when their corresponding "enabled" flags are true. When disabled, they are set to `null` to allow the RavenDB client API to use values from conventions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
