### PR TITLE
RavenDB-24552 - Handle non json format possible response from agent

### DIFF
--- a/src/Raven.Server/Documents/AI/AbstractChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/AbstractChatCompletionClient.cs
@@ -19,8 +19,8 @@ using Microsoft.IdentityModel.Tokens;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
-using Raven.Client.Util;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
 using JsonSerializer = System.Text.Json.JsonSerializer;
@@ -232,16 +232,22 @@ public abstract class AbstractChatCompletionClient<TContext> : IChatCompletionCl
     public virtual async Task<BlittableJsonReaderObject> GetResponseContentAsync(JsonOperationContext context, HttpResponseMessage response, CancellationToken token)
     {
         await using (var responseStream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false))
+        await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
-            var contentLength = response.Content.Headers.ContentLength;
-            if (contentLength.HasValue && contentLength == 0)
-                return null;
-
-            // we intentionally don't dispose the reader here, we'll be using it
-            // in the command, any associated memory will be released on context reset
-            await using (var stream = new StreamWithTimeout(responseStream))
+            await responseStream.CopyToAsync(ms, token);
+            ms.Position = 0;
+            try
             {
-                return await context.ReadForMemoryAsync(stream, "response/object").ConfigureAwait(false);
+                return await context.ReadForMemoryAsync(ms, "response/object").ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                ms.Position = 0;
+                string content = Encoding.UTF8.GetString(ms.GetMemory().Span);
+                throw new UnexpectedResponseException($"Got unrecognized response from the server: {content}. {response.StatusCode}", e)
+                {
+                    RequestId = GetRequestId(response.Headers)
+                };
             }
         }
     }

--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -4,8 +4,16 @@ using System.Net;
 namespace Raven.Server.Documents.AI
 {
     /// <summary>Base for all Gen‑AI service errors.</summary>
-    public class AiException(string message) : Exception(message)
+    public class AiException : Exception
     {
+        public AiException(string message) : base(message)
+        {
+        }
+
+        public AiException(string message, Exception e) : base(message, e)
+        {
+        }
+
         public required string RequestId { get; set; }
     }
 
@@ -15,8 +23,14 @@ namespace Raven.Server.Documents.AI
         public string FinishReason;
     }
 
-    public sealed class UnexpectedResponseException(string message) : AiException(message)
+    public sealed class UnexpectedResponseException : AiException
     {
+        public UnexpectedResponseException(string message) : base(message)
+        {
+        }
+        public UnexpectedResponseException(string message, Exception e) : base(message, e)
+        {
+        }
     }
 
     public class UnsuccessfulRequestException : AiException


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24552/SlowTests.Server.Documents.AI.ChatCompletionClientTests.RefuseToAnsweroptions-DatabaseMode-Single-configuration

### Additional description

SlowTests.Server.Documents.AI.ChatCompletionClientTests.RefuseToAnswer(options: DatabaseMode = Single, configuration: OpenAi_AiIntegrationTask) fails because of InvalidDataException when tries to convert the content to blittable (because it isn't in json format - "error code: 502").
There is no problem with the test, BUT I took care about handling such response contents when we get error response status code - this scenario (of getting non-JSON content) could happen only on non-successful requests..

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
