### PR TITLE
RavenDB-24614 : GenAI: Inconsistent identifier naming

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AddAiEtlOperationResult.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AddAiEtlOperationResult.cs
@@ -1,0 +1,20 @@
+﻿using Raven.Client.Documents.Operations.ETL;
+
+namespace Raven.Client.Documents.Operations.AI
+{
+    /// <summary>
+    /// Common result for AI ETL “add” operations.
+    /// </summary>
+    public abstract class AddAiEtlOperationResult : AddEtlOperationResult
+    {
+        public string Identifier { get; set; }
+    }
+
+    public sealed class AddGenAiOperationResult : AddAiEtlOperationResult
+    {
+    }
+
+    public sealed class AddEmbeddingsGenerationOperationResult : AddAiEtlOperationResult
+    {
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/AddAiTaskOperationResult.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AddAiTaskOperationResult.cs
@@ -5,16 +5,16 @@ namespace Raven.Client.Documents.Operations.AI
     /// <summary>
     /// Common result for AI ETL “add” operations.
     /// </summary>
-    public abstract class AddAiEtlOperationResult : AddEtlOperationResult
+    public abstract class AddAiTaskOperationResult : AddEtlOperationResult
     {
         public string Identifier { get; set; }
     }
 
-    public sealed class AddGenAiOperationResult : AddAiEtlOperationResult
+    public sealed class AddGenAiOperationResult : AddAiTaskOperationResult
     {
     }
 
-    public sealed class AddEmbeddingsGenerationOperationResult : AddAiEtlOperationResult
+    public sealed class AddEmbeddingsGenerationOperationResult : AddAiTaskOperationResult
     {
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/AddEmbeddingsGenerationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AddEmbeddingsGenerationOperation.cs
@@ -15,43 +15,43 @@ public class AddEmbeddingsGenerationOperation(EmbeddingsGenerationConfiguration 
     {
         return new AddEmbeddingsGenerationCommand(conventions, configuration);
     }
-}
 
-internal class AddEmbeddingsGenerationCommand : RavenCommand<AddEmbeddingsGenerationOperationResult>, IRaftCommand
-{
-    private readonly DocumentConventions _conventions;
-    private readonly EmbeddingsGenerationConfiguration _configuration;
-
-    public AddEmbeddingsGenerationCommand(DocumentConventions conventions, EmbeddingsGenerationConfiguration configuration)
+    internal class AddEmbeddingsGenerationCommand : RavenCommand<AddEmbeddingsGenerationOperationResult>, IRaftCommand
     {
-        _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
-        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-    }
+        private readonly DocumentConventions _conventions;
+        private readonly EmbeddingsGenerationConfiguration _configuration;
 
-    public override bool IsReadRequest => false;
-
-    public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-    {
-        url = $"{node.Url}/databases/{node.Database}/admin/etl";
-
-        var request = new HttpRequestMessage
+        public AddEmbeddingsGenerationCommand(DocumentConventions conventions, EmbeddingsGenerationConfiguration configuration)
         {
-            Method = HttpMethod.Put,
-            Content = new BlittableJsonContent(
-                async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx))
-                    .ConfigureAwait(false), _conventions)
-        };
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
 
-        return request;
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/admin/etl";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Put,
+                Content = new BlittableJsonContent(
+                    async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx))
+                        .ConfigureAwait(false), _conventions)
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = JsonDeserializationClient.AddEmbeddingsGenerationOperationResult(response);
+        }
+
+        public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
     }
-
-    public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-    {
-        if (response == null)
-            ThrowInvalidResponse();
-
-        Result = JsonDeserializationClient.AddEmbeddingsGenerationOperationResult(response);
-    }
-
-    public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
 }

--- a/src/Raven.Client/Documents/Operations/AI/AddEmbeddingsGenerationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AddEmbeddingsGenerationOperation.cs
@@ -1,14 +1,57 @@
-﻿using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations.ETL;
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.AI;
 
-public class AddEmbeddingsGenerationOperation(EmbeddingsGenerationConfiguration configuration) : IMaintenanceOperation<AddEtlOperationResult>
+public class AddEmbeddingsGenerationOperation(EmbeddingsGenerationConfiguration configuration) : IMaintenanceOperation<AddEmbeddingsGenerationOperationResult>
 {
-    public RavenCommand<AddEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    public RavenCommand<AddEmbeddingsGenerationOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new AddEtlOperation<AiConnectionString>.AddEtlCommand(conventions, configuration);
+        return new AddEmbeddingsGenerationCommand(conventions, configuration);
     }
+}
+
+internal class AddEmbeddingsGenerationCommand : RavenCommand<AddEmbeddingsGenerationOperationResult>, IRaftCommand
+{
+    private readonly DocumentConventions _conventions;
+    private readonly EmbeddingsGenerationConfiguration _configuration;
+
+    public AddEmbeddingsGenerationCommand(DocumentConventions conventions, EmbeddingsGenerationConfiguration configuration)
+    {
+        _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public override bool IsReadRequest => false;
+
+    public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+    {
+        url = $"{node.Url}/databases/{node.Database}/admin/etl";
+
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Put,
+            Content = new BlittableJsonContent(
+                async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx))
+                    .ConfigureAwait(false), _conventions)
+        };
+
+        return request;
+    }
+
+    public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+    {
+        if (response == null)
+            ThrowInvalidResponse();
+
+        Result = JsonDeserializationClient.AddEmbeddingsGenerationOperationResult(response);
+    }
+
+    public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
 }

--- a/src/Raven.Client/Documents/Operations/AI/AddGenAiOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AddGenAiOperation.cs
@@ -1,35 +1,58 @@
-﻿using System.Net.Http;
-using System;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.AI;
 
-public class AddGenAiOperation(GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null) : IMaintenanceOperation<AddEtlOperationResult>
+public class AddGenAiOperation(GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null) : IMaintenanceOperation<AddGenAiOperationResult>
 {
-    public RavenCommand<AddEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    public RavenCommand<AddGenAiOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
         return new AddGenAiCommand(conventions, configuration, startingPoint);
     }
 
-    internal sealed class AddGenAiCommand : AddEtlOperation<AiConnectionString>.AddEtlCommand
+    internal sealed class AddGenAiCommand : RavenCommand<AddGenAiOperationResult>, IRaftCommand
     {
+        private readonly DocumentConventions _conventions;
         private readonly StartingPointChangeVector _startingPoint;
+        private readonly GenAiConfiguration _configuration;
 
-        public AddGenAiCommand(DocumentConventions conventions, GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null):base(conventions, configuration)
+        public AddGenAiCommand(DocumentConventions conventions, GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null)
         {
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             _startingPoint = startingPoint ?? StartingPointChangeVector.LastDocument;
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
+
+        public override bool IsReadRequest => false;
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            var request = base.CreateRequest(ctx, node, out url);
-
-            url += $"?changeVector={Uri.EscapeDataString(_startingPoint.Value)}";
+            url = $"{node.Url}/databases/{node.Database}/admin/etl?changeVector={Uri.EscapeDataString(_startingPoint.Value)}";
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Put,
+                Content = new BlittableJsonContent(
+                    async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx))
+                        .ConfigureAwait(false), _conventions)
+            };
 
             return request;
         }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = JsonDeserializationClient.AddGenAiOperationResult(response);
+        }
+
+        public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
@@ -63,7 +63,7 @@ public sealed class AiConnectionString : ConnectionString
 
     internal bool ValidateIdentifier(out List<string> errors)
     {
-        return EmbeddingsGenerationConfiguration.ValidateIdentifier(Identifier, out errors);
+        return AiTaskIdentifierHelper.ValidateIdentifier(Identifier, out errors);
     }
 
     public AiSettingsCompareDifferences Compare(AiConnectionString newConnectionString)

--- a/src/Raven.Client/Documents/Operations/AI/AiTaskIdentifierHelper.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiTaskIdentifierHelper.cs
@@ -9,7 +9,6 @@ namespace Raven.Client.Documents.Operations.AI;
 
 internal static class AiTaskIdentifierHelper
 {
-
     internal static bool ValidateIdentifier(string identifier, out List<string> errors)
     {
         errors = [];

--- a/src/Raven.Client/Documents/Operations/AI/AiTaskIdentifierHelper.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiTaskIdentifierHelper.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Raven.Client.Documents.Operations.ETL;
+using static Raven.Client.Constants;
+
+namespace Raven.Client.Documents.Operations.AI;
+
+internal static class AiTaskIdentifierHelper
+{
+
+    internal static bool ValidateIdentifier(string identifier, out List<string> errors)
+    {
+        errors = [];
+
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            errors.Add("Identifier cannot be empty or contain only whitespace;");
+            return false;
+        }
+
+        // Check that the string is already normalized (contains only a-z, 0-9 and hyphens)
+        if (identifier != identifier.Normalize(NormalizationForm.FormD))
+            errors.Add("Identifier contains diacritical marks or non-ASCII characters;");
+
+        // Check that there are no uppercase letters
+        if (identifier.Any(char.IsUpper))
+            errors.Add("Identifier contains uppercase letters;");
+
+        // Check for invalid characters and collect them
+        var invalidChars = identifier.Where(c => c is not (>= 'a' and <= 'z' or >= '0' and <= '9' or '-'))
+            .Distinct()
+            .ToList();
+        if (invalidChars.Count != 0)
+            errors.Add($"Identifier contains invalid characters: {string.Join(", ", invalidChars.Select(c => $"'{c}'"))}. " +
+                       $"Only lowercase letters (a-z), numbers (0-9) and hyphens (-) are allowed.");
+
+        // Check that there are no consecutive hyphens
+        if (identifier.Contains("--"))
+            errors.Add("Identifier contains consecutive hyphens;");
+
+        // Check that the string does not end with a hyphen
+        if (identifier.EndsWith("-"))
+            errors.Add("Identifier ends with a hyphen;");
+
+        return errors.Count == 0;
+    }
+
+    internal static string GenerateIdentifier(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return null;
+
+        var result = new StringBuilder();
+        var lastWasHyphen = false;
+
+        // First normalize to FormD to separate letters from their diacritics
+        foreach (var c in input.Normalize(NormalizationForm.FormD))
+        {
+            // Check if this is a letter that needs to be preserved
+            if (c is
+                >= 'a' and <= 'z' or
+                >= '0' and <= '9')
+            {
+                result.Append(c);
+                lastWasHyphen = false;
+            }
+            else if (c is >= 'A' and <= 'Z')
+            {
+                result.Append(char.ToLowerInvariant(c));
+                lastWasHyphen = false;
+            }
+            else if (lastWasHyphen == false && result.Length > 0) // Add hyphen for any other character
+            {
+                result.Append('-');
+                lastWasHyphen = true;
+            }
+        }
+
+        // Trim any trailing hyphens
+        var finalResult = result.ToString().TrimEnd('-');
+
+        // Ensure we have at least one character
+        return string.IsNullOrEmpty(finalResult) ? $"{nameof(AiConnectionString)}Identifier" : finalResult;
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -153,76 +153,11 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
 
     internal static string GenerateIdentifier(string input)
     {
-        if (string.IsNullOrWhiteSpace(input))
-            return null;
-
-        var result = new StringBuilder();
-        var lastWasHyphen = false;
-
-        // First normalize to FormD to separate letters from their diacritics
-        foreach (var c in input.Normalize(NormalizationForm.FormD))
-        {
-            // Check if this is a letter that needs to be preserved
-            if (c is
-                >= 'a' and <= 'z' or
-                >= '0' and <= '9')
-            {
-                result.Append(c);
-                lastWasHyphen = false;
-            }
-            else if (c is >= 'A' and <= 'Z')
-            {
-                result.Append(char.ToLowerInvariant(c));
-                lastWasHyphen = false;
-            }
-            else if (lastWasHyphen == false && result.Length > 0) // Add hyphen for any other character
-            {
-                result.Append('-');
-                lastWasHyphen = true;
-            }
-        }
-
-        // Trim any trailing hyphens
-        var finalResult = result.ToString().TrimEnd('-');
-
-        // Ensure we have at least one character
-        return string.IsNullOrEmpty(finalResult) ? $"{nameof(AiConnectionString)}Identifier" : finalResult;
+       return AiTaskIdentifierHelper.GenerateIdentifier(input);
     }
 
     internal static bool ValidateIdentifier(string identifier, out List<string> errors)
     {
-        errors = [];
-
-        if (string.IsNullOrWhiteSpace(identifier))
-        {
-            errors.Add("Identifier cannot be empty or contain only whitespace;");
-            return false;
-        }
-
-        // Check that the string is already normalized (contains only a-z, 0-9 and hyphens)
-        if (identifier != identifier.Normalize(NormalizationForm.FormD))
-            errors.Add("Identifier contains diacritical marks or non-ASCII characters;");
-
-        // Check that there are no uppercase letters
-        if (identifier.Any(char.IsUpper))
-            errors.Add("Identifier contains uppercase letters;");
-
-        // Check for invalid characters and collect them
-        var invalidChars = identifier.Where(c => c is not (>= 'a' and <= 'z' or >= '0' and <= '9' or '-'))
-            .Distinct()
-            .ToList();
-        if (invalidChars.Count != 0)
-            errors.Add($"Identifier contains invalid characters: {string.Join(", ", invalidChars.Select(c => $"'{c}'"))}. " +
-                       $"Only lowercase letters (a-z), numbers (0-9) and hyphens (-) are allowed.");
-
-        // Check that there are no consecutive hyphens
-        if (identifier.Contains("--"))
-            errors.Add("Identifier contains consecutive hyphens;");
-
-        // Check that the string does not end with a hyphen
-        if (identifier.EndsWith("-"))
-            errors.Add("Identifier ends with a hyphen;");
-
-        return errors.Count == 0;
+        return AiTaskIdentifierHelper.ValidateIdentifier(identifier, out errors);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -151,16 +151,11 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
 
     internal bool ValidateIdentifier(out List<string> errors)
     {
-        return ValidateIdentifier(Identifier, out errors);
+        return AiTaskIdentifierHelper.ValidateIdentifier(Identifier, out errors);
     }
 
     internal static string GenerateIdentifier(string input)
     {
        return AiTaskIdentifierHelper.GenerateIdentifier(input);
-    }
-
-    internal static bool ValidateIdentifier(string identifier, out List<string> errors)
-    {
-        return AiTaskIdentifierHelper.ValidateIdentifier(identifier, out errors);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -70,12 +70,15 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         }
     }
 
-    public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+    public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, bool validateIdentifier = true)
     {
         if (validateConnection && Initialized == false)
             throw new InvalidOperationException("Embeddings Generation configuration must be initialized");
 
         errors = [];
+
+        if (validateIdentifier && AiTaskIdentifierHelper.ValidateIdentifier(Identifier, out var idErrors) == false)
+            errors.AddRange(idErrors);
 
         if (validateName && string.IsNullOrEmpty(Name))
             errors.Add($"{nameof(Name)} of Embeddings Generation configuration cannot be empty");

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -61,12 +61,15 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         }
     }
 
-    public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+    public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, bool validateIdentifier = true)
     {
         if (validateConnection && Initialized == false)
             throw new InvalidOperationException("GenAi configuration must be initialized");
 
         errors = [];
+
+        if (validateIdentifier && AiTaskIdentifierHelper.ValidateIdentifier(Identifier, out var idErrors) == false)
+            errors.AddRange(idErrors);
 
         if (validateName && string.IsNullOrEmpty(Name))
             errors.Add($"{nameof(Name)} of GenAi configuration cannot be empty");

--- a/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
@@ -68,12 +68,10 @@ namespace Raven.Client.Documents.Operations.ETL
         }
     }
 
-    public sealed class AddEtlOperationResult
+    public class AddEtlOperationResult
     {
         public long RaftCommandIndex { get; set; }
 
         public long TaskId { get; set; }
-
-        public string Identifier { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/AddEtlOperation.cs
@@ -73,5 +73,7 @@ namespace Raven.Client.Documents.Operations.ETL
         public long RaftCommandIndex { get; set; }
 
         public long TaskId { get; set; }
+
+        public string Identifier { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -49,7 +49,7 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public bool Disabled { get; set; }
 
-        public virtual bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+        public virtual bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, bool validateIdentifier = true)
         {
             if (validateConnection && Initialized == false)
                 throw new InvalidOperationException("ETL configuration must be initialized");

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
 
         public bool SkipAutomaticQueueDeclaration { get; set; }
 
-        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, bool validateIdentifier = true)
         {
             var validationResult = base.Validate(out errors, validateName, validateConnection);
             if (Connection != null && BrokerType != Connection.BrokerType)

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
@@ -26,7 +26,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         public override EtlType EtlType => EtlType.Sql;
 
-        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, bool validateIdentifier = true)
         {
             base.Validate(out errors, validateName, validateConnection);
 

--- a/src/Raven.Client/Documents/Operations/ETL/Snowflake/SnowflakeEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Snowflake/SnowflakeEtlConfiguration.cs
@@ -22,7 +22,7 @@ public sealed class SnowflakeEtlConfiguration : EtlConfiguration<SnowflakeConnec
     public override EtlType EtlType => EtlType.Snowflake;
         
         
-    public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+    public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, bool validateIdentifier = true)
     {
         base.Validate(out errors, validateName, validateConnection);
 

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -226,6 +226,10 @@ namespace Raven.Client.Json.Serialization
         internal static readonly Func<BlittableJsonReaderObject, PullReplicationDefinition> PullReplicationDefinition = GenerateJsonDeserializationRoutine<PullReplicationDefinition>();
         
         internal static readonly Func<BlittableJsonReaderObject, AddEtlOperationResult> AddEtlOperationResult = GenerateJsonDeserializationRoutine<AddEtlOperationResult>();
+
+        internal static readonly Func<BlittableJsonReaderObject, AddEmbeddingsGenerationOperationResult> AddEmbeddingsGenerationOperationResult = GenerateJsonDeserializationRoutine<AddEmbeddingsGenerationOperationResult>();
+
+        internal static readonly Func<BlittableJsonReaderObject, AddGenAiOperationResult> AddGenAiOperationResult = GenerateJsonDeserializationRoutine<AddGenAiOperationResult>();
         
         internal static readonly Func<BlittableJsonReaderObject, AddQueueSinkOperationResult> AddQueueSinkOperationResult = GenerateJsonDeserializationRoutine<AddQueueSinkOperationResult>();
         

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -1183,8 +1183,8 @@ namespace Raven.Server.Documents.ETL
             testScript.Configuration.Initialize(connection);
 
             testScript.Configuration.TestMode = true;
-
-            if (testScript.Configuration.Validate(out List<string> errors) == false)
+            
+            if (testScript.Configuration.Validate(out List<string> errors, validateIdentifier: false) == false)
             {
                 throw new InvalidOperationException($"Invalid ETL configuration for '{testScript.Configuration.Name}'. " +
                                                     $"Reason{(errors.Count > 1 ? "s" : string.Empty)}: {string.Join(";", errors)}.");

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
@@ -32,38 +32,45 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
             AssertCanAddOrUpdateEtl(ref configuration);
 
+            string identifierProp = null;
+            string debugTag = null;
+
             switch (EtlConfiguration<ConnectionString>.GetEtlType(configuration))
             {
                 case EtlType.EmbeddingsGeneration:
                 {
-                    if (configuration.TryGet(nameof(EmbeddingsGenerationConfiguration.Identifier), out string id) == false || string.IsNullOrEmpty(id))
-                    {
-                        configuration.TryGet(nameof(EmbeddingsGenerationConfiguration.Name), out string name);
-                        var identifier = AiTaskIdentifierHelper.GenerateIdentifier(name);
-                        configuration.Modifications = new DynamicJsonValue(configuration)
-                        {
-                            [nameof(EmbeddingsGenerationConfiguration.Identifier)] = identifier
-                        };
-                    }
-
-                    configuration = context.ReadObject(configuration, "EmbeddingsGenerationConfig");
-                }
+                    identifierProp = nameof(EmbeddingsGenerationConfiguration.Identifier);
+                    debugTag = "EmbeddingsGenerationConfig";
                     break;
+                }
+                
                 case EtlType.GenAi:
                 {
-                    if (configuration.TryGet(nameof(GenAiConfiguration.Identifier), out string id) == false || string.IsNullOrEmpty(id))
-                    {
-                        configuration.TryGet(nameof(GenAiConfiguration.Name), out string name);
-                        var identifier = AiTaskIdentifierHelper.GenerateIdentifier(name);
-                        configuration.Modifications = new DynamicJsonValue(configuration)
-                        {
-                            [nameof(GenAiConfiguration.Identifier)] = identifier
-                        };
-                    }
-
-                    configuration = context.ReadObject(configuration, "GenAiConfig");
-                    }
+                    identifierProp = nameof(GenAiConfiguration.Identifier);
+                    debugTag = "GenAiConfig";
                     break;
+                }
+
+                default:
+                {
+                    return;
+                }
+            }
+
+            if (configuration.TryGet(identifierProp, out string id) == false || string.IsNullOrEmpty(id))
+            {
+                configuration.TryGet(nameof(AbstractAiIntegrationConfiguration.Name), out string name);
+                var identifier = AiTaskIdentifierHelper.GenerateIdentifier(name);
+
+                configuration.Modifications = new DynamicJsonValue(configuration)
+                {
+                    [identifierProp] = identifier
+                };
+            }
+
+            if (configuration.Modifications !=  null)
+            {
+                configuration = context.ReadObject(configuration, debugTag);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
@@ -31,6 +31,40 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         protected override void OnBeforeUpdateConfiguration(ref BlittableJsonReaderObject configuration, JsonOperationContext context)
         {
             AssertCanAddOrUpdateEtl(ref configuration);
+
+            switch (EtlConfiguration<ConnectionString>.GetEtlType(configuration))
+            {
+                case EtlType.EmbeddingsGeneration:
+                {
+                    if (configuration.TryGet(nameof(EmbeddingsGenerationConfiguration.Identifier), out string id) == false || string.IsNullOrEmpty(id))
+                    {
+                        configuration.TryGet(nameof(EmbeddingsGenerationConfiguration.Name), out string name);
+                        var identifier = AiTaskIdentifierHelper.GenerateIdentifier(name);
+                        configuration.Modifications = new DynamicJsonValue(configuration)
+                        {
+                            [nameof(EmbeddingsGenerationConfiguration.Identifier)] = identifier
+                        };
+                    }
+
+                    configuration = context.ReadObject(configuration, "EmbeddingsGenerationConfig");
+                }
+                    break;
+                case EtlType.GenAi:
+                {
+                    if (configuration.TryGet(nameof(GenAiConfiguration.Identifier), out string id) == false || string.IsNullOrEmpty(id))
+                    {
+                        configuration.TryGet(nameof(GenAiConfiguration.Name), out string name);
+                        var identifier = AiTaskIdentifierHelper.GenerateIdentifier(name);
+                        configuration.Modifications = new DynamicJsonValue(configuration)
+                        {
+                            [nameof(GenAiConfiguration.Identifier)] = identifier
+                        };
+                    }
+
+                    configuration = context.ReadObject(configuration, "GenAiConfig");
+                    }
+                    break;
+            }
         }
 
         protected override async ValueTask OnAfterUpdateConfiguration(TransactionOperationContext _, BlittableJsonReaderObject configuration, string raftRequestId)

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
@@ -25,11 +26,11 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 case EtlType.GenAi:
                     var genAiCfg = JsonDeserializationCluster.GenAiConfiguration(configuration);
                     responseJson[nameof(GenAi.ChangeVector)] = GetChangeVector();
-                    responseJson[nameof(AddEtlOperationResult.Identifier)] = genAiCfg.Identifier;
+                    responseJson[nameof(AddGenAiOperationResult.Identifier)] = genAiCfg.Identifier;
                     break;
                 case EtlType.EmbeddingsGeneration:
                     var embCfg = JsonDeserializationCluster.EmbeddingsGenerationConfiguration(configuration);
-                    responseJson[nameof(AddEtlOperationResult.Identifier)] = embCfg.Identifier;
+                    responseJson[nameof(AddEmbeddingsGenerationOperationResult.Identifier)] = embCfg.Identifier;
                     break;
                 default:
                     return;

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForAddEtl.cs
@@ -3,6 +3,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -22,7 +23,13 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             switch (EtlConfiguration<ConnectionString>.GetEtlType(configuration))
             {
                 case EtlType.GenAi:
+                    var genAiCfg = JsonDeserializationCluster.GenAiConfiguration(configuration);
                     responseJson[nameof(GenAi.ChangeVector)] = GetChangeVector();
+                    responseJson[nameof(AddEtlOperationResult.Identifier)] = genAiCfg.Identifier;
+                    break;
+                case EtlType.EmbeddingsGeneration:
+                    var embCfg = JsonDeserializationCluster.EmbeddingsGenerationConfiguration(configuration);
+                    responseJson[nameof(AddEtlOperationResult.Identifier)] = embCfg.Identifier;
                     break;
                 default:
                     return;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -27,6 +27,7 @@ using Sparrow.Json;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
+using AddEmbeddingsGenerationCommand = Raven.Server.ServerWide.Commands.AI.AddEmbeddingsGenerationCommand;
 
 namespace Raven.Server.ServerWide;
 

--- a/src/Raven.Server/ServerWide/Commands/AI/AddGenAiCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AI/AddGenAiCommand.cs
@@ -58,7 +58,7 @@ public sealed class AddGenAiCommand : AddEtlCommand<GenAiConfiguration, AiConnec
         if (string.IsNullOrWhiteSpace(Configuration.Identifier))
             throw new RachisApplyException("Integration task identifier must be set, but it is not");
 
-        if (EmbeddingsGenerationConfiguration.ValidateIdentifier(Configuration.Identifier, out var errors) == false)
+        if (AiTaskIdentifierHelper.ValidateIdentifier(Configuration.Identifier, out var errors) == false)
             throw new RachisApplyException($"Invalid identifier format. Validation errors:{Environment.NewLine} - {string.Join($"{Environment.NewLine} - ", errors)}");
 
         var isUpdate = databaseRecord.GenAis.Any(x => x.Name == Configuration.Name);

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -39,6 +39,7 @@ using Raven.Server.ServerWide.Commands.Subscriptions;
 using Sparrow.Json;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.ServerWide.Commands.AI;
+using AddEmbeddingsGenerationCommand = Raven.Server.ServerWide.Commands.AI.AddEmbeddingsGenerationCommand;
 
 namespace Raven.Server.ServerWide
 {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2230,6 +2230,8 @@ namespace Raven.Server.ServerWide
 
                         aiIntegration.Initialize(cs);
                         aiIntegration.Validate(out var aiIntegrationErr, validateName: false, validateConnection: true);
+                        AiTaskIdentifierHelper.ValidateIdentifier(aiIntegration.Identifier, out var idErrors);
+                        aiIntegrationErr.AddRange(idErrors);
                         if (ValidateConnectionString(rawRecord, aiIntegration.ConnectionStringName, aiIntegration.EtlType) == false)
                             aiIntegrationErr.Add(
                                 $"Could not find connection string named '{aiIntegration.ConnectionStringName}'. Please supply an existing connection string.");
@@ -2251,6 +2253,8 @@ namespace Raven.Server.ServerWide
 
                         genAi.Initialize(cs);
                         genAi.Validate(out var genAiErr, validateName: false, validateConnection: true);
+                        AiTaskIdentifierHelper.ValidateIdentifier(genAi.Identifier,  out var idErrors);
+                        genAiErr.AddRange(idErrors);
                         if (ValidateConnectionString(rawRecord, genAi.ConnectionStringName, genAi.EtlType) == false)
                             genAiErr.Add($"Could not find connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
@@ -2565,6 +2569,9 @@ namespace Raven.Server.ServerWide
                         raftRequestId);
                     break;
                 case ConnectionStringType.Ai:
+                    connectionString.TryGetMember(nameof(AiConnectionString.Identifier), out var identifier);
+                    if (AiTaskIdentifierHelper.ValidateIdentifier(identifier.ToString(), out var errors) == false)
+                        ThrowInvalidConfigurationIfNecessary(connectionString, errors);
                     command = new PutAiConnectionStringCommand(JsonDeserializationCluster.AiConnectionString(connectionString), databaseName, raftRequestId);
                     break;
                 default:

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -94,6 +94,7 @@ using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron;
 using Voron.Exceptions;
+using AddEmbeddingsGenerationCommand = Raven.Server.ServerWide.Commands.AI.AddEmbeddingsGenerationCommand;
 using Constants = Raven.Client.Constants;
 using DeleteSubscriptionCommand = Raven.Server.ServerWide.Commands.Subscriptions.DeleteSubscriptionCommand;
 using MemoryCache = Raven.Server.Utils.Imports.Memory.MemoryCache;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2229,9 +2229,10 @@ namespace Raven.Server.ServerWide
                         }
 
                         aiIntegration.Initialize(cs);
+                        if (string.IsNullOrWhiteSpace(aiIntegration.Identifier))
+                            aiIntegration.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(aiIntegration.Name);
+
                         aiIntegration.Validate(out var aiIntegrationErr, validateName: false, validateConnection: true);
-                        AiTaskIdentifierHelper.ValidateIdentifier(aiIntegration.Identifier, out var idErrors);
-                        aiIntegrationErr.AddRange(idErrors);
                         if (ValidateConnectionString(rawRecord, aiIntegration.ConnectionStringName, aiIntegration.EtlType) == false)
                             aiIntegrationErr.Add(
                                 $"Could not find connection string named '{aiIntegration.ConnectionStringName}'. Please supply an existing connection string.");
@@ -2252,9 +2253,10 @@ namespace Raven.Server.ServerWide
                         }
 
                         genAi.Initialize(cs);
+                        if (string.IsNullOrWhiteSpace(genAi.Identifier))
+                            genAi.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(genAi.Name);
+
                         genAi.Validate(out var genAiErr, validateName: false, validateConnection: true);
-                        AiTaskIdentifierHelper.ValidateIdentifier(genAi.Identifier,  out var idErrors);
-                        genAiErr.AddRange(idErrors);
                         if (ValidateConnectionString(rawRecord, genAi.ConnectionStringName, genAi.EtlType) == false)
                             genAiErr.Add($"Could not find connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
@@ -2478,6 +2480,7 @@ namespace Raven.Server.ServerWide
 
                     case EtlType.EmbeddingsGeneration:
                         var aiIntegration = JsonDeserializationCluster.EmbeddingsGenerationConfiguration(etlConfiguration);
+
                         aiIntegration.Validate(out var aiIntegrationErr, validateName: false, validateConnection: false);
                         if (ValidateConnectionString(rawRecord, aiIntegration.ConnectionStringName, aiIntegration.EtlType) == false)
                             aiIntegrationErr.Add($"Could not find AI connection string named '{aiIntegration.ConnectionStringName}'. Please supply an existing connection string.");
@@ -2488,6 +2491,7 @@ namespace Raven.Server.ServerWide
                         break;
                     case EtlType.GenAi:
                         var genAi = JsonDeserializationCluster.GenAiConfiguration(etlConfiguration);
+
                         genAi.Validate(out var genAiErr, validateName: false, validateConnection: false);
                         if (ValidateConnectionString(rawRecord, genAi.ConnectionStringName, genAi.EtlType) == false)
                             genAiErr.Add($"Could not find AI connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
@@ -2569,10 +2573,12 @@ namespace Raven.Server.ServerWide
                         raftRequestId);
                     break;
                 case ConnectionStringType.Ai:
-                    connectionString.TryGetMember(nameof(AiConnectionString.Identifier), out var identifier);
-                    if (AiTaskIdentifierHelper.ValidateIdentifier(identifier.ToString(), out var errors) == false)
-                        ThrowInvalidConfigurationIfNecessary(connectionString, errors);
-                    command = new PutAiConnectionStringCommand(JsonDeserializationCluster.AiConnectionString(connectionString), databaseName, raftRequestId);
+                    var aiCs = JsonDeserializationCluster.AiConnectionString(connectionString);
+                    if (string.IsNullOrWhiteSpace(aiCs.Identifier))
+                        aiCs.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(aiCs.Name);
+                    if (AiTaskIdentifierHelper.ValidateIdentifier(aiCs.Identifier, out var idErrors) == false)
+                        ThrowInvalidConfigurationIfNecessary(connectionString, idErrors);
+                    command = new PutAiConnectionStringCommand(aiCs, databaseName, raftRequestId);
                     break;
                 default:
                     throw new NotSupportedException($"Unknown connection string type: {connectionStringType}");

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -75,7 +75,7 @@ namespace FastTests.Client
                 "AdoptOrphanedRevisionsCommand",
                 "AddPrefixedShardingSettingCommand", "DeletePrefixedShardingSettingCommand", "UpdatePrefixedShardingSettingCommand", "RevertRevisionsByIdCommand",
                 "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand",
-                "GetCollectionRevisionsStatisticsCommand", "AddGenAiCommand","UpdateGenAiCommand"
+                "GetCollectionRevisionsStatisticsCommand", "AddGenAiCommand","UpdateGenAiCommand", "AddEmbeddingsGenerationCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/SlowTests/Issues/RavenDB-24614.cs
+++ b/test/SlowTests/Issues/RavenDB-24614.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Commands.ConnectionStrings;
+using SlowTests.MailingList;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24614 : RavenTestBase
+    {
+        public RavenDB_24614(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.All, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task PutAiConnectionString_WithInvalidIdentifier_ShouldThrowException(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            configuration.Connection.Identifier = "_Invalid";
+
+            var op = new PutConnectionStringOperation<AiConnectionString>(configuration.Connection);
+            var ex = await Assert.ThrowsAsync<RavenException>(async () =>
+                await store.Maintenance.SendAsync(op)
+            );
+
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("Identifier contains invalid characters:", ex.InnerException.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task AddGenAiEtl_WithInvalidIdentifier_ShouldThrowException(
+            Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+
+            configuration.Identifier = "_Invalid";
+
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var op = new AddGenAiOperation(configuration);
+            var ex = await Assert.ThrowsAsync<RavenException>(async () =>
+                await store.Maintenance.SendAsync(op)
+            );
+
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("Identifier contains invalid characters:", ex.InnerException.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenAiEmbeddingsData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.All, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task AddEmbeddingEtl_WithInvalidIdentifier_ShouldThrowException(Options options, EmbeddingsGenerationConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+
+            configuration.Identifier = "_Invalid";
+
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var op = new AddEmbeddingsGenerationOperation(configuration);
+            var ex = await Assert.ThrowsAsync<RavenException>(async () =>
+                await store.Maintenance.SendAsync(op)
+            );
+
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("Identifier contains invalid characters:", ex.InnerException.Message);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
@@ -70,6 +70,7 @@ public class TasksManagementTests : RavenTestBase
         Assert.NotNull(addAiIntegrationTaskResult.TaskId);
 
         configuration.Disabled = true;
+        configuration.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(configuration.Name);
 
         var update = store.Maintenance.Send(new UpdateEmbeddingsGenerationOperation(addAiIntegrationTaskResult.TaskId, configuration));
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
@@ -70,7 +70,7 @@ public class TasksManagementTests : RavenTestBase
         Assert.NotNull(addAiIntegrationTaskResult.TaskId);
 
         configuration.Disabled = true;
-        configuration.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(configuration.Name);
+        configuration.Identifier = addAiIntegrationTaskResult.Identifier;
 
         var update = store.Maintenance.Send(new UpdateEmbeddingsGenerationOperation(addAiIntegrationTaskResult.TaskId, configuration));
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -220,7 +220,7 @@ for(const comment of this.Comments)
 "
         };
 
-        store.Maintenance.Send(new AddGenAiOperation(config));
+        var res = store.Maintenance.Send(new AddGenAiOperation(config));
 
         var op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi);
         var taskInfo = await store.Maintenance.SendAsync(op);
@@ -230,7 +230,7 @@ for(const comment of this.Comments)
 this.Comments[idx].LegitComment = $output.Blocked == false;
 ";
         config.UpdateScript = newUpdateScript;
-        config.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(config.Name);
+        config.Identifier = res.Identifier;
         store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
 
         op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi);

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -230,7 +230,7 @@ for(const comment of this.Comments)
 this.Comments[idx].LegitComment = $output.Blocked == false;
 ";
         config.UpdateScript = newUpdateScript;
-
+        config.Identifier = AiTaskIdentifierHelper.GenerateIdentifier(config.Name);
         store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
 
         op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24614/GenAI-Inconsistent-identifier-naming

### Additional description

adds validation for AI‑task identifiers across both `GenAI`, `EmbeddingsGeneration `and `ConnectionString`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
