### PR TITLE
RavenDB-24165 BinaryMatch builder enhancements

### DIFF
--- a/src/Corax/Querying/IndexSearcher.BinaryMatches.cs
+++ b/src/Corax/Querying/IndexSearcher.BinaryMatches.cs
@@ -2,95 +2,156 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
+using Corax.Querying.Matches.SpatialMatch;
 
 namespace Corax.Querying;
 
 public partial class IndexSearcher
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public BinaryMatch And<TInner, TOuter>(in TInner set1, in TOuter set2, in CancellationToken token = default)
+    public BinaryMatch And<TInner, TOuter>(in TInner innerSet, in TOuter outerSet, in CancellationToken token = default)
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
     {
-        // TODO: We need to create this code using a template or using typed delegates (which either way would need templating for boilerplate code generation)
-        // If any of the generic types is not known to be a struct (calling from interface) the code executed will
-        // do all the work to figure out what to emit. The cost is in instantiation not on execution.                         
-        if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldAnd(this, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldAnd(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldAnd(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldAnd(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
-        }
+        if (typeof(TInner) != typeof(IQueryMatch) && typeof(TOuter) != typeof(IQueryMatch))
+            return Build(innerSet, outerSet, token);
+        
+        return MatchTypeAndBuild(innerSet, outerSet, token);
+        BinaryMatch MatchTypeAndBuild<TFirstInner, TFirstOuter>(in TFirstInner firstInnerSet, in TFirstOuter firstOuterSet, in CancellationToken token)
+            where TFirstInner : IQueryMatch
+            where TFirstOuter : IQueryMatch 
+            => QueryBuilderHelper.GetQueryType(firstInnerSet) switch
+            {
+                QueryBuilderHelper.QueryType.TermMatch => OuterGenericMatcher((TermMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.BinaryMatch => OuterGenericMatcher((BinaryMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiTermMatch => OuterGenericMatcher((MultiTermMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.AndNotMatch => OuterGenericMatcher((AndNotMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.BoostingMatch => OuterGenericMatcher((BoostingMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchNoBoosting => OuterGenericMatcher((SpatialMatch<NoBoosting>)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchHasBoosting => OuterGenericMatcher((SpatialMatch<HasBoosting>)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiUnaryMatch => OuterGenericMatcher((MultiUnaryMatch)(object)firstInnerSet, firstOuterSet, token),
+                _ => OuterGenericMatcher(firstInnerSet, firstOuterSet, token),
+            };
 
-        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldAnd(this, in set1, in set2, token));
+        BinaryMatch OuterGenericMatcher<TSecondInner, TSecondOuter>(in TSecondInner secondInnerSet, in TSecondOuter secondOuterSet, in CancellationToken token = default)
+            where TSecondInner : IQueryMatch
+            where TSecondOuter : IQueryMatch
+            => QueryBuilderHelper.GetQueryType(secondOuterSet) switch
+            {
+                QueryBuilderHelper.QueryType.TermMatch => Build(secondInnerSet, (TermMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.BinaryMatch => Build(secondInnerSet, (BinaryMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiTermMatch => Build(secondInnerSet, (MultiTermMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.AndNotMatch => Build(secondInnerSet, (AndNotMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.BoostingMatch => Build(secondInnerSet, (BoostingMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchNoBoosting => Build(secondInnerSet, (SpatialMatch<NoBoosting>)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchHasBoosting => Build(secondInnerSet, (SpatialMatch<HasBoosting>)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiUnaryMatch => Build(secondInnerSet, (MultiUnaryMatch)(object)secondOuterSet, token),
+                _ => Build(secondInnerSet, secondOuterSet, token),
+            };
+
+        BinaryMatch Build<TBuildInner, TBuildOuter>(in TBuildInner buildInnerSet, in TBuildOuter buildOuterSet, in CancellationToken token = default)
+            where TBuildInner : IQueryMatch
+            where TBuildOuter : IQueryMatch 
+            => BinaryMatch.Create(BinaryMatch<TBuildInner, TBuildOuter, BinaryMatch.And>.YieldAnd(this, in buildInnerSet, in buildOuterSet, token));
     }
-
+    
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public BinaryMatch Or<TInner, TOuter>(in TInner set1, in TOuter set2, in CancellationToken token = default)
+    public BinaryMatch Or<TInner, TOuter>(in TInner innerSet, in TOuter outerSet, in CancellationToken token = default)
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
     {
         // When faced with a MultiTermMatch and something else, lets first calculate the something else.
-        if (set2.GetType() == typeof(MultiTermMatch) && set1.GetType() != typeof(MultiTermMatch))
-            return Or( set2, set1);
+        if (outerSet is MultiTermMatch && innerSet.GetType() != typeof(MultiTermMatch))
+            return Or(outerSet, innerSet);
 
-        // If any of the generic types is not known to be a struct (calling from interface) the code executed will
-        // do all the work to figure out what to emit. The cost is in instantiation not on execution. 
-        if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, TermMatch>.YieldOr(this, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, TermMatch>.YieldOr(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<TermMatch, BinaryMatch>.YieldOr(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
-        {
-            return BinaryMatch.Create(BinaryMatch<BinaryMatch, BinaryMatch>.YieldOr(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
-        }
+        if (typeof(TInner) != typeof(IQueryMatch) && typeof(TOuter) != typeof(IQueryMatch))
+            return Build(innerSet, outerSet, token);
+        
+        return MatchTypeAndBuild(innerSet, outerSet, token);
+        
+        BinaryMatch MatchTypeAndBuild<TFirstInner, TFirstOuter>(in TFirstInner firstInnerSet, in TFirstOuter firstOuterSet, in CancellationToken token)
+            where TFirstInner : IQueryMatch
+            where TFirstOuter : IQueryMatch 
+            => QueryBuilderHelper.GetQueryType(firstInnerSet) switch
+            {
+                QueryBuilderHelper.QueryType.TermMatch => OuterGenericMatcher((TermMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.BinaryMatch => OuterGenericMatcher((BinaryMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiTermMatch => OuterGenericMatcher((MultiTermMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.AndNotMatch => OuterGenericMatcher((AndNotMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.BoostingMatch => OuterGenericMatcher((BoostingMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchNoBoosting => OuterGenericMatcher((SpatialMatch<NoBoosting>)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchHasBoosting => OuterGenericMatcher((SpatialMatch<HasBoosting>)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiUnaryMatch => OuterGenericMatcher((MultiUnaryMatch)(object)firstInnerSet, firstOuterSet, token),
+                _ => OuterGenericMatcher(firstInnerSet, firstOuterSet, token),
+            };
 
-        return BinaryMatch.Create(BinaryMatch<TInner, TOuter>.YieldOr(this, in set1, in set2, token));
+        BinaryMatch OuterGenericMatcher<TSecondInner, TSecondOuter>(in TSecondInner secondInnerSet, in TSecondOuter secondOuterSet, in CancellationToken token = default)
+            where TSecondInner : IQueryMatch
+            where TSecondOuter : IQueryMatch 
+            => QueryBuilderHelper.GetQueryType(secondOuterSet) switch
+            {
+                QueryBuilderHelper.QueryType.TermMatch => Build(secondInnerSet, (TermMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.BinaryMatch => Build(secondInnerSet, (BinaryMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiTermMatch => Build(secondInnerSet, (MultiTermMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.AndNotMatch => Build(secondInnerSet, (AndNotMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.BoostingMatch => Build(secondInnerSet, (BoostingMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchNoBoosting => Build(secondInnerSet, (SpatialMatch<NoBoosting>)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchHasBoosting => Build(secondInnerSet, (SpatialMatch<HasBoosting>)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiUnaryMatch => Build(secondInnerSet, (MultiUnaryMatch)(object)secondOuterSet, token),
+                _ => Build(secondInnerSet, secondOuterSet, token),
+            };
+
+        BinaryMatch Build<TBuildInner, TBuildOuter>(in TBuildInner buildInnerSet, in TBuildOuter buildOuterSet, in CancellationToken token = default)
+            where TBuildInner : IQueryMatch
+            where TBuildOuter : IQueryMatch 
+            => BinaryMatch.Create(BinaryMatch<TBuildInner, TBuildOuter, BinaryMatch.Or>.YieldOr(this, in buildInnerSet, in buildOuterSet, token));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public AndNotMatch AndNot<TInner, TOuter>(in TInner set1, in TOuter set2, in CancellationToken token = default)
+    public AndNotMatch AndNot<TInner, TOuter>(in TInner innerSet, in TOuter outerSet, in CancellationToken token = default)
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
     {
+        if (typeof(TInner) != typeof(IQueryMatch) && typeof(TOuter) != typeof(IQueryMatch))
+            return Build(innerSet, outerSet, token);
 
-        // If any of the generic types is not known to be a struct (calling from interface) the code executed will
-        // do all the work to figure out what to emit. The cost is in instantiation not on execution.                         
-        if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(TermMatch))
-        {
-            return AndNotMatch.Create(AndNotMatch<TermMatch, TermMatch>.Create(this, (TermMatch)(object)set1, (TermMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(TermMatch))
-        {
-            return AndNotMatch.Create(AndNotMatch<BinaryMatch, TermMatch>.Create(this, (BinaryMatch)(object)set1, (TermMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(TermMatch) && set2.GetType() == typeof(BinaryMatch))
-        {
-            return AndNotMatch.Create(AndNotMatch<TermMatch, BinaryMatch>.Create(this, (TermMatch)(object)set1, (BinaryMatch)(object)set2, token));
-        }
-        else if (set1.GetType() == typeof(BinaryMatch) && set2.GetType() == typeof(BinaryMatch))
-        {
-            return AndNotMatch.Create(AndNotMatch<BinaryMatch, BinaryMatch>.Create(this, (BinaryMatch)(object)set1, (BinaryMatch)(object)set2, token));
-        }
+        return MatchTypeAndBuild(innerSet, outerSet, token);
+        
+        AndNotMatch MatchTypeAndBuild<TFirstInner, TFirstOuter>(in TFirstInner firstInnerSet, in TFirstOuter firstOuterSet, in CancellationToken token)
+            where TFirstInner : IQueryMatch
+            where TFirstOuter : IQueryMatch 
+            => QueryBuilderHelper.GetQueryType(firstInnerSet) switch
+            {
+                QueryBuilderHelper.QueryType.TermMatch => OuterGenericMatcher((TermMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.BinaryMatch => OuterGenericMatcher((BinaryMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiTermMatch => OuterGenericMatcher((MultiTermMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.AndNotMatch => OuterGenericMatcher((AndNotMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.BoostingMatch => OuterGenericMatcher((BoostingMatch)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchNoBoosting => OuterGenericMatcher((SpatialMatch<NoBoosting>)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchHasBoosting => OuterGenericMatcher((SpatialMatch<HasBoosting>)(object)firstInnerSet, firstOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiUnaryMatch => OuterGenericMatcher((MultiUnaryMatch)(object)firstInnerSet, firstOuterSet, token),
+                _ => OuterGenericMatcher(firstInnerSet, firstOuterSet, token),
+            };
 
-        return AndNotMatch.Create(AndNotMatch<TInner, TOuter>.Create(this, in set1, in set2, token));
+        AndNotMatch OuterGenericMatcher<TSecondInner, TSecondOuter>(in TSecondInner secondInnerSet, in TSecondOuter secondOuterSet, in CancellationToken token = default)
+            where TSecondInner : IQueryMatch
+            where TSecondOuter : IQueryMatch 
+            => QueryBuilderHelper.GetQueryType(secondOuterSet) switch
+            {
+                QueryBuilderHelper.QueryType.TermMatch => Build(secondInnerSet, (TermMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.BinaryMatch => Build(secondInnerSet, (BinaryMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiTermMatch => Build(secondInnerSet, (MultiTermMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.AndNotMatch => Build(secondInnerSet, (AndNotMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.BoostingMatch => Build(secondInnerSet, (BoostingMatch)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchNoBoosting => Build(secondInnerSet, (SpatialMatch<NoBoosting>)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.SpatialMatchHasBoosting => Build(secondInnerSet, (SpatialMatch<HasBoosting>)(object)secondOuterSet, token),
+                QueryBuilderHelper.QueryType.MultiUnaryMatch => Build(secondInnerSet, (MultiUnaryMatch)(object)secondOuterSet, token),
+                _ => Build(secondInnerSet, secondOuterSet, token),
+            };
+
+        AndNotMatch Build<TBuildInner, TBuildOuter>(in TBuildInner buildInnerSet, in TBuildOuter buildOuterSet, in CancellationToken token = default)
+            where TBuildInner : IQueryMatch
+            where TBuildOuter : IQueryMatch 
+            => AndNotMatch.Create(AndNotMatch<TBuildInner, TBuildOuter>.Create(this, in buildInnerSet, in buildOuterSet, token));
     }
 }

--- a/src/Corax/Querying/IndexSearcher.QueryBuilderHelper.cs
+++ b/src/Corax/Querying/IndexSearcher.QueryBuilderHelper.cs
@@ -1,0 +1,54 @@
+﻿using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Matches.SpatialMatch;
+
+namespace Corax.Querying;
+
+public partial class IndexSearcher
+{
+    private static class QueryBuilderHelper
+    {
+        public enum QueryType
+        {
+            TermMatch,
+            BinaryMatch,
+            MultiTermMatch,
+            AndNotMatch,
+            BoostingMatch,
+            SpatialMatchNoBoosting,
+            SpatialMatchHasBoosting,
+            MultiUnaryMatch,
+            IQueryMatch
+        }
+
+        public static QueryType GetQueryType<T>(in T match)
+        {
+            var type = match.GetType();
+            if (type == typeof(TermMatch))
+                return QueryType.TermMatch;
+
+            if (type == typeof(BinaryMatch))
+                return QueryType.BinaryMatch;
+            
+            if (type == typeof(MultiTermMatch))
+                return QueryType.MultiTermMatch;
+            
+            if (type == typeof(AndNotMatch))
+                return QueryType.AndNotMatch;
+            
+            if (type == typeof(BoostingMatch))
+                return QueryType.BoostingMatch;
+            
+            if (type == typeof(SpatialMatch<NoBoosting>))
+                return QueryType.SpatialMatchNoBoosting;
+            
+            if (type == typeof(SpatialMatch<HasBoosting>))
+                return QueryType.SpatialMatchHasBoosting;
+            
+            if (type == typeof(MultiUnaryMatch))
+                return QueryType.MultiUnaryMatch;
+
+            return QueryType.IQueryMatch;
+        }
+    }
+}

--- a/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
@@ -9,13 +9,13 @@ using Sparrow.Server.Utils;
 
 namespace Corax.Querying.Matches
 {
-    unsafe partial struct BinaryMatch<TInner, TOuter>
+    unsafe partial struct BinaryMatch<TInner, TOuter, TBinaryOperationMarker>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BinaryMatch<TInner, TOuter> YieldAnd(Querying.IndexSearcher searcher, in TInner inner, in TOuter outer, in CancellationToken token)
+        public static BinaryMatch<TInner, TOuter, TBinaryOperationMarker> YieldAnd(Querying.IndexSearcher searcher, in TInner inner, in TOuter outer, in CancellationToken token)
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static int FillFunc(ref BinaryMatch<TInner, TOuter> match, Span<long> matches)
+            static int FillFunc(ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker> match, Span<long> matches)
             {
                 match._token.ThrowIfCancellationRequested();
                 ref var inner = ref match._inner;
@@ -85,7 +85,7 @@ namespace Corax.Querying.Matches
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            static int AndWith(ref BinaryMatch<TInner, TOuter> match, Span<long> buffer, int matches)
+            static int AndWith(ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker> match, Span<long> buffer, int matches)
             {
                 ref var inner = ref match._inner;
                 match._token.ThrowIfCancellationRequested();
@@ -98,7 +98,7 @@ namespace Corax.Querying.Matches
                 return outer.AndWith(buffer, results);
             }
 
-            static QueryInspectionNode InspectFunc(ref BinaryMatch<TInner, TOuter> match)
+            static QueryInspectionNode InspectFunc(ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker> match)
             {
                 return new QueryInspectionNode($"{nameof(BinaryMatch)} [And]",
                     children: new List<QueryInspectionNode> { match._inner.Inspect(), match._outer.Inspect() },
@@ -119,15 +119,15 @@ namespace Corax.Querying.Matches
             else
                 confidence = inner.Confidence.Min(outer.Confidence);
 
-            return new BinaryMatch<TInner, TOuter>(searcher, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, Math.Min(inner.Count, outer.Count), confidence, SkipSortingResult.ResultsNativelySorted, token);
+            return new BinaryMatch<TInner, TOuter, TBinaryOperationMarker>(searcher, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, Math.Min(inner.Count, outer.Count), confidence, SkipSortingResult.ResultsNativelySorted, token);
         }
 
-        public static BinaryMatch<TInner, TOuter> YieldOr(Querying.IndexSearcher indexSearcher, in TInner inner, in TOuter outer, in CancellationToken token)
+        public static BinaryMatch<TInner, TOuter, TBinaryOperationMarker> YieldOr(Querying.IndexSearcher indexSearcher, in TInner inner, in TOuter outer, in CancellationToken token)
         {
 #if !DEBUG
             [SkipLocalsInit]
 #endif
-            static int AndWith(ref BinaryMatch<TInner, TOuter> match, Span<long> buffer, int matches)
+            static int AndWith(ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker> match, Span<long> buffer, int matches)
             {
                 match._token.ThrowIfCancellationRequested();
                 ref var inner = ref match._inner;
@@ -160,7 +160,7 @@ namespace Corax.Querying.Matches
 #if !DEBUG
             [SkipLocalsInit]
 #endif
-            static int FillFunc(ref BinaryMatch<TInner, TOuter> match, Span<long> matches)
+            static int FillFunc(ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker> match, Span<long> matches)
             {
                 match._token.ThrowIfCancellationRequested();
                 ref var inner = ref match._inner;
@@ -298,7 +298,7 @@ namespace Corax.Querying.Matches
                 return totalLength;
             }      
 
-            static QueryInspectionNode InspectFunc(ref BinaryMatch<TInner, TOuter> match)
+            static QueryInspectionNode InspectFunc(ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker> match)
             {
                 return new QueryInspectionNode($"{nameof(BinaryMatch)} [Or]",
                     children: new List<QueryInspectionNode> { match._inner.Inspect(), match._outer.Inspect() },
@@ -319,7 +319,7 @@ namespace Corax.Querying.Matches
             else
                 confidence = inner.Confidence.Min(outer.Confidence);
 
-            return new BinaryMatch<TInner, TOuter>(indexSearcher, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, inner.Count + outer.Count, confidence,
+            return new BinaryMatch<TInner, TOuter, TBinaryOperationMarker>(indexSearcher, in inner, in outer, &FillFunc, &AndWith, &InspectFunc, inner.Count + outer.Count, confidence,
                 // For OR, assume (Name = 'Mario' or endsWith(Name, 'o') 
                 // We get Mario from the left, and get Arlo, Enzo and Nico from the right in one Fill()
                 // and in the next, we get nothing from the left and Mario from the right. 

--- a/src/Corax/Querying/Matches/BinaryMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Erasure.cs
@@ -68,9 +68,10 @@ namespace Corax.Querying.Matches
             }
         }
 
-        private static class StaticFunctionCache<TInner, TOuter>
+        private static class StaticFunctionCache<TInner, TOuter, TBinaryOperationMarker>
             where TInner : IQueryMatch
             where TOuter : IQueryMatch
+            where TBinaryOperationMarker : IBinaryMatchMarker
         {
             public static readonly FunctionTable FunctionTable;
 
@@ -78,13 +79,13 @@ namespace Corax.Querying.Matches
             {
                 static long CountFunc(ref BinaryMatch match)
                 {
-                    return ((BinaryMatch<TInner, TOuter>)match._inner).Count;
+                    return ((BinaryMatch<TInner, TOuter, TBinaryOperationMarker>)match._inner).Count;
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 static int FillFunc(ref BinaryMatch match, Span<long> matches)
                 {
-                    if (match._inner is BinaryMatch<TInner, TOuter> inner)
+                    if (match._inner is BinaryMatch<TInner, TOuter, TBinaryOperationMarker> inner)
                     {
                         var result = inner.Fill(matches);
                         match._inner = inner;
@@ -96,7 +97,7 @@ namespace Corax.Querying.Matches
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 static int AndWithFunc(ref BinaryMatch match, Span<long> buffer, int matches)
                 {
-                    if (match._inner is BinaryMatch<TInner, TOuter> inner)
+                    if (match._inner is BinaryMatch<TInner, TOuter, TBinaryOperationMarker> inner)
                     {
                         var result = inner.AndWith(buffer, matches);
                         match._inner = inner;
@@ -108,7 +109,7 @@ namespace Corax.Querying.Matches
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 static void ScoreFunc(ref BinaryMatch match, Span<long> matches, Span<float> scores, float boostFactor)
                 {
-                    if (match._inner is BinaryMatch<TInner, TOuter> inner)
+                    if (match._inner is BinaryMatch<TInner, TOuter, TBinaryOperationMarker> inner)
                     {
                         inner.Score(matches, scores, boostFactor);
                         match._inner = inner;
@@ -120,13 +121,17 @@ namespace Corax.Querying.Matches
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static BinaryMatch Create<TInner, TOuter>(in BinaryMatch<TInner, TOuter> query)
+        public static BinaryMatch Create<TInner, TOuter, TBinaryOperationMarker>(in BinaryMatch<TInner, TOuter, TBinaryOperationMarker> query)
             where TInner : IQueryMatch
             where TOuter : IQueryMatch
+            where TBinaryOperationMarker : IBinaryMatchMarker
         {
-            return new BinaryMatch(query, StaticFunctionCache<TInner, TOuter>.FunctionTable);
+            return new BinaryMatch(query, StaticFunctionCache<TInner, TOuter, TBinaryOperationMarker>.FunctionTable);
         }
 
         string DebugView => Inspect().ToString();
+        
+        public struct And : IBinaryMatchMarker;
+        public struct Or : IBinaryMatchMarker;
     }
 }

--- a/src/Corax/Querying/Matches/BinaryMatch.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.cs
@@ -8,13 +8,14 @@ using Sparrow.Server;
 namespace Corax.Querying.Matches
 {
     [DebuggerDisplay("{DebugView,nq}")]
-    public unsafe partial struct BinaryMatch<TInner, TOuter> : IQueryMatch
+    public unsafe partial struct BinaryMatch<TInner, TOuter, TBinaryOperationMarker> : IQueryMatch
         where TInner : IQueryMatch
         where TOuter : IQueryMatch
+        where TBinaryOperationMarker : IBinaryMatchMarker
     {
-        private readonly delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int> _fillFunc;
-        private readonly delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int, int> _andWithFunc;
-        private readonly delegate*<ref BinaryMatch<TInner, TOuter>, QueryInspectionNode> _inspectFunc;
+        private readonly delegate*<ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker>, Span<long>, int> _fillFunc;
+        private readonly delegate*<ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker>, Span<long>, int, int> _andWithFunc;
+        private readonly delegate*<ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker>, QueryInspectionNode> _inspectFunc;
 
         private TInner _inner;
         private TOuter _outer;
@@ -39,9 +40,9 @@ namespace Corax.Querying.Matches
         private BinaryMatch(
             Querying.IndexSearcher indexSearcher,
             in TInner inner, in TOuter outer,
-            delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int> fillFunc,
-            delegate*<ref BinaryMatch<TInner, TOuter>, Span<long>, int, int> andWithFunc,
-            delegate*<ref BinaryMatch<TInner, TOuter>, QueryInspectionNode> inspectionFunc,
+            delegate*<ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker>, Span<long>, int> fillFunc,
+            delegate*<ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker>, Span<long>, int, int> andWithFunc,
+            delegate*<ref BinaryMatch<TInner, TOuter, TBinaryOperationMarker>, QueryInspectionNode> inspectionFunc,
             long totalResults,
             QueryCountConfidence confidence,
             SkipSortingResult skipSortingResult,

--- a/src/Corax/Querying/Matches/Meta/BinaryMatchOperationMarker.cs
+++ b/src/Corax/Querying/Matches/Meta/BinaryMatchOperationMarker.cs
@@ -1,0 +1,3 @@
+﻿namespace Corax.Querying.Matches.Meta;
+
+public interface IBinaryMatchMarker;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24165

### Additional description

Added better `BinaryMatch` builder to match multiple combinations of generic types and also added generic type which allows identifying the type of binary operation from the stack trace (Or/And).


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
