### PR TITLE
RavenDB-24392 : GenAI Test should show added / removed documents

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
@@ -7,10 +7,6 @@ namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
 
 public class GenAiResultItem
 {
-    public List<string> DebugOutput { get; set; }
-
-    public DynamicJsonValue DebugActions { get; set; }
-
     public ModelOutput ModelOutput { get; set; }
 
     public ContextOutput ContextOutput { get; set; }
@@ -23,8 +19,6 @@ public class GenAiResultItem
     {
         return new DynamicJsonValue
         {
-            [nameof(DebugOutput)] = DebugOutput == null ? null : new DynamicJsonArray(DebugOutput),
-            [nameof(DebugActions)] = DebugActions,
             [nameof(ContextOutput)] = ContextOutput?.ToJson(),
             [nameof(ModelOutput)] = ModelOutput?.ToJson()
         };

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
@@ -330,7 +331,9 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
     {
         List<GenAiResultItem> items;
         BlittableJsonReaderObject outputDocument = null;
-
+        DynamicJsonValue debugActions = null;
+        List<string> debugOutput = null;
+        PatchStatus status = PatchStatus.NotModified;
         Document document = null;
 
         switch (testGenAiScript.TestStage)
@@ -430,20 +433,28 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                             patchIfMissing: default,
                             createIfMissing: null,
                             identityPartsSeparator: Database.IdentityPartsSeparator,
-                            isTest: false,
-                            debugMode: false,
+                            isTest: true,
+                            debugMode: true,
                             collectResultsNeeded: true,
                             returnDocument: false,
                             ignoreMaxStepsForScript: false);
 
                         cmd.Execute(context, recordingState: null);
-
-                        item.DebugActions = cmd.DebugActions;
-                        item.DebugOutput = cmd.DebugOutput;
                     }
 
-                    if (lastPatch?.PatchResult?.ModifiedDocument != null)
-                        outputDocument = GenAiBatchPatchCommand.UpdateHashesInMetadata(document.Id, lastPatch.PatchResult.ModifiedDocument, Configuration.Identifier, hashes, context);
+
+                    if (lastPatch != null)
+                    {
+                        status = lastPatch.PatchResult.Status;
+                        debugActions = lastPatch?.DebugActions;
+                        debugOutput = lastPatch?.DebugOutput;
+
+                        if (lastPatch?.PatchResult?.ModifiedDocument != null)
+                        {
+                            outputDocument = GenAiBatchPatchCommand.UpdateHashesInMetadata(document.Id, lastPatch.PatchResult.ModifiedDocument, Configuration.Identifier,
+                                hashes, context);
+                        }
+                    }
 
                     break;
                 }
@@ -451,13 +462,19 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             default:
                 throw new InvalidOperationException("Unknown TestStage type : " + testGenAiScript.TestStage.GetType());
         }
-
+        var originalDoc = document?.Data;
+        var modifiedDoc = outputDocument;
         return new GenAiTestScriptResult
         {
-            InputDocument = document?.Data,
+            Status = status,
+            InputDocument = originalDoc,
+            OriginalDocument = originalDoc,
+            OutputDocument = modifiedDoc,
+            ModifiedDocument = modifiedDoc,
             Results = items,
-            OutputDocument = outputDocument,
-            TransformationErrors = Statistics.TransformationErrorsInCurrentBatch.Errors.ToList()
+            DebugActions = debugActions,
+            DebugOutput = debugOutput,
+            TransformationErrors = Statistics.TransformationErrorsInCurrentBatch.Errors.ToList(),
         };
     }
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -433,7 +433,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                             patchIfMissing: default,
                             createIfMissing: null,
                             identityPartsSeparator: Database.IdentityPartsSeparator,
-                            isTest: true,
+                            isTest: false,
                             debugMode: true,
                             collectResultsNeeded: true,
                             returnDocument: false,

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
@@ -43,13 +43,12 @@ public class GenAiTestScriptResult : TestEtlScriptResult
         DynamicJsonValue dbg = null;
 
         if (DebugOutput?.Count > 0)
-            dbg = new DynamicJsonValue { ["Output"] = new DynamicJsonArray(DebugOutput ?? []) };
-        
+            dbg = new DynamicJsonValue { [nameof(DebugOutput)] = new DynamicJsonArray(DebugOutput ?? []) };
 
         if (DebugActions != null)
-            (dbg ??= new DynamicJsonValue())["Actions"] = DebugActions;
+            (dbg ??= new DynamicJsonValue())[nameof(DebugActions)] = DebugActions;
         
-        json["Debug"] = dbg;
+        json[nameof(PatchResult.Debug)] = dbg;
 
         return json;
     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
@@ -26,7 +26,7 @@ public class GenAiTestScriptResult : TestEtlScriptResult
     public override DynamicJsonValue ToJson(JsonOperationContext context)
     {
         var json = base.ToJson(context);
-        
+
         json[nameof(Status)] = Status;
 
         if (ModifiedDocument != null)
@@ -40,14 +40,12 @@ public class GenAiTestScriptResult : TestEtlScriptResult
         if (Results != null)
             json[nameof(Results)] = new DynamicJsonArray(Results.Select(x => x.ToJson()));
 
-        DynamicJsonValue dbg = null;
+        DynamicJsonValue dbg = new()
+        {
+            [nameof(DebugOutput)] = new DynamicJsonArray(DebugOutput),
+            [nameof(DebugActions)] = DebugActions
+        };
 
-        if (DebugOutput?.Count > 0)
-            dbg = new DynamicJsonValue { [nameof(DebugOutput)] = new DynamicJsonArray(DebugOutput ?? []) };
-
-        if (DebugActions != null)
-            (dbg ??= new DynamicJsonValue())[nameof(DebugActions)] = DebugActions;
-        
         json[nameof(PatchResult.Debug)] = dbg;
 
         return json;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Raven.Client.Documents.Operations;
 using Raven.Server.Documents.ETL.Test;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -8,20 +9,47 @@ namespace Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
 
 public class GenAiTestScriptResult : TestEtlScriptResult
 {
+    public BlittableJsonReaderObject ModifiedDocument;
+
+    public BlittableJsonReaderObject OriginalDocument;
+
     public List<GenAiResultItem> Results;
 
     public BlittableJsonReaderObject InputDocument;
 
     public BlittableJsonReaderObject OutputDocument;
 
+    public DynamicJsonValue DebugActions;
+
+    public PatchStatus Status;
+
     public override DynamicJsonValue ToJson(JsonOperationContext context)
     {
         var json = base.ToJson(context);
-        json[nameof(InputDocument)] = InputDocument;
+        
+        json[nameof(Status)] = Status;
+
+        if (ModifiedDocument != null)
+            json[nameof(ModifiedDocument)] = ModifiedDocument;
+        if (OriginalDocument != null)
+            json[nameof(OriginalDocument)] = OriginalDocument;
+
         json[nameof(OutputDocument)] = OutputDocument;
+        json[nameof(InputDocument)] = InputDocument;
 
         if (Results != null)
             json[nameof(Results)] = new DynamicJsonArray(Results.Select(x => x.ToJson()));
+
+        DynamicJsonValue dbg = null;
+
+        if (DebugOutput?.Count > 0)
+            dbg = new DynamicJsonValue { ["Output"] = new DynamicJsonArray(DebugOutput ?? []) };
+        
+
+        if (DebugActions != null)
+            (dbg ??= new DynamicJsonValue())["Actions"] = DebugActions;
+        
+        json["Debug"] = dbg;
 
         return json;
     }

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -808,7 +808,10 @@ namespace Orders
 
     static testGenAiResults_update(): Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.GenAiTestScriptResult {
         return {
-            DebugActions: null, ModifiedDocument: null, OriginalDocument: null, Status: null,
+            DebugActions: null,
+            ModifiedDocument: null,
+            OriginalDocument: null,
+            Status: null,
             TransformationErrors: [],
             DebugOutput: [],
             InputDocument: {

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -680,6 +680,10 @@ namespace Orders
 
     static testGenAiResults_context(): Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.GenAiTestScriptResult {
         return {
+            DebugActions: null,
+            ModifiedDocument: null,
+            OriginalDocument: null,
+            Status: null,
             TransformationErrors: [],
             DebugOutput: [],
             InputDocument: {
@@ -700,8 +704,6 @@ namespace Orders
             OutputDocument: null,
             Results: [
                 {
-                    DebugOutput: [],
-                    DebugActions: null,
                     ContextOutput: {
                         Context: {
                             Text: "This is spam",
@@ -714,8 +716,6 @@ namespace Orders
                     ModelOutput: null,
                 },
                 {
-                    DebugOutput: [],
-                    DebugActions: null,
                     ContextOutput: {
                         Context: {
                             Text: "This is not spam",
@@ -733,6 +733,10 @@ namespace Orders
 
     static testGenAiResults_model(): Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.GenAiTestScriptResult {
         return {
+            DebugActions: null,
+            ModifiedDocument: null,
+            OriginalDocument: null,
+            Status: null,
             TransformationErrors: [],
             DebugOutput: [],
             InputDocument: {
@@ -753,8 +757,6 @@ namespace Orders
             OutputDocument: null,
             Results: [
                 {
-                    DebugOutput: [],
-                    DebugActions: null,
                     ContextOutput: {
                         Context: {
                             Text: "This is spam",
@@ -778,8 +780,6 @@ namespace Orders
                     },
                 },
                 {
-                    DebugOutput: [],
-                    DebugActions: null,
                     ContextOutput: {
                         Context: {
                             Text: "This is not spam",
@@ -808,6 +808,7 @@ namespace Orders
 
     static testGenAiResults_update(): Raven.Server.Documents.ETL.Providers.AI.GenAi.Test.GenAiTestScriptResult {
         return {
+            DebugActions: null, ModifiedDocument: null, OriginalDocument: null, Status: null,
             TransformationErrors: [],
             DebugOutput: [],
             InputDocument: {
@@ -837,8 +838,6 @@ namespace Orders
             },
             Results: [
                 {
-                    DebugOutput: [],
-                    DebugActions: null,
                     ContextOutput: {
                         Context: {
                             Text: "This is spam",
@@ -862,8 +861,6 @@ namespace Orders
                     },
                 },
                 {
-                    DebugOutput: [],
-                    DebugActions: null,
                     ContextOutput: {
                         Context: {
                             Text: "This is not spam",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24392/GenAI-Test-should-show-added-removed-documents

### Additional description

fixes the GenAI “Test update Script" endpoint so that Studio’s Added / Removed documents panel will be able to represent the same kind of window as the patch test does(changed the returned Json format to be similar and include all the info needed).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
