### PR TITLE
RavenDB-24402 : flaky test adjustments  

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -798,7 +798,7 @@ for(const comment of this.Comments)
         value = await WaitForValueAsync(() =>
         {
             stats2 = etlProcess.GetPerformanceStats()
-                .Where(x => x.NumberOfLoadedItems > 0 && x.LastLoadedEtag > etag && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
+                .Where(x => x.NumberOfLoadedItems > 0 && x.LastLoadedEtag == etag + 1 && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
                 .ToArray();
             return stats2.Length > 0;
         }, expectedVal: true, timeout: 60_000);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24402/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenSchemaChangesoptions-DatabaseMode-Single-configuration

### Additional description

Ensure that we're examining the relevant stats (after update there's another ETL batch that does nothing and new stats which are irrelevant for the test)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
