### PR TITLE
RavenDB-24525 Add withNestedSubmit to AiConnectionString

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
@@ -28,6 +28,7 @@ import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import classNames from "classnames";
 import Form from "react-bootstrap/Form";
+import { withNestedSubmit } from "components/utils/common";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -75,7 +76,11 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
 
     return (
         <FormProvider {...form}>
-            <Form id="connection-string-form" onSubmit={handleSubmit(handleSave)} className="vstack gap-3">
+            <Form
+                id="connection-string-form"
+                onSubmit={withNestedSubmit(handleSubmit(handleSave))}
+                className="vstack gap-3"
+            >
                 <div className="mb-2">
                     <FormLabel>Name</FormLabel>
                     <FormInput

--- a/src/Raven.Studio/typescript/components/utils/common.ts
+++ b/src/Raven.Studio/typescript/components/utils/common.ts
@@ -11,6 +11,14 @@ export function withPreventDefault(action: (...args: any[]) => void): MouseEvent
     };
 }
 
+export function withNestedSubmit(action: (...args: any[]) => void) {
+    return (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        action();
+    };
+}
+
 export function createIdleState(): loadableData<any> {
     return {
         data: null,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24525/GenAI-saving-new-connection-string-triggers-GenAI-form-submit

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
