### PR TITLE
RavenDB-24211 the collection of ai agents conversation is always @converstations

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -302,7 +302,6 @@ namespace Raven.Client
 
                 internal const string GenAiHashes = "@gen-ai-hashes";
 
-
                 internal sealed class Sharding
                 {
                     internal const string ShardNumber = "@shard-number";
@@ -332,6 +331,11 @@ namespace Raven.Client
                 public const string EmbeddingsCacheCollection = "@embeddings-cache";
 
                 public const string AiAgentConversationCollection = "@conversations";
+            }
+
+            internal sealed class Ai
+            {
+                public const string AiAgentIdPrefix = "Conversations";
             }
 
             public sealed class Indexing

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentPersistenceConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentPersistenceConfiguration.cs
@@ -19,28 +19,28 @@ namespace Raven.Client.Documents.Operations.AI.Agents
         /// Initializes a new instance of the <see cref="AiAgentPersistenceConfiguration"/> class
         /// with the specified target collection and optional expiration.
         /// </summary>
-        /// <param name="collection">
-        /// The name of the database collection where chat session documents should be stored.
-        /// This is typically a collection like "Chats" or "Conversations".
+        /// <param name="conversationIdPrefix">
+        /// The prefix of the conversation ID.
+        /// This is typically a collection like "Chats/" or "Conversations/".
         /// </param>
         /// <param name="expires">
         /// Optional expiration duration. If provided, chat documents will expire (and be deleted)
         /// automatically after this time has passed since creation.
         /// </param>
-        public AiAgentPersistenceConfiguration(string collection, TimeSpan? expires = null)
+        public AiAgentPersistenceConfiguration(string conversationIdPrefix, TimeSpan? expires = null)
         {
-            ValidationMethods.AssertNotNullOrEmpty(collection, nameof(collection));
+            ValidationMethods.AssertNotNullOrEmpty(conversationIdPrefix, nameof(conversationIdPrefix));
 
-            Collection = collection;
+            ConversationIdPrefix = conversationIdPrefix;
             Expires = expires;
         }
 
         /// <summary>
-        /// The name of the database collection where chat session documents should be stored.
-        /// This is typically a collection like "Chats" or "Conversations".
+        /// The prefix of the conversation ID.
+        /// This is typically a collection like "Chats/" or "Conversations/".
         /// This allows separation between different types of persisted AI conversations.
         /// </summary>
-        public string Collection { get; set; }
+        public string ConversationIdPrefix { get; set; }
 
         /// <summary>
         /// Optional expiration duration. If provided, chat documents will expire (and be deleted)
@@ -50,7 +50,11 @@ namespace Raven.Client.Documents.Operations.AI.Agents
 
         public DynamicJsonValue ToJson()
         {
-            return new DynamicJsonValue { [nameof(Collection)] = Collection, [nameof(Expires)] = Expires?.TotalMilliseconds };
+            return new DynamicJsonValue
+            {
+                [nameof(ConversationIdPrefix)] = ConversationIdPrefix, 
+                [nameof(Expires)] = Expires?.TotalMilliseconds
+            };
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentPersistenceConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentPersistenceConfiguration.cs
@@ -21,23 +21,21 @@ namespace Raven.Client.Documents.Operations.AI.Agents
         /// </summary>
         /// <param name="conversationIdPrefix">
         /// The prefix of the conversation ID.
-        /// This is typically a collection like "Chats/" or "Conversations/".
+        /// This is typically like "chats/" or "conversations/".
         /// </param>
         /// <param name="expires">
         /// Optional expiration duration. If provided, chat documents will expire (and be deleted)
         /// automatically after this time has passed since creation.
         /// </param>
-        public AiAgentPersistenceConfiguration(string conversationIdPrefix, TimeSpan? expires = null)
+        public AiAgentPersistenceConfiguration(string conversationIdPrefix = null, TimeSpan? expires = null)
         {
-            ValidationMethods.AssertNotNullOrEmpty(conversationIdPrefix, nameof(conversationIdPrefix));
-
             ConversationIdPrefix = conversationIdPrefix;
             Expires = expires;
         }
 
         /// <summary>
         /// The prefix of the conversation ID.
-        /// This is typically a collection like "Chats/" or "Conversations/".
+        /// This is typically like "chats/" or "conversations/".
         /// This allows separation between different types of persisted AI conversations.
         /// </summary>
         public string ConversationIdPrefix { get; set; }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -140,18 +140,10 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 configuration = GetAiAgentConfiguration(agentId);
                 conversationDocument = new ConversationDocument(agentId, body.Parameters);
                 conversationDocument.Initialize(context, configuration, body.UserPrompt);
-                conversationId = BuildId(configuration);
+                conversationId = configuration.Persistence?.ConversationIdPrefix ?? ":InMemory:";
             }
 
             await HandleRequest(context, configuration, conversationId, conversationDocument, body, token.Token);
-        }
-
-        private string BuildId(AiAgentConfiguration configuration)
-        {
-            var agentPrefix = $"{configuration.Identifier}{RequestHandler.IdentityPartsSeparator}";
-            var collection = configuration.Persistence?.Collection ?? Constants.Documents.Collections.AiAgentConversationCollection;
-
-            return $"{agentPrefix}{collection}{RequestHandler.IdentityPartsSeparator}";
         }
 
         public async Task<RequestBody> ReadRequestBodyAsync(JsonOperationContext context, CancellationToken token)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -140,10 +140,23 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 configuration = GetAiAgentConfiguration(agentId);
                 conversationDocument = new ConversationDocument(agentId, body.Parameters);
                 conversationDocument.Initialize(context, configuration, body.UserPrompt);
-                conversationId = configuration.Persistence?.ConversationIdPrefix ?? ":InMemory:";
+                conversationId = BuildId(configuration);
             }
 
             await HandleRequest(context, configuration, conversationId, conversationDocument, body, token.Token);
+        }
+
+        private string BuildId(AiAgentConfiguration configuration)
+        {
+            if (configuration.Persistence?.ConversationIdPrefix != null)
+            {
+                if (configuration.Persistence.ConversationIdPrefix.EndsWith(RequestHandler.IdentityPartsSeparator) == false)
+                    return $"{configuration.Persistence.ConversationIdPrefix}{RequestHandler.IdentityPartsSeparator}";
+
+                return configuration.Persistence.ConversationIdPrefix;
+            }
+
+            return $"{Constants.Documents.Ai.AiAgentIdPrefix}{RequestHandler.IdentityPartsSeparator}";
         }
 
         public async Task<RequestBody> ReadRequestBodyAsync(JsonOperationContext context, CancellationToken token)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -39,14 +39,6 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
         
         ValidateConfiguration(context, cfg);
 
-        if (cfg.Persistence?.ConversationIdPrefix != null)
-        {
-            if (cfg.Persistence.ConversationIdPrefix.EndsWith(RequestHandler.IdentityPartsSeparator) == false)
-            {
-                cfg.Persistence.ConversationIdPrefix += RequestHandler.IdentityPartsSeparator;
-            }
-        }
-
         var r = await ServerStore.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(RequestHandler.DatabaseName, cfg, RequestHandler.GetRaftRequestIdFromQuery()),
             token.Token);
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -38,7 +38,15 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
             cfg.Identifier = EmbeddingsGenerationConfiguration.GenerateIdentifier(cfg.Name);
         
         ValidateConfiguration(context, cfg);
-        
+
+        if (cfg.Persistence?.ConversationIdPrefix != null)
+        {
+            if (cfg.Persistence.ConversationIdPrefix.EndsWith(RequestHandler.IdentityPartsSeparator) == false)
+            {
+                cfg.Persistence.ConversationIdPrefix += RequestHandler.IdentityPartsSeparator;
+            }
+        }
+
         var r = await ServerStore.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(RequestHandler.DatabaseName, cfg, RequestHandler.GetRaftRequestIdFromQuery()),
             token.Token);
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -50,7 +50,7 @@ public class ConversationDocument(string agent, BlittableJsonReaderObject parame
     {
         var metadata = new DynamicJsonValue
         {
-            [Constants.Documents.Metadata.Collection] = configuration.Persistence.Collection,
+            [Constants.Documents.Metadata.Collection] = Constants.Documents.Collections.AiAgentConversationCollection,
         };
         
         if (expiration.HasValue)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBackupRestore.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBackupRestore.cs
@@ -86,7 +86,7 @@ public class AiAgentBackupRestore : ReplicationTestBase
         var agent0 = new AiAgentConfiguration("shopping assistant", aiConfig.ConnectionStringName,
             "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
         agent0.Identifier = "shopping-assistant";
-        agent0.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+        agent0.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats/", Expires = TimeSpan.FromDays(30) };
 
         agent0.Parameters.Add("company");
         agent0.Queries =
@@ -110,7 +110,7 @@ public class AiAgentBackupRestore : ReplicationTestBase
 
         var agent1 = new AiAgentConfiguration("warehouse manager", aiConfig.ConnectionStringName, "You are an AI agent managing a warehouse.");
         agent1.Identifier = "warehouse-manager";
-        agent1.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+        agent1.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats/", Expires = TimeSpan.FromDays(30) };
         agent1.Actions =
         [
             new AiAgentToolAction

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+            agent.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(30) };
             agent.Parameters.Add("company");
             agent.Queries =
             [
@@ -98,7 +98,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+            agent.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(30) };
             agent.Parameters.Add("company");
             agent.Queries =
             [
@@ -148,7 +148,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+            agent.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(30) };
 
             agent.Actions =
             [
@@ -195,7 +195,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping-assistant", config.ConnectionStringName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent.Identifier = "shopping-assistant";
-            agent.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+            agent.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(30) };
 
             agent.Actions =
             [

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -49,7 +49,7 @@ public class AiAgentClientApiBasics : RavenTestBase
 
         agent.Persistence = new AiAgentPersistenceConfiguration
         {
-            Collection = "Chats",
+            ConversationIdPrefix = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
         
@@ -121,7 +121,7 @@ public class AiAgentClientApiBasics : RavenTestBase
 
         agent.Persistence = new AiAgentPersistenceConfiguration
         {
-            Collection = "Chats",
+            ConversationIdPrefix = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
 
@@ -195,7 +195,7 @@ public class AiAgentClientApiBasics : RavenTestBase
 
         agent.Persistence = new AiAgentPersistenceConfiguration
         {
-            Collection = "Chats",
+            ConversationIdPrefix = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
         
@@ -274,7 +274,7 @@ public class AiAgentClientApiBasics : RavenTestBase
 
         agent.Persistence = new AiAgentPersistenceConfiguration
         {
-            Collection = "Chats",
+            ConversationIdPrefix = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
         

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             agent.Persistence = new AiAgentPersistenceConfiguration
             {
-                Collection = "Chats",
+                ConversationIdPrefix = "Chats",
                 Expires = TimeSpan.FromDays(30)
             };
 
@@ -74,7 +74,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             agent.Persistence = new AiAgentPersistenceConfiguration
             {
-                Collection = "Chats",
+                ConversationIdPrefix = "Chats",
                 Expires = TimeSpan.FromDays(30)
             };
 
@@ -117,7 +117,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             agent.Persistence = new AiAgentPersistenceConfiguration
             {
-                Collection = "Chats",
+                ConversationIdPrefix = "Chats",
                 Expires = TimeSpan.FromDays(30)
             };
             

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -60,7 +60,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -107,7 +107,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -155,7 +155,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -215,7 +215,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -277,7 +277,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -326,7 +326,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -377,7 +377,7 @@ public class AiAgentErrors : RavenTestBase
             "You are customer manager"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery
@@ -457,7 +457,7 @@ public class AiAgentErrors : RavenTestBase
             "You are an ai agent that answer knowledge questions"
         )
         {
-            Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(1) },
+            Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(1) },
             Queries =
             [
                 new AiAgentToolQuery

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -62,7 +62,7 @@ public class RavenDB_24407 : RavenTestBase
         agent.Parameters.Add("company");
         agent.Persistence = new AiAgentPersistenceConfiguration
         {
-            Collection = "Chats",
+            ConversationIdPrefix = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
         agent.Queries =
@@ -217,7 +217,7 @@ public class RavenDB_24407 : RavenTestBase
 
         agent.Persistence = new AiAgentPersistenceConfiguration
         {
-            Collection = "Chats",
+            ConversationIdPrefix = "Chats",
             Expires = TimeSpan.FromDays(30)
         };
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24458.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24458.cs
@@ -90,7 +90,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
             agent0.Identifier = "shopping-assistant";
             agent0.Parameters.Add("company");
-            agent0.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+            agent0.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats/", Expires = TimeSpan.FromDays(30) };
             agent0.Queries =
             [
                 new AiAgentToolQuery
@@ -110,7 +110,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             ];
 
             var agent1 = new AiAgentConfiguration("warehouse manager", aiConfig.ConnectionStringName, "You are an AI agent managing a warehouse.");
-            agent1.Persistence = new AiAgentPersistenceConfiguration { Collection = "Chats", Expires = TimeSpan.FromDays(30) };
+            agent1.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats/", Expires = TimeSpan.FromDays(30) };
             agent1.Actions =
             [
                 new AiAgentToolAction


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24211 

### Additional description

- The collection of ai agents conversation is always @converstations
- User can control the id prefix of the conversation

studio changes required here:
- the ai agent shouldn't list all the chats
- continuing the chat should be done by going to the document at the `@converstations` collection and have a button there to continue the chat

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
