### PR TITLE
RavenDB-24389 Cloning an archived document should remove "@archived: true"  

### DIFF
--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents
         ForceRevisionCreation = 0x10000,
         AllowDataAsNull = 0x20000,
         FromResharding = 0x40000,
-        UnarchiveFromPatch = 0x80000,
+        Unarchive = 0x80000,
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -60,7 +60,8 @@ namespace Raven.Server.Documents
         LegacyDeleteMarker = 0x8000,
         ForceRevisionCreation = 0x10000,
         AllowDataAsNull = 0x20000,
-        FromResharding = 0x40000
+        FromResharding = 0x40000,
+        UnarchiveFromPatch = 0x80000,
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -180,16 +180,9 @@ namespace Raven.Server.Documents
                     newFlags = _documentsStorage.GetFlagsFromOldDocumentForPut(newFlags, oldFlags, nonPersistentFlags);
                     
                     // if doc was Archived and isn't currently unarchived, leave the Archived flag
-                    if (oldFlags.Contain(DocumentFlags.Archived))
+                    if (oldFlags.Contain(DocumentFlags.Archived) && nonPersistentFlags.Contain(NonPersistentDocumentFlags.UnarchiveFromPatch) == false)
                     {
-                        if (document.TryGetMetadata(out BlittableJsonReaderObject newDocMetadata))
-                        {
-                            newDocMetadata.TryGet(Constants.Documents.Metadata.Archived, out bool isStillArchived);
-                            if (isStillArchived)
-                            {
-                                newFlags |= DocumentFlags.Archived;
-                            }
-                        }
+                        newFlags |= DocumentFlags.Archived;
                     }
                 }
 
@@ -242,22 +235,35 @@ namespace Raven.Server.Documents
 
                 if (document.TryGetMetadata(out BlittableJsonReaderObject docMetadata))
                 {
-                    // drop the @archived: true metadata field for new documents (happens often by cloning archived documents from Studio)
-                    if (oldValue.Pointer == null && newFlags.Contain(DocumentFlags.Archived) == false)
+                    bool shouldRebuildDocument = false;
+                    if (newFlags.Contain(DocumentFlags.Archived))
                     {
-                        if (docMetadata.TryGet(Constants.Documents.Metadata.Archived, out bool isArchivedInMetadata))
+                        // If document has archived flag, but @archived is dropped, rebuild it
+                        // If document has archived flag, but @archived is set to false, revert it to true
+                        if (docMetadata.TryGet(Constants.Documents.Metadata.Archived, out bool isArchived) == false || isArchived == false)
                         {
-                            if (isArchivedInMetadata)
-                            {
-                                docMetadata.Modifications = new DynamicJsonValue(docMetadata);
-                                docMetadata.Modifications.Remove(Constants.Documents.Metadata.Archived);
-                            }
-
-                            document.Modifications = new DynamicJsonValue(document);
-                            document.Modifications[Constants.Documents.Metadata.Key] = docMetadata;
-                            document = context.ReadObject(document, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                            ValidateDocument(id, document, ref documentDebugHash);
+                            docMetadata.Modifications = new DynamicJsonValue(docMetadata);
+                            docMetadata.Modifications[Constants.Documents.Metadata.Archived] = true;
+                            shouldRebuildDocument = true;
                         }
+                    }
+                    else
+                    {
+                        // If document has no archived flag, but @archived is in metadata, drop the metadata entry
+                        if (docMetadata.TryGet(Constants.Documents.Metadata.Archived, out bool _))
+                        {
+                            docMetadata.Modifications = new DynamicJsonValue(docMetadata);
+                            docMetadata.Modifications.Remove(Constants.Documents.Metadata.Archived);
+                            shouldRebuildDocument = true;
+                        }
+                    }
+
+                    if (shouldRebuildDocument)
+                    {
+                        document.Modifications = new DynamicJsonValue(document);
+                        document.Modifications[Constants.Documents.Metadata.Key] = docMetadata;
+                        document = context.ReadObject(document, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                        ValidateDocument(id, document, ref documentDebugHash);
                     }
                 }
 

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -240,6 +240,27 @@ namespace Raven.Server.Documents
                     }
                 }
 
+                if (document.TryGetMetadata(out BlittableJsonReaderObject docMetadata))
+                {
+                    // drop the @archived: true metadata field for new documents (happens often by cloning archived documents from Studio)
+                    if (oldValue.Pointer == null && newFlags.Contain(DocumentFlags.Archived) == false)
+                    {
+                        if (docMetadata.TryGet(Constants.Documents.Metadata.Archived, out bool isArchivedInMetadata))
+                        {
+                            if (isArchivedInMetadata)
+                            {
+                                docMetadata.Modifications = new DynamicJsonValue(docMetadata);
+                                docMetadata.Modifications.Remove(Constants.Documents.Metadata.Archived);
+                            }
+
+                            document.Modifications = new DynamicJsonValue(document);
+                            document.Modifications[Constants.Documents.Metadata.Key] = docMetadata;
+                            document = context.ReadObject(document, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                            ValidateDocument(id, document, ref documentDebugHash);
+                        }
+                    }
+                }
+
                 FlagsProperlySet(newFlags, changeVector);
                 using (Slice.From(context.Allocator, changeVector.AsString(), out var cv))
                 using (table.Allocate(out TableValueBuilder tvb))
@@ -263,11 +284,11 @@ namespace Raven.Server.Documents
                     }
                 }
 
-                if (collectionName.IsHiLo == false && document.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))
+                if (collectionName.IsHiLo == false && docMetadata != null)
                 {
-                    var hasExpirationDate = metadata.TryGet(Constants.Documents.Metadata.Expires, out string expirationDate);
-                    var hasRefreshDate = metadata.TryGet(Constants.Documents.Metadata.Refresh, out string refreshDate);
-                    var hasArchiveAtDate= metadata.TryGet(Constants.Documents.Metadata.ArchiveAt, out string archiveAtDate);
+                    var hasExpirationDate = docMetadata.TryGet(Constants.Documents.Metadata.Expires, out string expirationDate);
+                    var hasRefreshDate = docMetadata.TryGet(Constants.Documents.Metadata.Refresh, out string refreshDate);
+                    var hasArchiveAtDate= docMetadata.TryGet(Constants.Documents.Metadata.ArchiveAt, out string archiveAtDate);
 
                     if (hasExpirationDate)
                         _documentsStorage.ExpirationStorage.Put(context, lowerId, expirationDate);

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents
                     newFlags = _documentsStorage.GetFlagsFromOldDocumentForPut(newFlags, oldFlags, nonPersistentFlags);
                     
                     // if doc was Archived and isn't currently unarchived, leave the Archived flag
-                    if (oldFlags.Contain(DocumentFlags.Archived) && nonPersistentFlags.Contain(NonPersistentDocumentFlags.UnarchiveFromPatch) == false)
+                    if (oldFlags.Contain(DocumentFlags.Archived) && nonPersistentFlags.Contain(NonPersistentDocumentFlags.Unarchive) == false)
                     {
                         newFlags |= DocumentFlags.Archived;
                     }
@@ -235,7 +235,6 @@ namespace Raven.Server.Documents
 
                 if (document.TryGetMetadata(out BlittableJsonReaderObject docMetadata))
                 {
-                    bool shouldRebuildDocument = false;
                     if (newFlags.Contain(DocumentFlags.Archived))
                     {
                         // If document has archived flag, but @archived is dropped, rebuild it
@@ -244,7 +243,6 @@ namespace Raven.Server.Documents
                         {
                             docMetadata.Modifications = new DynamicJsonValue(docMetadata);
                             docMetadata.Modifications[Constants.Documents.Metadata.Archived] = true;
-                            shouldRebuildDocument = true;
                         }
                     }
                     else
@@ -254,11 +252,10 @@ namespace Raven.Server.Documents
                         {
                             docMetadata.Modifications = new DynamicJsonValue(docMetadata);
                             docMetadata.Modifications.Remove(Constants.Documents.Metadata.Archived);
-                            shouldRebuildDocument = true;
                         }
                     }
 
-                    if (shouldRebuildDocument)
+                    if (docMetadata.Modifications != null)
                     {
                         document.Modifications = new DynamicJsonValue(document);
                         document.Modifications[Constants.Documents.Metadata.Key] = docMetadata;

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -949,7 +949,7 @@ namespace Raven.Server.Documents.Patch
         
                     using (var updated = _docsCtx.ReadObject(doc.Data, archivedDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                     {
-                         _database.DocumentsStorage.Put(_docsCtx, archivedDocId, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction));
+                         _database.DocumentsStorage.Put(_docsCtx, archivedDocId, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction), nonPersistentFlags: NonPersistentDocumentFlags.UnarchiveFromPatch);
                     }
                 }
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -949,7 +949,7 @@ namespace Raven.Server.Documents.Patch
         
                     using (var updated = _docsCtx.ReadObject(doc.Data, archivedDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                     {
-                         _database.DocumentsStorage.Put(_docsCtx, archivedDocId, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction), nonPersistentFlags: NonPersistentDocumentFlags.UnarchiveFromPatch);
+                         _database.DocumentsStorage.Put(_docsCtx, archivedDocId, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction), nonPersistentFlags: NonPersistentDocumentFlags.Unarchive);
                     }
                 }
 

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
@@ -26,6 +26,7 @@ using Raven.Server.Documents.DataArchival;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -173,7 +174,7 @@ namespace SlowTests.Server.Documents.DataArchival
         }
 
         [RavenFact(RavenTestCategory.ExpirationRefresh | RavenTestCategory.Revisions)]
-        public async Task ArchiveFlagShouldNotBeRemoved()
+        public async Task ArchiveFlagShouldNotBeRemovedAfterDocumentUpdate()
         {
             using (var store = GetDocumentStore())
             {
@@ -255,6 +256,199 @@ namespace SlowTests.Server.Documents.DataArchival
                     Assert.True(flagsValue.ToString().Contains("HasRevisions"));
                     
                     Assert.True(flagsValue.ToString().Contains("Archived"));
+                }
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ExpirationRefresh)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ShouldNotApplyArchivedMetadataForNewDocuments(bool archivedValue)      
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var metadataPropNameToTest = "@archived";
+                    var executor = store.GetRequestExecutor();
+                    using var dis = executor.ContextPool.AllocateOperationContext(out var context);
+                    var p = context.ReadObject(new DynamicJsonValue
+                        {
+                            [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                            {
+                                [metadataPropNameToTest] = archivedValue
+
+                            }
+                        }, $"{nameof(metadataPropNameToTest)} {metadataPropNameToTest}");
+                    session.Store(p, null, "archived/1");
+                    session.SaveChanges();
+                }
+
+                // Assert no flag in "@flags", assert no "@archived"
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<DynamicJsonValue>("archived/1");
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    Assert.False(archivedUserMetadata.ContainsKey("@archived"));
+                    if (archivedUserMetadata.TryGetValue("@flags", out object flagsValue))
+                    {
+                        Assert.False(flagsValue.ToString().Contains("Archived"));
+                    }
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ExpirationRefresh)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ShouldNotApplyArchivedMetadataForUnarchivedDocsUpdates(bool archivedValue)
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "aaa" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    metadata[Constants.Documents.Metadata.Archived] = archivedValue;
+                    session.SaveChanges();
+                }
+                // Assert no "@flags", assert no "@archived"
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<User>("users/1");
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    Assert.False(archivedUserMetadata.ContainsKey("@archived"));
+                    if (archivedUserMetadata.TryGetValue("@flags", out object flagsValue))
+                    {
+                        Assert.False(flagsValue.ToString().Contains("Archived"));
+                    }
+                }
+            }
+        }
+        
+        
+        [RavenFact(RavenTestCategory.ExpirationRefresh)]
+        public async Task ShouldRebuildArchivedInMetadataIfArchivedDocumentUpdateRemovesIt ()
+        {
+            using (var store = GetDocumentStore())
+            {
+                // Create document 
+                // ===============
+                var user = new User {Name = "aaa"};
+                var archiveAt = SystemTime.UtcNow.AddSeconds(30);
+                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(user);
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    metadata[Constants.Documents.Metadata.ArchiveAt] = archiveAt.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                    session.SaveChanges();
+                }
+                
+                // Activate the archival
+                await SetupDataArchival(store);
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                var documentsArchiver = database.DataArchivist;
+                await documentsArchiver.ArchiveDocs();
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                
+                // Verify that @flags contains the "Archived" flag, try to delete it
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<User>(user.Id);
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    
+                    var flagsValue = archivedUserMetadata["@flags"];
+                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                    
+                    archivedUserMetadata.Remove(Constants.Documents.Metadata.Archived);
+                    session.SaveChanges();
+                }
+
+                // Assert flag and "@archived" still here
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<User>(user.Id);
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    
+                    Assert.True(archivedUserMetadata.TryGetValue("@archived", out object archivedValue));
+                    Assert.Equal("True", archivedValue.ToString());
+                    
+                    Assert.True(archivedUserMetadata.TryGetValue("@flags", out object flagsValue));
+                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                }
+            }
+        }
+        
+        [RavenFact(RavenTestCategory.ExpirationRefresh)]
+        public async Task ShouldRevertArchivedMetadataToTrueIfArchivedDocumentUpdateSetItToFalse()
+        {
+            using (var store = GetDocumentStore())
+            {
+                // Create document 
+                // ===============
+                var user = new User {Name = "aaa"};
+                var archiveAt = SystemTime.UtcNow.AddSeconds(30);
+                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(user);
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    metadata[Constants.Documents.Metadata.ArchiveAt] = archiveAt.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                    session.SaveChanges();
+                }
+                
+                // Activate the archival
+                await SetupDataArchival(store);
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                var documentsArchiver = database.DataArchivist;
+                await documentsArchiver.ArchiveDocs();
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                
+                // Verify that @flags contains the "Archived" flag, try to set it to false
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<User>(user.Id);
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    
+                    var flagsValue = archivedUserMetadata["@flags"];
+                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                    
+                    archivedUserMetadata[Constants.Documents.Metadata.Archived] = false;
+                    session.SaveChanges();
+                }
+
+                // Assert flag and "@archived: true" still here
+                // ===============================================
+                using (var session = store.OpenSession())
+                {
+                    var archivedUser = session.Load<User>(user.Id);
+                    var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
+                    
+                    Assert.True(archivedUserMetadata.TryGetValue("@flags", out object flagsValue));
+                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                    
+                    Assert.True(archivedUserMetadata.TryGetValue("@archived", out object archivedValue));
+                    Assert.Equal("True", archivedValue.ToString());
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
@@ -26,7 +26,6 @@ using Raven.Server.Documents.DataArchival;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
-using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -263,24 +262,15 @@ namespace SlowTests.Server.Documents.DataArchival
         [RavenTheory(RavenTestCategory.ExpirationRefresh)]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ShouldNotApplyArchivedMetadataForNewDocuments(bool archivedValue)      
+        public void ShouldNotApplyArchivedMetadataForNewDocuments(bool archivedValue)      
         {
             using (var store = GetDocumentStore())
             {
                 using (var session = store.OpenSession())
                 {
-                    var metadataPropNameToTest = "@archived";
-                    var executor = store.GetRequestExecutor();
-                    using var dis = executor.ContextPool.AllocateOperationContext(out var context);
-                    var p = context.ReadObject(new DynamicJsonValue
-                        {
-                            [Constants.Documents.Metadata.Key] = new DynamicJsonValue
-                            {
-                                [metadataPropNameToTest] = archivedValue
-
-                            }
-                        }, $"{nameof(metadataPropNameToTest)} {metadataPropNameToTest}");
-                    session.Store(p, null, "archived/1");
+                    session.Store(new User(), null, "archived/1");
+                    var metadata = session.Advanced.GetMetadataFor(session.Load<User>("archived/1"));
+                    metadata[Constants.Documents.Metadata.Archived] = archivedValue;
                     session.SaveChanges();
                 }
 
@@ -288,12 +278,12 @@ namespace SlowTests.Server.Documents.DataArchival
                 // ===============================================
                 using (var session = store.OpenSession())
                 {
-                    var archivedUser = session.Load<DynamicJsonValue>("archived/1");
+                    var archivedUser = session.Load<User>("archived/1");
                     var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
                     Assert.False(archivedUserMetadata.ContainsKey("@archived"));
                     if (archivedUserMetadata.TryGetValue("@flags", out object flagsValue))
                     {
-                        Assert.False(flagsValue.ToString().Contains("Archived"));
+                        Assert.DoesNotContain(flagsValue.ToString(), "Archived");
                     }
                 }
             }
@@ -302,7 +292,7 @@ namespace SlowTests.Server.Documents.DataArchival
         [RavenTheory(RavenTestCategory.ExpirationRefresh)]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ShouldNotApplyArchivedMetadataForUnarchivedDocsUpdates(bool archivedValue)
+        public void ShouldNotApplyArchivedMetadataForUnarchivedDocsUpdates(bool archivedValue)
         {
             using (var store = GetDocumentStore())
             {
@@ -328,7 +318,7 @@ namespace SlowTests.Server.Documents.DataArchival
                     Assert.False(archivedUserMetadata.ContainsKey("@archived"));
                     if (archivedUserMetadata.TryGetValue("@flags", out object flagsValue))
                     {
-                        Assert.False(flagsValue.ToString().Contains("Archived"));
+                        Assert.DoesNotContain(flagsValue.ToString(), "Archived");
                     }
                 }
             }
@@ -372,7 +362,7 @@ namespace SlowTests.Server.Documents.DataArchival
                     var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
                     
                     var flagsValue = archivedUserMetadata["@flags"];
-                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                    Assert.Contains(flagsValue.ToString(), "Archived");
                     
                     archivedUserMetadata.Remove(Constants.Documents.Metadata.Archived);
                     session.SaveChanges();
@@ -445,7 +435,7 @@ namespace SlowTests.Server.Documents.DataArchival
                     var archivedUserMetadata = session.Advanced.GetMetadataFor(archivedUser);
                     
                     Assert.True(archivedUserMetadata.TryGetValue("@flags", out object flagsValue));
-                    Assert.True(flagsValue.ToString().Contains("Archived"));
+                    Assert.Contains(flagsValue.ToString(), "Archived");
                     
                     Assert.True(archivedUserMetadata.TryGetValue("@archived", out object archivedValue));
                     Assert.Equal("True", archivedValue.ToString());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24389/Cloning-an-archived-document-should-remove-archived-true

### Additional description

Reusing the metadata in DocumentPutAction to minimize performance hit
<img width="1043" height="224" alt="image" src="https://github.com/user-attachments/assets/90b3fd7f-d94f-4f9e-9ef8-cfcf0e4d1094" />



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing (as Clone document is a Studio feature)
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
