### PR TITLE
RavenDB-24625 Fix EnterpriseAi showing free license message

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
@@ -114,7 +114,8 @@ function LicenseTable(props: LicenseTableProps) {
 
     const showUpgradeButton = licenseType !== "EnterpriseAi";
 
-    const isDeveloperOrEnterprise = licenseType === "Developer" || licenseType === "Enterprise" || licenseType == "EnterpriseAi;
+    const isDeveloperOrEnterprise =
+        licenseType === "Developer" || licenseType === "Enterprise" || licenseType === "EnterpriseAi";
 
     const getColumnHeader = (column: LicenseColumn) => {
         if (column === "community" && licenseType === "Essential") {

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
@@ -114,7 +114,7 @@ function LicenseTable(props: LicenseTableProps) {
 
     const showUpgradeButton = licenseType !== "EnterpriseAi";
 
-    const isDeveloperOrEnterprise = licenseType === "Developer" || licenseType === "Enterprise";
+    const isDeveloperOrEnterprise = licenseType === "Developer" || licenseType === "Enterprise" || licenseType == "EnterpriseAi;
 
     const getColumnHeader = (column: LicenseColumn) => {
         if (column === "community" && licenseType === "Essential") {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24625/EnterpriseAi-showing-free-license-message

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
