### PR TITLE
RavenDB-24487 : Handle javascript index for retired attachments (Phase 1)

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentNameObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentNameObjectInstance.cs
@@ -47,7 +47,10 @@ namespace Raven.Server.Documents.Indexes.Static.JavaScript
                     value = new PropertyDescriptor(new JsString(hash), writable: false, enumerable: false, configurable: false);
                 else if (property == nameof(AttachmentName.Size) && _attachmentName.TryGet(nameof(AttachmentName.Size), out long size))
                     value = new PropertyDescriptor(size, writable: false, enumerable: false, configurable: false);
-
+                else if (property == nameof(AttachmentName.Flags) && _attachmentName.TryGet(nameof(AttachmentName.Flags), out string flags))
+                    value = new PropertyDescriptor(new JsString(flags.ToString()), writable: false, enumerable: false, configurable: false);
+                else if (property == nameof(AttachmentName.RetireAt) && _attachmentName.TryGet(nameof(AttachmentName.RetireAt), out DateTime retiredAt))
+                    value =  new PropertyDescriptor(new JsDate(_engine, retiredAt), writable: false, enumerable: false, configurable: false);
                 if (value != null)
                     _properties[property] = value;
             }

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentObjectInstance.cs
@@ -6,7 +6,9 @@ using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Exceptions;
 
 namespace Raven.Server.Documents.Indexes.Static.JavaScript
 {
@@ -25,6 +27,9 @@ namespace Raven.Server.Documents.Indexes.Static.JavaScript
 
         private JsValue GetContentAsString(JsValue self, JsValue[] args)
         {
+            if (_attachment.Flags == AttachmentFlags.Retired)
+                throw new RetiredAttachmentIndexingException($"Attempted to '{nameof(GetContentAsString)}' on retired attachment named '{_attachment.Name}' which is no longer available locally.");
+
             var encoding = Encoding.UTF8;
             if (args.Length > 0)
             {
@@ -83,9 +88,9 @@ namespace Raven.Server.Documents.Indexes.Static.JavaScript
                 else if (property == nameof(IAttachmentObject.Size))
                     value = new PropertyDescriptor(_attachment.Size, writable: false, enumerable: false, configurable: false);
                 else if (property == nameof(IAttachmentObject.Flags))
-                    value = new PropertyDescriptor((int)_attachment.Flags, writable: false, enumerable: false, configurable: false);
+                    value = new PropertyDescriptor(new JsString(_attachment.Flags.ToString()), writable: false, enumerable: false, configurable: false);
                 else if (property == nameof(IAttachmentObject.RetireAt))
-                    value = _attachment.RetireAt.HasValue ? new PropertyDescriptor(new JsDate(_engine, _attachment.RetireAt.Value), writable: false, enumerable: false, configurable: false) : null;
+                    value = _attachment.RetireAt is DateTime dt ? new PropertyDescriptor(new JsDate(_engine, dt), writable: false, enumerable: false, configurable: false) : null;
                 else if (property == GetContentAsStringMethodName)
                     value = new PropertyDescriptor(new ClrFunction(Engine, GetContentAsStringMethodName, GetContentAsString), writable: false, enumerable: false, configurable: false);
                 if (value != null)

--- a/test/SlowTests/Issues/RavenDB_24487.cs
+++ b/test/SlowTests/Issues/RavenDB_24487.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Retired;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Indexes;
+using SlowTests.Server.Documents.Attachments;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24487 : RetiredAttachmentsS3Base
+    {
+        public RavenDB_24487(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [AmazonS3RetryFact]
+        public async Task ShouldThrowRetiredAttachmentIndexingExceptionWhenAccessingRetiredAttachmentAsString()
+        {
+            await using(var holder = CreateCloudSettings())
+            {
+                using var store = GetDocumentStore();
+                await SetupRetiredAttachmentsConfiguration(Settings, store);
+                await CreateDocumentsWithVariousRetirementTimes(store);
+
+                await AssertRetiredAttachmentIndexingException(new RetiredAttachmentIndexString(), store);
+            }
+        }
+
+        [AmazonS3RetryFact]
+        public async Task CanIndexRetiredAttachmentRetiredAndRetiredAt()
+        {
+            await using (var holder = CreateCloudSettings())
+            {
+                {
+                    using var store = GetDocumentStore();
+                    await SetupRetiredAttachmentsConfiguration(Settings, store);
+                    DateTime baseline = await CreateDocumentsWithVariousRetirementTimes(store);
+
+                    await TestRetiredAndRetiredAtIndexing(store, baseline);
+                }
+            }
+        }
+
+        private async Task TestRetiredAndRetiredAtIndexing(DocumentStore store, DateTime baseline)
+        {
+            var index = new RetiredAttachmentIndexLoadAttachment();
+            await index.ExecuteAsync(store);
+            var index2 = new RetiredAttachmentIndexAttachmentsFor();
+            await index2.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+            using (var session = store.OpenSession())
+            {
+                var resultLoadAtt = session.Query<RetiredAttachmentIndexLoadAttachment.Result, RetiredAttachmentIndexLoadAttachment>()
+                    .Where(x => (x.RetiredAt != null && x.RetiredAt > baseline.AddMinutes(2))).ToList();
+                
+                Assert.NotNull(resultLoadAtt);
+                Assert.Equal(2, resultLoadAtt.Count);
+                
+                var resultLoadAttByFlag = session.Query<RetiredAttachmentIndexLoadAttachment.Result, RetiredAttachmentIndexLoadAttachment>().Where(x => x.Flags == AttachmentFlags.Retired)
+                    .ProjectInto<RetiredAttachmentIndexLoadAttachment.Result>().ToList();
+                
+                Assert.Equal(AttachmentFlags.Retired, resultLoadAttByFlag[0].Flags);
+                if (resultLoadAttByFlag[0].RetiredAt != null)
+                    Assert.Equal(baseline.AddMinutes(1), resultLoadAttByFlag[0].RetiredAt.Value, TimeSpan.FromMilliseconds(1));
+                Assert.NotNull(resultLoadAttByFlag);
+                Assert.Equal(1, resultLoadAttByFlag.Count);
+
+                var resultAttFor = session.Query<RetiredAttachmentIndexAttachmentsFor.Result, RetiredAttachmentIndexAttachmentsFor>()
+                    .Where(x => (x.RetiredAt != null && x.RetiredAt > baseline.AddDays(7))).ProjectInto<RetiredAttachmentIndexAttachmentsFor.Result>().ToList();
+
+                Assert.Equal(AttachmentFlags.None, resultAttFor[0].Flags);
+                if (resultAttFor[0].RetiredAt != null) 
+                    Assert.Equal(baseline.AddDays(365), resultAttFor[0].RetiredAt.Value, TimeSpan.FromMilliseconds(1));
+                Assert.NotNull(resultAttFor);
+                Assert.Equal(1, resultAttFor.Count);
+
+                var resultAttForByFlag = session.Query<RetiredAttachmentIndexAttachmentsFor.Result, RetiredAttachmentIndexAttachmentsFor>().Where(x => x.Flags == AttachmentFlags.Retired)
+                    .ProjectInto<RetiredAttachmentIndexAttachmentsFor.Result>().ToList();
+
+                Assert.Equal(AttachmentFlags.Retired, resultAttForByFlag[0].Flags);
+                if (resultAttForByFlag[0].RetiredAt != null) 
+                    Assert.Equal(baseline.AddMinutes(1), resultAttForByFlag[0].RetiredAt.Value, TimeSpan.FromMilliseconds(1));
+                Assert.NotNull(resultAttForByFlag);
+                Assert.Equal(1, resultAttForByFlag.Count);
+            }
+        }
+
+        private async Task<DateTime> CreateDocumentsWithVariousRetirementTimes(DocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "John", AttName = "greeting1.txt" }, "users/1");
+                await session.StoreAsync(new User { Name = "Johny", AttName = "greeting2.txt" }, "users/2");
+                await session.StoreAsync(new User { Name = "JohnySilverhand", AttName = "greeting3.txt" }, "users/3");
+                await session.SaveChangesAsync();
+            }
+
+            DateTime baseline = DateTime.UtcNow;
+            var retireAt1 = baseline.AddDays(7);
+            var retireAt2 = baseline.AddMinutes(1);
+            var retireAt3 = baseline.AddDays(365);
+
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello")))
+            {
+                var parameters1 = new StoreAttachmentParameters("greeting1.txt", ms) { RetireAt = retireAt1 };
+                var putOp1 = new PutAttachmentOperation("users/1", parameters1);
+                await store.Operations.SendAsync(putOp1);
+                ms.Position = 0;
+                var parameters2 = new StoreAttachmentParameters("greeting2.txt", ms) { RetireAt = retireAt2 };
+                var putOp2 = new PutAttachmentOperation("users/2", parameters2);
+                await store.Operations.SendAsync(putOp2);
+                ms.Position = 0;
+                var parameters4 = new StoreAttachmentParameters("greeting3.txt", ms) { RetireAt = retireAt3 };
+                var putOp4 = new PutAttachmentOperation("users/3", parameters4);
+                await store.Operations.SendAsync(putOp4);
+            }
+
+            int count = 0;
+            var retired = await WaitForValueAsync(async () =>
+            {
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(3);
+                count += await database.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+                return count;
+            }, 1, interval: 1000);
+            return baseline;
+        }
+
+        private static async Task SetupRetiredAttachmentsConfiguration(S3Settings s3Settings, DocumentStore store)
+        {
+            var conf = new RetiredAttachmentsConfiguration { Disabled = false, RetireFrequencyInSec = 1, S3Settings = s3Settings };
+            await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRetiredAttachmentsOperation(conf));
+        }
+
+        private async Task AssertRetiredAttachmentIndexingException(AbstractJavaScriptIndexCreationTask index, IDocumentStore store)
+        {
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            var indexErrors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { index.IndexName }));
+            var errorString = indexErrors[0].Errors[0].Error;
+            Assert.Contains("RetiredAttachmentIndexingException: Attempted to 'GetContentAsString' on retired attachment named 'greeting2.txt' which is no longer available locally.", errorString);
+        }
+
+        private class RetiredAttachmentIndexString : AbstractJavaScriptIndexCreationTask
+        {
+            public RetiredAttachmentIndexString()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"  
+                map('Users', function (u) {  
+                    return {  
+                        attAsStream: loadAttachment(u, u.AttName).getContentAsString()  
+                    };  
+                })  
+                "
+                };
+            }
+        }
+
+        private class RetiredAttachmentIndexAttachmentsFor : AbstractJavaScriptIndexCreationTask
+        {
+            public class Result
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+                public AttachmentFlags Flags { get; set; }
+                public DateTime? RetiredAt { get; set; }
+            }
+
+            public RetiredAttachmentIndexAttachmentsFor()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"
+            map('Users', u => {
+                var att = attachmentsFor(u);
+                    return att.map(a => {
+                        return {
+                        Name: a.Name,
+                        Flags: a.Flags,
+                        RetiredAt: a.RetireAt
+                        };
+                    });
+            })
+            "
+            };
+                Fields.Add(Constants.Documents.Indexing.Fields.AllFields, new IndexFieldOptions { Storage = FieldStorage.Yes });
+            }
+        }
+
+        private class RetiredAttachmentIndexLoadAttachment : AbstractJavaScriptIndexCreationTask
+        {
+            public class Result
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+                public AttachmentFlags Flags { get; set; }
+                public DateTime? RetiredAt { get; set; }
+            }
+
+            public RetiredAttachmentIndexLoadAttachment()
+            {
+
+                Maps = new HashSet<string>
+                {
+                    @"
+            map('Users', function(u) {
+                var att = loadAttachment(u, u.AttName);
+                return {
+                    Name : att.Name,
+                    Flags : att.Flags,         
+                    RetiredAt: att.RetireAt      
+                };
+            })
+            "
+                };
+                Fields.Add(Constants.Documents.Indexing.Fields.AllFields, new IndexFieldOptions { Storage = FieldStorage.Yes });
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string AttName { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24487/Retire-attachments-Server-Side-Indexing-handle-javascript-index-for-retired-attachments-Phase-1

### Additional description

Guard on JS attachment access: always expose Flags and RetireAt, and in getContentAsString() throw RetiredAttachmentIndexingException if the attachment is retired.

Exception tests: verify that getContentAsString() calls against a retired attachment fail with the expected exception.

Metadata indexing tests: map Flags, and RetireAt in a JS index, then assert you can query by Flags == Retired and by date range on RetireAt.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
