### PR TITLE
RavenDB-24433 Fixed tests for consistent behavior across platforms

### DIFF
--- a/test/LicenseTests/Helpers/LicenseOptionTestHelper.cs
+++ b/test/LicenseTests/Helpers/LicenseOptionTestHelper.cs
@@ -31,9 +31,12 @@ public static class LicenseOptionTestHelper
         return licenseJsonPath;
     }
 
+
+    static string Normalize(string s) => s.Replace("\r\n", "\n");
+
     internal static void AssertLicenseVerificationException(Exception exception, LicenseHelper.LicenseVerificationErrorBuilder expectedMessageBuilder)
     {
-        Assert.True(exception.Message.Contains(expectedMessageBuilder.ToString()),
+        Assert.True(Normalize(exception.Message).Contains(Normalize(expectedMessageBuilder.ToString())),
             userMessage: $"Exception message: {exception.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
     }
 
@@ -41,7 +44,7 @@ public static class LicenseOptionTestHelper
     {
         Assert.NotNull(exception.InnerException);
         Assert.IsType<T>(exception.InnerException);
-        Assert.True(exception.InnerException.Message.Contains(expectedMessageBuilder.ToString()),
+        Assert.True(Normalize(exception.InnerException.Message).Contains(Normalize(expectedMessageBuilder.ToString())),
             userMessage: $"Exception message: {exception.InnerException.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
     }
 
@@ -62,22 +65,22 @@ public static class LicenseOptionTestHelper
                 Assert.Null(options.Licensing.License);
                 Assert.Null(options.Licensing.LicensePath);
 
-                Environment.SetEnvironmentVariable("RAVEN_License", license);
-                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE", license);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE_PATH", null);
 
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), license);
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE"), license);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE_PATH"), null);
                 break;
 
             case LicenseSource.ServerOption:
                 options.Licensing.License = license;
                 Assert.Null(options.Licensing.LicensePath);
 
-                Environment.SetEnvironmentVariable("RAVEN_License", null);
-                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE", null);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE_PATH", null);
 
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE_PATH"), null);
                 break;
 
             default:
@@ -95,22 +98,22 @@ public static class LicenseOptionTestHelper
                 Assert.Null(options.Licensing.License);
                 Assert.Null(options.Licensing.LicensePath);
 
-                Environment.SetEnvironmentVariable("RAVEN_License", null);
-                Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE", null);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE_PATH", licensePath);
 
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), licensePath);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE_PATH"), licensePath);
                 break;
 
             case LicenseSource.ServerOption:
                 options.Licensing.LicensePath = licensePath;
                 Assert.Null(options.Licensing.License);
 
-                Environment.SetEnvironmentVariable("RAVEN_License", null);
-                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE", null);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE_PATH", null);
 
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
-                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_LICENSE_PATH"), null);
                 break;
 
             default:

--- a/test/LicenseTests/Helpers/LicenseOptionTestHelper.cs
+++ b/test/LicenseTests/Helpers/LicenseOptionTestHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Raven.Embedded;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
+using Tests.Infrastructure;
 using Xunit;
 
 namespace LicenseTests.Helpers;
@@ -31,21 +32,16 @@ public static class LicenseOptionTestHelper
         return licenseJsonPath;
     }
 
-
-    static string Normalize(string s) => s.Replace("\r\n", "\n");
-
     internal static void AssertLicenseVerificationException(Exception exception, LicenseHelper.LicenseVerificationErrorBuilder expectedMessageBuilder)
     {
-        Assert.True(Normalize(exception.Message).Contains(Normalize(expectedMessageBuilder.ToString())),
-            userMessage: $"Exception message: {exception.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
+        RavenTestHelper.AssertContainsRespectingNewLines(expectedMessageBuilder.ToString(), exception.Message);
     }
 
     internal static void AssertInnerLicenseVerificationException<T>(Exception exception, LicenseHelper.LicenseVerificationErrorBuilder expectedMessageBuilder) where T:Exception
     {
         Assert.NotNull(exception.InnerException);
         Assert.IsType<T>(exception.InnerException);
-        Assert.True(Normalize(exception.InnerException.Message).Contains(Normalize(expectedMessageBuilder.ToString())),
-            userMessage: $"Exception message: {exception.InnerException.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
+        RavenTestHelper.AssertContainsRespectingNewLines(expectedMessageBuilder.ToString(), exception.InnerException.Message);
     }
 
     internal static void ProcessLicenseOptions(string license, LicenseSource licenseSource, string configurationKeyToTest, ServerOptions options)

--- a/test/LicenseTests/LicenseOptionsEmbeddedTests.cs
+++ b/test/LicenseTests/LicenseOptionsEmbeddedTests.cs
@@ -293,8 +293,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
 
     private void StartEmbeddedServerLicenseOptionTest(bool? throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)
     {
-        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
-        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
+        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
+        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_LICENSE_PATH");
 
         options = CopyServerAndCreateOptions();
 
@@ -319,7 +319,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
 
     private static void CreateEmbeddedServer(ServerOptions options)
     {
-        RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = new List<string> { "RAVEN_License", "RAVEN_License.Path" };
+        RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = new List<string> { "RAVEN_LICENSE", "RAVEN_LICENSE_PATH" };
 
         using (var embedded = new EmbeddedServer())
         {
@@ -331,8 +331,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = null;
 
-        Environment.SetEnvironmentVariable("RAVEN_License", originalLicense);
-        Environment.SetEnvironmentVariable("RAVEN_License.Path", originalLicensePath);
+        Environment.SetEnvironmentVariable("RAVEN_LICENSE", originalLicense);
+        Environment.SetEnvironmentVariable("RAVEN_LICENSE_PATH", originalLicensePath);
 
         var path = Path.Combine(options.ServerDirectory, "license.json");
         if (File.Exists(path)) File.Delete(path);

--- a/test/LicenseTests/LicenseOptionsTestDriverTests.cs
+++ b/test/LicenseTests/LicenseOptionsTestDriverTests.cs
@@ -30,8 +30,8 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
 
     private void RunScenario(LicenseOptionsTestDriverScenario optionsTestDriverScenario)
     {
-        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
-        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
+        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
+        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_LICENSE_PATH");
 
         var testServerOptions = new TestServerOptions { ServerDirectory = _serverDirectory };
 
@@ -57,8 +57,8 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
             }
             finally
             {
-                Environment.SetEnvironmentVariable("RAVEN_License", originalLicense);
-                Environment.SetEnvironmentVariable("RAVEN_License.Path", originalLicensePath);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE", originalLicense);
+                Environment.SetEnvironmentVariable("RAVEN_LICENSE_PATH", originalLicensePath);
 
                 var path = Path.Combine(_serverDirectory, "license.json");
                 if (File.Exists(path)) File.Delete(path);

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -177,6 +177,14 @@ namespace Tests.Infrastructure
             Assert.StartsWith(convertedExpected, convertedActual);
         }
 
+        public static void AssertContainsRespectingNewLines(string expected, string actual)
+        {
+            var convertedExpected = ConvertRespectingNewLines(expected);
+            var convertedActual = ConvertRespectingNewLines(actual);
+
+            Assert.Contains(convertedExpected, convertedActual);
+        }
+
         public static void AreEquivalent<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         {
             var forMonitor = actual.ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24433

### Additional description

Fixed tests for consistent behavior across platforms:

Normalized line endings (\r\n → \n) to avoid mismatches between Windows and Linux.

Converted strings to uppercase to avoid case-sensitivity issues on Linux.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
