### PR TITLE
RavenDB-24635 - Fix AiAgentClientApiBasicTest test

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -129,29 +129,28 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         
         usage.UpdateFrom(usageJson);
 
+        if (msg.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray calls))
+        {
+            var resp = new AiResponse(AiResponseType.Tool) { ToolCalls = [], Message = msg };
+            foreach (BlittableJsonReaderObject call in calls)
+            {
+                if (call.TryGet("id", out string callId) is false ||
+                    call.TryGet("function", out BlittableJsonReaderObject function) is false ||
+                    function.TryGet("name", out string name) is false ||
+                    function.TryGet("arguments", out string args) is false)
+                    throw new UnexpectedResponseException("Invalid function call: " + call.ToString())
+                    {
+                        RequestId = GetRequestId(response.Headers)
+                    };
+                resp.ToolCalls.Add(new AiToolCall(callId, name, args));
+            }
+
+            return resp;
+        }
+
         if (string.IsNullOrEmpty(content))
         {
-            if (choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason) && 
-                finishReason == Constants.ResponseFields.ToolCalls && 
-                msg.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray calls))
-            {
-                var resp = new AiResponse(AiResponseType.Tool) { ToolCalls = [], Message = msg};
-                foreach (BlittableJsonReaderObject call in calls)
-                {
-                    if (call.TryGet("id", out string callId) is false ||
-                        call.TryGet("function", out BlittableJsonReaderObject function) is false ||
-                        function.TryGet("name", out string name) is false ||
-                        function.TryGet("arguments", out string args) is false)
-                        throw new UnexpectedResponseException("Invalid function call: " + call.ToString())
-                        {
-                            RequestId = GetRequestId(response.Headers)
-                        };
-                    resp.ToolCalls.Add(new AiToolCall(callId, name, args));
-                }
-                
-                return resp;
-            }
-            
+            choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
             choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal); 
             //TODO: full output if we get here?
             throw new RefusedToAnswerException("The request was refused by the model")

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24635.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24635.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_24635 : RavenTestBase
+    {
+        public RavenDB_24635(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ToolCallsWithNoEmptyContentShouldntFail(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agent = new AiAgentConfiguration("my assistant", config.ConnectionStringName,
+                "You are a tool-calling assistant." +
+                "When you perform a tool call, always include a short explanation to the user in the `content` field about what is about to happen, and then in the `tool_calls` field the parameters for the call.");
+
+            agent.Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats", Expires = TimeSpan.FromDays(30) };
+
+            agent.Parameters.Add("company");
+            agent.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "ProductSearch",
+                    Description = "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                },
+                new AiAgentToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSampleObject = "{}"
+                }
+            ];
+
+            var identifier = (await store.AI.CreateAgentAsync<AiAgentBasics.OutputSchema>(agent)).Identifier;
+
+            var chat = store.AI.StartConversation<AiAgentBasics.OutputSchema>(identifier,
+                p => p.AddParameter("company", "companies/90-A"));
+
+            chat.SetUserPrompt("run tool 'RecentOrder'");
+            await chat.RunAsync(CancellationToken.None);
+            chat.SetUserPrompt("run tool 'RecentOrder'");
+            await chat.RunAsync(CancellationToken.None); // Fail
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24635/SlowTests.Server.Documents.AI.AiAgent.AiAgentClientApiBasics.AiAgentClientApiBasicTestoptions-DatabaseMode-Single-config

### Additional description

Exception:
```
Raven.Server.Documents.AI.UnsuccessfulRequestException: An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.The following tool_call_ids did not have response messages: call_n6KqoOfJXzyLAtKKbHbbivBB
```


 Conversation Messages that caused the exception:
```
 {
    "role": "system",
    "content": "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.",
    "date": "2025-07-16T10:28:27.3670308Z"
}{
    "role": "user",
    "content": "what goes well with my cheese?",
    "date": "2025-07-16T10:28:27.3670511Z"
}{
    "role": "assistant",
    "content": "{\"Answer\":\"To find great complementary products for your cheese, such as crackers, wine, or fruit preserves, I can look up related items in our catalog. Please hold on a moment.\",\"Relevant\":true,\"RelevantOrdersId\":[],\"MatchingProductsId\":[]}",
    "tool_calls": [{
            "id": "call_n6KqoOfJXzyLAtKKbHbbivBB",
            "type": "function",
            "function": {
                "name": "ProductSearch",
                "arguments": "{\"query\":[\"cheese pairing\",\"cheese accompaniment\",\"crackers for cheese\",\"wine for cheese\",\"fruit preserve for cheese\"]}"
            }
        }
    ],
    "refusal": null,
    "annotations": [],
    "date": "2025-07-16T10:28:30.9724968Z",
    "usage": {
        "PromptTokens": 253,
        "CompletionTokens": 136,
        "TotalTokens": 389,
        "CachedTokens": 0
    }
}{
    "role": "user",
    "content": "what goes well with my cheese?"
}
```

The issue when receiving a "tool_calls request" message like this from the model:
```
{
    "role": "assistant",
    "content": "{\"Answer\":\"To find great complementary products for your cheese, such as crackers, wine, or fruit preserves, I can look up related items in our catalog. Please hold on a moment.\",\"Relevant\":true,\"RelevantOrdersId\":[],\"MatchingProductsId\":[]}",
    "tool_calls": [{
            "id": "call_n6KqoOfJXzyLAtKKbHbbivBB",
            "type": "function",
            "function": {
                "name": "ProductSearch",
                "arguments": "{\"query\":[\"cheese pairing\",\"cheese accompaniment\",\"crackers for cheese\",\"wine for cheese\",\"fruit preserve for cheese\"]}"
            }
        }
    ],
    "refusal": null,
    "annotations": [],
    "date": "2025-07-16T10:28:30.9724968Z",
    "usage": {
        "PromptTokens": 253,
        "CompletionTokens": 136,
        "TotalTokens": 389,
        "CachedTokens": 0
    }
}
```
The unexpected case here is that w have `tool_calls` field *AND* non-empty `content` field.
We currently treat any non‑empty content as an `AiResponseType.Result`, even if the response also includes `tool_calls`. 
Instead, if a model response contains a `tool_calls` field, CompleteAsync should *ALWAYS* return `AiResponseType.Tool`, regardless if the content is empty or not.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
