### PR TITLE
RavenDB-23681 fix test ShouldRescheduleBackupTimerIfDocumentDatabaseF…

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -96,6 +96,7 @@ namespace Raven.Server.Documents
             internal bool PreventNodePromotion = false;
             internal Func<ServerStore, Task> BeforeHandleClusterTransactionOnDatabaseChanged;
             internal Action DelayNotifyFeaturesAboutStateChange;
+            internal ManualResetEventSlim AfterDatabaseRemovedFromIdle = null;
         }
 
         private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType, object changeState)
@@ -714,6 +715,7 @@ namespace Raven.Server.Documents
                         ForTestingPurposes?.AfterDatabaseCreation?.Invoke((t.GetAwaiter().GetResult(), caller));
 
                         _serverStore.IdleDatabases.TryRemove(databaseName.Value, out _);
+                        ForTestingPurposes?.AfterDatabaseRemovedFromIdle?.Set();
                     }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else

--- a/test/StressTests/Issues/RavenDB_18420.cs
+++ b/test/StressTests/Issues/RavenDB_18420.cs
@@ -64,6 +64,9 @@ public class RavenDB_18420 : RavenTestBase
                 Backup.WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, putConfiguration.TaskId);
                 Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
 
+                var idleRemovedSignal = new ManualResetEventSlim(false);
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = idleRemovedSignal;
+
                 // enable backup and this will set wakeup timer
                 await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
 
@@ -72,6 +75,7 @@ public class RavenDB_18420 : RavenTestBase
                 server.ServerStore.DatabasesLandlord._concurrentDatabaseLoadTimeout = old_concurrentDatabaseLoadTimeout;
                 server.ServerStore.DatabasesLandlord._dueTimeOnRetry = old_dueTimeOnRetry;
 
+                Assert.True(idleRemovedSignal.Wait(TimeSpan.FromSeconds(65)));
                 // db should wake up after dueTimeOnRetry is hit
                 Assert.Equal(0, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 0, interval: 333));
 


### PR DESCRIPTION
…ailedToLoad

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23681

### Additional description

Unable to reproduce the issue. Added a wait to ensure the database is removed from the idle list before continuing

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
