### PR TITLE
RavenDB-24387 fix test ShouldGettingBackToTheNodeAfterExperiencingTim…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20202.cs
+++ b/test/SlowTests/Issues/RavenDB_20202.cs
@@ -40,10 +40,19 @@ public class RavenDB_20202 : ClusterTestBase
             Conventions = new DocumentConventions { RequestTimeout = timeOut, }
         }.Initialize())
         {
+            await WaitForValueAsync(async () =>
+            {
+                var databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+                return databaseRecordWithEtag.Topology.Members.Count;
+            }, 3);
+
+            var databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            Assert.Equal(3, databaseRecordWithEtag.Topology.Members.Count);
+
             List<string> originalNodesOrder = new() { "A", "B", "C" };
             await store.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(store.Database, originalNodesOrder));
 
-            var databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+            databaseRecordWithEtag = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
             Assert.Equal(originalNodesOrder, databaseRecordWithEtag.Topology.Members);
 
             // We'll hold database settings load and health check executions for nodes 'A' and 'B' only


### PR DESCRIPTION
…eoutAndTopologyUpdateSimultaneously

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24387

### Additional description

Unable to reproduce the test failure locally. 
Added a wait and verification of the topology before performing the reorder

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
