### PR TITLE
RavenDB-24616 Use unmanaged allocation in Tree.Stream instead of LOH managed allocation

### DIFF
--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Sparrow;
+using Sparrow.Platform;
 using Sparrow.Server.Utils;
-using Sparrow.Utils;
 using Voron.Data.Fixed;
 using Voron.Exceptions;
 using Voron.Global;
@@ -53,6 +52,10 @@ namespace Voron.Data.BTrees
         
         private struct StreamToPageWriter
         {
+            private static readonly int BufferSize = PlatformDetails.Is32Bits == false
+                ? 512 * Constants.Size.Kilobyte
+                : 16 * Constants.Size.Kilobyte;
+            
             private int _chunkNumber;
 
             private byte* _writePos;
@@ -79,8 +82,7 @@ namespace Voron.Data.BTrees
 
             public void Write(Stream stream)
             {
-                const int bufferSize = 512 * Constants.Size.Kilobyte;
-                using (_parent._tx.Allocator.Allocate(bufferSize, out Span<byte> localBuffer))
+                using (_parent._tx.Allocator.Allocate(BufferSize, out Span<byte> localBuffer))
                 {
                     AllocateNextPage();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24616

### Additional description
Use a smaller size for stream write on x86.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
