### PR TITLE
RavenDB-24357 Adds more test cases for vector search test

### DIFF
--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using FastTests.Voron;
+using FastTests.Voron.FixedSize;
 using Tests.Infrastructure;
 using Voron.Data.Graphs;
 using Xunit;
@@ -13,13 +14,16 @@ namespace SlowTests.Voron.Graphs;
 
 public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CanReturnAllOfVector()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineData(1241232)]
+    public void CanReturnAllOfVector(int seed)
     {
         const int vectorSize = 1536;
         const int vectorSizeInBytes = vectorSize * sizeof(float);
         const int numberOfEntries = 1024;
-        var random = new Random(1241232);
+        var random = new Random(seed);
         Dictionary<long, float[]> storage = new();
         for (int i = 1; i <= numberOfEntries; ++i)
             storage.Add(i, Enumerable.Range(0, vectorSize).Select(_ => GetNextDim()).ToArray());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24357
### Additional description

 Adds fuzzy test cases for vector search test since current seed is not reproducing the seed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
