### PR TITLE
RavenDB-24548 do not treat shared journal as an index

### DIFF
--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -5,6 +5,7 @@ using Raven.Server.Logging;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
+using Sparrow.Collections;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
 
@@ -17,6 +18,7 @@ namespace Raven.Server.Documents
         internal TimeSpan NoFailurePeriod = TimeSpan.FromMinutes(15);
 
         private readonly ConcurrentDictionary<Guid, FailureStats> _errorsPerEnvironment = new ConcurrentDictionary<Guid, FailureStats>();
+        private readonly ConcurrentSet<string> _errorsPerPath = new ConcurrentSet<string>();
 
         private readonly DatabasesLandlord _databasesLandlord;
         private readonly ServerStore _serverStore;
@@ -36,9 +38,13 @@ namespace Raven.Server.Documents
             return false;
         }
 
+        public bool ErrorAtPath(string path) => _errorsPerPath.Contains(path);
+
         public void Execute(string databaseName, Exception e, Guid environmentId, string path, string stacktrace)
         {
             var stats = _errorsPerEnvironment.GetOrAdd(environmentId, x => FailureStats.Create(MaxDatabaseUnloads));
+            if (string.IsNullOrEmpty(path) == false)
+                _errorsPerPath.TryAdd(path);
 
             if (stats.WillUnloadDatabase == false)
             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -396,6 +396,10 @@ namespace Raven.Server.Web.System
 
                 foreach (var indexPath in Directory.GetDirectories(indexesPath))
                 {
+                    var pathSetting = new PathSetting(indexPath);
+                    if (databaseConfiguration.Indexing.SharedJournalsPath.Equals(pathSetting))
+                        continue;
+
                     Index index = null;
                     try
                     {

--- a/test/SlowTests/Issues/RavenDB_24548.cs
+++ b/test/SlowTests/Issues/RavenDB_24548.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24548 : RavenTestBase
+    {
+        public RavenDB_24548(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Voron)]
+        public async Task CanStartDatabaseWithSharedJournalWithoutErrors()
+        {
+            var path = NewDataPath();
+            var name = GetDatabaseName();
+            string shardJournalPath;
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDatabaseName =_ => name,
+                       Path = path,
+                       DeleteDatabaseOnDispose = false
+                   }))
+            {
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                shardJournalPath = database.IndexStore.SharedJournals.Env.Options.BasePath.FullPath;
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Indexes));
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: false));
+            }
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDatabaseName =_ => name,
+                       Path = path,
+                   }))
+            {
+                Assert.False(Server.ServerStore.DatabasesLandlord.CatastrophicFailureHandler.ErrorAtPath(shardJournalPath));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24548 

### Additional description

Since the shared journal is inside the Indexes folder, it was treated as such upon start up.
So we tried to create it as an index and failed here:
https://github.com/ravendb/ravendb/blob/7697e88e9b737da5fb498000f9df18464669002f/src/Raven.Server/Web/System/AdminDatabasesHandler.cs#L397-L405


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
