### PR TITLE
[RavenDB-24587] Prevent unloading by idle on long running operations

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationTask.cs
@@ -137,31 +137,35 @@ public sealed class EmbeddingsGenerationTask : EtlProcess<EmbeddingsGenerationIt
 
         var taskId = new EmbeddingsGenerationTaskIdentifier(Configuration.Identifier);
 
-        var batch = Database.EmbeddingsGeneratorEtl.BatchFor(taskId);
-        using (var storageScope = scope.For(EmbeddingsGenerationOperations.GenerateInAiService))
+        // Prevent database unloading during long-running AI operations
+        using (Database.PreventFromUnloadingByIdleOperations())
         {
-            foreach (var embeddingItem in embeddingsScriptRun.Additions)
+            var batch = Database.EmbeddingsGeneratorEtl.BatchFor(taskId);
+            using (var storageScope = scope.For(EmbeddingsGenerationOperations.GenerateInAiService))
             {
-                batch.StartGenerateEmbeddingFor(context, embeddingItem.DocumentId, embeddingItem.DocumentCollectionName,
-                    embeddingItem.Fields);
+                foreach (var embeddingItem in embeddingsScriptRun.Additions)
+                {
+                    batch.StartGenerateEmbeddingFor(context, embeddingItem.DocumentId, embeddingItem.DocumentCollectionName,
+                        embeddingItem.Fields);
+                }
+                // We only wait for embeddings generation here, documents creation (and update) is done in the background
+                // https://issues.hibernatingrhinos.com/issue/RavenDB-24062
+                batch.WaitForGenerationAsync().GetAwaiter().GetResult();
+                storageScope.NumberOfEmbeddingsInCache = batch.CachedEmbeddings;
+                storageScope.NumberOfGeneratedEmbeddings = embeddingsScriptRun.Additions.Count;
             }
-            // We only wait for embeddings generation here, documents creation (and update) is done in the background
-            // https://issues.hibernatingrhinos.com/issue/RavenDB-24062
-            batch.WaitForGenerationAsync().GetAwaiter().GetResult();
-            storageScope.NumberOfEmbeddingsInCache = batch.CachedEmbeddings;
-            storageScope.NumberOfGeneratedEmbeddings = embeddingsScriptRun.Additions.Count;
-        }
 
-        foreach (var embeddingItem in embeddingsScriptRun.Removals)
-        {
-            batch.Delete(embeddingItem.DocumentId);
-        }
-        using (var storageScope = scope.For(EmbeddingsGenerationOperations.Storage))
-        {
-            batch.StoreResults().GetAwaiter().GetResult();
-            
-            storageScope.NumberOfPutEmbeddingDocuments = embeddingsScriptRun.Additions.Count;
-            storageScope.NumberOfDeletedEmbeddingDocuments = embeddingsScriptRun.Removals.Count;
+            foreach (var embeddingItem in embeddingsScriptRun.Removals)
+            {
+                batch.Delete(embeddingItem.DocumentId);
+            }
+            using (var storageScope = scope.For(EmbeddingsGenerationOperations.Storage))
+            {
+                batch.StoreResults().GetAwaiter().GetResult();
+                
+                storageScope.NumberOfPutEmbeddingDocuments = embeddingsScriptRun.Additions.Count;
+                storageScope.NumberOfDeletedEmbeddingDocuments = embeddingsScriptRun.Removals.Count;
+            }
         }
         
         _fallbackCounter = 0;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -153,7 +153,13 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         if (results.Count is 0)
             return 0;
 
-        var exceptions = SendToModel(results, context, scope);
+        List<Exception> exceptions;
+        
+        // Prevent database unloading during long-running AI operations
+        using (Database.PreventFromUnloadingByIdleOperations())
+        {
+            exceptions = SendToModel(results, context, scope);
+        }
 
         ApplyUpdateScript(context, results, scope);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24587

### Additional description

We wrapped the external call by using the PreventFromUnloadingByIdleOperations() mechanism to avoid the Idle to kick in while we wait for the results.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
