### PR TITLE
RavenDB-24211 add parameters to the ai agent configuration

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Raven.Client.Documents.Linq;
-using Raven.Client.Documents.Session;
 using Raven.Client.Util;
-using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.AI.Agents;
@@ -84,6 +81,12 @@ public class AiAgentConfiguration : IDynamicJson
     /// </summary>
     public PersistenceConfiguration Persistence { get; set; }
 
+    /// <summary>
+    /// Names of the required parameters that are used in the agent's queries and actions.
+    /// Which has to be provided by the user each time we start a new chat.
+    /// </summary>
+    public HashSet<string> Parameters { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
     public class PersistenceConfiguration : IDynamicJson
     {
         public string Collection { get; set; }
@@ -115,28 +118,15 @@ public class AiAgentConfiguration : IDynamicJson
             };
         }
     }
+
     public class ToolQuery : IDynamicJson
     {
-        public static ToolQuery Build<T>(string name, string description, IRavenQueryable<T> query)
-        {
-            var dq = (AsyncDocumentQuery<T>)query.ToAsyncDocumentQuery();
-            using (var context = JsonOperationContext.ShortTermSingleUse())
-            {
-                return new ToolQuery
-                {
-                    Name = name,
-                    Description = description,
-                    Query = dq.ToString(),
-                    ParametersSampleObject = context.ReadObject(DynamicJsonValue.Convert(dq.QueryParameters), "params").ToString()
-                };
-            }
-        }
-
         public string Name { get; set; }
         public string Description { get; set; }
         public string Query { get; set; }
         public string ParametersSampleObject { get; set; }
         public string ParametersSchema { get; set; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
@@ -181,7 +171,8 @@ public class AiAgentConfiguration : IDynamicJson
             [nameof(SampleObject)] = SampleObject,
             [nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null,
             [nameof(Actions)] = Actions != null ? new DynamicJsonArray(Actions) : null,
-            [nameof(Persistence)] = Persistence?.ToJson()
+            [nameof(Persistence)] = Persistence?.ToJson(),
+            [nameof(Parameters)] = new DynamicJsonArray(Parameters)
         };
     }
 }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -585,7 +585,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         return _forTestingPurposes = new IChatCompletionClientForTesting.TestingStuff();
     }
 
-    private static class Constants
+    public static class Constants
     {
         public static class ResponseFields
         {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -57,7 +57,7 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
         foreach (var tool in configuration.Queries)
         {
             var q = QueryMetadata.ParseQuery(tool.Query, QueryType.Select);
-            var queryParams = new HashSet<string>(q.Parameters.Select(x => x.Value));
+            var queryParams = new HashSet<string>(q.Parameters.Select(x => x.Value), StringComparer.OrdinalIgnoreCase);
             queryParams.ExceptWith(scopeParams);
 
             string paramsSchema = ChatCompletionClient.GetSchemaForTool(tool.ParametersSchema, tool.ParametersSampleObject);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -1,11 +1,19 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.AST;
 using Raven.Server.ServerWide.Commands.AI;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents;
 internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
@@ -23,9 +31,11 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
         var options = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "ai/agent", token.Token);
         
         var name = RequestHandler.GetStringQueryString("name", required: true);
-        var cfg = JsonDeserializationClient.AiAgentConfiguration(options);
+        var configuration = JsonDeserializationClient.AiAgentConfiguration(options);
 
-        var r = await ServerStore.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(RequestHandler.DatabaseName, name, cfg, RequestHandler.GetRaftRequestIdFromQuery()), token.Token);
+        ValidateConfiguration(context, configuration);
+
+        var r = await ServerStore.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(RequestHandler.DatabaseName, name, configuration, RequestHandler.GetRaftRequestIdFromQuery()), token.Token);
         
         RequestHandler.LogTaskToAudit($"Add/Update AI Agent '{name}'", r.Index, options);
 
@@ -40,5 +50,46 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
 
             context.Write(writer, json);
         }
+    }
+
+    private static void ValidateConfiguration(JsonOperationContext context, AiAgentConfiguration configuration)
+    {
+        var scopeParams = configuration.Parameters;
+        var toolParams = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var llmParams = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tool in configuration.Queries)
+        {
+            var q = QueryMetadata.ParseQuery(tool.Query, QueryType.Select);
+
+            foreach (var p in q.Parameters)
+            {
+                toolParams.Add(p.Value);
+            }
+
+            string paramsSchema = ChatCompletionClient.GetSchemaForTool(tool.ParametersSchema, tool.ParametersSampleObject);
+            var schema = context.Sync.ReadForMemory(paramsSchema, "tool-schema");
+            if (schema.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Required, out BlittableJsonReaderArray required))
+            {
+                foreach (var arg in required)
+                {
+                    llmParams.Add(arg.ToString());
+                }
+            }
+        }
+
+        var missingToolSchema = llmParams.Except(toolParams).ToList();
+        if (missingToolSchema.Count > 0)
+            throw new InvalidOperationException($"Queries contain parameters that are not defined in the tool schema: '{string.Join(", ", missingToolSchema)}'");
+
+        var requiredScope = toolParams.Except(llmParams).ToList();
+        
+        var missingScopeParams = requiredScope.Except(scopeParams).ToList();
+        if (missingScopeParams.Count > 0)
+            throw new InvalidOperationException($"Agent configuration missing parameters that is required by the tools: '{string.Join(", ", missingScopeParams)}'");
+
+        var unusedParams = scopeParams.Except(requiredScope).ToList();
+        if (unusedParams.Count > 0)
+            throw new InvalidOperationException($"Agent configuration has unused parameters: '{string.Join(", ", unusedParams)}'");
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -10,7 +10,6 @@ using Raven.Server.Documents.Handlers.Processors;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.ServerWide.Commands.AI;
-using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
@@ -55,17 +54,11 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
     private static void ValidateConfiguration(JsonOperationContext context, AiAgentConfiguration configuration)
     {
         var scopeParams = configuration.Parameters;
-        var toolParams = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var llmParams = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
         foreach (var tool in configuration.Queries)
         {
             var q = QueryMetadata.ParseQuery(tool.Query, QueryType.Select);
-
-            foreach (var p in q.Parameters)
-            {
-                toolParams.Add(p.Value);
-            }
+            var queryParams = new HashSet<string>(q.Parameters.Select(x => x.Value));
+            queryParams.ExceptWith(scopeParams);
 
             string paramsSchema = ChatCompletionClient.GetSchemaForTool(tool.ParametersSchema, tool.ParametersSampleObject);
             var schema = context.Sync.ReadForMemory(paramsSchema, "tool-schema");
@@ -73,23 +66,17 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
             {
                 foreach (var arg in required)
                 {
-                    llmParams.Add(arg.ToString());
+                    string queryArg = arg.ToString();
+                    if (scopeParams.Contains(queryArg))
+                        throw new InvalidOperationException($"Parameter {queryArg} is defined on both the agent level and the query level for {tool.Name}");
+
+                    queryParams.Remove(queryArg);
                 }
             }
+
+            if (queryParams.Count > 0)
+                throw new InvalidOperationException(
+                    $"Tool query '{tool.Name}' contains parameters that are not defined in the agent configuration: '{string.Join(", ", queryParams)}'");
         }
-
-        var missingToolSchema = llmParams.Except(toolParams).ToList();
-        if (missingToolSchema.Count > 0)
-            throw new InvalidOperationException($"Queries contain parameters that are not defined in the tool schema: '{string.Join(", ", missingToolSchema)}'");
-
-        var requiredScope = toolParams.Except(llmParams).ToList();
-        
-        var missingScopeParams = requiredScope.Except(scopeParams).ToList();
-        if (missingScopeParams.Count > 0)
-            throw new InvalidOperationException($"Agent configuration missing parameters that is required by the tools: '{string.Join(", ", missingScopeParams)}'");
-
-        var unusedParams = scopeParams.Except(requiredScope).ToList();
-        if (unusedParams.Count > 0)
-            throw new InvalidOperationException($"Agent configuration has unused parameters: '{string.Join(", ", unusedParams)}'");
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForStartChat.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForStartChat.cs
@@ -22,7 +22,7 @@ internal class AiAgentProcessorForStartChat : AbstractAiAgentProcessor
         var body = GetStartChatOptions(options);
         var chat = new ChatDocument(name, body.Parameter);
 
-        chat.Initialize(context, configuration.SystemPrompt, body.UserPrompt);
+        chat.Initialize(context, configuration, body.UserPrompt);
         var r = await TalkAsync(context, configuration, chat, token);
 
         var conversationId = await TryPersistAsync(configuration, $"{configuration.Persistence.Collection}{RequestHandler.Database.IdentityPartsSeparator}", r.Document);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestChat.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestChat.cs
@@ -1,7 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Json.Serialization;
+using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents;
 
@@ -16,14 +20,31 @@ internal class AiAgentProcessorForTestChat : AbstractAiAgentProcessor
         using var _ = ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
         using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
         var options = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "ai-agent", token.Token);
-        var cfg = JsonDeserializationClient.AiAgentConfiguration(options);
+        var test = JsonDeserializationServer.AiAgentTestRequest(options);
 
         var body = GetStartChatOptions(options);
         var chat = new ChatDocument("test", body.Parameter);
-        chat.Initialize(context, cfg.SystemPrompt, body.UserPrompt);
+        chat.Initialize(context, test.Configuration, body.UserPrompt);
 
-        var r = await TalkAsync(context, cfg, chat, token);
+        var r = await TalkAsync(context, test.Configuration, chat, token);
 
         await WriteResponseAsync(context, "test", r);
+    }
+
+    public class AiAgentTestRequest
+    {
+        public string Prompt;
+        public BlittableJsonReaderObject Parameters;
+        public AiAgentConfiguration Configuration;
+
+        public void Validate()
+        {
+            if (string.IsNullOrEmpty(Prompt))
+                throw new ArgumentException("Prompt is required for AI Agent test.");
+            if (Configuration == null)
+                throw new ArgumentException("Configuration is required for AI Agent test.");
+            if (Parameters == null)
+                throw new ArgumentException("Parameters are required for AI Agent test.");
+        }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ChatDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ChatDocument.cs
@@ -18,15 +18,21 @@ public class ChatDocument(string agent, BlittableJsonReaderObject parameters)
     public BlittableJsonReaderObject Parameters = parameters ;
     public List<BlittableJsonReaderObject> Messages = [];
     public AiUsage TotalUsage;
-    public void Initialize(JsonOperationContext context, string systemPrompt, string userPrompt)
+    public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, string userPrompt)
     {
         if (Messages.Count > 0)
             throw new InvalidOperationException("Chat document is already initialized. Cannot re-initialize.");
 
+        foreach (var parameter in configuration.Parameters)
+        {
+            if (Parameters == null || Parameters.TryGet(parameter, out object _) == false)
+                throw new ArgumentException($"Parameter '{parameter}' is missing.");
+        }
+
         AddMessage(context, context.ReadObject(new DynamicJsonValue
         {
             ["role"] = "system",
-            ["content"] = systemPrompt
+            ["content"] = configuration.SystemPrompt
         }, "system/msg"));
 
         AddMessage(context, context.ReadObject(new DynamicJsonValue

--- a/src/Raven.Server/Documents/Queries/AST/Query.cs
+++ b/src/Raven.Server/Documents/Queries/AST/Query.cs
@@ -28,6 +28,8 @@ namespace Raven.Server.Documents.Queries.AST
         public ValueExpression FilterLimit;
 
         public List<(QueryExpression Expression, OrderByFieldType FieldType, bool Ascending)> CachedOrderBy;
+        
+        public HashSet<StringSegment> Parameters = new HashSet<StringSegment>(StringSegmentComparer.OrdinalIgnoreCase);
 
         public Query ShallowCopy()
         {

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -30,11 +30,18 @@ namespace Raven.Server.Documents.Queries.Parser
 
         public QueryScanner Scanner;
 
+        public Query Query;
+
         public void Init(string q)
         {
             _depth = 0;
             Scanner.Init(q);
+            Query = new Query
+            {
+                QueryText = Scanner.Input
+            };
         }
+
 
         public Query Parse(QueryType queryType = QueryType.Select, bool recursive = false)
         {
@@ -46,10 +53,7 @@ namespace Raven.Server.Documents.Queries.Parser
 
         public bool TryParse(out Query query, out string message, QueryType queryType = QueryType.Select, bool recursive = false)
         {
-            query = new Query
-            {
-                QueryText = Scanner.Input
-            };
+            query = Query;
             message = string.Empty;
 
             while (Scanner.TryScan("DECLARE"))
@@ -1460,6 +1464,8 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
                     Scanner.Token,
                     ValueTokenType.Parameter
                 );
+
+                Query.Parameters.Add(Scanner.Token);
                 return true;
             }
             val = null;

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Indexes.Analysis;
 using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Indexes.TimeSeries;
 using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.ETL.Snowflake;
@@ -37,12 +38,15 @@ using Raven.Server.Documents.Commands.OngoingTasks;
 using Raven.Server.Documents.Commands.Replication;
 using Raven.Server.Documents.Commands.Revisions;
 using Raven.Server.Documents.Commands.Tombstones;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings.Test;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
 using Raven.Server.Documents.ETL.Providers.ElasticSearch.Test;
 using Raven.Server.Documents.ETL.Providers.OLAP.Test;
 using Raven.Server.Documents.ETL.Providers.Queue.Test;
 using Raven.Server.Documents.ETL.Providers.Raven.Test;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common;
 using Raven.Server.Documents.Handlers;
+using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.Documents.Handlers.Debugging;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
@@ -80,10 +84,6 @@ using DatabasesInfo = Raven.Client.ServerWide.Operations.DatabasesInfo;
 using FacetSetup = Raven.Client.Documents.Queries.Facets.FacetSetup;
 using MigrationConfiguration = Raven.Server.Smuggler.Migration.MigrationConfiguration;
 using StudioConfiguration = Raven.Client.Documents.Operations.Configuration.StudioConfiguration;
-using Raven.Server.Documents.ETL.Providers.AI.Embeddings.Test;
-using Raven.Client.Documents.Operations.AI;
-using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
-using Raven.Server.Documents.AI;
 
 namespace Raven.Server.Json
 {
@@ -354,6 +354,8 @@ namespace Raven.Server.Json
 
         internal static readonly Func<BlittableJsonReaderObject, StudioTasksHandler.AiModelsRequest> AiModelsRequest = GenerateJsonDeserializationRoutine<StudioTasksHandler.AiModelsRequest>();
         
+        internal static readonly Func<BlittableJsonReaderObject, AiAgentProcessorForTestChat.AiAgentTestRequest> AiAgentTestRequest = GenerateJsonDeserializationRoutine<AiAgentProcessorForTestChat.AiAgentTestRequest>();
+
         public sealed class Parameters
         {
             private Parameters()

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBackupRestore.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBackupRestore.cs
@@ -90,7 +90,7 @@ public class AiAgentBackupRestore : ReplicationTestBase
             "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
 
         agent0.Persistence = new AiAgentConfiguration.PersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
-
+        agent0.Parameters.Add("company");
         agent0.Queries =
         [
             new AiAgentConfiguration.ToolQuery

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -143,7 +143,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         public async Task AnswerActionToolRequest(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -6,6 +6,8 @@ using FastTests;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.Handlers.AI.Agents;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -35,7 +37,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         public async Task CanCreateAiAgent(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
@@ -49,7 +50,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 Collection = "Chats",
                 Expires = TimeSpan.FromDays(30)
             };
-
+            agent.Parameters.Add("company");
             agent.Queries =
             [
                 new AiAgentConfiguration.ToolQuery
@@ -100,7 +101,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 Collection = "Chats",
                 Expires = TimeSpan.FromDays(30)
             };
-
+            agent.Parameters.Add("company");
             agent.Queries =
             [
                 new AiAgentConfiguration.ToolQuery
@@ -204,23 +205,24 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         public async Task CanRunTest(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
 
-            var body = @$"{{
+            var body = @$"{{    
+""{nameof(AiAgentProcessorForTestChat.AiAgentTestRequest.Parameters)}"": {{
+        ""company"": ""companies/90-A""
+    }},
+""{nameof(AiAgentProcessorForTestChat.AiAgentTestRequest.Prompt)}"": ""Help to find something more to my recent order"",
+""{nameof(AiAgentProcessorForTestChat.AiAgentTestRequest.Configuration)}"":{{
     ""ConnectionStringName"": ""{config.ConnectionStringName}"",
     ""SystemPrompt"": ""You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well."",
     ""SampleObject"": ""{{\""Answer\"": \""Answer to the user question\"", \""Relevant\"": true, \""RelevantOrdersId\"":[\""The order ids relevant to the query or response\""], \""MatchingProductsId\"":[\""All the product ids referenced either by the user or the system\""] }}"",
-    ""Parameters"": {{
-        ""company"": ""companies/90-A""
-    }},
-    ""Prompt"": ""Help to find something more to my recent order"",
     ""Persistence"": {{
         ""Collection"": ""Chats"",
         ""Expires"": ""3.00:00:00""
     }},
+    ""Parameters"": [""company""],
     ""Queries"": [
         {{
             ""Name"": ""ProductSearch"",
@@ -235,7 +237,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             ""ParametersSampleObject"": ""{{}}""
         }}
     ]
-}}";
+}}}}";
             using var test = new HttpRequestMessage
             {
                 RequestUri = new Uri($"{store.Urls[0]}/databases/{store.Database}/ai/agent/test", UriKind.Absolute),

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -2,10 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
-using FastTests.Client;
-using Orders;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -40,7 +36,6 @@ public class AiAgentClientApiBasics : RavenTestBase
     public async Task AiAgentClientApiBasicTest(Options options, GenAiConfiguration config, bool sendSchema)
     {
         using var store = GetDocumentStore(options);
-        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
@@ -54,26 +49,35 @@ public class AiAgentClientApiBasics : RavenTestBase
             Collection = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
-
-        var queryTool1 = AiAgentConfiguration.ToolQuery.Build(
-            "ProductSearch",
-            "semantic search the store product catalog",
-            session.Query<Product>().VectorSearch(v => v.WithText(p => p.Name), v => v.ByText("$query")));
         
-        var queryTool2 = AiAgentConfiguration.ToolQuery.Build(
-            "RecentOrder",
-            "Get the recent orders of the current user",
-            session.Query<Query.Order>().Where(o => o.Company == "$company").OrderByDescending(o => o.OrderedAt).Take(10));
+        agent.Parameters.Add("company");
+        agent.Queries =
+        [
+            new AiAgentConfiguration.ToolQuery
+            {
+                Name = "ProductSearch", 
+                Description =  "semantic search the store product catalog",
+                Query = "from Products where vector.search(embedding.text(Name), $query)",
+                ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            }
+            ,
+            new AiAgentConfiguration.ToolQuery
+            {
+                Name = "RecentOrder",
+                Description = "Get the recent orders of the current user",
+                Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                ParametersSampleObject = "{}"
+            }
+        ];
 
         if (sendSchema)
         {
-            queryTool1.ParametersSchema = ChatCompletionClient.GetSchemaForTool(null, queryTool1.ParametersSampleObject);
-            queryTool2.ParametersSchema = ChatCompletionClient.GetSchemaForTool(null, queryTool2.ParametersSampleObject);
-            queryTool1.ParametersSampleObject = null;
-            queryTool2.ParametersSampleObject = null;
-        }
+            agent.Queries[0].ParametersSchema = ChatCompletionClient.GetSchemaForTool(null, agent.Queries[0].ParametersSampleObject);
+            agent.Queries[0].ParametersSampleObject = null;
 
-        agent.Queries = [ queryTool1, queryTool2 ];
+            agent.Queries[1].ParametersSchema = ChatCompletionClient.GetSchemaForTool(null, agent.Queries[1].ParametersSampleObject);
+            agent.Queries[1].ParametersSampleObject = null;
+        }
 
         await store.AI.CreateAgentAsync<OutputSchema>("shopping assistant", agent);
 
@@ -102,7 +106,6 @@ public class AiAgentClientApiBasics : RavenTestBase
     public async Task AiAgentClientApiAnswerActionTool(Options options, GenAiConfiguration config, bool sendSchema)
     {
         using var store = GetDocumentStore(options);
-        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
@@ -56,12 +56,12 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             ];
 
             var e = await Assert.ThrowsAsync<RavenException>( () => store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent)));
-            Assert.Contains("Agent configuration missing parameters that is required by the tools", e.Message);
+            Assert.Contains("Tool query 'RecentOrder' contains parameters that are not defined in the agent configuration: 'company'", e.Message);
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
-        public async Task ThrowOnMissingToolParameter(Options options, GenAiConfiguration config)
+        public async Task ThrowOnDuplicateToolParameterUsage(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore(options);
 
@@ -85,8 +85,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 {
                     Name = "ProductSearch", 
                     Description =  "semantic search the store product catalog",
-                    Query = "from Products where vector.search(embedding.text(Name), $foo)",
-                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                    Query = "from Products where vector.search(embedding.text(Name), $company)",
+                    ParametersSampleObject = "{\"company\": [\"term or phrase to search in the catalog\"]}"
                 }
                 ,
                 new AiAgentConfiguration.ToolQuery
@@ -99,53 +99,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             ];
 
             var e = await Assert.ThrowsAsync<RavenException>( () => store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent)));
-            Assert.Contains("Queries contain parameters that are not defined in the tool schema", e.Message);
+            Assert.Contains("Parameter company is defined on both the agent level and the query level for ProductSearch", e.Message);
         }
-
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
-        public async Task ThrowOnMissingParameter(Options options, GenAiConfiguration config)
-        {
-            using var store = GetDocumentStore(options);
-
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
-
-            using var session = store.OpenAsyncSession();
-
-            var agent = new AiAgentConfiguration(config.ConnectionStringName,
-                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
-
-            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
-            {
-                Collection = "Chats",
-                Expires = TimeSpan.FromDays(30)
-            };
-
-            agent.Parameters.Add("company");
-            agent.Parameters.Add("order");
-            agent.Queries =
-            [
-                new AiAgentConfiguration.ToolQuery
-                {
-                    Name = "ProductSearch", 
-                    Description =  "semantic search the store product catalog",
-                    Query = "from Products where vector.search(embedding.text(Name), $query)",
-                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
-                }
-                ,
-                new AiAgentConfiguration.ToolQuery
-                {
-                    Name = "RecentOrder",
-                    Description = "Get the recent orders of the current user",
-                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
-                    ParametersSampleObject = "{}"
-                }
-            ];
-
-            var e = await Assert.ThrowsAsync<RavenException>( () => store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent)));
-            Assert.Contains("Agent configuration has unused parameters", e.Message);
-        }
-
 
         [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentConfigurationValidation : RavenTestBase
+    {
+        public AiAgentConfigurationValidation(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ThrowOnMissingAgentParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration(config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+            {
+                Collection = "Chats",
+                Expires = TimeSpan.FromDays(30)
+            };
+
+            agent.Queries =
+            [
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+                ,
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSampleObject = "{}"
+                }
+            ];
+
+            var e = await Assert.ThrowsAsync<RavenException>( () => store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent)));
+            Assert.Contains("Agent configuration missing parameters that is required by the tools", e.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ThrowOnMissingToolParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration(config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+            {
+                Collection = "Chats",
+                Expires = TimeSpan.FromDays(30)
+            };
+
+            agent.Parameters.Add("company");
+            agent.Queries =
+            [
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $foo)",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+                ,
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSampleObject = "{}"
+                }
+            ];
+
+            var e = await Assert.ThrowsAsync<RavenException>( () => store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent)));
+            Assert.Contains("Queries contain parameters that are not defined in the tool schema", e.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ThrowOnMissingParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration(config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+            {
+                Collection = "Chats",
+                Expires = TimeSpan.FromDays(30)
+            };
+
+            agent.Parameters.Add("company");
+            agent.Parameters.Add("order");
+            agent.Queries =
+            [
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+                ,
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSampleObject = "{}"
+                }
+            ];
+
+            var e = await Assert.ThrowsAsync<RavenException>( () => store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent)));
+            Assert.Contains("Agent configuration has unused parameters", e.Message);
+        }
+
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ThrowOnMissingChatParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration(config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Persistence = new AiAgentConfiguration.PersistenceConfiguration
+            {
+                Collection = "Chats",
+                Expires = TimeSpan.FromDays(30)
+            };
+            
+            agent.Parameters.Add("company");
+            agent.Queries =
+            [
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+                ,
+                new AiAgentConfiguration.ToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSampleObject = "{}"
+                }
+            ];
+
+            await store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<AiAgentBasics.OutputSchema>("shopping assistant", agent));
+            var e = await Assert.ThrowsAsync<RavenException>(() => store.Maintenance.SendAsync(new StartChatOperation<AiAgentBasics.OutputSchema>("shopping assistant", "what goes well with my cheese for recent orders?")));
+            Assert.Contains($"Parameter 'company' is missing", e.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24211

### Additional description

For better UX and studio work we require to have parameters in order to validate that we fill the agent config properly and that we start the chat with all the required parameters.

Bonus: we also have in this PR some preparation for a strongly typed API

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
