### PR TITLE
RavenDB-24634 - Connection-string dropdown shows non-compatible items

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.spec.tsx
@@ -23,7 +23,7 @@ describe("ConnectionStrings", () => {
         const { screen } = await rtlRender_WithWaitForLoad(<DefaultConnectionStrings />);
 
         expect(screen.queryByText(selectors.emptyList)).not.toBeInTheDocument();
-        expect(screen.queryAllByClassName("rich-panel-name")).toHaveLength(10);
+        expect(screen.queryAllByClassName("rich-panel-name")).toHaveLength(11);
     });
 
     it("can render action buttons when has access database admin", async () => {
@@ -33,8 +33,8 @@ describe("ConnectionStrings", () => {
         expect(screen.queryAllByRole("button", { name: selectors.addNew })).toHaveLength(11);
 
         // one per connection string
-        expect(screen.queryAllByRole("button", { name: selectors.edit })).toHaveLength(10);
-        expect(screen.queryAllByRole("button", { name: selectors.delete })).toHaveLength(10);
+        expect(screen.queryAllByRole("button", { name: selectors.edit })).toHaveLength(11);
+        expect(screen.queryAllByRole("button", { name: selectors.delete })).toHaveLength(11);
     });
 
     it("can hide action buttons when has access below database admin", async () => {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.stories.tsx
@@ -77,9 +77,9 @@ export const Summary: StoryObj = {
 };
 
 async function navigateToStep(canvas: Canvas, step: EditGenAiTaskStepId) {
-    await userEvent.type(await canvas.findByLabelText("Task Name"), "some-name");
+    await userEvent.type(await canvas.findByLabelText("Task Name"), "ai-name-gen-ai");
     await userEvent.click(canvas.getByText("Select..."));
-    await userEvent.click(canvas.getByText("ai-name"));
+    await userEvent.click(canvas.getByText("ai-name-gen-ai"));
 
     if (step === "basic") {
         return;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
@@ -41,7 +41,7 @@ export default function EditGenAiTaskBasicFields() {
 
         dispatch(editGenAiTaskActions.aiConnectionStringsSet(result.AiConnectionStrings));
 
-        const connectionStrings = Object.values(result.AiConnectionStrings).map((x) => x.Name);
+        const connectionStrings = Object.values(result.AiConnectionStrings).filter(x => x.ModelType === "Chat").map((x) => x.Name);
 
         return sortBy(connectionStrings, (x) => x.toUpperCase()).map(
             (x) => ({ value: x, label: x }) satisfies SelectOption

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
@@ -41,7 +41,9 @@ export default function EditGenAiTaskBasicFields() {
 
         dispatch(editGenAiTaskActions.aiConnectionStringsSet(result.AiConnectionStrings));
 
-        const connectionStrings = Object.values(result.AiConnectionStrings).filter(x => x.ModelType === "Chat").map((x) => x.Name);
+        const connectionStrings = Object.values(result.AiConnectionStrings)
+            .filter((x) => x.ModelType === "Chat")
+            .map((x) => x.Name);
 
         return sortBy(connectionStrings, (x) => x.toUpperCase()).map(
             (x) => ({ value: x, label: x }) satisfies SelectOption

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -603,6 +603,23 @@ export class DatabasesStubs {
                     OpenAiSettings: null,
                     MistralAiSettings: null,
                 },
+                "ai-name-gen-ai": {
+                    Type: "Ai",
+                    Name: "ai-name-gen-ai",
+                    Identifier: "some-identifier",
+                    ModelType: "Chat",
+                    GoogleSettings: {
+                        ApiKey: "some-api-key",
+                        Model: "some-model",
+                        AiVersion: "V1",
+                    },
+                    AzureOpenAiSettings: null,
+                    HuggingFaceSettings: null,
+                    OllamaSettings: null,
+                    EmbeddedSettings: null,
+                    OpenAiSettings: null,
+                    MistralAiSettings: null,
+                },
             },
         };
     }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -226,9 +226,11 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
         return new getConnectionStringsCommand(this.db)
             .execute()
             .done((result: Raven.Client.Documents.Operations.ConnectionStrings.GetConnectionStringsResult) => {
-                this.aiConnectionStrings(Object.values(result.AiConnectionStrings));
+                this.aiConnectionStrings(Object.values(result.AiConnectionStrings).filter(x => x.ModelType === "TextEmbeddings"));
 
-                const connectionStringsNames = Object.keys(result.AiConnectionStrings);
+                const connectionStringsNames = Object.keys(result.AiConnectionStrings).filter(key =>
+                    result.AiConnectionStrings[key].ModelType === "TextEmbeddings",
+                );
                 this.connectionStringsNames(typeUtils.sortBy(connectionStringsNames, x => x.toUpperCase()));
             });
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24634

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
