### PR TITLE
RavenDB-24553 Exception when enabling CompressAllCollections

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupSettings.cs
@@ -132,6 +132,7 @@ namespace Raven.Client.Documents.Operations.Backups
             var djv = base.ToJson();
 
             djv[nameof(FolderPath)] = FolderPath;
+            djv[nameof(ShardNumber)] = ShardNumber;
 
             return djv;
         }

--- a/test/SlowTests/Issues/RavenDB_24553.cs
+++ b/test/SlowTests/Issues/RavenDB_24553.cs
@@ -1,0 +1,40 @@
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24553 : RavenTestBase
+{
+    public RavenDB_24553(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public void CanUpdateDatabaseCompressionAfterServerwideBackup()
+    {
+        using (var store = GetDocumentStore())
+        {
+            // Create serverwide backup
+            var backupConfig = new ServerWideBackupConfiguration
+            {
+                Disabled = false,
+                FullBackupFrequency = "0 2 * * 0",
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = NewDataPath()
+                }
+            };
+
+            store.Maintenance.Server.Send(new PutServerWideBackupConfigurationOperation(backupConfig));
+
+            // Update database compression settings
+            var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+            record.DocumentsCompression.CompressAllCollections = true;
+            store.Maintenance.Server.Send(new UpdateDatabaseOperation(record, record.Etag));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24553

### Additional description

When we attempt to modify the DatabaseRecord (e.g., to update compression settings), we get an exception stating that we can’t update the backup configuration this way.
I found that:
The old record (from ReadRawDatabaseRecord) is deserialized using BlittableJsonReaderObject, and in LocalSettings, the ShardNumber field is not present at all.
The new record (from ToBlittable) does include "ShardNumber": null in LocalSettings.

As a result, the Equals() comparison between the two records returns false, even though there is no actual change in meaning.

To resolve this, I added logic to include the ShardNumber field in ToJson, ensuring consistency between the serialized forms.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
