### PR TITLE
RavenDB-24613 - Allowing a script to emit multiple embeddings.generat…

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
@@ -356,7 +356,18 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
 
         var mainObj = args[0].AsObject();
 
-        var aiEtlEmbeddingItem = new EmbeddingGenerationScriptResult(Current.DocumentId, Current.Collection);
+        EmbeddingGenerationScriptResult aiEtlEmbeddingItem;
+        bool isNewInstance;
+        if (_currentRun.Additions.Count > 0 && _currentRun.Additions[^1].DocumentId == Current.DocumentId)
+        {
+            isNewInstance = false;
+            aiEtlEmbeddingItem = _currentRun.Additions[^1];
+        }
+        else
+        {
+            isNewInstance = true;
+            aiEtlEmbeddingItem = new EmbeddingGenerationScriptResult(Current.DocumentId, Current.Collection);
+        }
 
         foreach (var propertyKey in mainObj.GetOwnPropertyKeys())
         {
@@ -405,7 +416,10 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
             }
         }
 
-        _currentRun.Additions.Add(aiEtlEmbeddingItem);
+        if (isNewInstance)
+        {
+            _currentRun.Additions.Add(aiEtlEmbeddingItem);
+        }
 
         return JsValue.Null;
     }

--- a/test/SlowTests/Issues/RavenDB_24613.cs
+++ b/test/SlowTests/Issues/RavenDB_24613.cs
@@ -1,0 +1,77 @@
+﻿using Raven.Server.Documents.ETL.Providers.AI;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using SlowTests.Server.Documents.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24613_MultipleEmbeddingsGenerateCalls(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Ai)]
+    public void MultipleEmbeddingsGenerateCallsShouldCreateAllEmbeddings()
+    {
+        using var store = GetDocumentStore();
+
+        // Create a test document with data for multiple embeddings
+        var testDoc = new TestDocument
+        {
+            Summary = "This is a test document summary", KeyWords = "test, document, summary, keywords", Content = "This is the main content of the test document"
+        };
+
+        string docId;
+        using (var session = store.OpenSession())
+        {
+            session.Store(testDoc);
+            session.SaveChanges();
+            docId = testDoc.Id;
+        }
+
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+
+        // Create embeddings generation task with script that has multiple embeddings.generate() calls
+        var script = @"
+                // BUG: Multiple embeddings.generate() calls - only the last one actually works
+                // Expected: All three embeddings should be created
+                // Actual: Only the last embedding (third_embedding) is created
+                embeddings.generate({
+                    'first_embedding': this.Summary || 'default summary'
+                });
+                
+                embeddings.generate({
+                    'second_embedding': this.KeyWords || 'default keywords'
+                });
+                
+                embeddings.generate({
+                    'third_embedding': this.Content || 'default content'
+                });
+            ";
+
+        var (config, connection) = AddEmbeddingsGenerationTask(store, script: script, collectionName: "TestDocuments");
+
+        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
+        var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+        var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
+
+        // All three embeddings should be created, but due to the bug, only the last one will exist
+        // This test will fail until the bug is fixed
+
+        // This assertion should pass - the last call works
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "third_embedding", [testDoc.Content], docId);
+
+        // These assertions will fail due to the bug - the first two calls are ignored
+        // After the bug is fixed, these should pass
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "first_embedding", [testDoc.Summary], docId);
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "second_embedding", [testDoc.KeyWords], docId);
+    }
+
+    private class TestDocument
+    {
+        public string Id { get; set; }
+        public string Summary { get; set; }
+        public string KeyWords { get; set; }
+        public string Content { get; set; }
+    }
+}


### PR DESCRIPTION
…e() on a single document

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24613

### Additional description

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
