### PR TITLE
RavenDB-24616 Use unmanaged allocation in Tree.Stream instead of LOH managed allocation

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -50,7 +50,7 @@ namespace Voron.Data.BTrees
         }
 
         private const int MaxNumberOfPagerPerChunk = 4 * Constants.Size.Megabyte / Constants.Storage.PageSize;
-
+        
         private struct StreamToPageWriter
         {
             private int _chunkNumber;
@@ -79,54 +79,56 @@ namespace Voron.Data.BTrees
 
             public void Write(Stream stream)
             {
-                AllocateNextPage();
-
-                ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
-
                 const int bufferSize = 512 * Constants.Size.Kilobyte;
-                using (_parent._tx.Allocator.Allocate(bufferSize, out var localBuffer))
+                using (_parent._tx.Allocator.Allocate(bufferSize, out Span<byte> localBuffer))
                 {
-                    var buffer = new Span<byte>(localBuffer.Ptr, bufferSize);
-                    while (true)
-                    {
-                        var read = stream.Read(buffer);
-                        if (read == 0)
-                            break;
+                    AllocateNextPage();
 
-                        var toWrite = 0L;
+                    ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
+
+                    fixed (byte* pBuffer = localBuffer)
+                    {
                         while (true)
                         {
-                            toWrite += WriteBufferToPage(localBuffer.Ptr + toWrite, read - toWrite);
-                            if (toWrite == read)
+                            var read = stream.Read(localBuffer);
+                            if (read == 0)
                                 break;
 
-                            // run out of room, need to allocate more
-                            RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
-                            AllocateNextPage();
+                            var toWrite = 0L;
+                            while (true)
+                            {
+                                toWrite += WriteBufferToPage(pBuffer + toWrite, read - toWrite);
+                                if (toWrite == read)
+                                    break;
+
+                                // run out of room, need to allocate more
+                                RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
+                                AllocateNextPage();
+                            }
                         }
+
+                        var chunkSize = (int)(_writePos - _currentPage.DataPointer);
+                        RecordChunkPage(_currentPage.PageNumber, chunkSize);
+
+                        var remaining = _writePosEnd - _writePos;
+                        var infoSize = StreamInfo.SizeOf;
+
+                        if (_tag != null)
+                            infoSize += _tag.Value.Size;
+
+                        if (remaining < infoSize)
+                        {
+                            _numberOfPagesPerChunk = 1;
+                            AllocateNextPage();
+                            chunkSize = 0;
+                            RecordChunkPage(_currentPage.PageNumber, chunkSize);
+                        }
+
+                        RecordStreamInfo();
+
+                        _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
                     }
                 }
-
-                var chunkSize = (int)(_writePos - _currentPage.DataPointer);
-                RecordChunkPage(_currentPage.PageNumber, chunkSize);
-
-                var remaining = _writePosEnd - _writePos;
-                var infoSize = StreamInfo.SizeOf;
-
-                if (_tag != null)
-                    infoSize += _tag.Value.Size;
-
-                if (remaining < infoSize)
-                {
-                    _numberOfPagesPerChunk = 1;
-                    AllocateNextPage();
-                    chunkSize = 0;
-                    RecordChunkPage(_currentPage.PageNumber, chunkSize);
-                }
-
-                RecordStreamInfo();
-
-                _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
             }
 
             private long WriteBufferToPage(byte* pBuffer, long size)

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -51,14 +51,6 @@ namespace Voron.Data.BTrees
 
         private const int MaxNumberOfPagerPerChunk = 4 * Constants.Size.Megabyte / Constants.Storage.PageSize;
 
-        [ThreadStatic]
-        private static byte[] _localBuffer;
-
-        static Tree()
-        {
-            ThreadLocalCleanup.ReleaseThreadLocalState += () => _localBuffer = null;
-        }
-
         private struct StreamToPageWriter
         {
             private int _chunkNumber;
@@ -87,60 +79,54 @@ namespace Voron.Data.BTrees
 
             public void Write(Stream stream)
             {
-                _localBuffer = ArrayPool<byte>.Shared.Rent(512 * Constants.Size.Kilobyte);
-                try
+                AllocateNextPage();
+
+                ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
+
+                const int bufferSize = 512 * Constants.Size.Kilobyte;
+                using (_parent._tx.Allocator.Allocate(bufferSize, out var localBuffer))
                 {
-                    AllocateNextPage();
-
-                    ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
-
-                    fixed (byte* pBuffer = _localBuffer)
+                    var buffer = new Span<byte>(localBuffer.Ptr, bufferSize);
+                    while (true)
                     {
+                        var read = stream.Read(buffer);
+                        if (read == 0)
+                            break;
+
+                        var toWrite = 0L;
                         while (true)
                         {
-                            var read = stream.Read(_localBuffer, 0, _localBuffer.Length);
-                            if (read == 0)
+                            toWrite += WriteBufferToPage(localBuffer.Ptr + toWrite, read - toWrite);
+                            if (toWrite == read)
                                 break;
 
-                            var toWrite = 0L;
-                            while (true)
-                            {
-                                toWrite += WriteBufferToPage(pBuffer + toWrite, read - toWrite);
-                                if (toWrite == read)
-                                    break;
-
-                                // run out of room, need to allocate more
-                                RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
-                                AllocateNextPage();
-                            }
-                        }
-
-                        var chunkSize = (int)(_writePos - _currentPage.DataPointer);
-                        RecordChunkPage(_currentPage.PageNumber, chunkSize);
-
-                        var remaining = _writePosEnd - _writePos;
-                        var infoSize = StreamInfo.SizeOf;
-
-                        if (_tag != null)
-                            infoSize += _tag.Value.Size;
-
-                        if (remaining < infoSize)
-                        {
-                            _numberOfPagesPerChunk = 1;
+                            // run out of room, need to allocate more
+                            RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
                             AllocateNextPage();
-                            chunkSize = 0;
-                            RecordChunkPage(_currentPage.PageNumber, chunkSize);
                         }
-
-                        RecordStreamInfo();
-
-                        _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
                     }
                 }
-                finally
+
+                var chunkSize = (int)(_writePos - _currentPage.DataPointer);
+                RecordChunkPage(_currentPage.PageNumber, chunkSize);
+
+                var remaining = _writePosEnd - _writePos;
+                var infoSize = StreamInfo.SizeOf;
+
+                if (_tag != null)
+                    infoSize += _tag.Value.Size;
+
+                if (remaining < infoSize)
                 {
-                    ArrayPool<byte>.Shared.Return(_localBuffer);
+                    _numberOfPagesPerChunk = 1;
+                    AllocateNextPage();
+                    chunkSize = 0;
+                    RecordChunkPage(_currentPage.PageNumber, chunkSize);
                 }
+
+                RecordStreamInfo();
+
+                _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
             }
 
             private long WriteBufferToPage(byte* pBuffer, long size)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24616

### Additional description
In this PR we just replace managed allocation with unmanaged especially since this is a 500KB allocation and is exists on the LOG.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
