### PR TITLE
RavenDB-24418 exposed number of open file descriptors for server

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.5/ProcessOpenFileDescriptors.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.5/ProcessOpenFileDescriptors.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using Lextm.SharpSnmpLib;
+using Sparrow.Platform;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server
+{
+    public sealed class ProcessOpenFileDescriptors() : ScalarObjectBase<Integer32>(SnmpOids.Server.ProcessOpenFileDescriptors)
+    {
+        protected override Integer32 GetData()
+        {
+            if (PlatformDetails.RunningOnLinux == false)
+                return new Integer32(-1);
+            
+            try
+            {
+                var processId = Environment.ProcessId;
+                var fdPath = $"/proc/{processId}/fd";
+                
+                if (Directory.Exists(fdPath))
+                {
+                    var fdCount = Directory.GetFileSystemEntries(fdPath).Length;
+                    return new Integer32(fdCount);
+                }
+                
+                return Integer32.Zero;
+            }
+            catch (Exception)
+            {
+                // If we can't read the file descriptors, return -1
+                return new Integer32(-1);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -110,6 +110,10 @@ namespace Raven.Server.Monitoring.Snmp
             [Description("Total number of pages written by the server since last start (across all databases & indexes)")]
             public const string TotalPagesWritten = "1.5.5.2";
             
+            [SnmpDataType(SnmpType.Integer32)]
+            [Description("Number of open file descriptors for Server (Linux only)")]
+            public const string ProcessOpenFileDescriptors = "1.5.6";
+            
             [SnmpDataType(SnmpType.Gauge32)]
             [Description("Server allocated memory in MB")]
             public const string TotalMemory = "1.6.1";

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -392,6 +392,8 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new TotalPagesRead());
             store.Add(new TotalPagesWritten());
 
+            store.Add(new ProcessOpenFileDescriptors());
+            
             store.Add(new CpuCreditsBase(server.CpuCreditsBalance));
             store.Add(new CpuCreditsMax(server.CpuCreditsBalance));
             store.Add(new CpuCreditsRemaining(server.CpuCreditsBalance));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24418

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
