### PR TITLE
RavenDB-24191 Cannot register includes: Unclear error message

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2652,7 +2652,10 @@ more responsive application.
             if (NoTracking == false)
                 return;
 
-            throw new InvalidOperationException("This session does not track any entities, because of that registering includes is forbidden to avoid false expectations when later load operations are performed on those and no requests are being sent to the server. Please avoid any 'Include' operations during non-tracking session actions like load or query.");
+            throw new InvalidOperationException(
+                "Cannot register includes when NoTracking is enabled. " +
+                "Included documents are not tracked, so subsequent Load operations for that data will still trigger additional server requests. " +
+                "To avoid confusion, 'Include' operations are disallowed when tracking is disabled on the session or query.");
         }
     }
 

--- a/test/SlowTests/Issues/RavenDB_21339.cs
+++ b/test/SlowTests/Issues/RavenDB_21339.cs
@@ -42,7 +42,7 @@ public class RavenDB_21339 : RavenTestBase
             }))
             {
                 var e = Assert.Throws<InvalidOperationException>(() => session.Load<Product>("products/1", includes => includes.IncludeDocuments(x => x.Supplier)));
-                Assert.Contains("registering includes is forbidden", e.Message);
+                Assert.Contains("Cannot register includes when NoTracking is enabled", e.Message);
             }
 
             using (var session = store.OpenAsyncSession(new SessionOptions
@@ -51,7 +51,7 @@ public class RavenDB_21339 : RavenTestBase
             }))
             {
                 var e = await Assert.ThrowsAsync<InvalidOperationException>(() => session.LoadAsync<Product>("products/1", includes => includes.IncludeDocuments(x => x.Supplier)));
-                Assert.Contains("registering includes is forbidden", e.Message);
+                Assert.Contains("Cannot register includes when NoTracking is enabled", e.Message);
             }
 
             using (var session = store.OpenSession(new SessionOptions
@@ -60,7 +60,7 @@ public class RavenDB_21339 : RavenTestBase
             }))
             {
                 var e = Assert.Throws<InvalidOperationException>(() => session.Query<Product>().Include(x => x.Supplier).ToList());
-                Assert.Contains("registering includes is forbidden", e.Message);
+                Assert.Contains("Cannot register includes when NoTracking is enabled", e.Message);;
             }
 
             using (var session = store.OpenAsyncSession(new SessionOptions
@@ -69,7 +69,7 @@ public class RavenDB_21339 : RavenTestBase
             }))
             {
                 var e = await Assert.ThrowsAsync<InvalidOperationException>(() => session.Query<Product>().Include(x => x.Supplier).ToListAsync());
-                Assert.Contains("registering includes is forbidden", e.Message);
+                Assert.Contains("Cannot register includes when NoTracking is enabled", e.Message);
             }
 
             using (var session = store.OpenSession(new SessionOptions
@@ -78,7 +78,7 @@ public class RavenDB_21339 : RavenTestBase
             }))
             {
                 var e = Assert.Throws<InvalidOperationException>(() => session.Advanced.DocumentQuery<Product>().Include(x => x.Supplier).ToList());
-                Assert.Contains("registering includes is forbidden", e.Message);
+                Assert.Contains("Cannot register includes when NoTracking is enabled", e.Message);
             }
 
             using (var session = store.OpenAsyncSession(new SessionOptions
@@ -87,7 +87,7 @@ public class RavenDB_21339 : RavenTestBase
             }))
             {
                 var e = await Assert.ThrowsAsync<InvalidOperationException>(() => session.Advanced.AsyncDocumentQuery<Product>().Include(x => x.Supplier).ToListAsync());
-                Assert.Contains("registering includes is forbidden", e.Message);
+                Assert.Contains("Cannot register includes when NoTracking is enabled", e.Message);
             }
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24191/Cannot-register-includes-Unclear-error-message

### Additional description
Fix the error msg when trying to use include when NoTracking is enabled

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
