### PR TITLE
RavenDB-24471 - Cannot run test index when configuration key field is empty

### DIFF
--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -270,14 +270,13 @@ class indexDefinition {
 
         return fields;
     }
-
+    
     private configurationToDto(): Raven.Client.Documents.Indexes.IndexConfiguration {
         const result = {} as Raven.Client.Documents.Indexes.IndexConfiguration;
-
-        this.configuration().forEach((configItem: configurationItem) => {
-            result[configItem.key()] = configItem.value();
-        });
-
+        
+        const existingConfigurationOptions = this.configuration().filter(configItem => configurationItem.PerDatabaseIndexingConfigurationOptions.includes(configItem.key()));
+        existingConfigurationOptions.forEach((configItem: configurationItem) => result[configItem.key()] = configItem.value());
+        
         return result;
     }
     


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24471

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
