### PR TITLE
RavenDB-24212 add concurrency control to ai conversations

### DIFF
--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -94,5 +94,6 @@ public class AiOperations
     /// </summary>
     /// <typeparam name="TSchema">The schema type for the conversation response.</typeparam>
     /// <param name="conversationId">The ID of the existing conversation.</param>
-    public IConversationOperations<TSchema> ResumeConversation<TSchema>(string conversationId) where TSchema : new() => new Conversation<TSchema>(this, conversationId);
+    /// <param name="changeVector">Optional parameter to control concurrency.</param>
+    public IConversationOperations<TSchema> ResumeConversation<TSchema>(string conversationId, string changeVector = null) where TSchema : new() => new Conversation<TSchema>(this, conversationId, changeVector);
 }

--- a/src/Raven.Client/Documents/AI/Conversation.cs
+++ b/src/Raven.Client/Documents/AI/Conversation.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Exceptions;
 using Raven.Client.Util;
 
 namespace Raven.Client.Documents.AI;
@@ -17,7 +18,7 @@ internal class Conversation<T> : IConversationOperations<T> where T : new()
     private List<AiAgentActionRequest> _actionRequests;
     private List<AiAgentActionResponse> _actionResponses = [];
     private string _userPrompt;
-
+    private string _changeVector;
     public Conversation(AiOperations aiOperations, string agentId, Dictionary<string, object> parameters)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -27,12 +28,13 @@ internal class Conversation<T> : IConversationOperations<T> where T : new()
         _parameters = parameters;
     }
 
-    public Conversation(AiOperations aiOperations, string conversationId)
+    public Conversation(AiOperations aiOperations, string conversationId, string changeVector)
     {
         ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
 
         _aiOperations = aiOperations;
         _conversationId = conversationId;
+        _changeVector = changeVector;
     }
 
     public IEnumerable<AiAgentActionRequest> RequiredActions() => _actionRequests ?? throw new InvalidOperationException($"You have to call {nameof(Run)}/{nameof(RunAsync)} first");
@@ -69,9 +71,6 @@ internal class Conversation<T> : IConversationOperations<T> where T : new()
 
     public async Task<bool> RunAsync(CancellationToken token = default)
     {
-        // clear to avoid reusing old conversation answer
-        _answer = default;
-
         IMaintenanceOperation<ConversationResult<T>> op;
         if (string.IsNullOrWhiteSpace(_conversationId))
         {
@@ -84,15 +83,21 @@ internal class Conversation<T> : IConversationOperations<T> where T : new()
             if (_actionRequests != null && string.IsNullOrEmpty(_userPrompt) && _actionResponses.Count == 0)
                 return false;
 
-            op = new RunConversationOperation<T>(_conversationId, _userPrompt, _actionResponses);
+            op = new RunConversationOperation<T>(_conversationId, _userPrompt, _actionResponses, _changeVector);
         }
 
         try
         {
             var r = await _aiOperations._executor.SendAsync(op, token).ConfigureAwait(false);
+            r.ChangeVector = _changeVector;
             _conversationId = r.ConversationId;
             _actionRequests = r.ActionRequests ?? new List<AiAgentActionRequest>();
             _answer = r.Response;
+        }
+        catch (ConcurrencyException e)
+        {
+            _changeVector = e.ActualChangeVector;
+            throw;
         }
         finally
         {

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -19,6 +19,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
 
     private readonly string _conversationId;
     private readonly List<AiAgentActionResponse> _actionResponses;
+    private readonly string _changeVector;
+
     public RunConversationOperation(string agentId, string userPrompt, Dictionary<string, object> parameters)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -29,18 +31,19 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _parameters = parameters;
     }
 
-    public RunConversationOperation(string conversationId, string userPrompt = null, List<AiAgentActionResponse> actionResponses = null)
+    public RunConversationOperation(string conversationId, string userPrompt = null, List<AiAgentActionResponse> actionResponses = null, string changeVector = null)
     {
         ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
      
         _conversationId = conversationId;
         _userPrompt = userPrompt;
         _actionResponses = actionResponses;
+        _changeVector = changeVector;
     }
 
     public RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new RunConversationOperationCommand(_conversationId, _agentId, _userPrompt, _parameters, _actionResponses, conventions);
+        return new RunConversationOperationCommand(_conversationId, _agentId, _userPrompt, _parameters, _actionResponses, _changeVector, conventions);
     }
 
     internal sealed class RunConversationOperationCommand : RavenCommand<ConversationResult<TSchema>>
@@ -50,15 +53,18 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         private readonly string _prompt;
         private readonly Dictionary<string, object> _parameters;
         private readonly List<AiAgentActionResponse> _actionResponses;
+        private readonly string _changeVector;
         private readonly DocumentConventions _conventions;
 
-        public RunConversationOperationCommand(string conversationId, string agentId, string prompt, Dictionary<string, object> parameters, List<AiAgentActionResponse> actionResponses, DocumentConventions conventions)
+        public RunConversationOperationCommand(string conversationId, string agentId, string prompt, Dictionary<string, object> parameters,
+            List<AiAgentActionResponse> actionResponses, string changeVector, DocumentConventions conventions)
         {
             _conversationId = conversationId;
             _agentId = agentId;
             _prompt = prompt;
             _parameters = parameters;
             _actionResponses = actionResponses;
+            _changeVector = changeVector;
             _conventions = conventions;
         }
         public override bool IsReadRequest => false;
@@ -74,6 +80,9 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             {
                 url += $"?conversationId={Uri.EscapeDataString(_conversationId)}";
             }
+
+            if (_changeVector != null)
+                url += $"&changeVector={Uri.EscapeDataString(_changeVector)}";
 
             var body = new ConversionRequestBody
             {
@@ -123,6 +132,7 @@ internal class ConversionRequestBody : IDynamicJson
 public class ConversationResult<TSchema>
 {
     public string ConversationId { get; set; }
+    public string ChangeVector { get; set; }
     public TSchema Response { get; set; }
     public AiUsage Usage { get; set; }
     public List<AiAgentActionRequest> ActionRequests { get; set; }
@@ -132,6 +142,7 @@ public class ConversationResult<TSchema>
         response.TryGet(nameof(Usage), out BlittableJsonReaderObject usage);
         response.TryGet(nameof(Response), out BlittableJsonReaderObject result);
         response.TryGet(nameof(ConversationId), out string conversationId);
+        response.TryGet(nameof(ChangeVector), out string changeVector);
 
         List<AiAgentActionRequest> requests = null;
         if (response.TryGet(nameof(ActionRequests), out BlittableJsonReaderArray actionRequests) && actionRequests != null)
@@ -147,6 +158,7 @@ public class ConversationResult<TSchema>
         return new ConversationResult<TSchema>
         {
             ConversationId = conversationId,
+            ChangeVector = changeVector,
             ActionRequests = requests,
             Usage = JsonDeserializationClient.AiUsage(usage),
             Response = result == null ? default : conventions.Serialization.DefaultConverter.FromBlittable<TSchema>(result, conversationId)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -1,25 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Server.Documents.AI;
-using Raven.Server.Documents.AI.AiGen;
-using Raven.Server.Documents.Handlers.Processors;
-using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
-using Sparrow.Json.Parsing;
-using Sparrow.Server.Json.Sync;
-using System.Net;
-using Raven.Client;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.AiGen;
+using Raven.Server.Documents.Handlers.Processors;
 using Raven.Server.Documents.Handlers.Processors.MultiGet;
+using Raven.Server.ServerWide.Context;
 using Sparrow;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Json.Sync;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents
 {
@@ -82,6 +82,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
             var conversationId = RequestHandler.GetStringQueryString("conversationId", required: false);
             var agentId = RequestHandler.GetStringQueryString("agentId", required: false);
+            var changeVector = RequestHandler.GetStringQueryString("changeVector", required: false);
 
             if (string.IsNullOrEmpty(conversationId) && string.IsNullOrEmpty(agentId))
                 throw new ArgumentException("conversation ID or agent name must be provided.");
@@ -103,6 +104,20 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     throw new DocumentDoesNotExistException(conversationId);
 
                 conversationDocument = ConversationDocument.ToDocument(conversationId, conversation.Data);
+
+                if (changeVector != null)
+                {
+                    if (conversation.ChangeVector != changeVector)
+                        throw new ConcurrencyException($"The conversation '{conversationId}' was changed, please try again")
+                        {
+                            ExpectedChangeVector = changeVector,
+                            ActualChangeVector = conversation.ChangeVector,
+                            Id = conversationId
+                        };
+
+                    conversationDocument.ChangeVector = conversation.ChangeVector;
+                }
+               
                 configuration = GetAiAgentConfiguration(conversationDocument.Agent);
             }
 
@@ -220,6 +235,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             var output = new DynamicJsonValue
             {
                 [nameof(ConversationResult<object>.ConversationId)] = conversationId,
+                [nameof(ConversationResult<object>.ChangeVector)] = r.Document.ChangeVector,
                 [nameof(ConversationResult<object>.Response)] = r.Response,
                 [nameof(ConversationResult<object>.ActionRequests)] = new DynamicJsonArray(r.Document.OpenActionCalls.Select(t => t.Value.ToJson())),
                 [nameof(ConversationResult<object>.Usage)] = r.Document.TotalUsage.ToJson()
@@ -330,11 +346,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         }
         public async Task<string> TryPersistAsync(JsonOperationContext context, AiAgentConfiguration configuration, string conversationId, ConversationDocument conversation)
         {
+            var changeVectorLsv = context.GetLazyString(conversation.ChangeVector);
             if (configuration.Persistence is not null)
             {
                 // we don't pass change vector here, so last write wins
-                MergedPutCommand putCmd = new(conversation.ToBlittable(context, configuration), conversationId, changeVector: null, RequestHandler.Database);
+                MergedPutCommand putCmd = new(conversation.ToBlittable(context, configuration), conversationId, changeVectorLsv, RequestHandler.Database);
                 await RequestHandler.Database.TxMerger.Enqueue(putCmd);
+                conversation.ChangeVector = putCmd.PutResult.ChangeVector;
                 return putCmd.PutResult.Id;
             }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -20,6 +20,7 @@ public class ConversationDocument(string agent, BlittableJsonReaderObject parame
     public List<BlittableJsonReaderObject> Messages = [];
     public Dictionary<string, AiAgentActionRequest> OpenActionCalls = [];
     public AiUsage TotalUsage = new AiUsage();
+    public string ChangeVector;
     public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, string userPrompt)
     {
         if (Messages.Count > 0)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -250,4 +250,60 @@ public class AiAgentClientApiBasics : RavenTestBase
         r = await chat.RunAsync(CancellationToken.None);
         Assert.False(r);
     }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task ThrowConcurrencyException(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        using var session = store.OpenAsyncSession();
+
+        var agent = new AiAgentConfiguration("shopping assistant",config.ConnectionStringName,
+            "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+        agent.Persistence = new AiAgentPersistenceConfiguration
+        {
+            Collection = "Chats",
+            Expires = TimeSpan.FromDays(30)
+        };
+        
+        agent.Parameters.Add("company");
+        agent.Queries =
+        [
+            new AiAgentToolQuery
+            {
+                Name = "ProductSearch", 
+                Description =  "semantic search the store product catalog",
+                Query = "from Products where vector.search(embedding.text(Name), $query)",
+                ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            }
+            ,
+            new AiAgentToolQuery
+            {
+                Name = "RecentOrder",
+                Description = "Get the recent orders of the current user",
+                Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                ParametersSampleObject = "{}"
+            }
+        ];
+
+        var identifier = (await store.AI.CreateAgentAsync<OutputSchema>(agent)).Identifier;
+
+        var chat = store.AI.StartConversation<OutputSchema>(identifier,
+            p => p.AddParameter("company", "companies/90-A"));
+        chat.SetUserPrompt("what goes well with my cheese?");
+        var r = await chat.RunAsync(CancellationToken.None);
+        Assert.False(r);
+
+        chat = store.AI.ResumeConversation<OutputSchema>(chat.Id, "foo");
+        chat.SetUserPrompt("Can you give me some alternatives?");
+        await Assert.ThrowsAsync<ConcurrencyException>(() => chat.RunAsync(CancellationToken.None));
+
+        chat.SetUserPrompt("Can you give me some alternatives?");
+        r = await chat.RunAsync(CancellationToken.None);
+        Assert.False(r);
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24212

### Additional description

Introduce a concurrency control mechanism for AI conversations by adding support for a `changeVector` parameter. This ensures that concurrent modifications to conversations are detected and handled appropriately

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No
