### PR TITLE
RavenDB-24478: Obsolete test fact attribute warnings

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
@@ -131,7 +131,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
     });
 }";
     
-    [RequiresNpgSqlFact]
+    [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.NpgSql)]
     public async Task CanReplicateToArraysInPostgresSQL()
     {
         MigrationProvider provider = MigrationProvider.NpgSQL;

--- a/test/SlowTests/Server/Documents/Migration/MongoDBMigrationTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/MongoDBMigrationTest.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Server.Documents.Migration
             }
         }
 
-        [RequiresMongoDBFact]
+        [RavenFact(RavenTestCategory.BackupExportImport, Requires = RavenServiceRequirement.MongoDB)]
         public async Task MigrateMongodb_WhenHasTwoCollectionAndImportAll_ShouldImportTheTwoCollectionWithAllThereDocuments()
         {
             var expectedBooks = new[] { new Book { Title = "Great Book1!!!" } };

--- a/test/SlowTests/Server/Documents/Migration/NpgSQLSchemaTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/NpgSQLSchemaTest.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Server.Documents.Migration
         {
         }
 
-        [RequiresNpgSqlFact]
+        [RavenFact(RavenTestCategory.BackupExportImport, Requires = RavenServiceRequirement.NpgSql)]
         public void CanFetchSchema()
         {
             using (WithSqlDatabase(MigrationProvider.NpgSQL, out var connectionString, out string schemaName, includeData: false))

--- a/test/SlowTests/Server/Documents/Migration/OracleSQLSchemaTest.cs
+++ b/test/SlowTests/Server/Documents/Migration/OracleSQLSchemaTest.cs
@@ -13,7 +13,7 @@ namespace SlowTests.Server.Documents.Migration
         {
         }
 
-        [RequiresOracleSqlFact]
+        [RavenFact(RavenTestCategory.BackupExportImport, Requires = RavenServiceRequirement.OracleSql)]
         public void CanFetchSchema()
         {
             using (WithSqlDatabase(MigrationProvider.Oracle, out var connectionString, out string schemaName, includeData: false))

--- a/test/Tests.Infrastructure/LicenseRequiredTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/LicenseRequiredTheoryAttribute.cs
@@ -8,8 +8,8 @@ namespace Tests.Infrastructure
         {
             get
             {
-                if (LicenseRequiredFactAttribute.ShouldSkip())
-                    return LicenseRequiredFactAttribute.SkipMessage;
+                if (RavenFactAttribute.ShouldSkipLicense(out var skipMessage))
+                    return skipMessage;
 
                 return null;
             }

--- a/test/Tests.Infrastructure/RavenFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenFactAttribute.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using System;
+using Tests.Infrastructure.ConnectionString;
+using Xunit;
 using Xunit.Sdk;
 
 namespace Tests.Infrastructure;
@@ -16,37 +18,79 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
 
     public bool LicenseRequired { get; set; }
 
-    public bool MsSqlRequired { get; set; }
-
-    public bool ElasticSearchRequired { get; set; }
-
-    public bool AzureQueueStorageRequired { get; set; }
-
     public bool NightlyBuildRequired { get; set; }
+
+    public RavenServiceRequirement Requires { get; set; } = RavenServiceRequirement.None;
+
+    // Legacy properties for backward compatibility
+    public bool MsSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.MsSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.MsSql : Requires & ~RavenServiceRequirement.MsSql;
+    }
+
+    public bool ElasticSearchRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.ElasticSearch);
+        set => Requires = value ? Requires | RavenServiceRequirement.ElasticSearch : Requires & ~RavenServiceRequirement.ElasticSearch;
+    }
+
+    public bool AzureQueueStorageRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.AzureQueueStorage);
+        set => Requires = value ? Requires | RavenServiceRequirement.AzureQueueStorage : Requires & ~RavenServiceRequirement.AzureQueueStorage;
+    }
+
+    public bool OracleSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.OracleSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.OracleSql : Requires & ~RavenServiceRequirement.OracleSql;
+    }
+
+    public bool NpgSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.NpgSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.NpgSql : Requires & ~RavenServiceRequirement.NpgSql;
+    }
+
+    public bool MongoDBRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.MongoDB);
+        set => Requires = value ? Requires | RavenServiceRequirement.MongoDB : Requires & ~RavenServiceRequirement.MongoDB;
+    }
 
     public override string Skip
     {
         get
         {
-            return ShouldSkip(_skip, Category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, msSqlRequired: MsSqlRequired, elasticSearchRequired: ElasticSearchRequired, azureQueueStorageRequired: AzureQueueStorageRequired);
+            return ShouldSkip(_skip, Category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, serviceRequirement: Requires);
         }
 
         set => _skip = value;
     }
 
-    internal static string ShouldSkip(string skip, RavenTestCategory category, bool licenseRequired, bool nightlyBuildRequired, bool msSqlRequired, bool elasticSearchRequired, bool azureQueueStorageRequired)
+    internal static string ShouldSkip(string skip, RavenTestCategory category, bool licenseRequired, bool nightlyBuildRequired, RavenServiceRequirement serviceRequirement)
     {
         var s = ShouldSkip(skip, category, licenseRequired: licenseRequired, nightlyBuildRequired: nightlyBuildRequired);
         if (s != null)
             return s;
 
-        if (msSqlRequired && RequiresMsSqlFactAttribute.ShouldSkip(out skip))
+        if (serviceRequirement.HasFlag(RavenServiceRequirement.MsSql) && ShouldSkipMsSql(out skip))
             return skip;
 
-        if (elasticSearchRequired && RequiresElasticSearchRetryFactAttribute.ShouldSkip(out skip))
+        if (serviceRequirement.HasFlag(RavenServiceRequirement.OracleSql) && ShouldSkipOracleSql(out skip))
             return skip;
 
-        if (azureQueueStorageRequired && AzureQueueStorageHelper.ShouldSkip(out skip))
+        if (serviceRequirement.HasFlag(RavenServiceRequirement.NpgSql) && ShouldSkipNpgSql(out skip))
+            return skip;
+
+        if (serviceRequirement.HasFlag(RavenServiceRequirement.MongoDB) && ShouldSkipMongoDB(out skip))
+            return skip;
+
+        if (serviceRequirement.HasFlag(RavenServiceRequirement.ElasticSearch) && ShouldSkipElasticSearch(out skip))
+            return skip;
+
+        if (serviceRequirement.HasFlag(RavenServiceRequirement.AzureQueueStorage) && ShouldSkipAzureQueueStorage(out skip))
             return skip;
 
         return null;
@@ -63,12 +107,69 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
                 return RavenDataAttributeBase.ShardingSkipMessage;
         }
 
-        if (licenseRequired && LicenseRequiredFactAttribute.ShouldSkip())
-            return LicenseRequiredFactAttribute.SkipMessage;
+        if (licenseRequired && ShouldSkipLicense(out skip))
+            return skip;
 
         if (nightlyBuildRequired && NightlyBuildFactAttribute.ShouldSkip(out skip))
             return skip;
 
         return null;
+    }
+
+    private static bool ShouldSkipService(Func<bool> canConnect, string serviceName, out string skipMessage)
+    {
+        if (RavenTestHelper.SkipIntegrationTests)
+        {
+            skipMessage = RavenTestHelper.SkipIntegrationMessage;
+            return true;
+        }
+
+        if (RavenTestHelper.IsRunningOnCI)
+        {
+            skipMessage = null;
+            return false;
+        }
+
+        if (canConnect())
+        {
+            skipMessage = null;
+            return false;
+        }
+
+        skipMessage = $"Test requires {serviceName}";
+        return true;
+    }
+
+    private static bool ShouldSkipMsSql(out string skipMessage) =>
+        ShouldSkipService(() => MsSqlConnectionString.Instance.CanConnect, "MsSQL database", out skipMessage);
+
+    private static bool ShouldSkipOracleSql(out string skipMessage) =>
+        ShouldSkipService(() => OracleConnectionString.Instance.CanConnect, "Oracle database", out skipMessage);
+
+    private static bool ShouldSkipNpgSql(out string skipMessage) =>
+        ShouldSkipService(() => NpgSqlConnectionString.Instance.CanConnect, "NpgSQL database", out skipMessage);
+
+    private static bool ShouldSkipMongoDB(out string skipMessage) =>
+        ShouldSkipService(() => MongoDBConnectionString.Instance.CanConnect, "MongoDB", out skipMessage);
+
+    private static bool ShouldSkipElasticSearch(out string skipMessage) =>
+        ShouldSkipService(() => ElasticSearchTestNodes.Instance.CanConnect, "ElasticSearch instance", out skipMessage);
+
+    private static bool ShouldSkipAzureQueueStorage(out string skipMessage)
+    {
+        return AzureQueueStorageHelper.ShouldSkip(out skipMessage);
+    }
+
+    internal static bool ShouldSkipLicense(out string skipMessage)
+    {
+        var hasLicense = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("RAVEN_LICENSE"));
+        if (hasLicense)
+        {
+            skipMessage = null;
+            return false;
+        }
+
+        skipMessage = "Requires License to be set via 'RAVEN_LICENSE' environment variable.";
+        return true;
     }
 }

--- a/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
@@ -101,8 +101,8 @@ public class RavenMultiplatformFactAttribute : RavenFactAttribute
 
     internal static string ShouldSkip(RavenPlatform platform, RavenArchitecture architecture, RavenIntrinsics intrinsics, bool licenseRequired, bool nightlyBuildOnly)
     {
-        if (licenseRequired && LicenseRequiredFactAttribute.ShouldSkip())
-            return LicenseRequiredFactAttribute.SkipMessage;
+        if (licenseRequired && RavenFactAttribute.ShouldSkipLicense(out var licenseSkip))
+            return licenseSkip;
 
         if (nightlyBuildOnly && NightlyBuildTheoryAttribute.IsNightlyBuild == false)
             return NightlyBuildTheoryAttribute.SkipMessage;

--- a/test/Tests.Infrastructure/RavenRetryFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenRetryFactAttribute.cs
@@ -17,19 +17,52 @@ public class RavenRetryFactAttribute : RetryFactAttribute, ITraitAttribute
 
     public bool LicenseRequired { get; set; }
 
-    public bool MsSqlRequired { get; set; }
-
-    public bool ElasticSearchRequired { get; set; }
-
-    public bool AzureQueueStorageRequired { get; set; }
-
     public bool NightlyBuildRequired { get; set; }
+
+    public RavenServiceRequirement Requires { get; set; } = RavenServiceRequirement.None;
+
+    // Legacy properties for backward compatibility
+    public bool MsSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.MsSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.MsSql : Requires & ~RavenServiceRequirement.MsSql;
+    }
+
+    public bool ElasticSearchRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.ElasticSearch);
+        set => Requires = value ? Requires | RavenServiceRequirement.ElasticSearch : Requires & ~RavenServiceRequirement.ElasticSearch;
+    }
+
+    public bool AzureQueueStorageRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.AzureQueueStorage);
+        set => Requires = value ? Requires | RavenServiceRequirement.AzureQueueStorage : Requires & ~RavenServiceRequirement.AzureQueueStorage;
+    }
+
+    public bool OracleSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.OracleSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.OracleSql : Requires & ~RavenServiceRequirement.OracleSql;
+    }
+
+    public bool NpgSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.NpgSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.NpgSql : Requires & ~RavenServiceRequirement.NpgSql;
+    }
+
+    public bool MongoDBRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.MongoDB);
+        set => Requires = value ? Requires | RavenServiceRequirement.MongoDB : Requires & ~RavenServiceRequirement.MongoDB;
+    }
 
     public override string Skip
     {
         get
         {
-            return RavenFactAttribute.ShouldSkip(_skip, _category, licenseRequired: LicenseRequired, nightlyBuildRequired: MsSqlRequired, msSqlRequired: ElasticSearchRequired, elasticSearchRequired: NightlyBuildRequired, azureQueueStorageRequired: AzureQueueStorageRequired);
+            return RavenFactAttribute.ShouldSkip(_skip, _category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, serviceRequirement: Requires);
         }
 
         set => _skip = value;

--- a/test/Tests.Infrastructure/RavenRetryTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/RavenRetryTheoryAttribute.cs
@@ -23,11 +23,13 @@ public class RavenRetryTheoryAttribute : RetryTheoryAttribute, ITraitAttribute
 
     public bool AzureRequired { get; set; }
 
+    public RavenServiceRequirement Requires { get; set; } = RavenServiceRequirement.None;
+
     public override string Skip
     {
         get
         {
-            return RavenTheoryAttribute.ShouldSkip(_skip, _category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, s3Required: S3Required, azureRequired: AzureRequired);
+            return RavenTheoryAttribute.ShouldSkip(_skip, _category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, serviceRequirement: Requires, s3Required: S3Required, azureRequired: AzureRequired);
         }
 
         set => _skip = value;

--- a/test/Tests.Infrastructure/RavenServiceRequirement.cs
+++ b/test/Tests.Infrastructure/RavenServiceRequirement.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Tests.Infrastructure;
+
+/// <summary>
+/// Flags enum for external service requirements in RavenDB tests.
+/// These flags specify which external databases and services are required for tests to run.
+/// </summary>
+[Flags]
+public enum RavenServiceRequirement
+{
+    /// <summary>
+    /// No external service requirements.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Test requires Microsoft SQL Server database.
+    /// </summary>
+    MsSql = 1 << 0,
+
+    /// <summary>
+    /// Test requires Oracle SQL database.
+    /// </summary>
+    OracleSql = 1 << 1,
+
+    /// <summary>
+    /// Test requires PostgreSQL database.
+    /// </summary>
+    NpgSql = 1 << 2,
+
+    /// <summary>
+    /// Test requires MongoDB database.
+    /// </summary>
+    MongoDB = 1 << 3,
+
+    /// <summary>
+    /// Test requires ElasticSearch.
+    /// </summary>
+    ElasticSearch = 1 << 4,
+
+    /// <summary>
+    /// Test requires Azure Queue Storage.
+    /// </summary>
+    AzureQueueStorage = 1 << 5
+}

--- a/test/Tests.Infrastructure/RavenTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/RavenTheoryAttribute.cs
@@ -22,19 +22,58 @@ public class RavenTheoryAttribute : TheoryAttribute, ITraitAttribute
 
     public bool AzureRequired { get; set; }
 
+    public RavenServiceRequirement Requires { get; set; } = RavenServiceRequirement.None;
+
+    // Legacy properties for backward compatibility
+    public bool MsSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.MsSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.MsSql : Requires & ~RavenServiceRequirement.MsSql;
+    }
+
+    public bool ElasticSearchRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.ElasticSearch);
+        set => Requires = value ? Requires | RavenServiceRequirement.ElasticSearch : Requires & ~RavenServiceRequirement.ElasticSearch;
+    }
+
+    public bool AzureQueueStorageRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.AzureQueueStorage);
+        set => Requires = value ? Requires | RavenServiceRequirement.AzureQueueStorage : Requires & ~RavenServiceRequirement.AzureQueueStorage;
+    }
+
+    public bool OracleSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.OracleSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.OracleSql : Requires & ~RavenServiceRequirement.OracleSql;
+    }
+
+    public bool NpgSqlRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.NpgSql);
+        set => Requires = value ? Requires | RavenServiceRequirement.NpgSql : Requires & ~RavenServiceRequirement.NpgSql;
+    }
+
+    public bool MongoDBRequired 
+    { 
+        get => Requires.HasFlag(RavenServiceRequirement.MongoDB);
+        set => Requires = value ? Requires | RavenServiceRequirement.MongoDB : Requires & ~RavenServiceRequirement.MongoDB;
+    }
+
     public override string Skip
     {
         get
         {
-            return ShouldSkip(_skip, Category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, s3Required: S3Required, azureRequired: AzureRequired);
+            return ShouldSkip(_skip, Category, licenseRequired: LicenseRequired, nightlyBuildRequired: NightlyBuildRequired, serviceRequirement: Requires, s3Required: S3Required, azureRequired: AzureRequired);
         }
 
         set => _skip = value;
     }
 
-    internal static string ShouldSkip(string skip, RavenTestCategory category, bool licenseRequired, bool nightlyBuildRequired, bool s3Required, bool azureRequired)
+    internal static string ShouldSkip(string skip, RavenTestCategory category, bool licenseRequired, bool nightlyBuildRequired, RavenServiceRequirement serviceRequirement, bool s3Required, bool azureRequired)
     {
-        var s = RavenFactAttribute.ShouldSkip(skip, category, licenseRequired: licenseRequired, nightlyBuildRequired: nightlyBuildRequired);
+        var s = RavenFactAttribute.ShouldSkip(skip, category, licenseRequired: licenseRequired, nightlyBuildRequired: nightlyBuildRequired, serviceRequirement: serviceRequirement);
         if (s != null)
             return s;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24478

### Additional description

Replace obsolete database-specific fact attributes (RequiresOracleSqlFact, RequiresMsSqlFact, RequiresNpgSqlFact, RequiresMongoDBFact) with new unified RavenServiceRequirement.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
