### PR TITLE
RavenDB-23354 Unifying the implementation of StreamingWithTimeout with 5.4/6.2/7.0.

### DIFF
--- a/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
@@ -45,10 +45,20 @@ namespace Raven.Client.Documents.Commands
         {
             var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
+            var streamWithTimeout = new StreamWithTimeout(responseStream);
+
+            if (Timeout != null)
+            {
+                var timeout = (int)Timeout.Value.TotalMilliseconds;
+                
+                streamWithTimeout.ReadTimeout = timeout;
+                streamWithTimeout.WriteTimeout = timeout;           
+            }
+            
             Result = new StreamResult
             {
                 Response = response,
-                Stream = new StreamWithTimeout(responseStream)
+                Stream = streamWithTimeout
             };
 
             return ResponseDisposeHandling.Manually;

--- a/src/Raven.Client/Documents/Commands/StreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/StreamCommand.cs
@@ -31,15 +31,20 @@ namespace Raven.Client.Documents.Commands
         {
             var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
-            var timeout = (int)(Timeout ?? StreamWithTimeout.DefaultReadTimeout).TotalMilliseconds;
+            var streamWithTimeout = new StreamWithTimeout(responseStream);
+
+            if (Timeout != null)
+            {
+                var timeout = (int)Timeout.Value.TotalMilliseconds;
+                
+                streamWithTimeout.ReadTimeout = timeout;
+                streamWithTimeout.WriteTimeout = timeout;           
+            }
+            
             Result = new StreamResult
             {
                 Response = response,
-                Stream = new StreamWithTimeout(responseStream)
-                {
-                    ReadTimeout = timeout,
-                    WriteTimeout = timeout
-                }
+                Stream = streamWithTimeout
             };
 
             return ResponseDisposeHandling.Manually;

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -6,9 +6,13 @@ using System.Threading.Tasks;
 
 namespace Raven.Client.Util
 {
-    internal sealed class StreamWithTimeout : Stream
+    internal sealed class StreamWithTimeout : Stream, IAsyncDisposable
     {
+        private static readonly TimeSpan DefaultWriteTimeout = TimeSpan.FromSeconds(120);
         internal static TimeSpan DefaultReadTimeout { get; } = TimeSpan.FromSeconds(120);
+
+        private static readonly int DefaultMinimumWriteDelayTimeInMs = (int)(DefaultWriteTimeout.TotalMilliseconds / 3);
+        private static readonly int DefaultMinimumReadDelayTimeInMs = (int)(DefaultReadTimeout.TotalMilliseconds / 3);
 
         private Stopwatch _writeSw;
         private Stopwatch _readSw;
@@ -16,8 +20,10 @@ namespace Raven.Client.Util
         internal readonly Stream _stream;
         private int _writeTimeout;
         private int _readTimeout;
-        private int _minimumWriteDelayTimeInMs;
-        private int _minimumReadDelayTimeInMs;
+        private int _minimumWriteDelayTimeInMs = DefaultMinimumWriteDelayTimeInMs;
+        private int _minimumReadDelayTimeInMs = DefaultMinimumReadDelayTimeInMs;
+        private bool _canBaseStreamTimeoutOnWrite;
+        private bool _canBaseStreamTimeoutOnRead;
         private CancellationTokenSource _writeCts;
         private CancellationTokenSource _readCts;
 
@@ -26,12 +32,83 @@ namespace Raven.Client.Util
         private CancellationToken _requestWriteCts;
 #endif
 
-        private long _totalRead;
-        private long _totalWritten;
+        private long _totalRead = 0;
+        private long _totalWritten = 0;
 
         public StreamWithTimeout(Stream stream)
         {
             _stream = stream;
+            SetWriteTimeoutIfNeeded(DefaultWriteTimeout);
+            SetReadTimeoutIfNeeded(DefaultReadTimeout);
+        }
+
+        private void SetReadTimeoutIfNeeded(TimeSpan readTimeout)
+        {
+            try
+            {
+                _readTimeout = (int)readTimeout.TotalMilliseconds;
+                _canBaseStreamTimeoutOnRead = _stream.CanRead && _stream.CanTimeout;
+
+                if (_canBaseStreamTimeoutOnRead)
+                {
+                    var streamReadTimeout = _stream.ReadTimeout;
+                    if (streamReadTimeout > 0)
+                    {
+                        ReadTimeout = streamReadTimeout;
+                        return;
+                    }
+
+                    try
+                    {
+                        _stream.ReadTimeout = _readTimeout;
+                    }
+                    catch
+                    {
+                        if (streamReadTimeout <= _readTimeout)
+                            ReadTimeout = streamReadTimeout;
+                        else
+                            _canBaseStreamTimeoutOnRead = false;
+                    }
+                }
+            }
+            catch
+            {
+                _canBaseStreamTimeoutOnRead = false;
+            }
+        }
+
+        private void SetWriteTimeoutIfNeeded(TimeSpan writeTimeout)
+        {
+            try
+            {
+                _writeTimeout = (int)writeTimeout.TotalMilliseconds;
+                _canBaseStreamTimeoutOnWrite = _stream.CanWrite && _stream.CanTimeout;
+
+                if (_canBaseStreamTimeoutOnWrite)
+                {
+                    var streamWriteTimeout = _stream.WriteTimeout;
+                    if (streamWriteTimeout > 0)
+                    {
+                        WriteTimeout = streamWriteTimeout;
+                        return;
+                    }
+                    try
+                    {
+                        _stream.WriteTimeout = _writeTimeout;
+                    }
+                    catch
+                    {
+                        if (streamWriteTimeout <= _writeTimeout)
+                            WriteTimeout = streamWriteTimeout;
+                        else
+                            _canBaseStreamTimeoutOnWrite = false;
+                    }
+                }
+            }
+            catch
+            {
+                _canBaseStreamTimeoutOnWrite = false;
+            }
         }
 
         public override int ReadTimeout
@@ -39,11 +116,9 @@ namespace Raven.Client.Util
             get => _readTimeout;
             set
             {
-                if (_stream.CanRead && _stream.CanTimeout)
-                {
+                if (_canBaseStreamTimeoutOnRead)
                     _stream.ReadTimeout = value; // we only need to set it when base stream supports that, if not we are handling that ourselves
-                    return;
-                }
+
                 _readTimeout = value;
                 _minimumReadDelayTimeInMs = value / 3;
             }
@@ -54,11 +129,8 @@ namespace Raven.Client.Util
             get => _writeTimeout;
             set
             {
-                if (_stream.CanWrite && _stream.CanTimeout)
-                {
+                if (_canBaseStreamTimeoutOnWrite)
                     _stream.WriteTimeout = value;  // we only need to set it when base stream supports that, if not we are handling that ourselves
-                    return;
-                }
 
                 _writeTimeout = value;
                 _minimumWriteDelayTimeInMs = value / 3;
@@ -79,7 +151,7 @@ namespace Raven.Client.Util
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            if (_readTimeout == 0)
+            if (_canBaseStreamTimeoutOnRead)
             {
                 var read = _stream.Read(buffer, offset, count);
                 _totalRead += read;
@@ -98,21 +170,19 @@ namespace Raven.Client.Util
 
         private async Task<int> ReadAsyncWithTimeout(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (_readTimeout > 0)
+            if (_readCts == null)
             {
-                if (_readCts == null)
-                {
                 _readCts = GenerateCancellationTokenWithTimeout(_readTimeout, cancellationToken);
-                    _readSw = Stopwatch.StartNew();
+                _readSw = Stopwatch.StartNew();
 
 #if DEBUG
-                    _requestReadCts = cancellationToken;
+                _requestReadCts = cancellationToken;
 #endif
-                }
-                else if (_readSw.ElapsedMilliseconds > _minimumReadDelayTimeInMs)
-                {
-                    _readSw.Restart();
-                    _readCts.CancelAfter(_readTimeout);
+            }
+            else if (_readSw.ElapsedMilliseconds > _minimumReadDelayTimeInMs)
+            {
+                _readSw.Restart();
+                _readCts.CancelAfter(_readTimeout);
 
                 if (_readCts.IsCancellationRequested)
                 {
@@ -121,15 +191,12 @@ namespace Raven.Client.Util
                 }
 
 #if DEBUG
-                    if (_requestReadCts != cancellationToken)
-                        throw new InvalidOperationException("The cancellation token was changed during the request");
+                if (_requestReadCts != cancellationToken)
+                    throw new InvalidOperationException("The cancellation token was changed during the request");
 #endif
-                }
-
-                cancellationToken = _readCts.Token;
             }
 
-            var read = await _stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            var read = await _stream.ReadAsync(buffer, offset, count, _readCts.Token).ConfigureAwait(false);
             _totalRead += read;
             return read;
         }
@@ -148,7 +215,7 @@ namespace Raven.Client.Util
         {
             _totalWritten += count;
 
-            if (_writeTimeout == 0)
+            if (_canBaseStreamTimeoutOnWrite)
             {
                 _stream.Write(buffer, offset, count);
                 return;
@@ -166,21 +233,19 @@ namespace Raven.Client.Util
 
         private Task WriteAsyncWithTimeout(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (_writeTimeout > 0)
+            if (_writeCts == null)
             {
-                if (_writeCts == null)
-                {
                 _writeCts = GenerateCancellationTokenWithTimeout(_writeTimeout, cancellationToken);
-                    _writeSw = Stopwatch.StartNew();
+                _writeSw = Stopwatch.StartNew();
 
 #if DEBUG
-                    _requestWriteCts = cancellationToken;
+                _requestWriteCts = cancellationToken;
 #endif
-                }
-                else if (_writeSw.ElapsedMilliseconds > _minimumWriteDelayTimeInMs)
-                {
-                    _writeSw.Restart();
-                    _writeCts.CancelAfter(_writeTimeout);
+            }
+            else if (_writeSw.ElapsedMilliseconds > _minimumWriteDelayTimeInMs)
+            {
+                _writeSw.Restart();
+                _writeCts.CancelAfter(_writeTimeout);
 
                 if (_writeCts.IsCancellationRequested)
                 {
@@ -189,15 +254,12 @@ namespace Raven.Client.Util
                 }
 
 #if DEBUG
-                    if (_requestWriteCts != cancellationToken)
-                        throw new InvalidOperationException("The cancellation token was changed during the request");
+                if (_requestWriteCts != cancellationToken)
+                    throw new InvalidOperationException("The cancellation token was changed during the request");
 #endif
-                }
-
-                cancellationToken = _writeCts.Token;
             }
 
-            return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+            return _stream.WriteAsync(buffer, offset, count, _writeCts.Token);
         }
 
         private static CancellationTokenSource GenerateCancellationTokenWithTimeout(int timeout, CancellationToken ct)


### PR DESCRIPTION
Otherwise `StreamWithTimeout` never timed out so `StreamingWithTimeout.TimeoutOnHangingStreamQuery` test was hanging.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23354/HangingTest-StressTests.Client.StreamingWithTimeout.TimeoutOnHangingStreamQuery

### Additional description

This test was hanging only in v8.0 branch. The implementation of `StreamWithTimeout` was different there that in 6.x or 7.x and the issue is that we never get the timeout while this test is forcing that.

There were changes to `StreamWithTimeout` in https://github.com/ravendb/ravendb/pull/18908. In particular the following commits:

- https://github.com/ravendb/ravendb/commit/4bd2e881cd7d396ba67d29c6d4c9904bdf655735
- https://github.com/ravendb/ravendb/commit/f9cccffe4341fbc3da22efafeb1cfd203029aa56
- https://github.com/ravendb/ravendb/commit/54ae5e839d3c1981e2c6933514a328ac2494ac34

There was also a commit which explicitly set timeout for `StreamCommand` - https://github.com/ravendb/ravendb/commit/f182c566bea163bb4d864bee1a7b73f6b5644a6c, but it didn't set it in any other places where `new StreamWithTimeout()` was called. So effectively it wasn't set to timeout there as well.

---

Another thing is that the above changes were made long time ago, but meanwhile we had optimizations to `StreamWithTimeout` implementation that were not applied to v8.0 because the code was very different. I'm taking about PRs:

- https://github.com/ravendb/ravendb/pull/19096
- https://github.com/ravendb/ravendb/pull/19208

---

To summarize, this PR makes the implementation of `StreamWithTimeout` to be the same as in 5,4/6.2/7.0 so we'll properly time out wherever we use it.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
