### PR TITLE
RavenDB-24585 AI Agent: allow to resume the test

### DIFF
--- a/src/Raven.Client/Documents/AI/Conversation.cs
+++ b/src/Raven.Client/Documents/AI/Conversation.cs
@@ -91,7 +91,7 @@ internal class Conversation<T> : IConversationOperations<T> where T : new()
         {
             var r = await _aiOperations._executor.SendAsync(op, token).ConfigureAwait(false);
             _conversationId = r.ConversationId;
-            _actionRequests = r.ToolRequests ?? new List<AiAgentActionRequest>();
+            _actionRequests = r.ActionRequests ?? new List<AiAgentActionRequest>();
             _answer = r.Response;
         }
         finally

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -18,7 +18,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly Dictionary<string, object> _parameters;
 
     private readonly string _conversationId;
-    private readonly List<AiAgentActionResponse> _toolResponses;
+    private readonly List<AiAgentActionResponse> _actionResponses;
     public RunConversationOperation(string agentId, string userPrompt, Dictionary<string, object> parameters)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -29,18 +29,18 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _parameters = parameters;
     }
 
-    public RunConversationOperation(string conversationId, string userPrompt = null, List<AiAgentActionResponse> toolResponses = null)
+    public RunConversationOperation(string conversationId, string userPrompt = null, List<AiAgentActionResponse> actionResponses = null)
     {
         ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
      
         _conversationId = conversationId;
         _userPrompt = userPrompt;
-        _toolResponses = toolResponses;
+        _actionResponses = actionResponses;
     }
 
     public RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new RunConversationOperationCommand(_conversationId, _agentId, _userPrompt, _parameters, _toolResponses, conventions);
+        return new RunConversationOperationCommand(_conversationId, _agentId, _userPrompt, _parameters, _actionResponses, conventions);
     }
 
     internal sealed class RunConversationOperationCommand : RavenCommand<ConversationResult<TSchema>>
@@ -49,16 +49,16 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         private readonly string _agentId;
         private readonly string _prompt;
         private readonly Dictionary<string, object> _parameters;
-        private readonly List<AiAgentActionResponse> _toolResponses;
+        private readonly List<AiAgentActionResponse> _actionResponses;
         private readonly DocumentConventions _conventions;
 
-        public RunConversationOperationCommand(string conversationId, string agentId, string prompt, Dictionary<string, object> parameters, List<AiAgentActionResponse> toolResponses, DocumentConventions conventions)
+        public RunConversationOperationCommand(string conversationId, string agentId, string prompt, Dictionary<string, object> parameters, List<AiAgentActionResponse> actionResponses, DocumentConventions conventions)
         {
             _conversationId = conversationId;
             _agentId = agentId;
             _prompt = prompt;
             _parameters = parameters;
-            _toolResponses = toolResponses;
+            _actionResponses = actionResponses;
             _conventions = conventions;
         }
         public override bool IsReadRequest => false;
@@ -78,7 +78,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             var body = new ConversionRequestBody
             {
                 Parameters = _parameters ?? new Dictionary<string, object>(),
-                ActionResponses = _toolResponses,
+                ActionResponses = _actionResponses,
                 UserPrompt = _prompt
             };
 
@@ -125,7 +125,7 @@ public class ConversationResult<TSchema>
     public string ConversationId { get; set; }
     public TSchema Response { get; set; }
     public AiUsage Usage { get; set; }
-    public List<AiAgentActionRequest> ToolRequests { get; set; }
+    public List<AiAgentActionRequest> ActionRequests { get; set; }
 
     internal static ConversationResult<TSchema> Convert(BlittableJsonReaderObject response, DocumentConventions conventions)
     {
@@ -134,12 +134,12 @@ public class ConversationResult<TSchema>
         response.TryGet(nameof(ConversationId), out string conversationId);
 
         List<AiAgentActionRequest> requests = null;
-        if (response.TryGet(nameof(ToolRequests), out BlittableJsonReaderArray toolRequests) && toolRequests != null)
+        if (response.TryGet(nameof(ActionRequests), out BlittableJsonReaderArray actionRequests) && actionRequests != null)
         {
             requests = [];
-            foreach (BlittableJsonReaderObject toolRequest in toolRequests)
+            foreach (BlittableJsonReaderObject actionRequest in actionRequests)
             {
-                var r = JsonDeserializationClient.ToolRequest(toolRequest);
+                var r = JsonDeserializationClient.ActionRequest(actionRequest);
                 requests.Add(r);
             }
         }
@@ -147,7 +147,7 @@ public class ConversationResult<TSchema>
         return new ConversationResult<TSchema>
         {
             ConversationId = conversationId,
-            ToolRequests = requests,
+            ActionRequests = requests,
             Usage = JsonDeserializationClient.AiUsage(usage),
             Response = result == null ? default : conventions.Serialization.DefaultConverter.FromBlittable<TSchema>(result, conversationId)
         };

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -343,8 +343,8 @@ namespace Raven.Client.Json.Serialization
         
         public static readonly Func<BlittableJsonReaderObject, AiUsage> AiUsage = GenerateJsonDeserializationRoutine<AiUsage>();
 
-        public static readonly Func<BlittableJsonReaderObject, AiAgentActionRequest> ToolRequest = GenerateJsonDeserializationRoutine<AiAgentActionRequest>();
+        public static readonly Func<BlittableJsonReaderObject, AiAgentActionRequest> ActionRequest = GenerateJsonDeserializationRoutine<AiAgentActionRequest>();
 
-        public static readonly Func<BlittableJsonReaderObject, AiAgentActionResponse> ToolResponse = GenerateJsonDeserializationRoutine<AiAgentActionResponse>();
+        public static readonly Func<BlittableJsonReaderObject, AiAgentActionResponse> ActionResponse = GenerateJsonDeserializationRoutine<AiAgentActionResponse>();
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             {
                 foreach (BlittableJsonReaderObject tool in body.ActionResponses)
                 {
-                    var t = JsonDeserializationClient.ToolResponse(tool);
+                    var t = JsonDeserializationClient.ActionResponse(tool);
                     if (document.OpenActionCalls.Remove(t.ToolId) == false)
                         throw new InvalidOperationException($"{t.ToolId} is an unknown action ID for conversation '{conversationId}'");
 
@@ -221,7 +221,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             {
                 [nameof(ConversationResult<object>.ConversationId)] = conversationId,
                 [nameof(ConversationResult<object>.Response)] = r.Response,
-                [nameof(ConversationResult<object>.ToolRequests)] = new DynamicJsonArray(r.Document.OpenActionCalls.Select(t => t.Value.ToJson())),
+                [nameof(ConversationResult<object>.ActionRequests)] = new DynamicJsonArray(r.Document.OpenActionCalls.Select(t => t.Value.ToJson())),
                 [nameof(ConversationResult<object>.Usage)] = r.Document.TotalUsage.ToJson()
             };
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents;
 
@@ -22,12 +23,11 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         var options = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "ai-agent", token.Token);
         
         var body = JsonDeserializationServer.AiAgentTestRequest(options);
-        body.Validate();
 
         ConversationDocument conversation = null;
-        if (options.TryGet("Document", out BlittableJsonReaderObject doc))
+        if (body.Document != null)
         {
-            conversation = ConversationDocument.ToDocument("test", doc);
+            conversation = ConversationDocument.ToDocument("test", body.Document);
         }
 
         if (conversation == null)
@@ -46,14 +46,22 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
     {
         var output = new DynamicJsonValue
         {
-            ["Document"] = r.Document.ToJson(),
-            [nameof(ConversationResult<object>.Response)] = r.Response,
-            [nameof(ConversationResult<object>.ToolRequests)] = new DynamicJsonArray(r.Document.OpenActionCalls.Select(t => t.Value.ToJson())),
-            [nameof(ConversationResult<object>.Usage)] = r.Document.TotalUsage.ToJson()
+            [nameof(AiAgentTestResult.Document)] = r.Document.ToJson(),
+            [nameof(AiAgentTestResult.Response)] = r.Response,
+            [nameof(AiAgentTestResult.ActionRequests)] = new DynamicJsonArray(r.Document.OpenActionCalls.Select(t => t.Value.ToJson())),
+            [nameof(AiAgentTestResult.Usage)] = r.Document.TotalUsage.ToJson()
         };
 
         await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
         context.Write(writer, output);
+    }
+
+    public class AiAgentTestResult
+    {
+        public BlittableJsonReaderObject Document;
+        public BlittableJsonReaderObject Response;
+        public BlittableJsonReaderArray ActionRequests;
+        public AiUsage Usage;
     }
 
     public class AiAgentTestRequest
@@ -62,22 +70,13 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         public BlittableJsonReaderObject Parameters;
         public AiAgentConfiguration Configuration;
         public BlittableJsonReaderArray ActionResponses;
-
+        public BlittableJsonReaderObject Document;
+        
         public RequestBody RequestBody => new RequestBody
         {
             UserPrompt = UserPrompt,
             Parameters = Parameters,
             ActionResponses = ActionResponses
         };
-
-        public void Validate()
-        {
-            if (string.IsNullOrEmpty(UserPrompt))
-                throw new ArgumentException("Prompt is required for AI Agent test.");
-            if (Configuration == null)
-                throw new ArgumentException("Configuration is required for AI Agent test.");
-            if (Parameters == null)
-                throw new ArgumentException("Parameters are required for AI Agent test.");
-        }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -139,7 +139,7 @@ public class ConversationDocument(string agent, BlittableJsonReaderObject parame
         var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
         {
-            var call = JsonDeserializationClient.ToolRequest(openToolCalls[callId] as BlittableJsonReaderObject);
+            var call = JsonDeserializationClient.ActionRequest(openToolCalls[callId] as BlittableJsonReaderObject);
             openTools.Add(callId, call);
         }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -1,13 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Exceptions;
-using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Json.Sync;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -45,22 +52,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration
-            {
-                Collection = "Chats",
-                Expires = TimeSpan.FromDays(30)
-            };
+            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
             agent.Parameters.Add("company");
             agent.Queries =
             [
                 new AiAgentToolQuery
                 {
-                    Name = "ProductSearch", 
-                    Description =  "semantic search the store product catalog",
+                    Name = "ProductSearch",
+                    Description = "semantic search the store product catalog",
                     Query = "from Products where vector.search(embedding.text(Name), $query)",
                     ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
-                }
-                ,
+                },
                 new AiAgentToolQuery
                 {
                     Name = "RecentOrder",
@@ -96,22 +98,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration
-            {
-                Collection = "Chats",
-                Expires = TimeSpan.FromDays(30)
-            };
+            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
             agent.Parameters.Add("company");
             agent.Queries =
             [
                 new AiAgentToolQuery
                 {
-                    Name = "ProductSearch", 
-                    Description =  "semantic search the store product catalog",
+                    Name = "ProductSearch",
+                    Description = "semantic search the store product catalog",
                     Query = "from Products where vector.search(embedding.text(Name), $query)",
                     ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
-                }
-                ,
+                },
                 new AiAgentToolQuery
                 {
                     Name = "RecentOrder",
@@ -151,51 +148,38 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration
-            {
-                Collection = "Chats",
-                Expires = TimeSpan.FromDays(30)
-            };
+            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
 
             agent.Actions =
             [
                 new AiAgentToolAction
                 {
-                    Name = "ProductSearch", 
-                    Description =  "semantic search the store product catalog",
+                    Name = "ProductSearch",
+                    Description = "semantic search the store product catalog",
                     ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
-                }
-                ,
-                new AiAgentToolAction
-                {
-                    Name = "RecentOrder",
-                    Description = "Get the recent orders of the current user",
-                    ParametersSampleObject = "{}"
-                }
+                },
+                new AiAgentToolAction { Name = "RecentOrder", Description = "Get the recent orders of the current user", ParametersSampleObject = "{}" }
             ];
 
             var agentResult = await store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation<OutputSchema>(agent));
-            var r = await store.Maintenance.SendAsync(new RunConversationOperation<OutputSchema>(agentResult.Identifier, "what goes well with my cheese for recent orders?",
+            var r = await store.Maintenance.SendAsync(new RunConversationOperation<OutputSchema>(agentResult.Identifier,
+                "what goes well with my cheese for recent orders?",
                 parameters: null));
 
-            Assert.True(r.ToolRequests.Count > 0);
+            Assert.True(r.ActionRequests.Count > 0);
             Assert.NotNull(r.Usage);
             Assert.NotNull(r.ConversationId);
 
             var toolResponse = new List<AiAgentActionResponse>();
-            for (int i = 0; i < r.ToolRequests.Count; i++)
+            for (int i = 0; i < r.ActionRequests.Count; i++)
             {
-                var request = r.ToolRequests[i];
-                toolResponse.Add(new AiAgentActionResponse
-                {
-                    ToolId = request.ToolId,
-                    Content = "{}"
-                });
+                var request = r.ActionRequests[i];
+                toolResponse.Add(new AiAgentActionResponse { ToolId = request.ToolId, Content = "{}" });
             }
 
-            var r2 = await store.Maintenance.SendAsync(new RunConversationOperation<OutputSchema>(r.ConversationId, toolResponses: toolResponse));
+            var r2 = await store.Maintenance.SendAsync(new RunConversationOperation<OutputSchema>(r.ConversationId, actionResponses: toolResponse));
 
-            Assert.True(r2.Response?.Answer != null || r2.ToolRequests != null);
+            Assert.True(r2.Response?.Answer != null || r2.ActionRequests != null);
             Assert.NotNull(r2.Usage);
             Assert.NotNull(r2.ConversationId);
         }
@@ -208,44 +192,183 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
+            var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+            agent.Identifier = "shopping-assistant";
+            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
 
-            var body = @$"{{    
-""{nameof(AiAgentProcessorForTestConversation.AiAgentTestRequest.Parameters)}"": {{
-        ""company"": ""companies/90-A""
-    }},
-""{nameof(AiAgentProcessorForTestConversation.AiAgentTestRequest.UserPrompt)}"": ""Help to find something more to my recent order"",
-""{nameof(AiAgentProcessorForTestConversation.AiAgentTestRequest.Configuration)}"":{{
-    ""ConnectionStringName"": ""{config.ConnectionStringName}"",
-    ""SystemPrompt"": ""You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well."",
-    ""SampleObject"": ""{{\""Answer\"": \""Answer to the user question\"", \""Relevant\"": true, \""RelevantOrdersId\"":[\""The order ids relevant to the query or response\""], \""MatchingProductsId\"":[\""All the product ids referenced either by the user or the system\""] }}"",
-    ""Persistence"": {{
-        ""Collection"": ""Chats"",
-        ""Expires"": ""3.00:00:00""
-    }},
-    ""Parameters"": [""company""],
-    ""Queries"": [
-        {{
-            ""Name"": ""ProductSearch"",
-            ""Description"": ""semantic search the store product catalog"",
-            ""Query"": ""from Products where vector.search(embedding.text(Name), $query)"",
-            ""ParametersSampleObject"": ""{{\""query\"": [\""term or phrase to search in the catalog\""]}}""
-        }},
-        {{
-            ""Name"": ""RecentOrder"",
-            ""Description"": ""Get the recent orders of the current user"",
-            ""Query"": ""from Orders where Company = $company order by OrderedAt desc limit 10"",
-            ""ParametersSampleObject"": ""{{}}""
-        }}
-    ]
-}}}}";
-            using var test = new HttpRequestMessage
+            agent.Actions =
+            [
+                new AiAgentToolAction
+                {
+                    Name = "ProductSearch",
+                    Description = "semantic search the store product catalog",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                },
+                new AiAgentToolAction { Name = "RecentOrder", Description = "Get the recent orders of the current user", ParametersSampleObject = "{}" }
+            ];
+
+            var r = await store.Maintenance.SendAsync(new RunTestConversationOperation<OutputSchema>(
+                agent,
+                document: null,
+                "what goes well with my cheese for recent orders?",
+                new Dictionary<string, object> { ["company"] = "companies/90-A" },
+                actionResponses: null));
+
+            var responses = new List<AiAgentActionResponse>();
+            foreach (var request in r.ActionRequests)
             {
-                RequestUri = new Uri($"{store.Urls[0]}/databases/{store.Database}/ai/agent/test", UriKind.Absolute),
-                Method = HttpMethod.Post, 
-                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
-            };
-            using var r = await store.GetRequestExecutor().HttpClient.SendAsync(test);
-            Assert.True(r.IsSuccessStatusCode, "status code: " + r.StatusCode);
+                responses.Add(new AiAgentActionResponse
+                {
+                    ToolId = request.ToolId,
+                    Content = "{}" // Simulating an empty response for the action tool
+                });
+            }
+            r = await store.Maintenance.SendAsync(new RunTestConversationOperation<OutputSchema>(
+                agent,
+                document: r.Document,
+                userPrompt: null, // "what goes well with my cheese for recent orders?",
+                parameters: null,
+                actionResponses: responses));
+        }
+
+
+        private class RunTestConversationOperation<TSchema> : IMaintenanceOperation<TestResult<TSchema>> where TSchema : new()
+        {
+            private readonly AiAgentConfiguration _agent;
+            private readonly string _document;
+            private readonly string _userPrompt;
+            private readonly Dictionary<string, object> _parameters;
+            private readonly List<AiAgentActionResponse> _actionResponses;
+            public RunTestConversationOperation(AiAgentConfiguration agent, string document, string userPrompt, Dictionary<string, object> parameters, List<AiAgentActionResponse> actionResponses)
+            {
+                _agent = agent;
+                _document = document;
+                _userPrompt = userPrompt;
+                _parameters = parameters;
+                _actionResponses = actionResponses;
+            }
+            public RavenCommand<TestResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new RunConversationOperationCommand(_agent, _document, _userPrompt, _parameters, _actionResponses, conventions);
+            }
+
+            private sealed class RunConversationOperationCommand : RavenCommand<TestResult<TSchema>>
+            {
+                private readonly AiAgentConfiguration _agent;
+                private readonly string _document;
+                private readonly string _prompt;
+                private readonly Dictionary<string, object> _parameters;
+                private readonly List<AiAgentActionResponse> _toolResponses;
+                private readonly DocumentConventions _conventions;
+
+                public RunConversationOperationCommand(AiAgentConfiguration agent, string document, string prompt, Dictionary<string, object> parameters,
+                    List<AiAgentActionResponse> toolResponses, DocumentConventions conventions)
+                {
+                    _agent = agent;
+                    _document = document;
+                    _prompt = prompt;
+                    _parameters = parameters;
+                    _toolResponses = toolResponses;
+                    _conventions = conventions;
+                }
+
+                public override bool IsReadRequest => false;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/ai/agent/test";
+                   
+                    var body = new TestRequestBody
+                    {
+                        Configuration = _agent,
+                        Parameters = _parameters ?? new Dictionary<string, object>(), 
+                        ActionResponses = _toolResponses ?? [], 
+                        UserPrompt = _prompt,
+                    };
+
+                    var request = new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Post,
+                        Content = new BlittableJsonContent(async stream =>
+                        {
+                            if (_document != null)
+                                body.Document = ctx.Sync.ReadForMemory(_document, "test");
+
+                            body.Configuration.SampleObject ??= DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(new TSchema(), ctx).ToString();
+                            await ctx.WriteAsync(stream, ctx.ReadObject(body.ToJson(), "conversation-params")).ConfigureAwait(false);
+                        }, _conventions)
+                    };
+
+                    return request;
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    if (response == null)
+                        ThrowInvalidResponse();
+
+                    Result = TestResult<TSchema>.Convert(response, _conventions);
+                }
+            }
+            public class TestRequestBody : IDynamicJson
+            {
+                public string UserPrompt { get; set; }
+                public Dictionary<string, object> Parameters { get; set; }
+                public AiAgentConfiguration Configuration { get; set; }
+                public List<AiAgentActionResponse> ActionResponses { get; set; }
+
+                public BlittableJsonReaderObject Document;
+                public DynamicJsonValue ToJson()
+                {
+                    var json = new DynamicJsonValue
+                    {
+                        [nameof(UserPrompt)] = UserPrompt,
+                        [nameof(Parameters)] = DynamicJsonValue.Convert(Parameters),
+                        [nameof(Configuration)] = Configuration.ToJson(),
+                        [nameof(ActionResponses)] = new DynamicJsonArray(ActionResponses.Select(x => x.ToJson()))
+                    };
+
+                    if (Document != null)
+                        json[nameof(Document)] = Document;
+
+                    return json;
+                }
+            }
+        }
+
+        public class TestResult<TSchema> where TSchema : new()
+        {
+            public string Document;
+            public TSchema Response;
+            public List<AiAgentActionRequest> ActionRequests;
+            public AiUsage Usage;
+
+            internal static TestResult<TSchema> Convert(BlittableJsonReaderObject response, DocumentConventions conventions)
+            {
+                response.TryGet(nameof(Usage), out BlittableJsonReaderObject usage);
+                response.TryGet(nameof(Response), out BlittableJsonReaderObject result);
+                response.TryGet(nameof(Document), out BlittableJsonReaderObject document);
+
+                List<AiAgentActionRequest> requests = null;
+                if (response.TryGet(nameof(ActionRequests), out BlittableJsonReaderArray actionRequests) && actionRequests != null)
+                {
+                    requests = [];
+                    foreach (BlittableJsonReaderObject actionRequest in actionRequests)
+                    {
+                        var r = JsonDeserializationClient.ActionRequest(actionRequest);
+                        requests.Add(r);
+                    }
+                }
+
+                return new TestResult<TSchema>
+                {
+                    ActionRequests = requests,
+                    Usage = JsonDeserializationClient.AiUsage(usage),
+                    Document = document.ToString(),
+                    Response = result == null ? default : conventions.Serialization.DefaultConverter.FromBlittable<TSchema>(result, "test")
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24585 

### Additional description

allow to resume the conversation test by passing the document back to test EP

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
