### PR TITLE
DO NOT MARGE - RavenDB-24250 Validate license configuration before restore

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -581,7 +581,19 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord.DataArchival = smugglerDatabaseRecord.DataArchival;
                     databaseRecord.QueueSinks = smugglerDatabaseRecord.QueueSinks;
                     databaseRecord.SupportedFeatures = smugglerDatabaseRecord.SupportedFeatures;
+
+                    //Enforce license limitations on the restored database record.
+                    using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
+                        foreach (var command in ClusterStateMachine._licenseLimitsCommandsForCreateDatabase)
+                        {
+                            ServerStore.Engine.StateMachine.AssertLicenseLimits(command, ServerStore, databaseRecord, items, context);
+                        }
+                    }
                 };
+
             }
 
             smuggler.OnDatabaseRecordAction += smugglerDatabaseRecord =>

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -33,7 +33,7 @@ public sealed partial class ClusterStateMachine
     private const int MinBuildVersion60102 = 60_026;
     private const int MinBuildVersion60105 = 60_039;
 
-    private static readonly List<string> _licenseLimitsCommandsForCreateDatabase = new()
+    internal static readonly List<string> _licenseLimitsCommandsForCreateDatabase = new()
     {
         nameof(PutIndexesCommand),
         nameof(PutAutoIndexCommand),
@@ -60,7 +60,7 @@ public sealed partial class ClusterStateMachine
         nameof(PutServerWideExternalReplicationCommand),
     };
 
-    private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context)
+    internal void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context)
     {
         switch (type)
         {
@@ -299,60 +299,54 @@ public sealed partial class ClusterStateMachine
             if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
                 return;
 
-            throw new LicenseLimitException(LimitType.Indexes, $"The maximum number of auto indexes per cluster cannot exceed the limit of: {maxAutoIndexesPerDatabase}");
+            throw new LicenseLimitException(LimitType.Indexes, $"The maximum number of auto indexes per cluster cannot exceed the limit of: {maxAutoIndexesPerCluster}");
         }
     }
 
-    private void AssertRevisionConfiguration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
+    internal void AssertRevisionConfiguration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
-        if (databaseRecord.Revisions == null)
-            return;
-
-        if (databaseRecord.Revisions.Default == null &&
-            (databaseRecord.Revisions.Collections == null || databaseRecord.Revisions.Collections.Count == 0))
+        var revisions = databaseRecord.Revisions;
+        if (revisions?.Default == null && (revisions?.Collections?.Count ?? 0) == 0)
             return;
 
         var maxRevisionsToKeep = licenseStatus.MaxNumberOfRevisionsToKeep;
         var maxRevisionAgeToKeepInDays = licenseStatus.MaxNumberOfRevisionAgeToKeepInDays;
-        if (licenseStatus.CanSetupDefaultRevisionsConfiguration &&
-            maxRevisionsToKeep == null && maxRevisionAgeToKeepInDays == null)
+
+        if (licenseStatus.CanSetupDefaultRevisionsConfiguration && maxRevisionsToKeep == null && maxRevisionAgeToKeepInDays == null)
             return;
 
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
             return;
 
-        if (licenseStatus.CanSetupDefaultRevisionsConfiguration == false &&
-            databaseRecord.Revisions.Default != null &&
-            databaseRecord.Revisions.Default.Disabled == false)
-        {
+        if (licenseStatus.CanSetupDefaultRevisionsConfiguration == false && revisions.Default is { Disabled: false })
             throw new LicenseLimitException(LimitType.RevisionsConfiguration, "Your license doesn't allow the creation of a default configuration for revisions.");
-        }
 
-        if (databaseRecord.Revisions.Collections == null)
+        if (revisions.Collections == null)
             return;
 
-        foreach (KeyValuePair<string, RevisionsCollectionConfiguration> revisionPerCollectionConfiguration in databaseRecord.Revisions.Collections)
+        foreach (var (collectionName, config) in revisions.Collections)
         {
-            if (revisionPerCollectionConfiguration.Value.Disabled)
+            if (config.Disabled)
                 continue;
 
-            if (revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep != null &&
-                maxRevisionsToKeep != null &&
-                revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep > maxRevisionsToKeep)
-            {
-                throw new LicenseLimitException(LimitType.RevisionsConfiguration,
-                    $"The defined minimum revisions to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep}' " +
-                    $"for collection '{revisionPerCollectionConfiguration.Key}' exceeds the licensed one '{maxRevisionsToKeep}'");
-            }
+            var minRevisionsToKeep = config.MinimumRevisionsToKeep;
+            var minRevisionAge = config.MinimumRevisionAgeToKeep;
 
-            if (revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep != null &&
-                maxRevisionAgeToKeepInDays != null &&
-                revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep.Value.TotalDays > maxRevisionAgeToKeepInDays)
-            {
+            if (minRevisionsToKeep != null && maxRevisionsToKeep != null && minRevisionsToKeep > maxRevisionsToKeep)
                 throw new LicenseLimitException(LimitType.RevisionsConfiguration,
-                    $"The defined minimum revisions age to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep}' " +
-                    $"for collection '{revisionPerCollectionConfiguration.Key}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
-            }
+                    $"The defined minimum revisions to keep '{minRevisionsToKeep}' for collection '{collectionName}' exceeds the licensed one '{maxRevisionsToKeep}'");
+
+            if (minRevisionAge != null && maxRevisionAgeToKeepInDays != null && minRevisionAge.Value.TotalDays > maxRevisionAgeToKeepInDays)
+                throw new LicenseLimitException(LimitType.RevisionsConfiguration,
+                    $"The defined minimum revisions age to keep '{minRevisionAge}' for collection '{collectionName}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
+
+            if (minRevisionsToKeep == null && maxRevisionsToKeep != null)
+                throw new LicenseLimitException(LimitType.RevisionsConfiguration,
+                    $"The defined unlimited revisions to keep for collection '{collectionName}' exceeds the licensed one '{maxRevisionsToKeep}'");
+
+            if (minRevisionAge == null && maxRevisionAgeToKeepInDays != null)
+                throw new LicenseLimitException(LimitType.RevisionsConfiguration,
+                    $"The defined unlimited revisions age to keep for collection '{collectionName}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24250

### Additional description
Enforce license validation on DatabaseRecord before performing a restore.
This ensures that we don’t start a potentially long-running restore operation only to fail at the end due to license restrictions (e.g., revisions config, etc.)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
