### PR TITLE
RavenDB-24625 Offer developer license for all types except dev

### DIFF
--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.spec.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.spec.tsx
@@ -30,7 +30,7 @@ describe("FeatureAvailabilitySummary", () => {
         expect(screen.getByRole("link", { name: /See full comparison/ })).toBeInTheDocument();
     });
 
-    it.each(["None", "Community", "Essential", "Professional"] satisfies LicenseType[])(
+    it.each(["None", "Community", "Essential", "Professional", "Enterprise", "EnterpriseAi"] satisfies LicenseType[])(
         "can show 'Are you developing?' for %s license",
         (licenseType) => {
             const { screen } = rtlRender(<FeatureAvailabilitySummaryStory licenseType={licenseType} />);
@@ -40,13 +40,10 @@ describe("FeatureAvailabilitySummary", () => {
         }
     );
 
-    it.each(["Developer", "Enterprise"] satisfies LicenseType[])(
-        "can hide 'Are you developing?' for %s license",
-        (licenseType) => {
-            const { screen } = rtlRender(<FeatureAvailabilitySummaryStory licenseType={licenseType} />);
+    it("can hide 'Are you developing?' for Developer license", () => {
+        const { screen } = rtlRender(<FeatureAvailabilitySummaryStory licenseType="Developer" />);
 
-            expect(screen.queryByText(selectors.areYouDevelopingText)).not.toBeInTheDocument();
-            expect(screen.queryByRole("link", { name: selectors.developerLicenseLink })).not.toBeInTheDocument();
-        }
-    );
+        expect(screen.queryByText(selectors.areYouDevelopingText)).not.toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: selectors.developerLicenseLink })).not.toBeInTheDocument();
+    });
 });

--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
@@ -224,7 +224,7 @@ export function FeatureAvailabilitySummary(props: FeatureAvailabilitySummaryProp
                 </div>
             )}
             {currentLicense !== "Enterprise" && currentLicense !== "None" && <UpgradeLinkSection />}
-            {currentLicense !== "Enterprise" && currentLicense !== "Developer" && <DeveloperLicenseSection />}
+            {currentLicense !== "Developer" && <DeveloperLicenseSection />}
         </>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/about/AboutPage.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/AboutPage.spec.tsx
@@ -47,7 +47,7 @@ describe("AboutPage", function () {
             expect(screen.queryByText(selectors.registerLicense)).not.toBeInTheDocument();
             expect(screen.queryByText(selectors.forceUpdate)).toBeInTheDocument();
             expect(screen.queryByText(selectors.replaceLicense)).toBeInTheDocument();
-            expect(screen.queryByRole("link", { name: selectors.developerLicenseLink })).not.toBeInTheDocument();
+            expect(screen.queryByRole("link", { name: selectors.developerLicenseLink })).toBeInTheDocument();
         });
 
         it("professional", async () => {

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
@@ -115,8 +115,6 @@ function LicenseTable(props: LicenseTableProps) {
 
     const showUpgradeButton = licenseType !== "Enterprise";
 
-    const isDeveloperOrEnterprise = licenseType === "Developer" || licenseType === "Enterprise";
-
     const isAgpl = licenseType === "None" || licenseType === "Invalid";
 
     return (
@@ -264,7 +262,7 @@ function LicenseTable(props: LicenseTableProps) {
                     </div>
                 </div>
             )}
-            {!isDeveloperOrEnterprise && (
+            {licenseType !== "Developer" && (
                 <small className="pb-2 text-center text-muted">
                     <Icon icon="info" />
                     We offer a free{" "}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24625/EnterpriseAi-showing-free-license-message

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
