### PR TITLE
RavenDB-24375 DeleteByQuery - Collection Query: Process all documents within the etag range instead of only first 1024.

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -106,11 +106,12 @@ namespace Raven.Server.Documents
                     ids.Clear();
 
                     Database.ForTestingPurposes?.CollectionRunnerBeforeOpenReadTransaction?.Invoke();
-
+                    bool hadDocuments = false;
                     using (context.OpenReadTransaction())
                     {
                         foreach (var document in GetDocuments(context, collectionName, startEtag, startAfterId, alreadySeenIdsCount, OperationBatchSize, isAllDocs, DocumentFields.Id, out bool isStartsWithOrIdQuery, token.Token))
                         {
+                            hadDocuments = true;
                             using (document)
                             {
                                 cancellationToken.ThrowIfCancellationRequested();
@@ -149,7 +150,13 @@ namespace Raven.Server.Documents
                     }
 
                     if (ids.Count == 0)
+                    {
+                        // The current batch returned no documents; however, the current etag is still in range, so we have to read more documents.
+                        if (hadDocuments && startEtag <= lastEtag && end == false)
+                            continue;
+                        
                         break;
+                    }
 
                     do
                     {

--- a/test/SlowTests/Issues/RavenDB-24375.cs
+++ b/test/SlowTests/Issues/RavenDB-24375.cs
@@ -39,5 +39,8 @@ public class RavenDB_24375(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+#pragma warning disable CS9113 // Parameter is unread.
+    // ReSharper disable once InconsistentNaming
     private struct Dto(long Idx, string Id = null);
+#pragma warning restore CS9113 // Parameter is unread.
 }

--- a/test/SlowTests/Issues/RavenDB-24375.cs
+++ b/test/SlowTests/Issues/RavenDB-24375.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24375(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Patching)]
+    [InlineData(2047, 1023)]
+    [InlineData(2047, 1024)]
+    [InlineData(1025, 1023)]
+    [InlineData(1025, 1024)]
+    public async Task CanDeleteByQueryFromCollectionWhenSkipOffsetIsAtLeast1024(int size, int offset)
+    {
+        using var store = GetDocumentStore();
+
+        await using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0; i < size; i++)
+                await bulkInsert.StoreAsync(new Dto(i));
+        }
+
+        Operation deleteOperation = await store
+            .Operations
+            .SendAsync(new DeleteByQueryOperation($"from Dtos limit {offset}, {size}"));
+
+        await deleteOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(15));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var count = await session.Query<Dto>().CountAsync();
+            Assert.Equal(offset, count);
+        }
+    }
+
+    private struct Dto(long Idx, string Id = null);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24375

### Additional description

Instead of breaking, we need to go through all documents within the ETag range to ensure that we process all documents that are valid for the query.



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
