### PR TITLE
[5.4] RavenDB-24530 - Apply client configuration properties based on enabled flags

### DIFF
--- a/src/Raven.Studio/typescript/models/database/settings/clientConfigurationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/clientConfigurationModel.ts
@@ -39,13 +39,19 @@ class clientConfigurationModel {
             if (dto.LoadBalanceBehavior === "UseSessionContext") {
                 this.isDefined.push("useSessionContextForLoadBehavior");
                 this.useSessionContextForLoadBehavior("UseSessionContext");
-                
+
                 if (dto.LoadBalancerContextSeed || dto.LoadBalancerContextSeed === 0) {
                     this.isDefined.push("loadBalanceContextSeed");
                     this.loadBalanceContextSeed(dto.LoadBalancerContextSeed);
                     this.setLoadBalanceSeed(true);
                 }
-            } else if (dto.ReadBalanceBehavior != null) {
+            }
+            else if (dto.LoadBalanceBehavior === "None") {
+                this.isDefined.push("useSessionContextForLoadBehavior");
+                this.useSessionContextForLoadBehavior("None");
+            }
+
+            if (dto.ReadBalanceBehavior != null) {
                 this.isDefined.push("readBalanceBehavior");
                 this.readBalanceBehavior(dto.ReadBalanceBehavior);
             }

--- a/src/Raven.Studio/typescript/models/database/settings/clientConfigurationModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/clientConfigurationModel.ts
@@ -178,7 +178,7 @@ class clientConfigurationModel {
     toDto(): Raven.Client.Documents.Operations.Configuration.ClientConfiguration {
         return {
             IdentityPartsSeparator: _.includes(this.isDefined(), "identityPartsSeparator") ? this.identityPartsSeparator() : null,
-            LoadBalanceBehavior: _.includes(this.isDefined(), "useSessionContextForLoadBehavior") ? "UseSessionContext" : "None",
+            LoadBalanceBehavior: _.includes(this.isDefined(), "useSessionContextForLoadBehavior") ? this.useSessionContextForLoadBehavior() : null,
             LoadBalancerContextSeed: _.includes(this.isDefined(), "useSessionContextForLoadBehavior") && _.includes(this.isDefined(), "loadBalanceContextSeed") ? this.loadBalanceContextSeed() : null,
             ReadBalanceBehavior: _.includes(this.isDefined(), "readBalanceBehavior") ? this.readBalanceBehavior() : null,
             MaxNumberOfRequestsPerSession: _.includes(this.isDefined(), "maxNumberOfRequestsPerSession") ? this.maxNumberOfRequestsPerSession() : null,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24530/Client-configuration-properties-should-conditionally-apply-based-on-enabled-flags

### Additional description

- Separate the handling of `LoadBalanceBehavior` and `ReadBalanceBehavior` so they can be set independently.
- Changed `LoadBalanceBehavior` to use actual form value or null for conventions fallback - port from 6.2 - https://github.com/ravendb/ravendb/pull/20867.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
