### PR TITLE
RavenDB-24594 fixed race condition in the DeferrableTimeout

### DIFF
--- a/src/Raven.Server/ServerWide/DeferrableTimeout.cs
+++ b/src/Raven.Server/ServerWide/DeferrableTimeout.cs
@@ -25,16 +25,18 @@ public class DeferrableTimeout
 
         private Result ScheduleOrDefer(TimeSpan deferBy, out Task task)
         {
-            _completeAt = DateTime.UtcNow.Add(deferBy);
-            var prev = Interlocked.CompareExchange(ref _scheduled, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
-            task = _scheduled!.Task;
+            var newTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var prev = Interlocked.CompareExchange(ref _scheduled, newTcs, null);
 
             if (prev == null)
             {
+                _completeAt = DateTime.UtcNow.Add(deferBy);
+                task = newTcs.Task;
                 Promises.Enqueue(this);
                 return Result.Scheduled;
             }
 
+            task = prev.Task;
             return Result.Deferred;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24594

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
