### PR TITLE
RavenDB-24557 added small tolerance

### DIFF
--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -2208,9 +2208,10 @@ namespace SlowTests.Smuggler
             const int documentsToCreate = 150;
             const int maxReadOpsPerSecToTest = 10;
             const int expectedMinimumExportDurationInSeconds = (documentsToCreate - maxReadOpsPerSecToTest) / maxReadOpsPerSecToTest;
-
+            const int toleranceInSeconds = 2; // Add a small buffer for timing variations
+        
             var file = GetTempFileName();
-
+        
             using (var store = GetDocumentStore(options))
             {
                 // We want to store all documents in the same shard to get clear understanding the number of documents per shard to do clear measurements
@@ -2219,38 +2220,38 @@ namespace SlowTests.Smuggler
                     await session.StoreAsync(new User { Name = "InitialDocument" }, "foo/bar");
                     await session.SaveChangesAsync();
                 }
-
+        
                 for (int i = 1; i < documentsToCreate - 1; i++)
                     using (var session = store.OpenAsyncSession())
                     {
                         await session.StoreAsync(new User { Name = $"Name{i}" }, $"{nameof(User)}s/{i}$foo/bar");
                         await session.SaveChangesAsync();
                     }
-
+        
                 var exportOptions = new DatabaseSmugglerExportOptions();
-
+        
                 var sw = Stopwatch.StartNew();
                 var operation = await store.Smuggler.ExportAsync(exportOptions, file);
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
                 var exportDurationDefaultOptions = sw.Elapsed;
                 File.Delete(file);
-
+        
                 exportOptions.MaxReadOpsPerSecond = maxReadOpsPerSecToTest;
-
+        
                 sw.Restart();
                 operation = await store.Smuggler.ExportAsync(exportOptions, file);
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
                 var exportDurationWithMaxReadOps = sw.Elapsed;
-
+        
                 Assert.True(exportDurationWithMaxReadOps > exportDurationDefaultOptions,
                     $"Export with {nameof(exportOptions.MaxReadOpsPerSecond)} with value '{maxReadOpsPerSecToTest}' should take more time than default export, " +
                     $"but it took '{exportDurationWithMaxReadOps}' seconds, while with default value took '{exportDurationDefaultOptions}' seconds");
                 Assert.True(exportDurationDefaultOptions.TotalSeconds < expectedMinimumExportDurationInSeconds,
                     $"Export with default options should take less than '{expectedMinimumExportDurationInSeconds}' seconds, but it took " +
                     $"'{exportDurationDefaultOptions}' seconds despite {nameof(exportOptions.MaxReadOpsPerSecond)} was not set");
-                Assert.True(exportDurationWithMaxReadOps.TotalSeconds > expectedMinimumExportDurationInSeconds,
+                Assert.True(exportDurationWithMaxReadOps.TotalSeconds > expectedMinimumExportDurationInSeconds - toleranceInSeconds,
                     $"Export with {nameof(exportOptions.MaxReadOpsPerSecond)} with value '{maxReadOpsPerSecToTest}' should take more than " +
-                    $"'{expectedMinimumExportDurationInSeconds}' seconds, but it took '{exportDurationWithMaxReadOps}' seconds");
+                    $"'{expectedMinimumExportDurationInSeconds - toleranceInSeconds}' seconds, but it took '{exportDurationWithMaxReadOps}' seconds");
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24557

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
