### PR TITLE
RavenDB-22469 Read entry IDs (actual values) in bulk when performing deep paging.

### DIFF
--- a/bench/Micro.Benchmark/Program.cs
+++ b/bench/Micro.Benchmark/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Running;
 using Micro.Benchmark.Benchmarks.LZ4;
@@ -16,6 +17,8 @@ namespace Micro.Benchmark
 
             Console.WriteLine($"{nameof(Avx)} support: {Avx.IsSupported}");
             Console.WriteLine($"{nameof(Avx2)} support: {Avx2.IsSupported}");
+            Console.WriteLine($"{nameof(Avx512F)} support: {Avx512F.IsSupported}");
+            Console.WriteLine($"{nameof(Vector512)} support: {Vector512.IsHardwareAccelerated}");
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }

--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -79,7 +79,8 @@ namespace Corax
 
             public static readonly Slice LargePostingListsSetSlice, PostingListsSlice,  EntryIdToLocationSlice, LastEntryIdSlice, 
                 StoredFieldsSlice, EntriesTermsContainerSlice, FieldsSlice, NumberOfEntriesSlice, EntriesToSpatialSlice, EntriesToTermsSlice,
-                DynamicFieldsAnalyzersSlice, NumberOfTermsInIndex, MultipleTermsInField, NullPostingLists, NonExistingPostingLists;            
+                DynamicFieldsAnalyzersSlice, NumberOfTermsInIndex, MultipleTermsInField, NullPostingLists, NonExistingPostingLists,
+                PaginationBasedOnEntryIdSupportStatus;            
             
             public const int DynamicField = -2;
 
@@ -113,6 +114,7 @@ namespace Corax
                     Slice.From(ctx, "MultipleTermsInField", ByteStringType.Immutable, out MultipleTermsInField);
                     Slice.From(ctx, "NullPostingLists", ByteStringType.Immutable, out NullPostingLists);
                     Slice.From(ctx, "NonExistingPostingLists", ByteStringType.Immutable, out NonExistingPostingLists);
+                    Slice.From(ctx, "PaginationBasedOnEntryIdSupportStatus", ByteStringType.Immutable, out PaginationBasedOnEntryIdSupportStatus);
                 }
             }
         }

--- a/src/Corax/EntryIdPaginationSupportStatus.cs
+++ b/src/Corax/EntryIdPaginationSupportStatus.cs
@@ -1,0 +1,12 @@
+﻿namespace Corax;
+
+/// <summary>
+/// This allows us to determine if we can perform pagination based on Corax's entry IDs instead of raw IDs in certain cases.
+/// If we have a newer index with this capability, and the newer index contains only unique IDs, we can perform paging (eliminating duplicate IDs) by creating a hashmap of Corax's internal entry IDs.
+/// </summary>
+public enum EntryIdPaginationSupportStatus : long
+{
+    Unknown = 0L,
+    Supported = 1L,
+    Disabled = 1L << 1,
+}

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -95,7 +95,9 @@ namespace Corax.Indexing
         private HashSet<long> _nullTermsMarkers;
         private HashSet<long> _nonExistingTermsMarkers;
         private Dictionary<long, IndexedField> _fieldsByRootPage;
-
+        
+        internal EntryIdPaginationSupportStatus PaginationBasedOnEntryIdSupportStatus { get; private set; }
+        
         /// <summary>
         /// Method to update dynamic mapping in runtime. 
         /// </summary>
@@ -170,9 +172,28 @@ namespace Corax.Indexing
             _fieldsTree = _transaction.CreateTree(Constants.IndexWriter.FieldsSlice);
 
             _indexMetadata = _transaction.CreateTree(Constants.IndexMetadataSlice);
-            _initialNumberOfEntries = _indexMetadata?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
-            _lastEntryId = _indexMetadata?.ReadInt64(Constants.IndexWriter.LastEntryIdSlice) ?? 0;
-
+            Debug.Assert(_indexMetadata is not null);
+            
+            _initialNumberOfEntries = _indexMetadata.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
+            var paginationBasedOnEntryIdSupportStatus = _indexMetadata.ReadInt64(Constants.IndexWriter.PaginationBasedOnEntryIdSupportStatus);
+            if (paginationBasedOnEntryIdSupportStatus.HasValue == false)
+            {
+                if (_supportedFeatures.PaginationBasedOnEntryId)
+                {
+                    _indexMetadata.Add(Constants.IndexWriter.PaginationBasedOnEntryIdSupportStatus, (long)EntryIdPaginationSupportStatus.Supported);
+                    PaginationBasedOnEntryIdSupportStatus = EntryIdPaginationSupportStatus.Supported;
+                }
+                else
+                {
+                    PaginationBasedOnEntryIdSupportStatus = EntryIdPaginationSupportStatus.Disabled;
+                }
+            }
+            else
+            {
+                PaginationBasedOnEntryIdSupportStatus = (EntryIdPaginationSupportStatus)paginationBasedOnEntryIdSupportStatus.Value;
+            }
+            
+            _lastEntryId =  _indexMetadata?.ReadInt64(Constants.IndexWriter.LastEntryIdSlice) ?? 0;
             _documentBoost = _transaction.FixedTreeFor(Constants.DocumentBoostSlice, sizeof(float));
             _nullEntriesPostingListsTree = _transaction.CreateTree(Constants.IndexWriter.NullPostingLists);
             _nonExistingEntriesPostingListsTree = _transaction.CreateTree(Constants.IndexWriter.NonExistingPostingLists);
@@ -257,11 +278,20 @@ namespace Corax.Indexing
 
             // We do not dispose because we will be storing the slice in the hash set.
             Slice.From(_transaction.Allocator, key, ByteStringType.Immutable, out var keySlice);
-            _indexedEntries.Add(keySlice); // Register entry by key. 
+            var isUnique = _indexedEntries.Add(keySlice);  // Register entry by key.
+            if (isUnique == false && PaginationBasedOnEntryIdSupportStatus == EntryIdPaginationSupportStatus.Supported)
+                DisablePaginationBasedOnEntryIdSupport();
+
             int index = InsertTermsPerEntry(entryId);
             _builder.Init(entryId, index, keySlice);
 
             return _builder;
+        }
+
+        private void DisablePaginationBasedOnEntryIdSupport()
+        {
+            PaginationBasedOnEntryIdSupportStatus = EntryIdPaginationSupportStatus.Disabled;
+            _indexMetadata.Add(Constants.IndexWriter.PaginationBasedOnEntryIdSupportStatus, (long)EntryIdPaginationSupportStatus.Disabled);
         }
 
         private long InitBuilder()

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -53,7 +53,26 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     public bool IsAccelerated => Vector256.IsHardwareAccelerated && !ForceNonAccelerated;
 
     public long NumberOfEntries => _numberOfEntries ??= _metadataTree?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
-    
+
+    private EntryIdPaginationSupportStatus? _entryIdPaginationSupportStatus;
+
+    public EntryIdPaginationSupportStatus EntryIdPaginationSupportStatus
+    {
+        get
+        {
+            if (_entryIdPaginationSupportStatus is null)
+            {
+
+                var persistedConfiguration = _metadataTree?.ReadInt64(Constants.IndexWriter.PaginationBasedOnEntryIdSupportStatus);
+                _entryIdPaginationSupportStatus = persistedConfiguration.HasValue
+                    ? (EntryIdPaginationSupportStatus)persistedConfiguration.Value
+                    : EntryIdPaginationSupportStatus.Unknown;
+            }
+
+            return _entryIdPaginationSupportStatus.Value;
+        }
+    }
+
     public ByteStringContext Allocator => _transaction.Allocator;
 
     internal Transaction Transaction => _transaction;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -56,6 +56,21 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     private EntryIdPaginationSupportStatus? _entryIdPaginationSupportStatus;
 
+    private long? _lastEntryId;
+
+    public long LastEntryId
+    {
+        get
+        {
+            if (_lastEntryId is null)
+            {
+                _lastEntryId = _metadataTree?.ReadInt64(Constants.IndexWriter.LastEntryIdSlice) ?? 0;
+            }
+
+            return _lastEntryId.Value;
+        }
+    }
+
     public EntryIdPaginationSupportStatus EntryIdPaginationSupportStatus
     {
         get
@@ -574,11 +589,9 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         return new IncludeNonExistingMatch<TInner>(this, inner, field, forward);
     }
 
-    public DeduplicationMatch<TInner> DeduplicationMatch<TInner>(in TInner inner)
-    where TInner : IQueryMatch
-    {
-        return new DeduplicationMatch<TInner>(inner);
-    }
+    public DeduplicationMatch<TInner> DeduplicationMatch<TInner>(in TInner inner, bool forceHashset = false) 
+        where TInner : IQueryMatch 
+        => new(this, inner, forceHashset);
     
     private void InitializeSpecialTermsMarkers()
     {

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -573,6 +573,12 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     {
         return new IncludeNonExistingMatch<TInner>(this, inner, field, forward);
     }
+
+    public DeduplicationMatch<TInner> DeduplicationMatch<TInner>(in TInner inner)
+    where TInner : IQueryMatch
+    {
+        return new DeduplicationMatch<TInner>(inner);
+    }
     
     private void InitializeSpecialTermsMarkers()
     {

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -33,6 +33,7 @@ namespace Corax.Querying;
 
 public sealed unsafe partial class IndexSearcher : IDisposable
 {
+    internal static readonly long BitmapMemoryRequiredThresholdInBytes = new Size(32, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
     internal readonly Transaction _transaction;
     private Dictionary<string, Slice> _dynamicFieldNameMapping;
 
@@ -58,6 +59,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     private long? _lastEntryId;
 
+    
     public long LastEntryId
     {
         get

--- a/src/Corax/Querying/Matches/AllEntriesMatch.cs
+++ b/src/Corax/Querying/Matches/AllEntriesMatch.cs
@@ -36,7 +36,7 @@ namespace Corax.Querying.Matches
         public long Count => _count;
         public QueryCountConfidence Confidence => QueryCountConfidence.High;
         
-        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
 
         public int Fill(Span<long> matches)
         {

--- a/src/Corax/Querying/Matches/AllEntriesMatch.cs
+++ b/src/Corax/Querying/Matches/AllEntriesMatch.cs
@@ -35,6 +35,8 @@ namespace Corax.Querying.Matches
         public bool IsBoosting => false;
         public long Count => _count;
         public QueryCountConfidence Confidence => QueryCountConfidence.High;
+        
+        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
 
         public int Fill(Span<long> matches)
         {

--- a/src/Corax/Querying/Matches/AndNotMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/AndNotMatch.Erasure.cs
@@ -23,7 +23,7 @@ namespace Corax.Querying.Matches
 
         public long Count => _functionTable.CountFunc(ref this);
         
-        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
         
         public QueryCountConfidence Confidence => _inner.Confidence;
 

--- a/src/Corax/Querying/Matches/AndNotMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/AndNotMatch.Erasure.cs
@@ -22,7 +22,9 @@ namespace Corax.Querying.Matches
         public bool IsBoosting => _inner.IsBoosting;
 
         public long Count => _functionTable.CountFunc(ref this);
-
+        
+        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        
         public QueryCountConfidence Confidence => _inner.Confidence;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Querying/Matches/AndNotMatch.cs
+++ b/src/Corax/Querying/Matches/AndNotMatch.cs
@@ -20,7 +20,7 @@ namespace Corax.Querying.Matches
         private long _totalResults;
         private QueryCountConfidence _confidence;
         private readonly CancellationToken _token;
-        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
 
         public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
         public long Count => _totalResults;

--- a/src/Corax/Querying/Matches/AndNotMatch.cs
+++ b/src/Corax/Querying/Matches/AndNotMatch.cs
@@ -20,6 +20,7 @@ namespace Corax.Querying.Matches
         private long _totalResults;
         private QueryCountConfidence _confidence;
         private readonly CancellationToken _token;
+        public Duplicates DuplicatesStatus => Duplicates.Possible;
 
         public bool IsBoosting => _inner.IsBoosting || _outer.IsBoosting;
         public long Count => _totalResults;

--- a/src/Corax/Querying/Matches/BinaryMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Erasure.cs
@@ -133,6 +133,6 @@ namespace Corax.Querying.Matches
         
         public struct And : IBinaryMatchMarker;
         public struct Or : IBinaryMatchMarker;
-        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => _inner.DuplicatesOccurrenceStatus;
     }
 }

--- a/src/Corax/Querying/Matches/BinaryMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Erasure.cs
@@ -133,5 +133,6 @@ namespace Corax.Querying.Matches
         
         public struct And : IBinaryMatchMarker;
         public struct Or : IBinaryMatchMarker;
+        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
     }
 }

--- a/src/Corax/Querying/Matches/BinaryMatch.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.cs
@@ -133,5 +133,6 @@ namespace Corax.Querying.Matches
         }
 
         string DebugView => Inspect().ToString();
+        public Duplicates DuplicatesStatus => Duplicates.Possible;
     }
 }

--- a/src/Corax/Querying/Matches/BinaryMatch.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.cs
@@ -133,6 +133,6 @@ namespace Corax.Querying.Matches
         }
 
         string DebugView => Inspect().ToString();
-        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
     }
 }

--- a/src/Corax/Querying/Matches/BoostingMatch.cs
+++ b/src/Corax/Querying/Matches/BoostingMatch.cs
@@ -42,6 +42,8 @@ namespace Corax.Querying.Matches
         }
 
         public long Count => _inner.Count;
+        
+        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
 
         public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 

--- a/src/Corax/Querying/Matches/BoostingMatch.cs
+++ b/src/Corax/Querying/Matches/BoostingMatch.cs
@@ -43,7 +43,7 @@ namespace Corax.Querying.Matches
 
         public long Count => _inner.Count;
         
-        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => _inner.DuplicatesOccurrenceStatus;
 
         public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -14,7 +14,7 @@ public struct DeduplicationMatch<TInner> : IQueryMatch
     private TInner _inner;
     private GrowableHashSet<long> _ids;
     
-    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
     
     public DeduplicationMatch(TInner inner)
     {

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -26,13 +26,13 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
     public DeduplicationMatch(IndexSearcher indexSearcher, TInner inner, bool forceHashSet)
     {
         long maxBitId = indexSearcher.LastEntryId;
-        long numberOfEntries = indexSearcher.NumberOfEntries; // ensure not zero
-        var bitmapMemoryRequiredInBytes = maxBitId / 64;
-        var entriesMemoryRequiredInBytes = numberOfEntries / 64;
+        long numberOfEntries = indexSearcher.NumberOfEntries;
+        var bitmapMemoryRequiredInBytes = (maxBitId / 64) / sizeof(ulong);
+        var entriesMemoryRequiredInBytes = (numberOfEntries / 64) / sizeof(ulong);
 
         // If the bitmap is big enough and actually only around 1.5% entries exist, we will use a HashSet instead.
         if (bitmapMemoryRequiredInBytes > IndexSearcher.BitmapMemoryRequiredThresholdInBytes 
-            && entriesMemoryRequiredInBytes < (bitmapMemoryRequiredInBytes >> 6) || forceHashSet)
+            && entriesMemoryRequiredInBytes < (bitmapMemoryRequiredInBytes / 64) || bitmapMemoryRequiredInBytes > Voron.Global.Constants.Size.Gigabyte ||forceHashSet)
         {
             _hashset = new GrowableHashSet<long>();
             _fillFunc = &FillViaHashSet;

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Corax.Querying.Matches.Meta;
+using Corax.Utils;
+using Sparrow;
+
+namespace Corax.Querying.Matches;
+
+public struct DeduplicationMatch<TInner> : IQueryMatch
+    where TInner : IQueryMatch
+{
+    private TInner _inner;
+    private GrowableHashSet<long> _ids;
+    
+    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    
+    public DeduplicationMatch(TInner inner)
+    {
+        _ids = new();
+        _inner = inner;
+    }
+
+    public long Count => _inner.Count;
+    public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
+
+    public QueryCountConfidence Confidence => _inner.Confidence;
+    public bool IsBoosting => _inner.IsBoosting;
+
+    public int Fill(Span<long> matches)
+    {
+        var newResults = 0;
+        int read;
+        ref var startBuffer = ref MemoryMarshal.GetReference(matches);
+        ref var inner = ref _inner;
+        do
+        {
+            read = inner.Fill(matches);
+            for (int i = 0; i < read; ++i)
+            {
+                var currentId = Unsafe.Add(ref startBuffer, i);
+                Unsafe.Add(ref startBuffer, newResults) = currentId;
+                newResults += _ids.Add(currentId).ToInt32();
+            }
+        } while (read > 0 && newResults == 0);
+
+        return newResults;
+    }
+
+    public int AndWith(Span<long> buffer, int matches)
+    {
+        throw new NotSupportedException($"{nameof(DeduplicationMatch<TInner>)} is not supposed to be used as inner match of the query.");
+    }
+
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor) => _inner.Score(matches, scores, boostFactor);
+
+    public QueryInspectionNode Inspect()
+    {
+        return new QueryInspectionNode(nameof(DeduplicationMatch<TInner>), new List<QueryInspectionNode>() { { new QueryInspectionNode("Inner", [_inner.Inspect()]) } });
+    }
+}

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -17,22 +17,18 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
     private readonly GrowableHashSet<long> _hashset;
     private GrowableBitArray _bitmap;
     private readonly delegate*<ref DeduplicationMatch<TInner>, Span<long>, int> _fillFunc;
-
-    
-
     public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
-
 
     public DeduplicationMatch(IndexSearcher indexSearcher, TInner inner, bool forceHashSet)
     {
-        long maxBitId = indexSearcher.LastEntryId;
+        long maxBitId = (indexSearcher.LastEntryId + 1);
         long numberOfEntries = indexSearcher.NumberOfEntries;
-        var bitmapMemoryRequiredInBytes = (maxBitId / 64) / sizeof(ulong);
-        var entriesMemoryRequiredInBytes = (numberOfEntries / 64) / sizeof(ulong);
+        var bitmapMemoryRequiredInBytes = (maxBitId / 64 + (maxBitId % 64 != 0).ToInt32()) * sizeof(ulong);
+        var entriesMemoryRequiredInBytes = (numberOfEntries / 64 + (numberOfEntries % 64 != 0).ToInt32()) * sizeof(ulong);
 
         // If the bitmap is big enough and actually only around 1.5% entries exist, we will use a HashSet instead.
         if (bitmapMemoryRequiredInBytes > IndexSearcher.BitmapMemoryRequiredThresholdInBytes 
-            && entriesMemoryRequiredInBytes < (bitmapMemoryRequiredInBytes / 64) || bitmapMemoryRequiredInBytes > Voron.Global.Constants.Size.Gigabyte ||forceHashSet)
+            && entriesMemoryRequiredInBytes < (bitmapMemoryRequiredInBytes / 64) || forceHashSet)
         {
             _hashset = new GrowableHashSet<long>();
             _fillFunc = &FillViaHashSet;
@@ -71,6 +67,7 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
         int read;
         ref var startBuffer = ref MemoryMarshal.GetReference(matches);
         ref var inner = ref match._inner;
+        
         do
         {
             read = inner.Fill(matches);
@@ -81,9 +78,11 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
                 newResults += match._bitmap.Add(currentId).ToInt32();
             }
         } while (read > 0 && newResults == 0);
+        // We fetch data until we encounter the first unseen document(s). Duplicates are uncommon,
+        // and often we don't need the exact number of results. It's better to let the caller decide
+        // whether to continue, since it has better knowledge of the query.
 
-
-        // No more results. Can safely dispose the bit array.
+        // No more results. We can dispose the bitmap.
         if (read == 0)
             match._bitmap.Dispose();
 
@@ -106,7 +105,11 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
                 newResults += match._hashset.Add(currentId).ToInt32();
             }
         } while (read > 0 && newResults == 0);
-
+        // We fetch data until we encounter the first unseen document(s). Duplicates are uncommon,
+        // and often we don't need the exact number of results. It's better to let the caller decide
+        // whether to continue, since it has better knowledge of the query.
+        
+        
         return newResults;
     }
 

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -15,58 +15,32 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
 {
     private TInner _inner;
     private readonly GrowableHashSet<long> _hashset;
-    private BitArray _bitmap;
+    private GrowableBitArray _bitmap;
     private readonly delegate*<ref DeduplicationMatch<TInner>, Span<long>, int> _fillFunc;
 
-    private unsafe struct BitArray : IDisposable
-    {
-        private ulong* _bits;
-        private IDisposable _memoryScope;
-#if DEBUG
-        public bool IsValid = true;
-#endif
-        public BitArray(IndexSearcher indexSearcher, int numberOfEntriesPossible)
-        {
-            var numberOfUlongsToAllocate = numberOfEntriesPossible / 64 + (numberOfEntriesPossible % 64 == 0 ? 0 : 1);
-            _memoryScope = indexSearcher.Allocator.Allocate(numberOfUlongsToAllocate * sizeof(ulong), out ByteString memory);
-            memory.ToSpan<ulong>().Clear();
-            _bits = (ulong*)memory.Ptr;
-#if DEBUG
-            IsValid = true;
-#endif
-        }
-
-        public bool Add(long id)
-        {
-            var mask = 1UL << (int)(id & 63);
-            var bucket = _bits + (int)(id >> 6);
-            var result = *bucket & mask;
-            *bucket |= mask;
-            return result == 0;
-        }
-
-        public void Dispose()
-        {
-#if DEBUG
-            IsValid = false;
-#endif
-            _memoryScope.Dispose();
-        }
-    }
+    
 
     public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
 
+
     public DeduplicationMatch(IndexSearcher indexSearcher, TInner inner, bool forceHashSet)
     {
-        if (indexSearcher.LastEntryId + 1 <= int.MaxValue && forceHashSet == false)
-        {
-            _bitmap = new BitArray(indexSearcher, (int)indexSearcher.LastEntryId + 1);
-            _fillFunc = &FillViaBitmap;
-        }
-        else
+        long maxBitId = indexSearcher.LastEntryId;
+        long numberOfEntries = indexSearcher.NumberOfEntries; // ensure not zero
+        var bitmapMemoryRequiredInBytes = maxBitId / 64;
+        var entriesMemoryRequiredInBytes = numberOfEntries / 64;
+
+        // If the bitmap is big enough and actually only around 1.5% entries exist, we will use a HashSet instead.
+        if (bitmapMemoryRequiredInBytes > IndexSearcher.BitmapMemoryRequiredThresholdInBytes 
+            && entriesMemoryRequiredInBytes < (bitmapMemoryRequiredInBytes >> 6) || forceHashSet)
         {
             _hashset = new GrowableHashSet<long>();
             _fillFunc = &FillViaHashSet;
+        }
+        else
+        {
+            _bitmap = new GrowableBitArray(indexSearcher.Allocator, (int)indexSearcher.LastEntryId);
+            _fillFunc = &FillViaBitmap;
         }
 
         _inner = inner;

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -1,26 +1,78 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
 using Sparrow;
+using Sparrow.Server;
 
 namespace Corax.Querying.Matches;
 
-public struct DeduplicationMatch<TInner> : IQueryMatch
+public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
     where TInner : IQueryMatch
 {
     private TInner _inner;
-    private GrowableHashSet<long> _ids;
-    
-    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
-    
-    public DeduplicationMatch(TInner inner)
+    private readonly GrowableHashSet<long> _hashset;
+    private BitArray _bitmap;
+    private readonly delegate*<ref DeduplicationMatch<TInner>, Span<long>, int> _fillFunc;
+
+    private unsafe struct BitArray : IDisposable
     {
-        _ids = new();
+        private ulong* _bits;
+        private IDisposable _memoryScope;
+#if DEBUG
+        public bool IsValid = true;
+#endif
+        public BitArray(IndexSearcher indexSearcher, int numberOfEntriesPossible)
+        {
+            var numberOfUlongsToAllocate = numberOfEntriesPossible / 64 + (numberOfEntriesPossible % 64 == 0 ? 0 : 1);
+            _memoryScope = indexSearcher.Allocator.Allocate(numberOfUlongsToAllocate * sizeof(ulong), out ByteString memory);
+            memory.ToSpan<ulong>().Clear();
+            _bits = (ulong*)memory.Ptr;
+#if DEBUG
+            IsValid = true;
+#endif
+        }
+
+        public bool Add(long id)
+        {
+            var mask = 1UL << (int)(id & 63);
+            var bucket = _bits + (int)(id >> 6);
+            var result = *bucket & mask;
+            *bucket |= mask;
+            return result == 0;
+        }
+
+        public void Dispose()
+        {
+#if DEBUG
+            IsValid = false;
+#endif
+            _memoryScope.Dispose();
+        }
+    }
+
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
+
+    public DeduplicationMatch(IndexSearcher indexSearcher, TInner inner, bool forceHashSet)
+    {
+        if (indexSearcher.LastEntryId + 1 <= int.MaxValue && forceHashSet == false)
+        {
+            _bitmap = new BitArray(indexSearcher, (int)indexSearcher.LastEntryId + 1);
+            _fillFunc = &FillViaBitmap;
+        }
+        else
+        {
+            _hashset = new GrowableHashSet<long>();
+            _fillFunc = &FillViaHashSet;
+        }
+
         _inner = inner;
     }
+
+    public int Fill(Span<long> matches) => _fillFunc(ref this, matches);
 
     public long Count => _inner.Count;
     public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
@@ -28,12 +80,23 @@ public struct DeduplicationMatch<TInner> : IQueryMatch
     public QueryCountConfidence Confidence => _inner.Confidence;
     public bool IsBoosting => _inner.IsBoosting;
 
-    public int Fill(Span<long> matches)
+    [Conditional("DEBUG")]
+    private void AssertBitmapContainer()
     {
+#if DEBUG
+        if (_bitmap.IsValid == false)
+            throw new InvalidOperationException("Small ids container is not valid.");
+#endif
+    }
+
+    private static int FillViaBitmap(ref DeduplicationMatch<TInner> match, Span<long> matches)
+    {
+        match.AssertBitmapContainer();
+
         var newResults = 0;
         int read;
         ref var startBuffer = ref MemoryMarshal.GetReference(matches);
-        ref var inner = ref _inner;
+        ref var inner = ref match._inner;
         do
         {
             read = inner.Fill(matches);
@@ -41,12 +104,38 @@ public struct DeduplicationMatch<TInner> : IQueryMatch
             {
                 var currentId = Unsafe.Add(ref startBuffer, i);
                 Unsafe.Add(ref startBuffer, newResults) = currentId;
-                newResults += _ids.Add(currentId).ToInt32();
+                newResults += match._bitmap.Add(currentId).ToInt32();
+            }
+        } while (read > 0 && newResults == 0);
+
+
+        // No more results. Can safely dispose the bit array.
+        if (read == 0)
+            match._bitmap.Dispose();
+
+        return newResults;
+    }
+
+    private static int FillViaHashSet(ref DeduplicationMatch<TInner> match, Span<long> matches)
+    {
+        var newResults = 0;
+        int read;
+        ref var startBuffer = ref MemoryMarshal.GetReference(matches);
+        ref var inner = ref match._inner;
+        do
+        {
+            read = inner.Fill(matches);
+            for (int i = 0; i < read; ++i)
+            {
+                var currentId = Unsafe.Add(ref startBuffer, i);
+                Unsafe.Add(ref startBuffer, newResults) = currentId;
+                newResults += match._hashset.Add(currentId).ToInt32();
             }
         } while (read > 0 && newResults == 0);
 
         return newResults;
     }
+
 
     public int AndWith(Span<long> buffer, int matches)
     {

--- a/src/Corax/Querying/Matches/IncludeNonExistingMatch.cs
+++ b/src/Corax/Querying/Matches/IncludeNonExistingMatch.cs
@@ -25,6 +25,8 @@ public struct IncludeNonExistingMatch<TInner> : IQueryMatch
             _postingListIterator = searcher.GetPostingList(postingListId).Iterate();
     }
     
+    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    
     private TInner _inner;
     
     public long Count { get; }

--- a/src/Corax/Querying/Matches/IncludeNonExistingMatch.cs
+++ b/src/Corax/Querying/Matches/IncludeNonExistingMatch.cs
@@ -25,7 +25,7 @@ public struct IncludeNonExistingMatch<TInner> : IQueryMatch
             _postingListIterator = searcher.GetPostingList(postingListId).Iterate();
     }
     
-    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
     
     private TInner _inner;
     

--- a/src/Corax/Querying/Matches/IncludeNullMatch.cs
+++ b/src/Corax/Querying/Matches/IncludeNullMatch.cs
@@ -33,7 +33,9 @@ where TInner : IQueryMatch
     {
         return SkipSortingResult.WillSkipSorting;
     }
-
+    
+    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    
     public QueryCountConfidence Confidence { get; }
     public bool IsBoosting { get; }
     

--- a/src/Corax/Querying/Matches/IncludeNullMatch.cs
+++ b/src/Corax/Querying/Matches/IncludeNullMatch.cs
@@ -34,7 +34,7 @@ where TInner : IQueryMatch
         return SkipSortingResult.WillSkipSorting;
     }
     
-    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
     
     public QueryCountConfidence Confidence { get; }
     public bool IsBoosting { get; }

--- a/src/Corax/Querying/Matches/MemoizationMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Erasure.cs
@@ -16,7 +16,9 @@ namespace Corax.Querying.Matches
         }
 
         public bool IsBoosting => _inner.IsBoosting;
-
+        
+        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
+        
         public long Count => _functionTable.CountFunc(ref this);
 
         public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();

--- a/src/Corax/Querying/Matches/MemoizationMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Erasure.cs
@@ -17,7 +17,7 @@ namespace Corax.Querying.Matches
 
         public bool IsBoosting => _inner.IsBoosting;
         
-        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => _inner.DuplicatesOccurrenceStatus;
         
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -20,6 +20,8 @@ namespace Corax.Querying.Matches
         private readonly Querying.IndexSearcher _indexSearcher;
         private TInner _inner;
 
+        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _inner.Count;
         public QueryCountConfidence Confidence => _inner.Confidence;

--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -20,7 +20,7 @@ namespace Corax.Querying.Matches
         private readonly Querying.IndexSearcher _indexSearcher;
         private TInner _inner;
 
-        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
         
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _inner.Count;

--- a/src/Corax/Querying/Matches/MemoizationMatch.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.cs
@@ -30,7 +30,7 @@ namespace Corax.Querying.Matches
             _bufferCurrentIdx = 0;
         }
 
-        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
         
         public Span<long> FillAndRetrieve() => _inner.FillAndRetrieve();
         

--- a/src/Corax/Querying/Matches/MemoizationMatch.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.cs
@@ -30,6 +30,8 @@ namespace Corax.Querying.Matches
             _bufferCurrentIdx = 0;
         }
 
+        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        
         public Span<long> FillAndRetrieve() => _inner.FillAndRetrieve();
         
         public int Fill(Span<long> matches)

--- a/src/Corax/Querying/Matches/Meta/IQueryMatch.cs
+++ b/src/Corax/Querying/Matches/Meta/IQueryMatch.cs
@@ -70,7 +70,7 @@ public interface IQueryMatch
 
     string DebugView => Inspect().ToString();
     
-    Duplicates DuplicatesStatus { get; }
+    DuplicatesOccurrence DuplicatesOccurrenceStatus { get; }
 }
 
 public enum SkipSortingResult
@@ -80,7 +80,7 @@ public enum SkipSortingResult
     SortingIsRequired
 }
 
-public enum Duplicates
+public enum DuplicatesOccurrence
 {
     Possible,
     NotPossible

--- a/src/Corax/Querying/Matches/Meta/IQueryMatch.cs
+++ b/src/Corax/Querying/Matches/Meta/IQueryMatch.cs
@@ -69,6 +69,8 @@ public interface IQueryMatch
     QueryInspectionNode Inspect();
 
     string DebugView => Inspect().ToString();
+    
+    Duplicates DuplicatesStatus { get; }
 }
 
 public enum SkipSortingResult
@@ -76,4 +78,10 @@ public enum SkipSortingResult
     ResultsNativelySorted,
     WillSkipSorting,
     SortingIsRequired
+}
+
+public enum Duplicates
+{
+    Possible,
+    NotPossible
 }

--- a/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
@@ -24,7 +24,7 @@ namespace Corax.Querying.Matches
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _functionTable.CountFunc(ref this);
         
-        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
         
         public QueryCountConfidence Confidence => _inner.Confidence;
 

--- a/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
@@ -23,7 +23,9 @@ namespace Corax.Querying.Matches
 
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _functionTable.CountFunc(ref this);
-
+        
+        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        
         public QueryCountConfidence Confidence => _inner.Confidence;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -43,6 +43,7 @@ namespace Corax.Querying.Matches
 
         private int FrequenciesHolderSize => _frequenciesHolder?.Length ?? 0;
 
+        public Duplicates DuplicatesStatus => Duplicates.Possible;
 
         private TTermProvider _inner;
         private TermMatch _currentTerm;

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -43,7 +43,7 @@ namespace Corax.Querying.Matches
 
         private int FrequenciesHolderSize => _frequenciesHolder?.Length ?? 0;
 
-        public Duplicates DuplicatesStatus => Duplicates.Possible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
 
         private TTermProvider _inner;
         private TermMatch _currentTerm;

--- a/src/Corax/Querying/Matches/MultiUnaryMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MultiUnaryMatch.Erasure.cs
@@ -20,6 +20,9 @@ namespace Corax.Querying.Matches
         }
 
         public bool IsBoosting => _inner.IsBoosting;
+        
+        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
+
 
         public long Count => _functionTable.CountFunc(ref this);
 

--- a/src/Corax/Querying/Matches/MultiUnaryMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MultiUnaryMatch.Erasure.cs
@@ -21,7 +21,7 @@ namespace Corax.Querying.Matches
 
         public bool IsBoosting => _inner.IsBoosting;
         
-        public Duplicates DuplicatesStatus => _inner.DuplicatesStatus;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => _inner.DuplicatesOccurrenceStatus;
 
 
         public long Count => _functionTable.CountFunc(ref this);

--- a/src/Corax/Querying/Matches/MultiUnaryMatch.cs
+++ b/src/Corax/Querying/Matches/MultiUnaryMatch.cs
@@ -433,7 +433,7 @@ public struct MultiUnaryMatch<TInner> : IQueryMatch
 
     public long Count => _count;
     
-    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
     
     public SkipSortingResult AttemptToSkipSorting()
     {

--- a/src/Corax/Querying/Matches/MultiUnaryMatch.cs
+++ b/src/Corax/Querying/Matches/MultiUnaryMatch.cs
@@ -433,6 +433,8 @@ public struct MultiUnaryMatch<TInner> : IQueryMatch
 
     public long Count => _count;
     
+    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    
     public SkipSortingResult AttemptToSkipSorting()
     {
         return _inner.AttemptToSkipSorting();

--- a/src/Corax/Querying/Matches/PharseMatch.cs
+++ b/src/Corax/Querying/Matches/PharseMatch.cs
@@ -43,6 +43,9 @@ public struct PhraseMatch<TInner> : IQueryMatch
     }
 
     public long Count => _inner.Count;
+    
+    public Duplicates DuplicatesStatus => Duplicates.Possible;
+
     public SkipSortingResult AttemptToSkipSorting()
     {
         //Filter only, not changing order.

--- a/src/Corax/Querying/Matches/PharseMatch.cs
+++ b/src/Corax/Querying/Matches/PharseMatch.cs
@@ -44,7 +44,7 @@ public struct PhraseMatch<TInner> : IQueryMatch
 
     public long Count => _inner.Count;
     
-    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
 
     public SkipSortingResult AttemptToSkipSorting()
     {

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Erasure.cs
@@ -21,7 +21,9 @@ namespace Corax.Querying.Matches.SortingMatches
         }
 
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
-
+        
+        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        
         public long Count => throw new NotSupportedException();
         public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Erasure.cs
@@ -22,7 +22,7 @@ namespace Corax.Querying.Matches.SortingMatches
 
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
         
-        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
         
         public long Count => throw new NotSupportedException();
         public SkipSortingResult AttemptToSkipSorting() => _inner.AttemptToSkipSorting();

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -45,7 +45,9 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
     private SortingDataTransfer _sortingDataTransfer;
     public long TotalResults;
     public SkipSortingResult AttemptToSkipSorting() => throw new NotSupportedException();
-
+    
+    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    
     public SortingMatch(IndexSearcher searcher, in TInner inner, OrderMetadata orderMetadata, in CancellationToken cancellationToken, int take = -1)
     {
         _searcher = searcher;

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -46,7 +46,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
     public long TotalResults;
     public SkipSortingResult AttemptToSkipSorting() => throw new NotSupportedException();
     
-    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
     
     public SortingMatch(IndexSearcher searcher, in TInner inner, OrderMetadata orderMetadata, in CancellationToken cancellationToken, int take = -1)
     {

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -21,6 +21,8 @@ namespace Corax.Querying.Matches.SortingMatches;
 public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     where TInner : IQueryMatch
 {
+    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    
     private interface IEntryComparer : IComparer<int>, IComparer<UnmanagedSpan>
     {
         Slice GetSortFieldName(ref SortingMultiMatch<TInner> match);

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -21,7 +21,7 @@ namespace Corax.Querying.Matches.SortingMatches;
 public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     where TInner : IQueryMatch
 {
-    public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
     
     private interface IEntryComparer : IComparer<int>, IComparer<UnmanagedSpan>
     {

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Erasure.cs
@@ -20,7 +20,7 @@ namespace Corax.Querying.Matches.SortingMatches
 
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
         
-        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
 
         public long Count => throw new NotSupportedException();
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Erasure.cs
@@ -19,6 +19,8 @@ namespace Corax.Querying.Matches.SortingMatches
         }
 
         public long TotalResults => _functionTable.TotalResultsFunc(ref this);
+        
+        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
 
         public long Count => throw new NotSupportedException();
 

--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -68,6 +68,8 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         _fieldRootPage = _indexSearcher.FieldCache.GetLookupRootPage(field.FieldName);
     }
 
+    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    
     private bool GoNextMatch()
     {
         if (_termGenerator.MoveNext())

--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -68,7 +68,7 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         _fieldRootPage = _indexSearcher.FieldCache.GetLookupRootPage(field.FieldName);
     }
 
-    public Duplicates DuplicatesStatus => Duplicates.Possible;
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.Possible;
     
     private bool GoNextMatch()
     {

--- a/src/Corax/Querying/Matches/TermMatch.cs
+++ b/src/Corax/Querying/Matches/TermMatch.cs
@@ -35,7 +35,7 @@ namespace Corax.Querying.Matches
         public bool IsBoosting => _scoreFunc != null;
         public long Count => _totalResults;
         
-        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
         
 #if DEBUG
         public string Term;

--- a/src/Corax/Querying/Matches/TermMatch.cs
+++ b/src/Corax/Querying/Matches/TermMatch.cs
@@ -34,7 +34,9 @@ namespace Corax.Querying.Matches
         private ByteStringContext _ctx;
         public bool IsBoosting => _scoreFunc != null;
         public long Count => _totalResults;
-
+        
+        public Duplicates DuplicatesStatus => Duplicates.NotPossible;
+        
 #if DEBUG
         public string Term;
 #endif

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -1,13 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Numerics;
-using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using Sparrow;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
-using Sparrow.Server.Utils.VxSort;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
@@ -62,15 +58,22 @@ public unsafe struct TermsReader : IDisposable
     /// - the method modifies 'ids' (change the order) of the buffer (!)
     /// - the order of the terms is based on sorted ids values
     /// </summary>
-    public void GetAllTermsFromSet(Span<long> ids, out Span<UnmanagedSpan> termsSet)
+    public int GetAllTermsFromSet(Span<long> ids, out Span<UnmanagedSpan> termsSet)
     {
-        Sort.Run(ids);
+        const int pageSizeShift = 13;
+        Debug.Assert(1 << pageSizeShift == (long)Voron.Global.Constants.Storage.PageSize);
+        var maxToProcess = Math.Min(ids.Length, 1024);
+        ids = ids[..maxToProcess];
+
+        if (ids.IsEmpty)
+        {
+            termsSet = default;
+            return 0;
+        }
+        
         _termsLocation.ResetAndEnsureCapacity(ids.Length);
         _termsLocation.Count = ids.Length;
         _lookup.GetFor(ids, _termsLocation.ToSpan(), -1L);
-        
-        if (ids.Length < 128)
-            goto SkipPagePrefetching;
         
         var idX = 0;
         _pagesToPrefetch.ResetAndEnsureCapacity(ids.Length);
@@ -84,43 +87,41 @@ public unsafe struct TermsReader : IDisposable
             {
                 var ptr = _pagesToPrefetch.RawItems + idX;
                 var containers = Vector512.Load(ptr);
-                Vector512.Divide(containers, Vector512.Create((long)Voron.Global.Constants.Storage.PageSize)).Store(ptr);
+                Vector512.ShiftRightArithmetic(containers, pageSizeShift).Store(ptr);
             }
         }
-        
-        if (AdvInstructionSet.IsAcceleratedVector256)
+        else if (AdvInstructionSet.IsAcceleratedVector256)
         {
             var N = Vector256<long>.Count;
             for (; idX + N < _pagesToPrefetch.Count; idX += N)
             {
                 var ptr = _pagesToPrefetch.RawItems + idX;
                 var containers = Vector256.Load(ptr);
-                Vector256.Divide(containers, Vector256.Create((long)Voron.Global.Constants.Storage.PageSize)).Store(ptr);
+                Vector256.ShiftRightArithmetic(containers, pageSizeShift).Store(ptr);
             }
         }
-        
-        if (AdvInstructionSet.IsAcceleratedVector128)
+        else if (AdvInstructionSet.IsAcceleratedVector128)
         {
             var N = Vector128<long>.Count;
             for (; idX + N < _pagesToPrefetch.Count; idX += N)
             {
                 var ptr = _pagesToPrefetch.RawItems + idX;
                 var containers = Vector128.Load(ptr);
-                Vector128.Divide(containers, Vector128.Create((long)Voron.Global.Constants.Storage.PageSize)).Store(ptr);
+                Vector128.ShiftRightArithmetic(containers, pageSizeShift).Store(ptr);
             }
         }
 
         for (; idX < _pagesToPrefetch.Count; ++idX)
-            _pagesToPrefetch[idX] /= Voron.Global.Constants.Storage.PageSize;
+            _pagesToPrefetch[idX] >>= pageSizeShift;
         
         _pagesToPrefetch.Count = Sorting.SortAndRemoveDuplicates(_pagesToPrefetch.RawItems, _pagesToPrefetch.Count); 
         _llt.DataPager.MaybePrefetchMemory(_pagesToPrefetch.GetEnumerator());
         
-SkipPagePrefetching:
         _rawTermsContainer.ResetAndEnsureCapacity(ids.Length);
         _rawTermsContainer.Count = ids.Length;
         Container.GetAll(_llt, _termsLocation.ToSpan(), _rawTermsContainer.RawItems, -1L, _llt.PageLocator);
         termsSet = _rawTermsContainer.ToSpan();
+        return maxToProcess;
     }
     
     public bool TryGetRawTermFor(long id, out UnmanagedSpan term)

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -1,12 +1,20 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Utils;
+using Sparrow.Server.Utils.VxSort;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Impl;
+using Voron.Util;
 
 namespace Corax.Querying;
 
@@ -21,7 +29,10 @@ public unsafe struct TermsReader : IDisposable
     private ByteStringContext<ByteStringMemoryCache>.InternalScope _cacheScope;
     private Page _lastPage;
     private readonly long _dictionaryId;
-
+    private ContextBoundNativeList<long> _pagesToPrefetch;
+    private ContextBoundNativeList<long> _termsLocation;
+    private ContextBoundNativeList<UnmanagedSpan> _rawTermsContainer;
+    
     public TermsReader(LowLevelTransaction llt, Tree entriesToTermsTree, Slice name)
     {
         _llt = llt;
@@ -33,12 +44,83 @@ public unsafe struct TermsReader : IDisposable
         _xKeyScope = new CompactKeyCacheScope(_llt);
         _yKeyScope = new CompactKeyCacheScope(_llt);
         _dictionaryId = CompactTree.GetDictionaryId(llt);
+        _pagesToPrefetch = new ContextBoundNativeList<long>(_llt.Allocator);
+        _termsLocation = new ContextBoundNativeList<long>(_llt.Allocator);
+        _rawTermsContainer = new ContextBoundNativeList<UnmanagedSpan>(_llt.Allocator);
     }
 
     public string GetTermFor(long id)
     {
         TryGetTermFor(id, out string s);
         return s;
+    }
+    
+    /// <summary>
+    /// Read terms in bulk. The result is not associated with ids by index.
+    /// Caution:
+    /// - the `termsSet` span is being invalidated between calls.
+    /// - the method modifies 'ids' (change the order) of the buffer (!)
+    /// - the order of the terms is based on sorted ids values
+    /// </summary>
+    public void GetAllTermsFromSet(Span<long> ids, out Span<UnmanagedSpan> termsSet)
+    {
+        Sort.Run(ids);
+        _termsLocation.ResetAndEnsureCapacity(ids.Length);
+        _termsLocation.Count = ids.Length;
+        _lookup.GetFor(ids, _termsLocation.ToSpan(), -1L);
+        
+        if (ids.Length < 128)
+            goto SkipPagePrefetching;
+        
+        var idX = 0;
+        _pagesToPrefetch.ResetAndEnsureCapacity(ids.Length);
+        _pagesToPrefetch.Count = ids.Length;
+        _termsLocation.CopyTo(_pagesToPrefetch.ToSpan(), startFrom: 0);
+        
+        if (AdvInstructionSet.IsAcceleratedVector512)
+        {
+            var N = Vector512<long>.Count;
+            for (; idX + N < _pagesToPrefetch.Count; idX += N)
+            {
+                var ptr = _pagesToPrefetch.RawItems + idX;
+                var containers = Vector512.Load(ptr);
+                Vector512.Divide(containers, Vector512.Create((long)Voron.Global.Constants.Storage.PageSize)).Store(ptr);
+            }
+        }
+        
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            var N = Vector256<long>.Count;
+            for (; idX + N < _pagesToPrefetch.Count; idX += N)
+            {
+                var ptr = _pagesToPrefetch.RawItems + idX;
+                var containers = Vector256.Load(ptr);
+                Vector256.Divide(containers, Vector256.Create((long)Voron.Global.Constants.Storage.PageSize)).Store(ptr);
+            }
+        }
+        
+        if (AdvInstructionSet.IsAcceleratedVector128)
+        {
+            var N = Vector128<long>.Count;
+            for (; idX + N < _pagesToPrefetch.Count; idX += N)
+            {
+                var ptr = _pagesToPrefetch.RawItems + idX;
+                var containers = Vector128.Load(ptr);
+                Vector128.Divide(containers, Vector128.Create((long)Voron.Global.Constants.Storage.PageSize)).Store(ptr);
+            }
+        }
+
+        for (; idX < _pagesToPrefetch.Count; ++idX)
+            _pagesToPrefetch[idX] /= Voron.Global.Constants.Storage.PageSize;
+        
+        _pagesToPrefetch.Count = Sorting.SortAndRemoveDuplicates(_pagesToPrefetch.RawItems, _pagesToPrefetch.Count); 
+        _llt.DataPager.MaybePrefetchMemory(_pagesToPrefetch.GetEnumerator());
+        
+SkipPagePrefetching:
+        _rawTermsContainer.ResetAndEnsureCapacity(ids.Length);
+        _rawTermsContainer.Count = ids.Length;
+        Container.GetAll(_llt, _termsLocation.ToSpan(), _rawTermsContainer.RawItems, -1L, _llt.PageLocator);
+        termsSet = _rawTermsContainer.ToSpan();
     }
     
     public bool TryGetRawTermFor(long id, out UnmanagedSpan term)
@@ -151,6 +233,9 @@ public unsafe struct TermsReader : IDisposable
 
     public void Dispose()
     {
+        _pagesToPrefetch.Dispose();
+        _termsLocation.Dispose();
+        _rawTermsContainer.Dispose();
         _cacheScope.Dispose();
         _yKeyScope.Dispose();
         _xKeyScope .Dispose();

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -83,7 +83,7 @@ public unsafe struct TermsReader : IDisposable
         _pagesToPrefetch.Count = ids.Length;
         _termsLocation.CopyTo(_pagesToPrefetch.ToSpan(), startFrom: 0);
         
-        if (AdvInstructionSet.IsAcceleratedVector512)
+        if (AdvInstructionSet.IsAcceleratedVector128)
         {
             var N = Vector512<long>.Count;
             for (; idX + N < _pagesToPrefetch.Count; idX += N)
@@ -91,26 +91,6 @@ public unsafe struct TermsReader : IDisposable
                 var ptr = _pagesToPrefetch.RawItems + idX;
                 var containers = Vector512.Load(ptr);
                 Vector512.ShiftRightArithmetic(containers, pageSizeShift).Store(ptr);
-            }
-        }
-        else if (AdvInstructionSet.IsAcceleratedVector256)
-        {
-            var N = Vector256<long>.Count;
-            for (; idX + N < _pagesToPrefetch.Count; idX += N)
-            {
-                var ptr = _pagesToPrefetch.RawItems + idX;
-                var containers = Vector256.Load(ptr);
-                Vector256.ShiftRightArithmetic(containers, pageSizeShift).Store(ptr);
-            }
-        }
-        else if (AdvInstructionSet.IsAcceleratedVector128)
-        {
-            var N = Vector128<long>.Count;
-            for (; idX + N < _pagesToPrefetch.Count; idX += N)
-            {
-                var ptr = _pagesToPrefetch.RawItems + idX;
-                var containers = Vector128.Load(ptr);
-                Vector128.ShiftRightArithmetic(containers, pageSizeShift).Store(ptr);
             }
         }
 

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -62,7 +62,10 @@ public unsafe struct TermsReader : IDisposable
     {
         const int pageSizeShift = 13;
         Debug.Assert(1 << pageSizeShift == (long)Voron.Global.Constants.Storage.PageSize);
-        var maxToProcess = Math.Min(ids.Length, 1024);
+        
+        // Process a maximum of 1024 IDs per iteration to limit memory allocations within the terms reader.
+        // Testing demonstrated that larger buffer sizes do not provide additional benefits.
+        var maxToProcess = Math.Min(ids.Length, 1024); 
         ids = ids[..maxToProcess];
 
         if (ids.IsEmpty)

--- a/src/Corax/SupportedFeatures.cs
+++ b/src/Corax/SupportedFeatures.cs
@@ -1,9 +1,10 @@
 ﻿namespace Corax;
 
-public class SupportedFeatures(bool isPhraseQuerySupported, bool isStoreOnlySupported)
+public class SupportedFeatures(bool isPhraseQuerySupported, bool isStoreOnlySupported, bool isPaginationBasedOnEntryIdSupported)
 {
-    public static readonly SupportedFeatures All = new (true, true);
+    public static readonly SupportedFeatures All = new (true, true, true);
     
     public readonly bool PhraseQuery = isPhraseQuerySupported;
     public readonly bool StoreOnly = isStoreOnlySupported;
+    public readonly bool PaginationBasedOnEntryId = isPaginationBasedOnEntryIdSupported;
 }

--- a/src/Corax/Utils/GrowableBitArray.cs
+++ b/src/Corax/Utils/GrowableBitArray.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Runtime.CompilerServices;
+using Sparrow.Server;
+
+namespace Corax.Utils;
+
+internal unsafe struct GrowableBitArray : IDisposable
+{
+    internal static readonly int MaxCapacityPerBitmap = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(ulong);
+    internal static readonly long MaxCapacityPerBitmapInBits = MaxCapacityPerBitmap * 64L;
+    private BitArray[] _bitArrays;
+    private readonly long _capacity;
+    
+    /// <summary>
+    /// Creates a new growable bit array. It accepts when bits id between [0, capacity]
+    /// </summary>
+
+    public GrowableBitArray(ByteStringContext allocator, long capacity)
+    {
+        _capacity = capacity + 1; // ensure it's not zero and handles the last bit inclusively.
+        
+        var numberOfUlongsToAllocate = _capacity / 64 + (_capacity % 64 == 0 ? 0 : 1);
+        var numberOfBitArrays = (int)Math.Ceiling(numberOfUlongsToAllocate / (double)MaxCapacityPerBitmap);
+        _bitArrays = new BitArray[numberOfBitArrays];
+        var lastChunkSize = (int)(numberOfUlongsToAllocate - (long)(numberOfBitArrays - 1) * MaxCapacityPerBitmap);
+        for (int i = 0; i < numberOfBitArrays; ++i)
+        {
+            _bitArrays[i] = new BitArray(allocator, i == numberOfBitArrays - 1
+                ? lastChunkSize
+                : MaxCapacityPerBitmap);
+
+        }
+    }
+
+#if DEBUG
+    public bool IsValid
+    {
+        get
+        {
+            for (int i = 0; i < _bitArrays.Length; ++i)
+                if (_bitArrays[i].IsValid == false)
+                    return false;
+            return true;
+        }
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Add(long id)
+    {
+        if (id > _capacity)
+            throw new ArgumentOutOfRangeException($"Tried to modify bit no {id}, however the capacity is only { _capacity * 64}");
+        var bitmapIdx = (int)(id / MaxCapacityPerBitmapInBits);
+        return _bitArrays[(int)bitmapIdx].Add(id - bitmapIdx * MaxCapacityPerBitmapInBits);
+    }
+
+    public void Dispose()
+    {
+        for (int i = 0; i < _bitArrays.Length; ++i)
+            _bitArrays[i].Dispose();
+    }
+
+    private unsafe struct BitArray : IDisposable
+    {
+        private ulong* _bits;
+        private IDisposable _memoryScope;
+#if DEBUG
+        public bool IsValid = true;
+#endif
+        public BitArray(ByteStringContext allocator, int numberOfUlongsToAllocate)
+        {
+            _memoryScope = allocator.Allocate(numberOfUlongsToAllocate * sizeof(ulong), out ByteString memory);
+            memory.ToSpan<ulong>().Clear();
+            _bits = (ulong*)memory.Ptr;
+#if DEBUG
+            IsValid = true;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Add(long id)
+        {
+            var mask = 1UL << (int)(id & 63);
+            var bucket = _bits + (int)(id >> 6);
+            var result = *bucket & mask;
+            *bucket |= mask;
+            return result == 0;
+        }
+
+        public void Dispose()
+        {
+#if DEBUG
+            IsValid = false;
+#endif
+            _memoryScope.Dispose();
+        }
+    }
+}

--- a/src/Corax/Utils/GrowableBitArray.cs
+++ b/src/Corax/Utils/GrowableBitArray.cs
@@ -12,13 +12,11 @@ internal unsafe struct GrowableBitArray : IDisposable
     private readonly long _capacity;
     
     /// <summary>
-    /// Creates a new growable bit array. It accepts when bits id between [0, capacity]
+    /// Creates a new bit array. It accepts when bits id are between [0, capacity]
     /// </summary>
-
     public GrowableBitArray(ByteStringContext allocator, long capacity)
     {
         _capacity = capacity + 1; // ensure it's not zero and handles the last bit inclusively.
-        
         var numberOfUlongsToAllocate = _capacity / 64 + (_capacity % 64 == 0 ? 0 : 1);
         var numberOfBitArrays = (int)Math.Ceiling(numberOfUlongsToAllocate / (double)MaxCapacityPerBitmap);
         _bitArrays = new BitArray[numberOfBitArrays];
@@ -46,12 +44,12 @@ internal unsafe struct GrowableBitArray : IDisposable
 #endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Add(long id)
+    public bool Add(long pos)
     {
-        if (id > _capacity)
-            throw new ArgumentOutOfRangeException($"Tried to modify bit no {id}, however the capacity is only { _capacity * 64}");
-        var bitmapIdx = (int)(id / MaxCapacityPerBitmapInBits);
-        return _bitArrays[(int)bitmapIdx].Add(id - bitmapIdx * MaxCapacityPerBitmapInBits);
+        if (pos >= _capacity)
+            throw new ArgumentOutOfRangeException($"Tried to modify the bit at position '{pos}', however the capacity is only {_capacity}");
+        var bitmapIdx = (int)(pos / MaxCapacityPerBitmapInBits);
+        return _bitArrays[(int)bitmapIdx].Add(pos - bitmapIdx * MaxCapacityPerBitmapInBits);
     }
 
     public void Dispose()
@@ -60,7 +58,7 @@ internal unsafe struct GrowableBitArray : IDisposable
             _bitArrays[i].Dispose();
     }
 
-    private unsafe struct BitArray : IDisposable
+    private struct BitArray : IDisposable
     {
         private ulong* _bits;
         private IDisposable _memoryScope;
@@ -93,6 +91,8 @@ internal unsafe struct GrowableBitArray : IDisposable
             IsValid = false;
 #endif
             _memoryScope.Dispose();
+            _bits = null;
+            _memoryScope = null;
         }
     }
 }

--- a/src/Corax/Utils/GrowableHashSet.cs
+++ b/src/Corax/Utils/GrowableHashSet.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+
+namespace Corax.Utils;
+
+public sealed class GrowableHashSet<TItem>
+{
+    private List<HashSet<TItem>> _hashSetsBucket;
+    private HashSet<TItem> _newestHashSet;
+    private readonly int _maxSizePerCollection;
+    private readonly IEqualityComparer<TItem> _comparer;
+
+    public long Count
+    {
+        get
+        {
+            long result = _newestHashSet.Count;
+            if (_hashSetsBucket != null)
+            {
+                foreach (var hashBucket in _hashSetsBucket)
+                    result += hashBucket.Count;
+            }
+
+            return result;
+        }
+    }
+
+    public bool HasMultipleHashSets => _hashSetsBucket != null;
+
+    public GrowableHashSet(IEqualityComparer<TItem> comparer = null, int? maxSizePerCollection = null)
+    {
+        _comparer = comparer;
+        _hashSetsBucket = null;
+        _maxSizePerCollection = maxSizePerCollection ?? int.MaxValue;
+        CreateNewHashSet();
+    }
+
+    public bool Add(TItem item)
+    {
+        if (_newestHashSet!.Count >= _maxSizePerCollection)
+            UnlikelyGrowBuffer();
+
+        if (_hashSetsBucket != null && Contains(item))
+            return false;
+
+        return _newestHashSet.Add(item);
+    }
+
+    private void UnlikelyGrowBuffer()
+    {
+        _hashSetsBucket ??= new();
+        _hashSetsBucket.Add(_newestHashSet);
+        CreateNewHashSet();
+    }
+
+    public bool Contains(TItem item)
+    {
+        if (_hashSetsBucket != null)
+        {
+            foreach (var hashSet in _hashSetsBucket)
+                if (hashSet.Contains(item))
+                    return true;
+        }
+
+        return _newestHashSet!.Contains(item);
+    }
+
+    private void CreateNewHashSet()
+    {
+        if (_comparer == null)
+            _newestHashSet = new();
+        else
+            _newestHashSet = new(_comparer);
+    }
+}

--- a/src/Corax/Utils/GrowableHashSet.cs
+++ b/src/Corax/Utils/GrowableHashSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Corax.Utils;
 
@@ -25,12 +26,12 @@ public sealed class GrowableHashSet<TItem>
     }
 
     public bool HasMultipleHashSets => _hashSetsBucket != null;
-
+    private const int MaxSizePerCollection = 128_000_000;
     public GrowableHashSet(IEqualityComparer<TItem> comparer = null, int? maxSizePerCollection = null)
     {
         _comparer = comparer;
         _hashSetsBucket = null;
-        _maxSizePerCollection = maxSizePerCollection ?? (1 << 27); // 134M items
+        _maxSizePerCollection = Math.Min(maxSizePerCollection ?? MaxSizePerCollection, MaxSizePerCollection);
         CreateNewHashSet();
     }
 

--- a/src/Corax/Utils/GrowableHashSet.cs
+++ b/src/Corax/Utils/GrowableHashSet.cs
@@ -30,7 +30,7 @@ public sealed class GrowableHashSet<TItem>
     {
         _comparer = comparer;
         _hashSetsBucket = null;
-        _maxSizePerCollection = maxSizePerCollection ?? int.MaxValue;
+        _maxSizePerCollection = maxSizePerCollection ?? (1 << 27); // 134M items
         CreateNewHashSet();
     }
 

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -192,11 +192,12 @@ namespace Raven.Server.Documents.Indexes
             public const long CoraxSearchWildcardAdjustment_61 = 61_003; // RavenDB-22937
             public const long CoraxUnicodeAnalyzers_62 = 62_004; // RavenDB-22999
             private const long LowerCasedReferences_62 = 62_005; // RavenDB-23100
+            public const long CoraxPagingBasedOnEntriesId_62 = 62_006; // RavenDB-23100
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = LowerCasedReferences_62;
+            public const long CurrentVersion = CoraxPagingBasedOnEntriesId_62;
 
             public static bool IsLowerCasedReferencesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -171,7 +171,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         Dictionary<string, Dictionary<string, FacetValues>> facetsByRange = new();
 
         var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index, query.QueryParameters, _queryBuilderFactories,
-            _fieldMappings, null, null, -1, token: token);
+            _fieldMappings, null, null, -1, deduplicationDisabled: false, token: token);
         var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out _);
 
         var coraxPageSize = CoraxBufferSize(_indexSearcher, facetQuery.Query.PageSize, query);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading;
+using Corax;
 using Corax.Querying;
 using Corax.Mappings;
 using Corax.Querying.Matches;
@@ -368,7 +369,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
         // Even if there are no distinct statements we have to be sure that we are not including
         // documents that we have already included during this request. 
-        protected struct IdentityTracker<TDistinct> where TDistinct : struct, IHasDistinct
+        protected struct IdentityTracker<TDistinct, THasProjection>
+            where THasProjection : struct, IHasProjection
+            where TDistinct : struct, IHasDistinct
         {
             private Index _index;
             private IndexQueryServerSide _query;
@@ -379,10 +382,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             private bool _isMap;
 
             private GrowableHashSet<UnmanagedSpan> _alreadySeenDocumentKeysInPreviousPage;
+            private GrowableHashSet<long> _alreadySeenDocumentEntriesIdsInPreviousPage;
             private GrowableHashSet<ulong> _alreadySeenProjections;
             public long QueryStart;
             private TermsReader _documentIdReader;
-
+            private bool _canPerformPaginationBasedOnEntriesIds;
+            
             public void Initialize(Index index, IndexQueryServerSide query, IndexSearcher searcher, TermsReader documentIdReader, IndexFieldsMapping fieldsMapping, IQueryResultRetriever retriever)
             {
                 _index = index;
@@ -391,11 +396,19 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                
                 _fieldsMapping = fieldsMapping;
                 _retriever = retriever;
-                _documentIdReader = documentIdReader; 
-                _alreadySeenDocumentKeysInPreviousPage = new(UnmanagedSpanComparer.Instance);
+                _documentIdReader = documentIdReader;
+
                 QueryStart = _query.Start;
                 _isMap = index.Type.IsMap();
-               
+                
+                _canPerformPaginationBasedOnEntriesIds = searcher.EntryIdPaginationSupportStatus == EntryIdPaginationSupportStatus.Supported
+                                                        && typeof(THasProjection) == typeof(NoProjection)
+                                                        && query.Metadata.OrderBy is null;
+
+                if (_canPerformPaginationBasedOnEntriesIds)
+                    _alreadySeenDocumentEntriesIdsInPreviousPage = new();
+                else
+                    _alreadySeenDocumentKeysInPreviousPage = new(UnmanagedSpanComparer.Instance);
             }
 
             public long RegisterDuplicates<TProjection>(ref TProjection hasProjection, long currentIdx, Span<long> ids, CancellationToken token)
@@ -418,20 +431,24 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                 var distinctIds = ids.Slice(0, (int)limit);
 
-                if (_isMap && hasProjection.IsProjection == false)
+                if (hasProjection.IsProjection == false)
                 {
-                    Sort.Run(distinctIds);
-                    while (_documentIdReader.GetAllTermsFromSet(distinctIds, out var termsSet) is var read and > 0)
+                    var isSorting = _query.Metadata.OrderBy is not null;
+                    if (isSorting || _canPerformPaginationBasedOnEntriesIds == false)
                     {
-                        foreach (var key in termsSet)
-                            _alreadySeenDocumentKeysInPreviousPage.Add(key);
-
-                        distinctIds = distinctIds[read..];
+                        Sort.Run(distinctIds);
+                        while (_documentIdReader.GetAllTermsFromSet(distinctIds, out var termsSet) is var read and > 0)
+                        {
+                            foreach (var key in termsSet)
+                                _alreadySeenDocumentKeysInPreviousPage.Add(key);
+                            distinctIds = distinctIds[read..];
+                        }
                     }
-                    
-                    
-                    // Assumptions: we're in Map, so that mean we have ID of the doc saved in the tree. So we want to keep track what we returns
-                  //  _documentIdReader.GetAllTermsFromSet(distinctIds, out var keys);
+                    else
+                    {
+                        foreach (var id in distinctIds)
+                            _alreadySeenDocumentEntriesIdsInPreviousPage.Add(id);
+                    }
 
                     return limit;
                 }
@@ -475,10 +492,16 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 return limit;
             }
 
-            public bool ShouldIncludeIdentity<TProjection>(ref TProjection hasProjection, UnmanagedSpan identity)
+            public bool ShouldIncludeIdentity<TProjection>(ref TProjection hasProjection, UnmanagedSpan identity, long indexEntryId)
                 where TProjection : struct, IHasProjection
             {
-                return hasProjection.IsProjection || _alreadySeenDocumentKeysInPreviousPage.Add(identity);
+                if (hasProjection.IsProjection)
+                    return true;
+
+                return 
+                    _canPerformPaginationBasedOnEntriesIds 
+                        ? _alreadySeenDocumentEntriesIdsInPreviousPage.Add(indexEntryId)
+                        : _alreadySeenDocumentKeysInPreviousPage.Add(identity);
             }
 
             public bool ShouldIncludeDocument<TProjection>(ref TProjection hasProjection, Document doc)
@@ -569,7 +592,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             // distinct.
 
 
-            var identityTracker = new IdentityTracker<TDistinct>();
+            var identityTracker = new IdentityTracker<TDistinct, THasProjection>();
             identityTracker.Initialize(_index, query, IndexSearcher, _documentIdReader, _fieldMappings, retriever);
 
             long pageSize = query.PageSize;
@@ -700,7 +723,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         var identityExists = retriever.TryGetKeyCorax(_documentIdReader, indexEntryId, out var rawIdentity);
 
                         // If we have figured out that this document identity has already been seen, we are skipping it.
-                        if (identityExists && identityTracker.ShouldIncludeIdentity(ref hasProjections, rawIdentity) == false)
+                        if (identityExists && identityTracker.ShouldIncludeIdentity(ref hasProjections, rawIdentity, indexEntryId) == false)
                         {
                             docsToLoad++;
                             skippedResults.Value++;
@@ -839,7 +862,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
         }
 
-        protected virtual QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct> tracker, Document document,
+        protected virtual QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct, THasProjection> tracker, Document document,
             IndexQueryServerSide query, DocumentsOperationContext documentsContext, ref EntryTermsReader entryReader, FieldsToFetch highlightingFields, OrderMetadata[] orderByFields, ref THighlighting highlightings,
             Reference<long> skippedResults,
             ref THasProjection hasProjections, ref bool markedAsSkipped)
@@ -872,192 +895,53 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             Reference<long> scannedDocuments, IQueryResultRetriever retriever, DocumentsOperationContext documentsContext, Func<string, SpatialField> getSpatialField,
             CancellationToken token)
         {
-            if (query.Metadata.HasHighlightings)
-            {
-                if (query.Metadata.FilterScript is null)
+            // We've a chain-like builder here.
+            return BuildHighlightings();
+
+            IEnumerable<QueryResult> BuildHighlightings() => query.Metadata.HasHighlightings switch
                 {
-                    if (fieldsToFetch.IsProjection)
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<HasHighlighting, NoQueryFilter, HasProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<HasHighlighting, NoQueryFilter, HasProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                    else
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<HasHighlighting, NoQueryFilter, NoProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<HasHighlighting, NoQueryFilter, NoProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                }
-                else
+                    true => BuildFilterScript<HasHighlighting>(),
+                    _ => BuildFilterScript<NoHighlighting>()
+                };
+
+            IEnumerable<QueryResult> BuildFilterScript<THighlighting>()
+                where THighlighting : struct, ISupportsHighlighting
+                => (query.Metadata.FilterScript is null) switch
                 {
-                    if (fieldsToFetch.IsProjection)
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<HasHighlighting, HasQueryFilter, HasProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<HasHighlighting, HasQueryFilter, HasProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                    else
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<HasHighlighting, HasQueryFilter, NoProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<HasHighlighting, HasQueryFilter, NoProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                }
-            }
-            else
-            {
-                if (query.Metadata.FilterScript is null)
+                    true => BuildProjection<THighlighting, NoQueryFilter>(),
+                    _ => BuildProjection<THighlighting, HasQueryFilter>()
+                };
+
+            IEnumerable<QueryResult> BuildProjection<THighlighting, TQueryFilter>()
+                where THighlighting : struct, ISupportsHighlighting
+                where TQueryFilter : struct, ISupportsQueryFilter
+                => fieldsToFetch.IsProjection switch
                 {
-                    if (fieldsToFetch.IsProjection)
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<NoHighlighting, NoQueryFilter, HasProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<NoHighlighting, NoQueryFilter, HasProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                    else
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<NoHighlighting, NoQueryFilter, NoProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<NoHighlighting, NoQueryFilter, NoProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                }
-                else
+                    true => BuildDistinct<THighlighting, TQueryFilter, HasProjection>(),
+                    _ => BuildDistinct<THighlighting, TQueryFilter, NoProjection>()
+                };
+
+            IEnumerable<QueryResult> BuildDistinct<THighlighting, TQueryFilter, THasProjection>()
+                where THighlighting : struct, ISupportsHighlighting
+                where TQueryFilter : struct, ISupportsQueryFilter
+                where THasProjection : struct, IHasProjection
+                => query.Metadata.IsDistinct switch
                 {
-                    if (fieldsToFetch.IsProjection)
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<NoHighlighting, HasQueryFilter, HasProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<NoHighlighting, HasQueryFilter, HasProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                    else
-                    {
-                        if (query.Metadata.IsDistinct)
-                        {
-                            return QueryInternal<NoHighlighting, HasQueryFilter, NoProjection, HasDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                        else
-                        {
-                            return QueryInternal<NoHighlighting, HasQueryFilter, NoProjection, NoDistinct>(
-                                query, queryTimings, fieldsToFetch,
-                                totalResults, skippedResults, scannedDocuments,
-                                retriever, documentsContext,
-                                getSpatialField,
-                                token);
-                        }
-                    }
-                }
-            }
+                    true => BuildInternalQuery<THighlighting, TQueryFilter, THasProjection, HasDistinct>(),
+                    _ => BuildInternalQuery<THighlighting, TQueryFilter, THasProjection, NoDistinct>()
+                };
+            
+            IEnumerable<QueryResult> BuildInternalQuery<THighlighting, TQueryFilter, THasProjection, TDistinct>()
+                where THighlighting : struct, ISupportsHighlighting
+                where TQueryFilter : struct, ISupportsQueryFilter
+                where THasProjection : struct, IHasProjection
+                where TDistinct : struct, IHasDistinct
+                => QueryInternal<THighlighting, TQueryFilter, THasProjection, TDistinct>(
+                    query, queryTimings, fieldsToFetch,
+                    totalResults, skippedResults, scannedDocuments,
+                    retriever, documentsContext,
+                    getSpatialField,
+                    token);
         }
 
         private static int ProcessHighlightings(HighlightingField current, CoraxHighlightingTermIndex highlightingTerm, ReadOnlySpan<char> fieldFragment, List<string> fragments, int maxFragmentCount)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -382,7 +382,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             private bool _isMap;
 
             private GrowableHashSet<UnmanagedSpan> _alreadySeenDocumentKeysInPreviousPage;
-            private GrowableHashSet<long> _alreadySeenDocumentEntriesIdsInPreviousPage;
             private GrowableHashSet<ulong> _alreadySeenProjections;
             public long QueryStart;
             private TermsReader _documentIdReader;
@@ -402,12 +401,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 _isMap = index.Type.IsMap();
                 
                 _canPerformPaginationBasedOnEntriesIds = searcher.EntryIdPaginationSupportStatus == EntryIdPaginationSupportStatus.Supported
-                                                        && typeof(THasProjection) == typeof(NoProjection)
                                                         && query.Metadata.OrderBy is null;
 
-                if (_canPerformPaginationBasedOnEntriesIds)
-                    _alreadySeenDocumentEntriesIdsInPreviousPage = new();
-                else
+                if (_canPerformPaginationBasedOnEntriesIds == false)
                     _alreadySeenDocumentKeysInPreviousPage = new(UnmanagedSpanComparer.Instance);
             }
 
@@ -443,11 +439,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                                 _alreadySeenDocumentKeysInPreviousPage.Add(key);
                             distinctIds = distinctIds[read..];
                         }
-                    }
-                    else
-                    {
-                        foreach (var id in distinctIds)
-                            _alreadySeenDocumentEntriesIdsInPreviousPage.Add(id);
                     }
 
                     return limit;
@@ -492,16 +483,16 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 return limit;
             }
 
-            public bool ShouldIncludeIdentity<TProjection>(ref TProjection hasProjection, UnmanagedSpan identity, long indexEntryId)
+            public bool ShouldIncludeIdentity<TProjection>(ref TProjection hasProjection, UnmanagedSpan identity)
                 where TProjection : struct, IHasProjection
             {
                 if (hasProjection.IsProjection)
                     return true;
 
-                return 
-                    _canPerformPaginationBasedOnEntriesIds 
-                        ? _alreadySeenDocumentEntriesIdsInPreviousPage.Add(indexEntryId)
-                        : _alreadySeenDocumentKeysInPreviousPage.Add(identity);
+                if (_canPerformPaginationBasedOnEntriesIds == false)
+                    return _alreadySeenDocumentKeysInPreviousPage.Add(identity);
+
+                return true;
             }
 
             public bool ShouldIncludeDocument<TProjection>(ref TProjection hasProjection, Document doc)
@@ -723,7 +714,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         var identityExists = retriever.TryGetKeyCorax(_documentIdReader, indexEntryId, out var rawIdentity);
 
                         // If we have figured out that this document identity has already been seen, we are skipping it.
-                        if (identityExists && identityTracker.ShouldIncludeIdentity(ref hasProjections, rawIdentity, indexEntryId) == false)
+                        if (identityExists && identityTracker.ShouldIncludeIdentity(ref hasProjections, rawIdentity) == false)
                         {
                             docsToLoad++;
                             skippedResults.Value++;
@@ -1302,63 +1293,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             exceptionAggregator.Execute(() => IndexSearcher?.Dispose());
             exceptionAggregator.ThrowIfNeeded();
         }
-
-        internal sealed class GrowableHashSet<TItem>
-        {
-            private List<HashSet<TItem>> _hashSetsBucket;
-            private HashSet<TItem> _newestHashSet;
-            private readonly int _maxSizePerCollection;
-            private readonly IEqualityComparer<TItem> _comparer;
-
-            public bool HasMultipleHashSets => _hashSetsBucket != null;
-
-            public GrowableHashSet(IEqualityComparer<TItem> comparer = null, int? maxSizePerCollection = null)
-            {
-                _comparer = comparer;
-                _hashSetsBucket = null;
-                _maxSizePerCollection = maxSizePerCollection ?? int.MaxValue;
-                CreateNewHashSet();
-            }
-            
-            public bool Add(TItem item)
-            {
-                if (_newestHashSet!.Count >= _maxSizePerCollection)
-                    UnlikelyGrowBuffer();
-
-                if (_hashSetsBucket != null && Contains(item))
-                    return false;
-
-                return _newestHashSet.Add(item);
-            }
-
-            private void UnlikelyGrowBuffer()
-            {
-                _hashSetsBucket ??= new();
-                _hashSetsBucket.Add(_newestHashSet);
-                CreateNewHashSet();
-            }
-
-            public bool Contains(TItem item)
-            {
-                if (_hashSetsBucket != null)
-                {
-                    foreach (var hashSet in _hashSetsBucket)
-                        if (hashSet.Contains(item))
-                            return true;
-                }
-
-                return _newestHashSet!.Contains(item);
-            }
-
-            private void CreateNewHashSet()
-            {
-                if (_comparer == null)
-                    _newestHashSet = new();
-                else
-                    _newestHashSet = new(_comparer);
-            }
-        }
-
+        
         [DoesNotReturn]
         private static void ThrowDistinctOnBiggerCollectionThanInt32()
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -30,6 +30,7 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server;
+using Sparrow.Server.Utils.VxSort;
 using Voron;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
@@ -419,10 +420,19 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                 if (_isMap && hasProjection.IsProjection == false)
                 {
+                    Sort.Run(distinctIds);
+                    while (_documentIdReader.GetAllTermsFromSet(distinctIds, out var termsSet) is var read and > 0)
+                    {
+                        foreach (var key in termsSet)
+                            _alreadySeenDocumentKeysInPreviousPage.Add(key);
+
+                        distinctIds = distinctIds[read..];
+                    }
+                    
+                    
                     // Assumptions: we're in Map, so that mean we have ID of the doc saved in the tree. So we want to keep track what we returns
-                    _documentIdReader.GetAllTermsFromSet(distinctIds, out var keys);
-                    foreach (var key in keys)
-                        _alreadySeenDocumentKeysInPreviousPage.Add(key);
+                  //  _documentIdReader.GetAllTermsFromSet(distinctIds, out var keys);
+
                     return limit;
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -632,7 +632,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         }
 
                         builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, serverContext, documentsContext, query, _index,
-                            query.QueryParameters, QueryBuilderFactories, _fieldMappings, fieldsToFetch, highlightings.Terms, (int)take, indexReadOperation: this, token: token);
+                            query.QueryParameters, QueryBuilderFactories, _fieldMappings, fieldsToFetch, highlightings.Terms, (int)take, deduplicationDisabled: false, indexReadOperation: this, token: token);
 
                         using (closeServerTransaction)
                         {
@@ -1067,7 +1067,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 using (closeServerTransaction)
                 {
                     builderParameters = new(IndexSearcher, _allocator, serverContext, context, query, _index, query.QueryParameters, QueryBuilderFactories,
-                        _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, indexReadOperation: this, token: token);
+                        _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, deduplicationDisabled: true, indexReadOperation: this, token: token);
                     moreLikeThisQuery = CoraxQueryBuilder.BuildMoreLikeThisQuery(builderParameters, query.Metadata.Query.Where);
                 }
             }
@@ -1094,7 +1094,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
 
             builderParameters = new(IndexSearcher, _allocator, null, context, query, _index, query.QueryParameters, QueryBuilderFactories,
-                _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, indexReadOperation: this, token: token);
+                _fieldMappings, null, null /* allow highlighting? */, CoraxQueryBuilder.TakeAll, deduplicationDisabled:true, indexReadOperation: this, token: token);
             using var mlt = new RavenRavenMoreLikeThis(builderParameters, options);
             long? baseDocId = null;
 
@@ -1152,6 +1152,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 mltQuery = IndexSearcher.And(mltQuery, moreLikeThisQuery.FilterQuery);
             }
 
+            if (mltQuery.DuplicatesStatus == Duplicates.Possible)
+                mltQuery = IndexSearcher.DeduplicationMatch(mltQuery);
+            
             var ravenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             long[] ids = QueryPool.Rent(pageSize);
             var read = 0;
@@ -1221,7 +1224,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 take = CoraxConstants.IndexSearcher.TakeAll;
 
             IQueryMatch queryMatch;
-            var builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, null, null, query, _index, query.QueryParameters, QueryBuilderFactories, _fieldMappings, null, null, -1, indexReadOperation: this, token: token);
+            var builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, null, null, query, _index, query.QueryParameters, QueryBuilderFactories, _fieldMappings, null, null, -1, deduplicationDisabled: false, indexReadOperation: this, token: token);
             if ((queryMatch = CoraxQueryBuilder.BuildQuery(builderParameters, out _)) is null)
                 yield break;
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -369,9 +369,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
         // Even if there are no distinct statements we have to be sure that we are not including
         // documents that we have already included during this request. 
-        protected struct IdentityTracker<TDistinct, THasProjection>
-            where THasProjection : struct, IHasProjection
-            where TDistinct : struct, IHasDistinct
+        protected struct IdentityTracker<TDistinct> where TDistinct : struct, IHasDistinct
         {
             private Index _index;
             private IndexQueryServerSide _query;
@@ -399,9 +397,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                 QueryStart = _query.Start;
                 _isMap = index.Type.IsMap();
-                
-                _canPerformPaginationBasedOnEntriesIds = searcher.EntryIdPaginationSupportStatus == EntryIdPaginationSupportStatus.Supported
-                                                        && query.Metadata.OrderBy is null;
+
+                _canPerformPaginationBasedOnEntriesIds = searcher.EntryIdPaginationSupportStatus == EntryIdPaginationSupportStatus.Supported;
 
                 if (_canPerformPaginationBasedOnEntriesIds == false)
                     _alreadySeenDocumentKeysInPreviousPage = new(UnmanagedSpanComparer.Instance);
@@ -429,8 +426,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                 if (hasProjection.IsProjection == false)
                 {
-                    var isSorting = _query.Metadata.OrderBy is not null;
-                    if (isSorting || _canPerformPaginationBasedOnEntriesIds == false)
+                    if (_canPerformPaginationBasedOnEntriesIds == false)
                     {
                         Sort.Run(distinctIds);
                         while (_documentIdReader.GetAllTermsFromSet(distinctIds, out var termsSet) is var read and > 0)
@@ -583,7 +579,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             // distinct.
 
 
-            var identityTracker = new IdentityTracker<TDistinct, THasProjection>();
+            var identityTracker = new IdentityTracker<TDistinct>();
             identityTracker.Initialize(_index, query, IndexSearcher, _documentIdReader, _fieldMappings, retriever);
 
             long pageSize = query.PageSize;
@@ -853,7 +849,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             }
         }
 
-        protected virtual QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct, THasProjection> tracker, Document document,
+        protected virtual QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct> tracker, Document document,
             IndexQueryServerSide query, DocumentsOperationContext documentsContext, ref EntryTermsReader entryReader, FieldsToFetch highlightingFields, OrderMetadata[] orderByFields, ref THighlighting highlightings,
             Reference<long> skippedResults,
             ref THasProjection hasProjections, ref bool markedAsSkipped)
@@ -1152,7 +1148,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 mltQuery = IndexSearcher.And(mltQuery, moreLikeThisQuery.FilterQuery);
             }
 
-            if (mltQuery.DuplicatesStatus == Duplicates.Possible)
+            if (mltQuery.DuplicatesOccurrenceStatus == DuplicatesOccurrence.Possible)
                 mltQuery = IndexSearcher.DeduplicationMatch(mltQuery);
             
             var ravenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -397,7 +397,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                
             }
 
-            public long RegisterDuplicates<TProjection>(ref TProjection hasProjection, long currentIdx, ReadOnlySpan<long> ids, CancellationToken token)
+            public long RegisterDuplicates<TProjection>(ref TProjection hasProjection, long currentIdx, Span<long> ids, CancellationToken token)
                 where TProjection : struct, IHasProjection
             {
                 // From now on, we know we will try to skip duplicates.
@@ -420,12 +420,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 if (_isMap && hasProjection.IsProjection == false)
                 {
                     // Assumptions: we're in Map, so that mean we have ID of the doc saved in the tree. So we want to keep track what we returns
-                    foreach (var id in distinctIds)
-                    {
-                        _documentIdReader.TryGetRawTermFor(id, out var key);
+                    _documentIdReader.GetAllTermsFromSet(distinctIds, out var keys);
+                    foreach (var key in keys)
                         _alreadySeenDocumentKeysInPreviousPage.Add(key);
-                    }
-
                     return limit;
                 }
 
@@ -674,6 +671,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                         goto Done;
 
                     // If we are going to skip, we've better do it knowing how many we have passed. 
+                    // After this call the order of ids from 0 to `i` may be changed, and we cannot rely on it (a sorting case).
                     long i = identityTracker.RegisterDuplicates(ref hasProjections, totalResults.Value, ids.AsSpan(0, read), token);
                     totalResults.Value += read; // important that this is *after* RegisterDuplicates
 
@@ -1427,7 +1425,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 _maxSizePerCollection = maxSizePerCollection ?? int.MaxValue;
                 CreateNewHashSet();
             }
-
+            
             public bool Add(TItem item)
             {
                 if (_newestHashSet!.Count >= _maxSizePerCollection)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -45,7 +45,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             {
                 _indexWriter =  new IndexWriter(writeTransaction, knownFields, new SupportedFeatures(
                     isPhraseQuerySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes,
-                    isStoreOnlySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.StoreOnlySupportInCoraxIndexes));
+                    isStoreOnlySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.StoreOnlySupportInCoraxIndexes,
+                    isPaginationBasedOnEntryIdSupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.CoraxPagingBasedOnEntriesId_62));
             }
             catch (Exception e) when (e.IsOutOfMemory())
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -315,7 +315,7 @@ public static class CoraxQueryBuilder
 
             // The parser already throws parse exception if there is a syntax error.
             // We now return null in the case of a term query that has been fully analyzed, so we need to return a valid query.
-            if (builderParameters.DeduplicationDisabled || coraxQuery.DuplicatesStatus == Duplicates.NotPossible)
+            if (builderParameters.DeduplicationDisabled || coraxQuery.DuplicatesOccurrenceStatus == DuplicatesOccurrence.NotPossible)
                 return coraxQuery;
 
             return DeduplicationMatch(builderParameters, coraxQuery);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -309,12 +309,34 @@ public static class CoraxQueryBuilder
                 // optimization, but we have to sort again anyway, this ensure that this happens
                 if (streamingOptimization.SkipOrderByClause == false || sortMetadata.Length > 1)
                     coraxQuery = OrderBy(builderParameters, coraxQuery, sortMetadata);
-            } 
+            }
 
             // The parser already throws parse exception if there is a syntax error.
             // We now return null in the case of a term query that has been fully analyzed, so we need to return a valid query.
-            return coraxQuery;
+            if (coraxQuery.DuplicatesStatus == Duplicates.NotPossible)
+                return coraxQuery;
+
+            return DeduplicationMatch(builderParameters, coraxQuery);
         }
+    }
+
+    private static IQueryMatch DeduplicationMatch(Parameters parameters, IQueryMatch match)
+    {
+        var type = match.GetType();
+        if (type == typeof(MultiTermMatch))
+            return Build<MultiTermMatch>();
+        if (type == typeof(BinaryMatch))
+            return Build<BinaryMatch>();
+        if (type == typeof(AndNotMatch))
+            return Build<AndNotMatch>();
+        if (type == typeof(BoostingMatch))
+            return Build<BoostingMatch>();
+        if (type == typeof(MultiUnaryMatch))
+            return Build<MultiUnaryMatch>();
+        
+        return Build<IQueryMatch>();
+
+        IQueryMatch Build<TInner>() where TInner : IQueryMatch => parameters.IndexSearcher.DeduplicationMatch((TInner)match);
     }
 
     private static IQueryMatch ToCoraxQuery(Parameters builderParameters, QueryExpression expression, ref StreamingOptimization leftOnlyOptimization, bool exact = false, int? proximity = null)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -61,12 +61,13 @@ public static class CoraxQueryBuilder
         public readonly Lazy<List<string>> DynamicFields;
         public readonly ByteStringContext Allocator;
         public readonly bool HasBoost;
+        public readonly bool DeduplicationDisabled;
         public readonly IndexReadOperationBase IndexReadOperation;
         public StreamingOptimization StreamingDisabled;
 
         internal Parameters(IndexSearcher searcher, ByteStringContext allocator, TransactionOperationContext serverContext, DocumentsOperationContext documentsContext,
             IndexQueryServerSide query, Index index, BlittableJsonReaderObject queryParameters, QueryBuilderFactories factories, IndexFieldsMapping indexFieldsMapping,
-            FieldsToFetch fieldsToFetch, Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms, int take, IndexReadOperationBase indexReadOperation = null, List<string> buildSteps = null, CancellationToken token = default)
+            FieldsToFetch fieldsToFetch, Dictionary<string, CoraxHighlightingTermIndex> highlightingTerms, int take, bool deduplicationDisabled, IndexReadOperationBase indexReadOperation = null, List<string> buildSteps = null, CancellationToken token = default)
         {
             IndexSearcher = searcher;
             ServerContext = serverContext;
@@ -94,6 +95,7 @@ public static class CoraxQueryBuilder
                         HasBoostingAsOrderingType(query.Metadata.OrderBy)); 
             Allocator = allocator;
             IndexReadOperation = indexReadOperation;
+            DeduplicationDisabled = deduplicationDisabled;
         }
 
         private static bool HasBoostingAsOrderingType(OrderByField[] orderBy)
@@ -313,7 +315,7 @@ public static class CoraxQueryBuilder
 
             // The parser already throws parse exception if there is a syntax error.
             // We now return null in the case of a term query that has been fully analyzed, so we need to return a valid query.
-            if (coraxQuery.DuplicatesStatus == Duplicates.NotPossible)
+            if (builderParameters.DeduplicationDisabled || coraxQuery.DuplicatesStatus == Duplicates.NotPossible)
                 return coraxQuery;
 
             return DeduplicationMatch(builderParameters, coraxQuery);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -26,6 +26,9 @@ public struct CoraxBooleanItem : IQueryMatch
     public bool IsBoosting => Boosting.HasValue;
     public float? Boosting;
     public long Count { get; }
+    
+    public Duplicates DuplicatesStatus => throw new InvalidOperationException($"{nameof(DuplicatesStatus)} should never be used in {nameof(CoraxBooleanItem)}");
+
 
     private CoraxBooleanItem(IndexSearcher indexSearcher, FieldMetadata field, object term, UnaryMatchOperation operation)
     {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanItem.cs
@@ -27,7 +27,7 @@ public struct CoraxBooleanItem : IQueryMatch
     public float? Boosting;
     public long Count { get; }
     
-    public Duplicates DuplicatesStatus => throw new InvalidOperationException($"{nameof(DuplicatesStatus)} should never be used in {nameof(CoraxBooleanItem)}");
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => throw new InvalidOperationException($"{nameof(DuplicatesOccurrenceStatus)} should never be used in {nameof(CoraxBooleanItem)}");
 
 
     private CoraxBooleanItem(IndexSearcher indexSearcher, FieldMetadata field, object term, UnaryMatchOperation operation)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
@@ -13,7 +13,7 @@ public abstract class CoraxBooleanQueryBase : IQueryMatch
     protected readonly CoraxQueryBuilder.Parameters _parameters;
     protected bool _hasBinary;
     public bool HasBinary => _hasBinary;
-    public Duplicates DuplicatesStatus => throw new InvalidOperationException($"{nameof(DuplicatesStatus)} should never be used in {nameof(CoraxBooleanQueryBase)}");
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => throw new InvalidOperationException($"{nameof(DuplicatesOccurrenceStatus)} should never be used in {nameof(CoraxBooleanQueryBase)}");
 
     protected CoraxBooleanQueryBase(IndexSearcher indexSearcher, CoraxQueryBuilder.Parameters parameters)
     {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxBooleanQueryBase.cs
@@ -13,6 +13,7 @@ public abstract class CoraxBooleanQueryBase : IQueryMatch
     protected readonly CoraxQueryBuilder.Parameters _parameters;
     protected bool _hasBinary;
     public bool HasBinary => _hasBinary;
+    public Duplicates DuplicatesStatus => throw new InvalidOperationException($"{nameof(DuplicatesStatus)} should never be used in {nameof(CoraxBooleanQueryBase)}");
 
     protected CoraxBooleanQueryBase(IndexSearcher indexSearcher, CoraxQueryBuilder.Parameters parameters)
     {

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -29,7 +29,7 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
     {
     }
 
-    protected override QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct> tracker, Document document,
+    protected override QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct, THasProjection> tracker, Document document,
         IndexQueryServerSide query,
         DocumentsOperationContext documentsContext, ref EntryTermsReader entryReader, FieldsToFetch highlightingFields, OrderMetadata[] orderByFields, 
         ref THighlighting highlightings, Reference<long> skippedResults,

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -29,7 +29,7 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
     {
     }
 
-    protected override QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct, THasProjection> tracker, Document document,
+    protected override QueryResult CreateQueryResult<TDistinct, THasProjection, THighlighting>(ref IdentityTracker<TDistinct> tracker, Document document,
         IndexQueryServerSide query,
         DocumentsOperationContext documentsContext, ref EntryTermsReader entryReader, FieldsToFetch highlightingFields, OrderMetadata[] orderByFields, 
         ref THighlighting highlightings, Reference<long> skippedResults,

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -1413,7 +1413,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     /// Optimized to reduce the cost of traversing the tree
     /// Assumes that matches are sorted 
     /// </summary>
-    public void GetFor(Span<long> keys, Span<long> terms, long missingValue)
+    public void GetFor(ReadOnlySpan<long> keys, Span<long> terms, long missingValue)
     {
         if (typeof(TLookupKey) != typeof(Int64LookupKey))
         {

--- a/test/FastTests/Corax/CompoundFieldsOnIndex.cs
+++ b/test/FastTests/Corax/CompoundFieldsOnIndex.cs
@@ -132,12 +132,12 @@ public class CompoundFieldsOnIndex : RavenTestBase
     
     private async Task CanOptimizeToSkipSorting<TIndex>()  where TIndex : AbstractIndexCreationTask, new()
     {
-        await TestQueryBuilder<MultiTermMatch, TIndex>(s => s.Advanced.AsyncDocumentQuery<User, TIndex>()
+        await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>, TIndex>(s => s.Advanced.AsyncDocumentQuery<User, TIndex>()
             .WhereEquals(x => x.Location, "Hadera")
             .OrderBy(x => x.Name)
             .GetIndexQuery()
         );
-        await TestQueryBuilder<MultiTermMatch, TIndex>(s => s.Advanced.AsyncDocumentQuery<User, TIndex>()
+        await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>, TIndex>(s => s.Advanced.AsyncDocumentQuery<User, TIndex>()
             .WhereEquals(x => x.Name, "Corax")
             .OrderBy(x => x.Birthday)
             .GetIndexQuery()

--- a/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
+++ b/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
@@ -88,7 +88,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)] // where Name = X and Field < 1 order by Name => where Name = x and Field < 1
-    public async Task SortingMatchIsSkippedWhenIsAndBinaryMatch(bool hasMultipleValues) => await TestQueryBuilder<BinaryMatch>(hasMultipleValues, session =>
+    public async Task SortingMatchIsSkippedWhenIsAndBinaryMatch(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<BinaryMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereEquals(p => p.Name, "maciej")
             .AndAlso()
@@ -110,7 +110,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)] // where (Name = x and F < 1) and (S = 2 and F < 2 ) order by Name => skip order by
-    public async Task BinaryMatchOfBinaryMatchAnd(bool hasMultipleValues) => await TestQueryBuilder<BinaryMatch>(hasMultipleValues, session =>
+    public async Task BinaryMatchOfBinaryMatchAnd(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<BinaryMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .OpenSubclause()
             .WhereEquals(p => p.Name, "maciej")
@@ -188,7 +188,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task LessThanOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task LessThanOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereLessThan(p => p.First, 10)
             .OrderBy(x => x.First)
@@ -208,7 +208,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task LessThanOrEqualOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task LessThanOrEqualOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereLessThanOrEqual(p => p.First, 10)
             .OrderBy(x => x.First)
@@ -228,7 +228,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task GreaterThanOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task GreaterThanOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereGreaterThan(p => p.First, 10)
             .OrderBy(x => x.First)
@@ -248,7 +248,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task GreaterThanOrEqualOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task GreaterThanOrEqualOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereGreaterThanOrEqual(p => p.First, 10)
             .OrderBy(x => x.First)
@@ -268,7 +268,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task StartsWithOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task StartsWithOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereStartsWith(p => p.Name, "mac")
             .OrderBy(x => x.Name)
@@ -316,7 +316,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task EndsWithOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task EndsWithOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereEndsWith(p => p.Name, "mac")
             .OrderBy(x => x.Name)
@@ -345,7 +345,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task ExistsOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task ExistsOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereExists(p => p.Name)
             .OrderBy(x => x.Name)
@@ -374,7 +374,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying | RavenTestCategory.Indexes)]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task RegexOptimization(bool hasMultipleValues) => await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+    public async Task RegexOptimization(bool hasMultipleValues) => await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
         session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>()
             .WhereRegex(p => p.Name, "^[a-z ]{2,4}love")
             .OrderBy(x => x.Name)
@@ -404,7 +404,7 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
     [MemberData(nameof(RangesTests))]
     public async Task RangeTests(bool hasMultipleValues, bool leftInclusive, bool rightInclusive, bool ascending)
     {
-        await TestQueryBuilder<MultiTermMatch>(hasMultipleValues, session =>
+        await TestQueryBuilder<DeduplicationMatch<MultiTermMatch>>(hasMultipleValues, session =>
             {
                 var query = session.Advanced.AsyncDocumentQuery<Dto, DtoIndexSingleValues>();
 

--- a/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
+++ b/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
@@ -596,9 +596,8 @@ public class StreamingOptimization_QueryBuilder(ITestOutputHelper output) : Rave
             {
                 var indexQueryServerSide = new IndexQueryServerSide(indexQuery.Query, blittableParameters);
                 using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
-                CoraxQueryBuilder.Parameters parameters = new(searcher: indexSearcher, bsc, null, null, indexQueryServerSide, index, blittableParameters,
-                    queryBuilderFactories, mapping,
-                    null, null, int.MaxValue);
+                CoraxQueryBuilder.Parameters parameters = new(indexSearcher, bsc, null, null, indexQueryServerSide, index, blittableParameters,
+                    queryBuilderFactories, mapping, null, null, int.MaxValue, false);
                 var coraxQuery = CoraxQueryBuilder.BuildQuery(parameters, out _);
 
                 return coraxQuery;

--- a/test/SlowTests/Corax/GrowableBitArrayTests.cs
+++ b/test/SlowTests/Corax/GrowableBitArrayTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Utils;
+using FastTests;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class GrowableBitArrayTests : NoDisposalNeeded
+{
+    public GrowableBitArrayTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void CanCreateEmptyBitmap()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, 0);
+    }
+
+    public void CanCreateBitmapWithOneBitSet()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, 1);
+        Assert.True(lookup.Add(0));
+        Assert.False(lookup.Add(0));
+    }
+
+    public void Allocates63BitsBoundary()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, 63);
+        Assert.True(lookup.Add(63));
+        Assert.Throws<ArgumentOutOfRangeException>(() => lookup.Add(64));
+    }
+    
+ 
+    
+    [RavenFact(RavenTestCategory.Corax)]
+    public void IsZeroed()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, 128);
+        for (int i = 1; i <= 128; ++i)
+        {
+            Assert.True(lookup.Add(i), i.ToString());
+        }
+    }
+
+    [Fact]
+    public void CanSetSecondBitmap()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, GrowableBitArray.MaxCapacityPerBitmapInBits + 2);
+        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits));
+        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits));
+        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+1));
+        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+1));
+        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
+        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+3));
+    }
+}

--- a/test/SlowTests/Corax/GrowableBitArrayTests.cs
+++ b/test/SlowTests/Corax/GrowableBitArrayTests.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
 using FastTests;
+using FastTests.Voron.FixedSize;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Tests.Infrastructure;
@@ -24,6 +26,7 @@ public class GrowableBitArrayTests : NoDisposalNeeded
         using var lookup = new GrowableBitArray(allocator, 0);
     }
 
+    [RavenFact(RavenTestCategory.Corax)]
     public void CanCreateBitmapWithOneBitSet()
     {
         using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
@@ -32,6 +35,7 @@ public class GrowableBitArrayTests : NoDisposalNeeded
         Assert.False(lookup.Add(0));
     }
 
+    [RavenFact(RavenTestCategory.Corax)]
     public void Allocates63BitsBoundary()
     {
         using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
@@ -39,8 +43,6 @@ public class GrowableBitArrayTests : NoDisposalNeeded
         Assert.True(lookup.Add(63));
         Assert.Throws<ArgumentOutOfRangeException>(() => lookup.Add(64));
     }
-    
- 
     
     [RavenFact(RavenTestCategory.Corax)]
     public void IsZeroed()
@@ -53,7 +55,7 @@ public class GrowableBitArrayTests : NoDisposalNeeded
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Corax)]
     public void CanSetSecondBitmap()
     {
         using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
@@ -65,5 +67,38 @@ public class GrowableBitArrayTests : NoDisposalNeeded
         Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
         Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
         Assert.Throws<ArgumentOutOfRangeException>(() => lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+3));
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    public void FuzzyTestOfGrowableBitArray(int seed)
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        var random = new Random(seed);
+        var count = random.Next(1, 7_500_000);
+        var operations = random.Next(1, 10_000_000);
+        using var lookup = new GrowableBitArray(allocator, count);
+        HashSet<long> marked = new();
+        for (int i = 0; i < operations; ++i)
+        {
+            var idX = random.Next(1, count + 1);
+            var expectedAnswer = marked.Add(idX);
+            var actualAnswer = lookup.Add(idX);
+            Assert.Equal(expectedAnswer, actualAnswer);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax)]
+    [InlineData((long)int.MaxValue - 1)]
+    [InlineData((long)int.MaxValue )]
+    [InlineData((long)int.MaxValue + 1)]
+    public void CanStoreBigNumbers(long maxEntryId)
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, maxEntryId);
+        Assert.True(lookup.Add(maxEntryId));
+        Assert.False(lookup.Add(maxEntryId));
     }
 }

--- a/test/SlowTests/Corax/RavenDB-22469.cs
+++ b/test/SlowTests/Corax/RavenDB-22469.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using FastTests.Voron;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_22469(ITestOutputHelper output) : StorageTest(output)
+{
+    private const int e = 65_537;
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CanDeduplicateInPrimitive(bool useHashset)
+    {
+        List<long> entriesIds = new();
+        using var mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, "id()")
+            .AddBinding(1, "Name")
+            .Build();
+        using (var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            for (int i = 0; i < e; ++i)
+            {
+                using var builder = indexWriter.Index($"id/{i}");
+                builder.Write(0, Encodings.Utf8.GetBytes($"id/{i}"));
+                builder.IncrementList();
+                builder.Write(1, Encodings.Utf8.GetBytes($"_{i}"));
+                builder.Write(1, Encodings.Utf8.GetBytes($"_{e - i}"));
+                builder.DecrementList();
+                builder.EndWriting();
+                entriesIds.Add(builder.EntryId);
+            }
+            indexWriter.Commit();
+        }
+
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            var localResults = new List<long>();
+            Span<long> ids = new long[16];
+
+            var match = indexSearcher.DeduplicationMatch(indexSearcher.StartWithQuery("Name", "_"), forceHashset: useHashset);
+
+            while (match.Fill(ids) is var read and > 0)
+            {
+                localResults.AddRange(ids[..read]);       
+            }
+
+            Assert.Equal(entriesIds.Count, localResults.Count);
+            entriesIds.Sort();
+            localResults.Sort();
+            for (int i = 0; i < entriesIds.Count; ++i)
+            {
+                Assert.Equal(entriesIds[i], localResults[i]);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-19932.cs
+++ b/test/SlowTests/Issues/RavenDB-19932.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Corax.Utils;
 using FastTests;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Indexes.Persistence.Corax;
@@ -19,7 +20,7 @@ public class RavenDB_19932 : RavenTestBase
     [RavenFact(RavenTestCategory.Indexes)]
     public void GrowableHashSetForProjectionInCoraxIndexReadOperation()
     {
-        var growableHashSet = new CoraxIndexReadOperation.GrowableHashSet<ulong>(maxSizePerCollection: 100);
+        var growableHashSet = new GrowableHashSet<ulong>(maxSizePerCollection: 100);
         var random = new Random(64352);
         var hashset = new HashSet<ulong>();
 

--- a/test/SlowTests/Issues/RavenDB-24794.cs
+++ b/test/SlowTests/Issues/RavenDB-24794.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24794(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CorrectPaginationWhenStreamingFromStartsWith(Options options)
+    {
+        const int docAmount = (64 * 1024) + 1;
+        using var store = GetDocumentStore(options);
+        var ids = Enumerable.Range(0, docAmount * 3).Select(x => $"_{x:D8}").ToArray();
+        using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0; i < docAmount; ++i)
+            {
+                bulkInsert.Store(new Dto() { GroupingKey = i.ToString(), Names = [ids[i]] });
+                bulkInsert.Store(new Dto() { GroupingKey = i.ToString(), Names = [ids[ids.Length - 1 - i]] });
+            }
+        }
+
+        new ReduceIndex().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+        using (var session = store.OpenSession())
+        {
+            session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+            List<Dto> allResults = new();
+            List<Dto> pagedResults;
+            long totalResults = 0;
+            long skippedResults = 0;
+            int totalUniqueResults = 0;
+
+            int pageNumber = 0;
+            int pageSize = 10000;
+            do
+            {
+                if (pageNumber * pageSize + skippedResults > docAmount)
+                    Debugger.Break();
+                pagedResults = session.Advanced.DocumentQuery<Dto, ReduceIndex>()
+                    .WhereStartsWith("Names", "_")
+                    .Skip(pageNumber * pageSize + skippedResults)
+                    .Take(pageSize)
+                    .Statistics(out QueryStatistics stats)
+                    .ToList();
+
+                totalResults = stats.TotalResults; // Number of total matching documents (includes duplicates)
+                skippedResults += stats.SkippedResults; // Number of duplicate results that were skipped
+                totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
+
+                pageNumber++;
+                allResults.AddRange(pagedResults);
+            } while (pagedResults.Count > 0);
+
+            Assert.Equal(docAmount, allResults.Count);
+            Assert.Equal(docAmount, totalResults);
+            Assert.Equal(docAmount, totalUniqueResults);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CorrectPaginationWhenStreamingFromStartsWithMap(Options options)
+    {
+        const int docAmount = (64 * 1024) + 1;
+        using var store = GetDocumentStore(options);
+        var ids = Enumerable.Range(0, docAmount * 3).Select(x => $"_{x:D8}").ToArray();
+        using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0; i < docAmount; ++i)
+            {
+                bulkInsert.Store(new Dto() { GroupingKey = i.ToString(), Names = [ids[i],ids[ids.Length - 1 - i]] });
+            }
+        }
+        
+        new MapIndex().Execute(store);
+        Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+        using (var session = store.OpenSession())
+        {
+            session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+            List<Dto> allResults = new();
+            List<Dto> pagedResults;
+            long totalResults = 0;
+            long skippedResults = 0;
+            int totalUniqueResults = 0;
+
+            int pageNumber = 0;
+            int pageSize = 10000;
+            do
+            {
+                if (pageNumber * pageSize + skippedResults > docAmount)
+                    Debugger.Break();
+                pagedResults = session.Advanced.DocumentQuery<Dto, MapIndex>()
+                    .WhereStartsWith("Names", "_")
+                    .Skip(pageNumber * pageSize + skippedResults)
+                    .Take(pageSize)
+                    .Statistics(out QueryStatistics stats)
+                    .ToList();
+
+                totalResults = stats.TotalResults; // Number of total matching documents (includes duplicates)
+                skippedResults += stats.SkippedResults; // Number of duplicate results that were skipped
+                totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
+
+                pageNumber++;
+                allResults.AddRange(pagedResults);
+            } while (pagedResults.Count > 0);
+
+            Assert.Equal(docAmount, allResults.Count);
+            Assert.Equal(docAmount, totalResults);
+            Assert.Equal(docAmount, totalUniqueResults);
+        }
+    }
+    
+    private class MapIndex : AbstractIndexCreationTask<Dto>
+    {
+        public MapIndex()
+        {
+            Map = dtos => from doc in dtos
+                select new { doc.Names };
+        }
+    }
+    
+    private class Dto
+    {
+        public string GroupingKey { get; set; }
+        public string[] Names { get; set; }
+    }
+
+
+    
+    private class ReduceIndex : AbstractIndexCreationTask<Dto, Dto>
+    {
+        public ReduceIndex()
+        {
+            Map = dtos => from doc in dtos
+                select new Dto() { GroupingKey = doc.GroupingKey, Names = doc.Names };
+
+            Reduce = results => from result in results
+                group result by result.GroupingKey
+                into g
+                select new Dto() { GroupingKey = g.Key, Names = g.SelectMany(x => x.Names).ToArray() };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24152
https://issues.hibernatingrhinos.com/issue/RavenDB-22469
### Additional description

Read IDs required for proper paging in bulk instead of one-by-one.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
