### PR TITLE
RavenDB-25309: Several tests using metadata in GenAI scripts

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
@@ -118,6 +118,8 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
         {
             Debug.Assert(_configuration.EmbeddingsTransformation.Script != null, "_configuration.EmbeddingsTransformation.Script != null");
 
+            // RavenDB-24613: We need to ensure that the metadata is present to be accessible when running the script
+            Current.Document.EnsureMetadata();
             DocumentScript.Run(Context, Context, "execute", [Current.Document]);
 
             return;
@@ -127,6 +129,8 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
         {
             var aiEtlEmbeddingItem = new EmbeddingGenerationScriptResult(Current.DocumentId, Current.Collection);
 
+            // RavenDB-24613: We need to ensure that the metadata is present to be accessible when running the script
+            Current.Document.EnsureMetadata();
             foreach (var pathConfiguration in _configuration.EmbeddingsPathConfigurations)
             {
                 if (BlittableJsonTraverserHelper.TryRead(BlittableJsonTraverser.Default, Current.Document, pathConfiguration.Path, out var value) == false)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -86,6 +86,9 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
                     var args = CreatePatchArgs(context, item);
                     try
                     {
+                        // RavenDB-24613: We need to ensure that the metadata is present to be accessible when running the update script
+                        tuple.Doc.EnsureMetadata();
+                        
                         var documentInstance = (BlittableObjectInstance)runner.Translate(context, tuple.Doc).AsObject();
                         using (var scriptResult = runner.Run(context, context, "execute", item.DocumentId, [documentInstance, args]))
                         using (var old = tuple.Doc.Data)
@@ -103,7 +106,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
                         statsScope.UpdateFailures++;
                         _statistics.RecordPartialLoadError(msg, item.DocumentId);
-                        
+
                         if (_logger.IsWarnEnabled)
                             _logger.Warn(msg);
                     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -157,6 +157,9 @@ var ai = new AI();
 
             Debug.Assert(item.IsDelete is false);
 
+            // RavenDB-24613: We need to ensure that the metadata is present to be accessible when running the update script
+            Current.Document.EnsureMetadata();
+            
             DocumentScript.Run(Context, Context, "execute", [Current.Document]);
             ProcessScriptResults();
         }

--- a/test/FastTests/Server/Documents/AI/EmbeddingsWithMetadataTest.cs
+++ b/test/FastTests/Server/Documents/AI/EmbeddingsWithMetadataTest.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Documents.AI
+{
+    public class EmbeddingsWithMetadataTest(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        private class TestDocument
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<string> Tags { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public void CanCombineDocumentAndMetadataFields()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var docId = "articles/1";
+                
+                using (var session = store.OpenSession())
+                {
+                    var doc = new TestDocument
+                    {
+                        Id = docId,
+                        Name = "Technical Article",
+                        Description = "Deep dive into vector embeddings",
+                        Tags = new List<string> { "technical", "tutorial" }
+                    };
+                    
+                    session.Store(doc);
+                    
+                    var metadata = session.Advanced.GetMetadataFor(doc);
+                    metadata["author"] = "Jane Doe";
+                    metadata["publishDate"] = new DateTime(2024, 1, 15);
+                    metadata["seoDescription"] = "Learn about vector embeddings in RavenDB";
+                    metadata["targetAudience"] = "developers";
+                    
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<TestDocument>(docId);
+                    Assert.NotNull(doc);
+                    
+                    var metadata = session.Advanced.GetMetadataFor(doc);
+                    Assert.Equal("Jane Doe", metadata["author"]);
+                    Assert.Equal("developers", metadata["targetAudience"]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public void CanHandleSystemMetadataFields()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var docId = "system/1";
+                
+                using (var session = store.OpenSession())
+                {
+                    var doc = new TestDocument
+                    {
+                        Id = docId,
+                        Name = "System Test Document"
+                    };
+                    
+                    session.Store(doc);
+                    
+                    // Add custom metadata alongside system metadata
+                    var metadata = session.Advanced.GetMetadataFor(doc);
+                    metadata["customField"] = "Custom Value";
+                    
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<TestDocument>(docId);
+                    var metadata = session.Advanced.GetMetadataFor(doc);
+                    
+                    // Verify system metadata exists
+                    Assert.True(metadata.ContainsKey("@collection"));
+                    Assert.True(metadata.ContainsKey("@id"));
+                    Assert.True(metadata.ContainsKey("@change-vector"));
+                    
+                    // Verify custom metadata
+                    Assert.Equal("Custom Value", metadata["customField"]);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/Embeddings/MetadataEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/MetadataEmbeddingsTests.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.ETL.Providers.AI;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.Embeddings
+{
+    public class MetadataEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+    {
+        private class ProductDocument
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<string> Categories { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanGenerateEmbeddingsForMetadataFields()
+        {
+            using var store = GetDocumentStore();
+            string docId;
+            
+            using (var session = store.OpenSession())
+            {
+                var product = new ProductDocument
+                {
+                    Name = "Smart Watch",
+                    Description = "Advanced fitness tracking watch",
+                    Categories = new List<string> { "Electronics", "Wearables" }
+                };
+                
+                session.Store(product);
+                docId = product.Id;
+                
+                // Add metadata that we want to embed
+                var metadata = session.Advanced.GetMetadataFor(product);
+                metadata["brand"] = "TechCorp";
+                metadata["marketingDescription"] = "Experience the future of fitness tracking with our revolutionary smartwatch";
+                metadata["targetAudience"] = "Fitness enthusiasts and tech lovers";
+                metadata["searchTags"] = JArray.FromObject(new[] { "smartwatch", "fitness", "health", "wearable" });
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (config, connection) = AddEmbeddingsGenerationTask(store, embeddingsPaths:
+            [
+                new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "Description", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.brand", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.marketingDescription", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.targetAudience", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.searchTags", ChunkingOptions = DefaultChunkingOptions }
+            ]);
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+            var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
+
+            // Verify embeddings for document fields
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["Smart Watch"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Description", ["Advanced fitness tracking watch"], docId);
+            
+            // Verify embeddings for metadata fields
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.brand", ["TechCorp"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.marketingDescription", ["Experience the future of fitness tracking with our revolutionary smartwatch"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.targetAudience", ["Fitness enthusiasts and tech lovers"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.searchTags", ["smartwatch", "fitness", "health", "wearable"], docId);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanUpdateMetadataEmbeddings()
+        {
+            using var store = GetDocumentStore();
+            string docId;
+            
+            using (var session = store.OpenSession())
+            {
+                var product = new ProductDocument
+                {
+                    Name = "Laptop",
+                    Description = "High-performance laptop"
+                };
+                
+                session.Store(product);
+                docId = product.Id;
+                
+                var metadata = session.Advanced.GetMetadataFor(product);
+                metadata["category"] = "Computers";
+                metadata["keywords"] = JArray.FromObject(new[] { "laptop", "computer" });
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (config, connection) = AddEmbeddingsGenerationTask(store, embeddingsPaths:
+            [
+                new EmbeddingPathConfiguration() { Path = "@metadata.category", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.keywords", ChunkingOptions = DefaultChunkingOptions }
+            ]);
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+            var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
+
+            // Verify initial embeddings
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.category", ["Computers"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.keywords", ["laptop", "computer"], docId);
+
+            // Update metadata
+            aiTaskDone.Reset();
+            using (var session = store.OpenSession())
+            {
+                var product = session.Load<ProductDocument>(docId);
+                var metadata = session.Advanced.GetMetadataFor(product);
+                metadata["category"] = "Gaming Computers";
+                metadata["keywords"] = JArray.FromObject(new[] { "gaming", "laptop", "high-performance" });
+                
+                session.SaveChanges();
+            }
+
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            // Verify updated embeddings
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.category", ["Gaming Computers"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.keywords", ["gaming", "laptop", "high-performance"], docId);
+            
+            // Verify old embeddings are removed
+            AssertMissingEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.keywords", ["computer"], docId);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanUseTransformationScriptWithMetadata()
+        {
+            using var store = GetDocumentStore();
+            
+            using (var session = store.OpenSession())
+            {
+                var product = new ProductDocument
+                {
+                    Name = "Electric Bike",
+                    Description = "Eco-friendly transportation",
+                    Categories = new List<string> { "Transportation", "Green" }
+                };
+                
+                session.Store(product);
+                
+                var metadata = session.Advanced.GetMetadataFor(product);
+                metadata["manufacturer"] = "EcoBikes Inc";
+                metadata["sustainabilityScore"] = 95;
+                metadata["features"] = JArray.FromObject(new[] { "electric motor", "long battery life", "lightweight frame" });
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+            // Use a transformation script that combines document and metadata fields
+            var script = @"
+                const metadata = this['@metadata'];
+                const combined = {
+                    ProductInfo: this.Name + ' by ' + metadata.manufacturer,
+                    FullDescription: this.Description + '. Sustainability Score: ' + metadata.sustainabilityScore,
+                    AllFeatures: metadata.features
+                };
+                
+                embeddings.generate('ProductInfo', combined.ProductInfo);
+                embeddings.generate('FullDescription', combined.FullDescription);
+                
+                for (let feature of combined.AllFeatures) {
+                    embeddings.generate('AllFeatures', feature);
+                }
+            ";
+            
+            var (config, connection) = AddEmbeddingsGenerationTask(
+                store, 
+                script: script,
+                collectionName: "ProductDocuments"
+            );
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanHandleNestedMetadataStructures()
+        {
+            using var store = GetDocumentStore();
+            string docId;
+            
+            using (var session = store.OpenSession())
+            {
+                var product = new ProductDocument
+                {
+                    Name = "Smart Home Hub",
+                    Description = "Central control for your smart home"
+                };
+                
+                session.Store(product);
+                docId = product.Id;
+                
+                var metadata = session.Advanced.GetMetadataFor(product);
+                metadata["specifications"] = JObject.FromObject(new
+                {
+                    connectivity = new
+                    {
+                        wifi = "802.11ac",
+                        bluetooth = "5.0",
+                        protocols = new[] { "Zigbee", "Z-Wave", "Matter" }
+                    },
+                    compatibility = new
+                    {
+                        platforms = new[] { "iOS", "Android", "Web" },
+                        voiceAssistants = new[] { "Alexa", "Google Assistant", "Siri" }
+                    }
+                });
+                metadata["marketing"] = JObject.FromObject(new
+                {
+                    tagline = "Your home, smarter",
+                    benefits = new[] { "Easy setup", "Universal compatibility", "Secure" }
+                });
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (config, connection) = AddEmbeddingsGenerationTask(store, embeddingsPaths:
+            [
+                new EmbeddingPathConfiguration() { Path = "@metadata.specifications.connectivity.protocols", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.specifications.compatibility.voiceAssistants", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.marketing.tagline", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.marketing.benefits", ChunkingOptions = DefaultChunkingOptions }
+            ]);
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+            var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
+
+            // Verify embeddings for nested metadata
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, 
+                "@metadata.specifications.connectivity.protocols", ["Zigbee", "Z-Wave", "Matter"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, 
+                "@metadata.specifications.compatibility.voiceAssistants", ["Alexa", "Google Assistant", "Siri"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, 
+                "@metadata.marketing.tagline", ["Your home, smarter"], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, 
+                "@metadata.marketing.benefits", ["Easy setup", "Universal compatibility", "Secure"], docId);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanMixDocumentFieldsAndMetadataInSingleTask()
+        {
+            using var store = GetDocumentStore();
+            var docIds = new List<string>();
+            
+            using (var session = store.OpenSession())
+            {
+                // Create multiple documents with different metadata
+                var products = new[]
+                {
+                    new ProductDocument
+                    {
+                        Name = "Wireless Headphones",
+                        Description = "Premium audio experience",
+                        Categories = new List<string> { "Audio", "Wireless" }
+                    },
+                    new ProductDocument
+                    {
+                        Name = "Bluetooth Speaker",
+                        Description = "Portable sound system",
+                        Categories = new List<string> { "Audio", "Portable" }
+                    }
+                };
+
+                foreach (var product in products)
+                {
+                    session.Store(product);
+                    docIds.Add(product.Id);
+                    
+                    var metadata = session.Advanced.GetMetadataFor(product);
+                    metadata["audioQuality"] = "High-Resolution";
+                    metadata["batteryLife"] = "20 hours";
+                    metadata["specialFeatures"] = JArray.FromObject(new[] { "Noise cancellation", "Water resistant" });
+                }
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (config, connection) = AddEmbeddingsGenerationTask(store, embeddingsPaths:
+            [
+                // Document fields
+                new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "Description", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "Categories", ChunkingOptions = DefaultChunkingOptions },
+                // Metadata fields
+                new EmbeddingPathConfiguration() { Path = "@metadata.audioQuality", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.batteryLife", ChunkingOptions = DefaultChunkingOptions },
+                new EmbeddingPathConfiguration() { Path = "@metadata.specialFeatures", ChunkingOptions = DefaultChunkingOptions }
+            ]);
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+            var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
+
+            // Verify embeddings for both documents
+            foreach (var docId in docIds)
+            {
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<ProductDocument>(docId);
+                    
+                    // Verify document field embeddings
+                    AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", [doc.Name], docId);
+                    AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Description", [doc.Description], docId);
+                    AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Categories", doc.Categories.ToArray(), docId);
+                    
+                    // Verify metadata embeddings
+                    AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.audioQuality", ["High-Resolution"], docId);
+                    AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.batteryLife", ["20 hours"], docId);
+                    AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "@metadata.specialFeatures", ["Noise cancellation", "Water resistant"], docId);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/Embeddings/MetadataQueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/MetadataQueryingTests.cs
@@ -1,0 +1,440 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.ETL.Providers.AI;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.Embeddings
+{
+    public class MetadataQueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+    {
+        private class ResearchPaper
+        {
+            public string Id { get; set; }
+            public string Title { get; set; }
+            public string Abstract { get; set; }
+            public List<string> Authors { get; set; }
+        }
+
+        [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public async Task CanQueryByMetadataEmbeddings(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            
+            var papers = new List<(ResearchPaper paper, Dictionary<string, object> metadata)>
+            {
+                (
+                    new ResearchPaper
+                    {
+                        Title = "Neural Networks in Healthcare",
+                        Abstract = "Application of deep learning in medical diagnosis",
+                        Authors = new List<string> { "Dr. Smith", "Dr. Jones" }
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["field"] = "Medical AI",
+                        ["keywords"] = new[] { "healthcare", "neural networks", "diagnosis" },
+                        ["institution"] = "Medical Research Institute"
+                    }
+                ),
+                (
+                    new ResearchPaper
+                    {
+                        Title = "Quantum Computing Basics",
+                        Abstract = "Introduction to quantum mechanics in computing",
+                        Authors = new List<string> { "Prof. Anderson" }
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["field"] = "Quantum Physics",
+                        ["keywords"] = new[] { "quantum", "computing", "physics" },
+                        ["institution"] = "Physics Department University"
+                    }
+                ),
+                (
+                    new ResearchPaper
+                    {
+                        Title = "AI Ethics Framework",
+                        Abstract = "Ethical considerations in artificial intelligence development",
+                        Authors = new List<string> { "Dr. Williams" }
+                    },
+                    new Dictionary<string, object>
+                    {
+                        ["field"] = "AI Ethics",
+                        ["keywords"] = new[] { "ethics", "AI", "framework", "responsibility" },
+                        ["institution"] = "Ethics in Technology Center"
+                    }
+                )
+            };
+
+            // Store documents with metadata
+            using (var session = store.OpenSession())
+            {
+                foreach (var (paper, metadataDict) in papers)
+                {
+                    session.Store(paper);
+                    var metadata = session.Advanced.GetMetadataFor(paper);
+                    
+                    foreach (var kvp in metadataDict)
+                    {
+                        if (kvp.Value is string[] array)
+                            metadata[kvp.Key] = JArray.FromObject(array);
+                        else
+                            metadata[kvp.Key] = kvp.Value.ToString();
+                    }
+                }
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, 
+                embeddingsPaths:
+                [
+                    new EmbeddingPathConfiguration() { Path = "Title", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "Abstract", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.field", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.keywords", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.institution", ChunkingOptions = DefaultChunkingOptions }
+                ],
+                collectionName: "ResearchPapers"
+            );
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            using (var session = store.OpenSession())
+            {
+                // Query by metadata field
+                var medicalResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.field").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("Medical AI"), minimumSimilarity: 0.7f)
+                    .ToList();
+                
+                Assert.Single(medicalResults);
+                Assert.Contains("Healthcare", medicalResults[0].Title);
+
+                // Query by metadata keywords
+                var ethicsResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.keywords").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("ethical responsibility"), minimumSimilarity: 0.6f)
+                    .ToList();
+                
+                Assert.Single(ethicsResults);
+                Assert.Contains("Ethics", ethicsResults[0].Title);
+
+                // Query by institution metadata
+                var institutionResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.institution").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("Medical Institute"), minimumSimilarity: 0.7f)
+                    .ToList();
+                
+                Assert.Single(institutionResults);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public async Task CanCombineDocumentAndMetadataVectorQueries(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            
+            using (var session = store.OpenSession())
+            {
+                var paper1 = new ResearchPaper
+                {
+                    Title = "Machine Learning in Finance",
+                    Abstract = "Predictive models for financial markets"
+                };
+                session.Store(paper1);
+                var metadata1 = session.Advanced.GetMetadataFor(paper1);
+                metadata1["sector"] = "FinTech";
+                metadata1["applicationArea"] = "Stock market prediction and risk assessment";
+
+                var paper2 = new ResearchPaper
+                {
+                    Title = "Traditional Finance Models",
+                    Abstract = "Classical approaches to market analysis"
+                };
+                session.Store(paper2);
+                var metadata2 = session.Advanced.GetMetadataFor(paper2);
+                metadata2["sector"] = "Traditional Finance";
+                metadata2["applicationArea"] = "Historical market analysis methods";
+
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, 
+                embeddingsPaths:
+                [
+                    new EmbeddingPathConfiguration() { Path = "Title", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.sector", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.applicationArea", ChunkingOptions = DefaultChunkingOptions }
+                ],
+                collectionName: "ResearchPapers"
+            );
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            using (var session = store.OpenSession())
+            {
+                // Query that should match based on title
+                var titleResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText(d => d.Title).UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("AI in Financial Markets"), minimumSimilarity: 0.6f)
+                    .ToList();
+                
+                Assert.Single(titleResults);
+                Assert.Contains("Machine Learning", titleResults[0].Title);
+
+                // Query that should match based on metadata
+                var metadataResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.applicationArea").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("predict stock prices"), minimumSimilarity: 0.6f)
+                    .ToList();
+                
+                Assert.Single(metadataResults);
+                Assert.Contains("Machine Learning", metadataResults[0].Title);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public async Task CanQueryNestedMetadataEmbeddings(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            
+            using (var session = store.OpenSession())
+            {
+                var paper = new ResearchPaper
+                {
+                    Title = "Advanced NLP Techniques",
+                    Abstract = "State-of-the-art natural language processing"
+                };
+                
+                session.Store(paper);
+                
+                var metadata = session.Advanced.GetMetadataFor(paper);
+                metadata["research"] = JObject.FromObject(new
+                {
+                    methodology = "Transformer-based architecture with attention mechanisms",
+                    dataset = new
+                    {
+                        name = "Large Language Corpus",
+                        description = "Multilingual text dataset with 100B tokens",
+                        languages = new[] { "English", "Spanish", "French", "German" }
+                    },
+                    results = new
+                    {
+                        accuracy = 0.95,
+                        summary = "Achieved state-of-the-art performance on multiple benchmarks"
+                    }
+                });
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, 
+                embeddingsPaths:
+                [
+                    new EmbeddingPathConfiguration() { Path = "@metadata.research.methodology", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.research.dataset.description", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.research.dataset.languages", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.research.results.summary", ChunkingOptions = DefaultChunkingOptions }
+                ],
+                collectionName: "ResearchPapers"
+            );
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            using (var session = store.OpenSession())
+            {
+                // Query by nested methodology
+                var methodologyResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.research.methodology").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("transformer attention"), minimumSimilarity: 0.7f)
+                    .ToList();
+                
+                Assert.Single(methodologyResults);
+
+                // Query by nested dataset description
+                var datasetResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.research.dataset.description").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("multilingual corpus"), minimumSimilarity: 0.7f)
+                    .ToList();
+                
+                Assert.Single(datasetResults);
+
+                // Query by languages array
+                var languageResults = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.research.dataset.languages").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText("Spanish French"), minimumSimilarity: 0.6f)
+                    .ToList();
+                
+                Assert.Single(languageResults);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public async Task MetadataEmbeddingsAreCached(Options options)
+        {
+            const string searchQuery = "innovative technology";
+            
+            using var store = GetDocumentStore(options);
+            
+            using (var session = store.OpenSession())
+            {
+                var paper = new ResearchPaper
+                {
+                    Title = "Tech Innovation Study",
+                    Abstract = "Research on technological innovations"
+                };
+                
+                session.Store(paper);
+                
+                var metadata = session.Advanced.GetMetadataFor(paper);
+                metadata["researchFocus"] = searchQuery; // Use same text as query
+                metadata["tags"] = JArray.FromObject(new[] { "innovation", "technology", "research" });
+                
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, 
+                embeddingsPaths:
+                [
+                    new EmbeddingPathConfiguration() { Path = "@metadata.researchFocus", ChunkingOptions = DefaultChunkingOptions },
+                    new EmbeddingPathConfiguration() { Path = "@metadata.tags", ChunkingOptions = DefaultChunkingOptions }
+                ],
+                collectionName: "ResearchPapers"
+            );
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            var connectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
+
+            using (var session = store.OpenSession())
+            {
+                // First query - should generate embedding for query
+                var results1 = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.researchFocus").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText(searchQuery), minimumSimilarity: 0.9f)
+                    .ToList();
+                
+                Assert.Single(results1);
+
+                // Verify query embedding was cached
+                var hash = EmbeddingsHelper.CalculateInputValueHash(searchQuery);
+                var cacheDocId = EmbeddingsHelper.GetEmbeddingCacheDocumentId(connectionStringIdentifier, hash, VectorEmbeddingType.Single);
+                
+                // Wait for cache document to be created
+                WaitForDocument<object>(store, cacheDocId, arg => true);
+                
+                var cacheDoc = session.Load<object>(cacheDocId);
+                Assert.NotNull(cacheDoc);
+
+                // Second query with same text - should use cached embedding
+                var results2 = session.Query<ResearchPaper>()
+                    .VectorSearch(x => x.WithText("@metadata.researchFocus").UsingTask(configuration.Identifier), 
+                        factory => factory.ByText(searchQuery), minimumSimilarity: 0.9f)
+                    .ToList();
+                
+                Assert.Single(results2);
+            }
+        }
+
+        private class MetadataVectorIndex : AbstractJavaScriptIndexCreationTask
+        {
+            public MetadataVectorIndex()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('ResearchPapers', function (paper) {
+                        var metadata = paper['@metadata'];
+                        return {
+                            Title: paper.Title,
+                            CategoryVector: createVector(metadata.category),
+                            TagsVector: metadata.tags ? createVector(metadata.tags.join(' ')) : null
+                        };
+                    })"
+                };
+
+                Fields = new Dictionary<string, IndexFieldOptions>
+                {
+                    { "CategoryVector", new IndexFieldOptions { Vector = new VectorOptions { SourceEmbeddingType = VectorEmbeddingType.Text, DestinationEmbeddingType = VectorEmbeddingType.Single } } },
+                    { "TagsVector", new IndexFieldOptions { Vector = new VectorOptions { SourceEmbeddingType = VectorEmbeddingType.Text, DestinationEmbeddingType = VectorEmbeddingType.Single } } }
+                };
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+        public void CanQueryMetadataVectorsViaStaticIndex(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            
+            using (var session = store.OpenSession())
+            {
+                var papers = new[]
+                {
+                    new ResearchPaper { Title = "AI Research Paper 1" },
+                    new ResearchPaper { Title = "AI Research Paper 2" },
+                    new ResearchPaper { Title = "Physics Paper" }
+                };
+
+                var categories = new[] { "Artificial Intelligence", "Machine Learning", "Quantum Physics" };
+                var tags = new[]
+                {
+                    new[] { "AI", "neural networks", "deep learning" },
+                    new[] { "AI", "algorithms", "optimization" },
+                    new[] { "physics", "quantum", "theory" }
+                };
+
+                for (int i = 0; i < papers.Length; i++)
+                {
+                    session.Store(papers[i]);
+                    var metadata = session.Advanced.GetMetadataFor(papers[i]);
+                    metadata["category"] = categories[i];
+                    metadata["tags"] = JArray.FromObject(tags[i]);
+                }
+                
+                session.SaveChanges();
+            }
+
+            new MetadataVectorIndex().Execute(store);
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                // Query by category vector
+                var aiResults = session.Query<ResearchPaper, MetadataVectorIndex>()
+                    .VectorSearch(f => f.WithField("CategoryVector"), v => v.ByText("AI and ML"))
+                    .ToList();
+                
+                Assert.Equal(2, aiResults.Count);
+                Assert.All(aiResults, r => Assert.Contains("AI", r.Title));
+
+                // Query by tags vector
+                var quantumResults = session.Query<ResearchPaper, MetadataVectorIndex>()
+                    .VectorSearch(f => f.WithField("TagsVector"), v => v.ByText("quantum mechanics"))
+                    .ToList();
+                
+                Assert.Single(quantumResults);
+                Assert.Contains("Physics", quantumResults[0].Title);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/Embeddings/MultipleEmbeddingsGenerateCallsReproTest.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/MultipleEmbeddingsGenerateCallsReproTest.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Server.Documents.AI.Embeddings;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using Raven.Server.Documents.ETL.Providers.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.Embeddings
+{
+    public class MultipleEmbeddingsGenerateCalls(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+    {
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task MultipleEmbeddingsGenerateCallsShouldCreateAllEmbeddings()
+        {
+            using var store = GetDocumentStore();
+            
+            // Create a test document with data for multiple embeddings
+            var testDoc = new TestDocument
+            {
+                Summary = "This is a test document summary",
+                KeyWords = "test, document, summary, keywords",
+                Content = "This is the main content of the test document"
+            };
+
+            string docId;
+            using (var session = store.OpenSession())
+            {
+                session.Store(testDoc);
+                session.SaveChanges();
+                docId = testDoc.Id;
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+            // Create embeddings generation task with script that has multiple embeddings.generate() calls
+            var script = @"
+                // BUG: Multiple embeddings.generate() calls - only the last one actually works
+                // Expected: All three embeddings should be created
+                // Actual: Only the last embedding (third_embedding) is created
+                embeddings.generate({
+                    'first_embedding': this.Summary || 'default summary'
+                });
+                
+                embeddings.generate({
+                    'second_embedding': this.KeyWords || 'default keywords'
+                });
+                
+                embeddings.generate({
+                    'third_embedding': this.Content || 'default content'
+                });
+            ";
+
+            var (config, connection) = AddEmbeddingsGenerationTask(store, script: script, collectionName: "TestDocuments");
+            
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+
+            var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+            var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
+
+            // All three embeddings should be created, but due to the bug, only the last one will exist
+            // This test will fail until the bug is fixed
+            
+            // This assertion should pass - the last call works
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "third_embedding", [testDoc.Content], docId);
+            
+            // These assertions will fail due to the bug - the first two calls are ignored
+            // After the bug is fixed, these should pass
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "first_embedding", [testDoc.Summary], docId);
+            AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "second_embedding", [testDoc.KeyWords], docId);
+        }
+
+        private class TestDocument
+        {
+            public string Id { get; set; }
+            public string Summary { get; set; }
+            public string KeyWords { get; set; }
+            public string Content { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiMetadataProcessing.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiMetadataProcessing.cs
@@ -1,0 +1,429 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.ETL;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi
+{
+    public class GenAiMetadataProcessing(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        private class CustomerSupport
+        {
+            public string Id { get; set; }
+            public string TicketId { get; set; }
+            public string Subject { get; set; }
+            public string Description { get; set; }
+            public List<Message> Messages { get; set; }
+            public string Status { get; set; }
+            public string AICategory { get; set; }
+            public int UrgencyScore { get; set; }
+            public List<string> Tags { get; set; }
+        }
+
+        private class Message
+        {
+            public string Id { get; set; }
+            public string Author { get; set; }
+            public string Content { get; set; }
+            public DateTime Timestamp { get; set; }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanAccessAndUpdateMetadataInGenAiProcessing(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var etl = Etl.WaitForEtlToComplete(store);
+
+            config.Prompt = "Analyze the support ticket and determine priority, category, and routing based on content and customer metadata";
+            config.Collection = "CustomerSupports";
+            config.SampleObject = JsonConvert.SerializeObject(new 
+            { 
+                Priority = "High/Medium/Low",
+                Category = "Technical/Billing/General",
+                RequiresEscalation = true,
+                Urgency = 1, // 1-5 scale
+                Tags = new[] { "tag1", "tag2" },
+                SuggestedTeam = "Engineering/Support/Sales",
+                Reason = "Brief explanation"
+            });
+            
+            // Comprehensive transformation script that accesses all types of metadata
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = @"
+// Access document metadata
+const metadata = this['@metadata'];
+
+// Skip processing based on metadata conditions
+if (metadata.processed === true || metadata.trustedUser === true) {
+    return;
+}
+
+// Build comprehensive context from document and metadata
+const context = {
+    // Document fields
+    TicketId: this.TicketId,
+    Subject: this.Subject,
+    Description: this.Description,
+    Status: this.Status,
+    MessageCount: this.Messages.length,
+    
+    // Customer metadata (simple fields)
+    CustomerTier: metadata.customerTier || 'Standard',
+    AccountAge: metadata.accountAge || 0,
+    PreviousTickets: metadata.previousTickets || 0,
+    ContractValue: metadata.contractValue || 0,
+    
+    // Nested metadata structures
+    SupportHistory: metadata.supportHistory || {
+        avgResolutionHours: 24,
+        satisfactionScore: 3
+    },
+    
+    // Computed values from metadata
+    IsVIP: metadata.customerTier === 'Enterprise' || metadata.contractValue > 100000,
+    
+    // Messages with metadata context
+    Messages: this.Messages.map(m => ({
+        Author: m.Author,
+        Content: m.Content,
+        UserReputation: metadata.userReputation || 0
+    }))
+};
+
+ai.genContext(context);
+"
+            };
+            
+            config.UpdateScript = @"
+// Update document fields
+this.Status = $output.RequiresEscalation ? 'Escalated' : this.Status;
+this.AICategory = $output.Category;
+this.UrgencyScore = $output.Urgency;
+
+if (!this.Tags) {
+    this.Tags = [];
+}
+this.Tags = this.Tags.concat($output.Tags);
+
+// Update metadata with AI analysis
+const metadata = this['@metadata'];
+metadata.aiPriority = $output.Priority;
+metadata.aiCategory = $output.Category;
+metadata.suggestedTeam = $output.SuggestedTeam;
+metadata.aiReason = $output.Reason;
+metadata.processed = true;
+metadata.processedAt = new Date().toISOString();
+
+// Track categorization history in nested structure
+if (!metadata.aiHistory) {
+    metadata.aiHistory = [];
+}
+metadata.aiHistory.push({
+    category: $output.Category,
+    priority: $output.Priority,
+    analyzedAt: new Date().toISOString(),
+    urgency: $output.Urgency
+});
+
+// Set escalation flag if high urgency
+if ($output.Urgency >= 4) {
+    metadata.escalationRequired = true;
+}
+";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            using (var session = store.OpenSession())
+            {
+                // Create a VIP ticket with rich metadata
+                var vipTicket = new CustomerSupport
+                {
+                    TicketId = "SUP-12345",
+                    Subject = "Critical system outage affecting production",
+                    Description = "Our production environment is completely down and we're losing revenue",
+                    Messages = new List<Message>
+                    {
+                        new Message
+                        {
+                            Id = "msg1",
+                            Author = "cto@enterprise.com",
+                            Content = "This is urgent! Our entire system is down!",
+                            Timestamp = DateTime.UtcNow.AddMinutes(-30)
+                        }
+                    },
+                    Status = "Open"
+                };
+                
+                session.Store(vipTicket);
+                
+                // Add comprehensive metadata
+                var metadata = session.Advanced.GetMetadataFor(vipTicket);
+                metadata["customerTier"] = "Enterprise";
+                metadata["accountAge"] = 5;
+                metadata["previousTickets"] = 3;
+                metadata["contractValue"] = 500000;
+                metadata["userReputation"] = 100;
+                metadata["supportHistory"] = JObject.FromObject(new
+                {
+                    avgResolutionHours = 4,
+                    satisfactionScore = 4.8
+                });
+                
+                // Create a regular ticket that should be skipped
+                var trustedTicket = new CustomerSupport
+                {
+                    TicketId = "TRUST-001",
+                    Subject = "Regular question",
+                    Messages = new List<Message>
+                    {
+                        new Message
+                        {
+                            Id = "msg1",
+                            Author = "trusted@customer.com",
+                            Content = "Some regular content",
+                            Timestamp = DateTime.UtcNow
+                        }
+                    },
+                    Status = "Open"
+                };
+                session.Store(trustedTicket);
+                var trustedMetadata = session.Advanced.GetMetadataFor(trustedTicket);
+                trustedMetadata["trustedUser"] = true;
+                
+                session.SaveChanges();
+            }
+
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
+
+            // Verify metadata was processed correctly
+            using (var session = store.OpenSession())
+            {
+                var vipTicket = session.Query<CustomerSupport>()
+                    .First(t => t.TicketId == "SUP-12345");
+                var metadata = session.Advanced.GetMetadataFor(vipTicket);
+                
+                // Verify AI processed the metadata
+                Assert.True(metadata.ContainsKey("aiPriority"));
+                Assert.True(metadata.ContainsKey("aiCategory"));
+                Assert.True(metadata.ContainsKey("suggestedTeam"));
+                Assert.True(metadata.ContainsKey("processed"));
+                Assert.Equal(true, metadata["processed"]);
+                
+                // Verify history tracking
+                Assert.True(metadata.ContainsKey("aiHistory"));
+                var history = metadata["aiHistory"] as JArray;
+                Assert.NotNull(history);
+                Assert.NotEmpty(history);
+                
+                // Verify document was updated
+                Assert.NotNull(vipTicket.AICategory);
+                Assert.True(vipTicket.UrgencyScore > 0);
+                
+                // Verify trusted user ticket was not processed
+                var trustedTicket = session.Query<CustomerSupport>()
+                    .First(t => t.TicketId == "TRUST-001");
+                var trustedMeta = session.Advanced.GetMetadataFor(trustedTicket);
+                Assert.False(trustedMeta.ContainsKey("processed"));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanWorkWithNestedMetadataStructures(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var etl = Etl.WaitForEtlToComplete(store);
+
+            config.Prompt = "Analyze content for SEO optimization and content improvement";
+            config.Collection = "ContentItems";
+            config.SampleObject = JsonConvert.SerializeObject(new 
+            { 
+                SeoTitle = "Optimized title",
+                MetaDescription = "Description for search engines",
+                Keywords = new[] { "keyword1", "keyword2" },
+                ReadabilityScore = 8.5,
+                ContentSuggestions = new[] { "suggestion1", "suggestion2" },
+                TargetAudienceMatch = 0.9
+            });
+            
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = @"
+const metadata = this['@metadata'];
+
+// Access nested metadata structures
+const seo = metadata.seo || {};
+const analytics = metadata.analytics || {};
+const audience = metadata.audience || {};
+
+// Build context from nested metadata
+const context = {
+    Content: {
+        Title: this.Title,
+        Body: this.Content,
+        Author: this.Author
+    },
+    
+    CurrentSEO: {
+        Title: seo.title,
+        Description: seo.description,
+        Keywords: seo.keywords || []
+    },
+    
+    Analytics: {
+        Views: analytics.pageViews || 0,
+        EngagementTime: analytics.avgTimeSeconds || 0,
+        BounceRate: analytics.bounceRate || 0
+    },
+    
+    TargetAudience: {
+        Primary: audience.primary || 'General',
+        Interests: audience.interests || [],
+        Demographics: audience.demographics || {}
+    }
+};
+
+ai.genContext(context);
+"
+            };
+            
+            config.UpdateScript = @"
+const metadata = this['@metadata'];
+
+// Update nested SEO metadata
+if (!metadata.seo) {
+    metadata.seo = {};
+}
+metadata.seo.title = $output.SeoTitle;
+metadata.seo.description = $output.MetaDescription;
+metadata.seo.keywords = $output.Keywords;
+metadata.seo.lastOptimized = new Date().toISOString();
+metadata.seo.optimizationScore = $output.ReadabilityScore;
+
+// Update AI recommendations in nested structure
+if (!metadata.ai) {
+    metadata.ai = {};
+}
+metadata.ai.recommendations = {
+    readabilityScore: $output.ReadabilityScore,
+    suggestions: $output.ContentSuggestions,
+    targetAudienceMatch: $output.TargetAudienceMatch,
+    generatedAt: new Date().toISOString()
+};
+
+// Maintain optimization history
+if (!metadata.optimizationHistory) {
+    metadata.optimizationHistory = [];
+}
+metadata.optimizationHistory.push({
+    timestamp: new Date().toISOString(),
+    score: $output.ReadabilityScore,
+    keywordCount: $output.Keywords.length
+});
+
+// Only keep last 5 history entries
+if (metadata.optimizationHistory.length > 5) {
+    metadata.optimizationHistory = metadata.optimizationHistory.slice(-5);
+}
+";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            using (var session = store.OpenSession())
+            {
+                var content = new ContentItem
+                {
+                    Title = "Getting Started with RavenDB",
+                    Content = "RavenDB is a NoSQL document database that makes it easy to build scalable applications...",
+                    Author = "Tech Writer",
+                    CreatedAt = DateTime.UtcNow
+                };
+                
+                session.Store(content);
+                
+                var metadata = session.Advanced.GetMetadataFor(content);
+                
+                // Add complex nested metadata
+                metadata["seo"] = JObject.FromObject(new
+                {
+                    title = "RavenDB Tutorial",
+                    description = "Learn RavenDB basics",
+                    keywords = new[] { "database", "nosql" }
+                });
+                
+                metadata["analytics"] = JObject.FromObject(new
+                {
+                    pageViews = 1500,
+                    avgTimeSeconds = 240,
+                    bounceRate = 0.25
+                });
+                
+                metadata["audience"] = JObject.FromObject(new
+                {
+                    primary = "Developers",
+                    demographics = new
+                    {
+                        experienceLevel = "Intermediate",
+                        primaryLanguage = "C#"
+                    },
+                    interests = new[] { "databases", "performance", "scalability" }
+                });
+                
+                session.SaveChanges();
+            }
+
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
+
+            // Verify nested metadata was processed
+            using (var session = store.OpenSession())
+            {
+                var content = session.Query<ContentItem>().First();
+                var metadata = session.Advanced.GetMetadataFor(content);
+                
+                // Check nested AI structure was created
+                Assert.True(metadata.ContainsKey("ai"));
+                var ai = metadata["ai"] as JObject;
+                Assert.NotNull(ai);
+                Assert.True(ai.ContainsKey("recommendations"));
+                
+                // Check SEO was updated
+                var seo = metadata["seo"] as JObject;
+                Assert.NotNull(seo);
+                Assert.True(seo.ContainsKey("lastOptimized"));
+                Assert.True(seo.ContainsKey("optimizationScore"));
+                
+                // Check history exists
+                Assert.True(metadata.ContainsKey("optimizationHistory"));
+                var history = metadata["optimizationHistory"] as JArray;
+                Assert.NotNull(history);
+                Assert.NotEmpty(history);
+            }
+        }
+
+        private class ContentItem
+        {
+            public string Id { get; set; }
+            public string Title { get; set; }
+            public string Content { get; set; }
+            public string Author { get; set; }
+            public DateTime CreatedAt { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24613

### Additional description

The ETL code hands a document to the JavaScript runtime without first calling `Document.EnsureMetadata()`, so `@metadata` never exists. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
