### PR TITLE
RavenDB-24560: Adds thinking mode control for Ollama AI

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/OllamaSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OllamaSettings.cs
@@ -29,6 +29,15 @@ public sealed class OllamaSettings : AbstractAiSettings
     /// </summary>
     public string Model { get; set; }
 
+    /// <summary>
+    /// Controls whether thinking models engage their reasoning process before responding.
+    /// When true, thinking models will perform their internal reasoning process (uses more tokens, slower, better quality for complex tasks).
+    /// When false, thinking models skip the reasoning process and respond directly (fewer tokens, faster, may reduce quality for complex reasoning).
+    /// When null, the parameter is not sent (backwards compatible).
+    /// Disable thinking for speed/efficiency in simple tasks, enable for complex tasks requiring reasoning.
+    /// </summary>
+    public bool? Think { get; set; } = true;
+
     public override void ValidateFields(List<string> errors)
     {
         if (string.IsNullOrWhiteSpace(Uri))
@@ -51,6 +60,9 @@ public sealed class OllamaSettings : AbstractAiSettings
         if (Uri != ollamaSettings.Uri)
             differences |= AiSettingsCompareDifferences.EndpointConfiguration;
 
+        if (Think != ollamaSettings.Think)
+            differences |= AiSettingsCompareDifferences.EndpointConfiguration;
+
         return differences;
     }
 
@@ -59,6 +71,7 @@ public sealed class OllamaSettings : AbstractAiSettings
         var json = base.ToJson();
         json[nameof(Model)] = Model;
         json[nameof(Uri)] = Uri;
+        json[nameof(Think)] = Think;
 
         return json;
     }

--- a/src/Raven.Client/Documents/Operations/AI/OllamaSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OllamaSettings.cs
@@ -36,7 +36,7 @@ public sealed class OllamaSettings : AbstractAiSettings
     /// When null, the parameter is not sent (backwards compatible).
     /// Disable thinking for speed/efficiency in simple tasks, enable for complex tasks requiring reasoning.
     /// </summary>
-    public bool? Think { get; set; } = true;
+    public bool? Think { get; set; } = null;
 
     public override void ValidateFields(List<string> errors)
     {

--- a/src/Raven.Server/Documents/AI/AbstractChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/AbstractChatCompletionClient.cs
@@ -209,6 +209,9 @@ public abstract class AbstractChatCompletionClient<TContext> : IChatCompletionCl
                 writer.WriteObject(GetStructuredOutputSchemaAsBlittable());
                 writer.WriteEndObject();
 
+                // Allow derived classes to add custom parameters
+                WriteCustomParameters(writer);
+
                 writer.WriteEndObject();
             }
         }, IChatCompletionClient.DefaultConventions);
@@ -480,6 +483,16 @@ public abstract class AbstractChatCompletionClient<TContext> : IChatCompletionCl
 
             return jsonObj;
         }
+    }
+
+    /// <summary>
+    /// Virtual method that allows derived classes to add custom parameters to the request payload.
+    /// Override this method in provider-specific implementations to add custom parameters.
+    /// </summary>
+    protected virtual void WriteCustomParameters(AsyncBlittableJsonTextWriter writer)
+    {
+        // Default implementation does nothing
+        // Derived classes can override to add custom parameters like Ollama's "think" parameter
     }
 
     public void Dispose()

--- a/src/Raven.Server/Documents/AI/GenAi/ChatCompletionClients.cs
+++ b/src/Raven.Server/Documents/AI/GenAi/ChatCompletionClients.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.AI.GenAi
 {
@@ -23,6 +25,8 @@ namespace Raven.Server.Documents.AI.GenAi
 
     internal class OllamaChatCompletionClient : AbstractChatCompletionClient<TransactionOperationContext>
     {
+        private readonly OllamaSettings _ollamaSettings;
+
         public OllamaChatCompletionClient(GenAiConfiguration configuration, string structuredOutputSchema, TransactionContextPool contextPool, DocumentConventions conventions)
             : base(
                 baseUri: new Uri(configuration.Connection.OllamaSettings.Uri),
@@ -34,6 +38,23 @@ namespace Raven.Server.Documents.AI.GenAi
                 contextPool,
                 conventions)
         {
+            _ollamaSettings = configuration.Connection.OllamaSettings;
+        }
+
+        /// <summary>
+        /// Override to add Ollama-specific parameters like "think" to the request payload.
+        /// The "think" parameter controls whether thinking models engage their reasoning process.
+        /// Setting think=false skips reasoning entirely, providing faster responses and lower token usage.
+        /// </summary>
+        protected override void WriteCustomParameters(AsyncBlittableJsonTextWriter writer)
+        {
+            // Add Ollama-specific "think" parameter if specified
+            if (_ollamaSettings.Think.HasValue)
+            {
+                writer.WriteComma();
+                writer.WritePropertyName("think");
+                writer.WriteBool(_ollamaSettings.Think.Value);
+            }
         }
     }
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
@@ -156,6 +156,7 @@ export interface AiConnection extends ConnectionBase {
     ollamaSettings?: {
         model?: string;
         uri?: string;
+        think?: boolean;
         embeddingsMaxConcurrentBatches?: number;
     };
     embeddedSettings?: {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
@@ -390,6 +390,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 model: null,
                 uri: null,
                 embeddingsMaxConcurrentBatches: null,
+                think: null,
             },
             embeddedSettings: {
                 embeddingsMaxConcurrentBatches: null,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
@@ -1,5 +1,5 @@
 import { FlexGrow } from "components/common/FlexGrow";
-import { FormInput, FormLabel, FormSelectAutocomplete } from "components/common/Form";
+import { FormInput, FormLabel, FormSelectAutocomplete, FormSwitch } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import {
     ConnectionFormData,
@@ -35,6 +35,7 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         return tasksService.testAiConnectionString(databaseName, "Ollama", formValues.modelType, {
             Model: formValues.ollamaSettings.model,
             Uri: formValues.ollamaSettings.uri,
+            Think: formValues.ollamaSettings.think,
         });
     });
 
@@ -91,6 +92,18 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     isLoading={asyncGetModelOptions.loading}
                 />
             </div>
+            {formValues.modelType === "Chat" && (
+                <div className="mb-2">
+                    <FormSwitch control={control} name="ollamaSettings.think">
+                        <FormLabel className="form-check-label">
+                            Enable thinking mode
+                            <PopoverWithHoverWrapper message="Controls whether thinking models engage their reasoning process. When enabled, models perform internal reasoning before responding (uses more tokens, slower, better quality for complex tasks). When disabled, they respond directly (fewer tokens, faster, may reduce quality for complex reasoning). Choose based on task complexity vs speed/cost requirements.">
+                                <Icon icon="info" color="info" id="think" margin="ms-1" />
+                            </PopoverWithHoverWrapper>
+                        </FormLabel>
+                    </FormSwitch>
+                </div>
+            )}
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="ollamaSettings" />}
             <div className="d-flex mb-2">
                 <FlexGrow />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
@@ -1,5 +1,5 @@
 import { FlexGrow } from "components/common/FlexGrow";
-import { FormInput, FormLabel, FormSelectAutocomplete, FormSwitch } from "components/common/Form";
+import { FormInput, FormLabel, FormSelect, FormSelectAutocomplete } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import {
     ConnectionFormData,
@@ -94,14 +94,13 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
             </div>
             {formValues.modelType === "Chat" && (
                 <div className="mb-2">
-                    <FormSwitch control={control} name="ollamaSettings.think">
-                        <FormLabel className="form-check-label">
-                            Enable thinking mode
-                            <PopoverWithHoverWrapper message="Controls whether thinking models engage their reasoning process. When enabled, models perform internal reasoning before responding (uses more tokens, slower, better quality for complex tasks). When disabled, they respond directly (fewer tokens, faster, may reduce quality for complex reasoning). Choose based on task complexity vs speed/cost requirements.">
-                                <Icon icon="info" color="info" id="think" margin="ms-1" />
-                            </PopoverWithHoverWrapper>
-                        </FormLabel>
-                    </FormSwitch>
+                    <FormLabel>
+                        Thinking mode
+                        <PopoverWithHoverWrapper message="Controls whether thinking models engage their reasoning process. When enabled, models perform internal reasoning before responding (uses more tokens, slower, better quality for complex tasks). When disabled, they respond directly (fewer tokens, faster, may reduce quality for complex reasoning). Choose based on task complexity vs speed/cost requirements.">
+                            <Icon icon="info" color="info" margin="ms-1" />
+                        </PopoverWithHoverWrapper>
+                    </FormLabel>
+                    <FormSelect control={control} name="ollamaSettings.think" options={thinkOptions} />
                 </div>
             )}
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="ollamaSettings" />}
@@ -120,3 +119,9 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         </>
     );
 }
+
+const thinkOptions: SelectOption<boolean>[] = [
+    { label: "Default", value: null },
+    { label: "Enabled", value: true },
+    { label: "Disabled", value: false },
+];

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
@@ -395,6 +395,7 @@ export function mapAiConnectionsFromDto(
                 ollamaSettings: {
                     model: connection.OllamaSettings?.Model,
                     uri: connection.OllamaSettings?.Uri,
+                    think: connection.OllamaSettings?.Think,
                     embeddingsMaxConcurrentBatches: connection.OllamaSettings?.EmbeddingsMaxConcurrentBatches,
                 },
                 embeddedSettings: {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -244,6 +244,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                 ? {
                       Model: connection.ollamaSettings.model,
                       Uri: connection.ollamaSettings.uri,
+                      Think: connection.ollamaSettings.think,
                       EmbeddingsMaxConcurrentBatches: connection.ollamaSettings.embeddingsMaxConcurrentBatches,
                   }
                 : null,

--- a/test/FastTests/OllamaThinkParameterTests.cs
+++ b/test/FastTests/OllamaThinkParameterTests.cs
@@ -1,0 +1,82 @@
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI.GenAi;
+using Raven.Server.Logging;
+using Sparrow.Logging;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests
+{
+    public class OllamaThinkParameterTests(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenTheory(RavenTestCategory.Ai)]
+        [InlineData(true, "\"think\":true")]
+        [InlineData(false, "\"think\":false")]
+        [InlineData(null, null)] // null means parameter should be omitted entirely
+        public async Task OllamaClient_ThinkParameter_ShouldSerializeInChatCompletionPayload(bool? thinkValue, string expectedJsonContent)
+        {
+            // Arrange - Create Ollama configuration with think parameter
+            var genAiConfig = new GenAiConfiguration
+            {
+                Name = "test-config",
+                ConnectionStringName = "test-connection", 
+                Collection = "TestDocs",
+                Prompt = "Test prompt",
+                Connection = new AiConnectionString
+                {
+                    Name = "test-connection",
+                    OllamaSettings = new OllamaSettings
+                    {
+                        Uri = "http://localhost:11434",
+                        Model = "test-model",
+                        Think = thinkValue
+                    }
+                }
+            };
+
+            // Create context pool for the client
+            using var contextPool = new TransactionContextPool(RavenLogManager.Instance.CreateNullLogger(), new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests()));
+            
+            // Create Ollama client and test WriteCustomParameters directly
+            using var client = new OllamaChatCompletionClient(genAiConfig, "{}", contextPool, Raven.Client.Documents.Conventions.DocumentConventions.DefaultForServer);
+            
+            // Test the WriteCustomParameters method by capturing what it writes
+            string capturedParameters = null;
+            
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            using (var stream = new MemoryStream())
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, stream))
+            {
+                // Simulate calling WriteCustomParameters like the real payload generation does
+                var method = typeof(OllamaChatCompletionClient).GetMethod("WriteCustomParameters", 
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                
+                method?.Invoke(client, [writer]);
+                await writer.FlushAsync();
+                
+                capturedParameters = Encoding.UTF8.GetString(stream.ToArray());
+            }
+
+            // Assert - Verify the parameters contain or don't contain the think parameter
+            if (expectedJsonContent == null)
+            {
+                // When Think is null, no parameters should be written
+                Assert.True(string.IsNullOrEmpty(capturedParameters));
+            }
+            else
+            {
+                // When Think has a value, verify the exact JSON content is written
+                Assert.Contains(expectedJsonContent, capturedParameters);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24560

### Additional description

Adds a "think" parameter to Ollama AI connections, enabling control over the reasoning process of thinking models.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
