### PR TITLE
RavenDB-24619 Allow to filter by Index engine type on Indexes view

### DIFF
--- a/src/Raven.Studio/typescript/components/models/indexes.ts
+++ b/src/Raven.Studio/typescript/components/models/indexes.ts
@@ -71,6 +71,7 @@ export interface IndexFilterCriteria {
     searchText: string;
     statuses: IndexStatus[];
     types: IndexType[];
+    searchEngine: SearchEngineType[];
     showOnlyIndexesWithIndexingErrors: boolean;
     autoRefresh: boolean;
     sortBy: IndexSortBy;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
@@ -8,17 +8,20 @@ import { Switch } from "components/common/Checkbox";
 import { SortDropdown, SortDropdownRadioList, sortItem } from "components/common/SortDropdown";
 import Button from "react-bootstrap/Button";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType;
 
 interface IndexFilterProps {
     filter: IndexFilterCriteria;
     setFilter: (x: IndexFilterCriteria) => void;
     filterByStatusOptions: InputItem<IndexStatus>[];
     filterByTypeOptions: InputItem<IndexType>[];
+    filterByEngineOptions: InputItem<SearchEngineType>[];
     indexesCount: number;
 }
 
 export default function IndexFilter(props: IndexFilterProps) {
-    const { filter, setFilter, filterByStatusOptions, filterByTypeOptions, indexesCount } = props;
+    const { filter, setFilter, filterByStatusOptions, filterByTypeOptions, filterByEngineOptions, indexesCount } =
+        props;
 
     // TODO sharding
 
@@ -71,6 +74,7 @@ export default function IndexFilter(props: IndexFilterProps) {
         );
     };
 
+    console.log("@@filetrs", filter);
     return (
         <div className="hstack flex-wrap align-items-end gap-3 my-3 justify-content-end">
             <div className="flex-grow">
@@ -109,6 +113,13 @@ export default function IndexFilter(props: IndexFilterProps) {
                 label="Filter by type"
                 selectedItems={filter.types}
                 setSelectedItems={(x) => onFilterValueChange("types", x)}
+                selectAllCount={indexesCount}
+            />
+            <MultiCheckboxToggle
+                inputItems={filterByEngineOptions}
+                label="Filter by engines"
+                selectedItems={filter.searchEngine}
+                setSelectedItems={(x) => onFilterValueChange("searchEngine", x)}
                 selectAllCount={indexesCount}
             />
             <div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
@@ -74,7 +74,6 @@ export default function IndexFilter(props: IndexFilterProps) {
         );
     };
 
-    console.log("@@filetrs", filter);
     return (
         <div className="hstack flex-wrap align-items-end gap-3 my-3 justify-content-end">
             <div className="flex-grow">

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -64,6 +64,7 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         setFilter,
         filterByStatusOptions,
         filterByTypeOptions,
+        filterByEngineOptions,
         regularIndexes,
         groups,
         replacements,
@@ -295,6 +296,7 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
                         filter={filter}
                         setFilter={(x) => setFilter(x)}
                         filterByStatusOptions={filterByStatusOptions}
+                        filterByEngineOptions={filterByEngineOptions}
                         filterByTypeOptions={filterByTypeOptions}
                         indexesCount={allIndexesCount}
                     />

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -43,6 +43,7 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import useBoolean from "components/hooks/useBoolean";
 import router from "plugins/router";
 import RichAlert from "components/common/RichAlert";
+import SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType;
 
 type IndexEvent =
     | Raven.Client.Documents.Changes.IndexChange
@@ -748,6 +749,16 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         ] satisfies InputItem<IndexType>[];
     }, [autoDatabaseLimit, staticDatabaseLimit, stats.indexes]);
 
+    const filterByEngineOptions: InputItem<SearchEngineType>[] = useMemo(() => {
+        const luceneCount = stats.indexes.filter((x) => x.searchEngine === "Lucene").length;
+        const coraxCount = stats.indexes.filter((x) => x.searchEngine === "Corax").length;
+
+        return [
+            { value: "Lucene", label: "Lucene", count: luceneCount },
+            { value: "Corax", label: "Corax", count: coraxCount },
+        ];
+    }, [stats.indexes]);
+
     const filterByStatusOptions: InputItem<IndexStatus>[] = useMemo(() => {
         let normal = 0,
             errorOrFaulty = 0,
@@ -800,6 +811,7 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         setFilter,
         filterByStatusOptions,
         filterByTypeOptions,
+        filterByEngineOptions,
         regularIndexes,
         groups,
         replacements,
@@ -845,6 +857,7 @@ export const defaultFilterCriteria: IndexFilterCriteria = {
     showOnlyIndexesWithIndexingErrors: false,
     searchText: "",
     sortBy: "name",
+    searchEngine: [],
     sortDirection: "asc",
     groupBy: "Collection",
 };
@@ -980,6 +993,14 @@ function matchesIndexType(index: IndexSharedInfo, types: IndexType[]) {
     );
 }
 
+function matchesIndexEngine(index: IndexSharedInfo, searchEngines: SearchEngineType[]): boolean {
+    if (!searchEngines || searchEngines.length === 0) {
+        return true;
+    }
+
+    return searchEngines.includes(index.searchEngine);
+}
+
 function indexMatchesFilter(
     index: IndexSharedInfo,
     filter: IndexFilterCriteria,
@@ -990,10 +1011,11 @@ function indexMatchesFilter(
     const indexingErrorsMatch =
         !filter.showOnlyIndexesWithIndexingErrors ||
         (filter.showOnlyIndexesWithIndexingErrors && index.nodesInfo.some((x) => x.details?.errorCount > 0));
+    const engineMatch = matchesIndexEngine(index, filter.searchEngine);
 
     const typeMatch = matchesIndexType(index, filter.types);
 
-    return nameMatch && statusMatch && indexingErrorsMatch && typeMatch;
+    return nameMatch && statusMatch && indexingErrorsMatch && typeMatch && engineMatch;
 }
 
 function getIndexInfoForDelete(indexes: IndexSharedInfo[]): DeleteIndexesConfirmBodyProps {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24619

### Additional description
<img width="2112" height="1126" alt="image" src="https://github.com/user-attachments/assets/16d4d339-1ae9-469e-812e-69be4f82a186" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
