### PR TITLE
RavenDB - 24505 : Need to block unsupported OpenAI models

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -86,6 +86,10 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         if (validateConnection && TestMode == false)
         {
             Connection.Validate(errors);
+        }
+
+        if (validateConnection)
+        {
             if (Connection.ModelType != AiModelType.TextEmbeddings)
                 errors.Add($"{nameof(Connection.ModelType)} of Embeddings Generation configuration must be {nameof(AiModelType.TextEmbeddings)}");
         }

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -77,6 +77,10 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         if (validateConnection && TestMode == false)
         {
             Connection.Validate(errors);
+        }
+
+        if (validateConnection)
+        {
             if (Connection.ModelType != AiModelType.Chat)
                 errors.Add($"{nameof(Connection.ModelType)} of GenAI configuration must be {nameof(AiModelType.Chat)}");
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2213,7 +2213,14 @@ namespace Raven.Server.ServerWide
                     case EtlType.EmbeddingsGeneration:
                     {
                         var aiIntegration = JsonDeserializationCluster.EmbeddingsGenerationConfiguration(etlConfiguration);
-                        aiIntegration.Validate(out var aiIntegrationErr, validateName: false, validateConnection: false);
+                        if (rawRecord.AiConnectionStrings?.TryGetValue(aiIntegration.ConnectionStringName, out var cs) != true)
+                        {
+                            throw new InvalidOperationException(
+                                $"Could not find connection string named '{aiIntegration.ConnectionStringName}' for ETL type '{EtlType.EmbeddingsGeneration}'. Please supply an existing connection string.");
+                        }
+
+                        aiIntegration.Initialize(cs);
+                        aiIntegration.Validate(out var aiIntegrationErr, validateName: false, validateConnection: true);
                         if (ValidateConnectionString(rawRecord, aiIntegration.ConnectionStringName, aiIntegration.EtlType) == false)
                             aiIntegrationErr.Add(
                                 $"Could not find connection string named '{aiIntegration.ConnectionStringName}'. Please supply an existing connection string.");
@@ -2227,7 +2234,14 @@ namespace Raven.Server.ServerWide
                             throw new NotSupportedInShardingException("GenAI is currently not supported in sharding");
 
                         var genAi = JsonDeserializationCluster.GenAiConfiguration(etlConfiguration);
-                        genAi.Validate(out var genAiErr, validateName: false, validateConnection: false);
+                        if (rawRecord.AiConnectionStrings?.TryGetValue(genAi.ConnectionStringName, out var cs) != true)
+                        {
+                            throw new InvalidOperationException(
+                                $"Could not find connection string named '{genAi.ConnectionStringName}' for ETL type '{EtlType.GenAi}'. Please supply an existing connection string.");
+                        }
+
+                        genAi.Initialize(cs);
+                        genAi.Validate(out var genAiErr, validateName: false, validateConnection: true);
                         if (ValidateConnectionString(rawRecord, genAi.ConnectionStringName, genAi.EtlType) == false)
                             genAiErr.Add($"Could not find connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);

--- a/test/SlowTests/Issues/RavenDB-24505.cs
+++ b/test/SlowTests/Issues/RavenDB-24505.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Server.Documents.AI.GenAi;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+#pragma warning disable SKEXP0001
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24505 : RavenTestBase
+    {
+        public RavenDB_24505(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
+        public async Task CanCreateOpenAiEmbeddingConnectionStringAndTestGenAiConnection1(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+
+            configuration.Connection.ModelType = AiModelType.TextEmbeddings;
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+
+            var database = await GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var testGenAiScript = new TestGenAiScript { Configuration = configuration };
+                var bjro = store.Conventions.Serialization.DefaultConverter.ToBlittable(testGenAiScript, context);
+                var cmd = new GenAiTestScript.GenAiTestCmd(DocumentConventions.DefaultForServer, bjro);
+
+                using var requestExecutor = store.GetRequestExecutor();
+                var error = await Assert.ThrowsAsync<RavenException>(async () => await requestExecutor.ExecuteAsync(cmd, context));
+
+                Assert.IsType<InvalidOperationException>(error.InnerException);
+                Assert.Contains("ModelType of GenAI configuration must be Chat", error.InnerException.Message);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenAiEmbeddingsData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
+        public async Task EmbeddingsGeneration_ShouldReject_ChatModelType(
+            Options options,
+            EmbeddingsGenerationConfiguration cfg)
+        {
+            using var store = GetDocumentStore(options);
+
+            cfg.Connection.ModelType = AiModelType.Chat;
+            
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(cfg.Connection));
+
+            var cmd = new AddEmbeddingsGenerationOperation(cfg);
+            
+            var ex = await Assert.ThrowsAsync<RavenException>(() =>
+                store.Maintenance.SendAsync(cmd));
+
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("ModelType of Embeddings Generation configuration must be TextEmbeddings",
+                ex.InnerException.Message);
+        } 
+    }
+}
+
+

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiTestScript.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiTestScript.cs
@@ -1729,7 +1729,7 @@ if($output.Blocked)
         }
     }
 
-    private class GenAiTestCmd : RavenCommand<BlittableJsonReaderObject>
+    internal class GenAiTestCmd : RavenCommand<BlittableJsonReaderObject>
     {
         private readonly DocumentConventions _conventions;
         private readonly BlittableJsonReaderObject _testScript;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24505/Need-to-block-unsupported-OpenAI-models-currently-results-in-server-exception

### Additional description

Adds validation that enforces the correct model‑type / task pairing:
- GenAI tasks may use only Chat‑type models
- Embeddings Generation tasks may use only TextEmbeddings‑type models

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
