### PR TITLE
RavenDB-24677 tests that create server-wide backups cannot use global server

### DIFF
--- a/test/SlowTests/Issues/RavenDB_24553.cs
+++ b/test/SlowTests/Issues/RavenDB_24553.cs
@@ -16,7 +16,8 @@ public class RavenDB_24553 : RavenTestBase
     [RavenFact(RavenTestCategory.BackupExportImport)]
     public void CanUpdateDatabaseCompressionAfterServerwideBackup()
     {
-        using (var store = GetDocumentStore())
+        using (var server = GetNewServer())
+        using (var store = GetDocumentStore(new Options { Server = server }))
         {
             // Create serverwide backup
             var backupConfig = new ServerWideBackupConfiguration


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24677

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
