### PR TITLE
RavenDB-23060

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -399,13 +399,15 @@ namespace Raven.Server.ServerWide.Maintenance
                             $"We got '{DatabaseStatus.NoChange}' for the database '{dbReport}', but it is missing in the last good report");
                     }
 
-                    previous.LastSentEtag = dbReport.LastSentEtag;
-                    previous.LastCompareExchangeIndex = dbReport.LastCompareExchangeIndex;
-                    previous.LastClusterWideTransactionRaftIndex = dbReport.LastClusterWideTransactionRaftIndex;
-                    previous.LastCompletedClusterTransaction = dbReport.LastCompletedClusterTransaction;
+                    var copy = new DatabaseStatusReport(previous);
 
-                    previous.UpTime = dbReport.UpTime;
-                    nodeReport.Report[dbName] = previous;
+                    copy.LastSentEtag = dbReport.LastSentEtag;
+                    copy.LastCompareExchangeIndex = dbReport.LastCompareExchangeIndex;
+                    copy.LastClusterWideTransactionRaftIndex = dbReport.LastClusterWideTransactionRaftIndex;
+                    copy.LastCompletedClusterTransaction = dbReport.LastCompletedClusterTransaction;
+
+                    copy.UpTime = dbReport.UpTime;
+                    nodeReport.Report[dbName] = copy;
                 }
             }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.ServerWide.Maintenance.Sharding;
 using Sparrow.Json.Parsing;
@@ -69,6 +70,41 @@ namespace Raven.Server.ServerWide.Maintenance
         public long LastCompareExchangeIndex { get; set; }
         public long LastClusterWideTransactionRaftIndex { get; set; }
 
+        public DatabaseStatusReport()
+        {
+        }
+
+        /// <summary>
+        /// This is a Shallow Copy Ctor
+        /// </summary>
+        public DatabaseStatusReport([NotNull] DatabaseStatusReport other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            Name = other.Name;
+            NodeName = other.NodeName;
+            DatabaseChangeVector = other.DatabaseChangeVector;
+
+            // shallow
+            LastIndexStats = other.LastIndexStats;
+            LastSentEtag = other.LastSentEtag;
+            ReportPerBucket = other.ReportPerBucket;
+
+            LastCompareExchangeIndex = other.LastCompareExchangeIndex;
+            LastClusterWideTransactionRaftIndex = other.LastClusterWideTransactionRaftIndex;
+            LastEtag = other.LastEtag;
+            LastTombstoneEtag = other.LastTombstoneEtag;
+            NumberOfConflicts = other.NumberOfConflicts;
+            NumberOfDocuments = other.NumberOfDocuments;
+            LastCompletedClusterTransaction = other.LastCompletedClusterTransaction;
+            Status = other.Status;
+            Error = other.Error;
+            UpTime = other.UpTime;
+            LastTransactionId = other.LastTransactionId;
+            EnvironmentsHash = other.EnvironmentsHash;
+        }
+
         public sealed class ObservedIndexStatus
         {
             public bool IsSideBySide;
@@ -128,6 +164,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     [nameof(stat.Value.State)] = stat.Value.State
                 };
             }
+
             dynamicJsonValue[nameof(LastIndexStats)] = indexStats;
 
             return dynamicJsonValue;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -316,14 +316,7 @@ namespace Raven.Server.ServerWide
         private PoolOfThreads.LongRunningWork _updateTopologyChangeNotification;
 
         public bool ValidateFixedPort = true;
-
-        public Dictionary<string, ClusterNodeStatusReport> ClusterStats()
-        {
-            if (_engine.LeaderTag != NodeTag)
-                throw new NotLeadingException($"Stats can be requested only from the raft leader {_engine.LeaderTag}");
-            return ClusterMaintenanceSupervisor?.GetStats();
-        }
-
+        
         internal LicenseType GetLicenseType()
         {
             return LicenseManager.LicenseStatus.Type;


### PR DESCRIPTION
reports from the GetStats method are being updated by reference (UpdateNodeReportIfNeeded) so the whole mechanism with prev and current stats does not work as it should, because it is updating the same instance anyway

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23060

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
