### PR TITLE
RavenDB-24157 : add tests that throw on sharded database for retire attachment endpoints

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedRetiredAttachmnentHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedRetiredAttachmnentHandler.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers;
+
+public sealed class ShardedRetiredAttachmentHandler : ShardedDatabaseRequestHandler
+{
+    [RavenShardedAction("/databases/*/admin/attachments/retire/config", "GET")]
+    public Task GetRetireConfig()
+    {
+        throw new NotSupportedInShardingException("Retired attachments does not support sharding");
+    }
+
+    [RavenShardedAction("/databases/*/admin/attachments/retire/config", "PUT")]
+    public Task AddRetireConfig()
+    {
+        throw new NotSupportedInShardingException("Retired attachments does not support sharding");
+    }
+}
+

--- a/test/SlowTests/Issues/RavenDB_24157.cs
+++ b/test/SlowTests/Issues/RavenDB_24157.cs
@@ -1,0 +1,55 @@
+﻿using FastTests;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Retired;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions.Sharding;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24157 : RavenTestBase
+    {
+        public RavenDB_24157(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Attachments)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void CanGetRetireConfigShardedShouldThrow(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var e = Assert.Throws<NotSupportedInShardingException>(() =>
+                {
+                    store.Maintenance.Send(new GetRetireAttachmentsConfigurationOperation());
+                });
+                Assert.Contains("Retired attachments does not support sharding", e.Message);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Attachments)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void CanAddRetireConfigShardedShouldThrow(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var cfg = new RetiredAttachmentsConfiguration
+                {
+                    RetireFrequencyInSec = 123,
+                    Disabled = true,
+                    S3Settings = new S3Settings
+                    {
+                        BucketName = "test-bucket-does-not-exist", AwsRegionName = "us-west-2", AwsAccessKey = "AKIAFAKEKEY", AwsSecretKey = "FAKESECRET"
+                    }
+                };
+                var e = Assert.Throws<NotSupportedInShardingException>(() =>
+                {
+                    store.Maintenance.Send(new ConfigureRetiredAttachmentsOperation(cfg));
+                });
+                Assert.Contains("Retired attachments does not support sharding", e.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24157/Retire-attachments-Server-Side-throw-on-sharded-database-Phase-1

### Additional description

Add tests that verify throw on endpoints in `RetiredAttachmentHandler` for sharded database


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
