### PR TITLE
RavenDB-24690 Use npm ci instead of npm install in RavenDB repo

### DIFF
--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -30,7 +30,7 @@ jobs:
       run: dotnet build
 
     - name: Install npm dependencies
-      run: npm install
+      run: npm ci
       working-directory: ./src/Raven.Studio
   
     - name: Restore Studio

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '14'
       - name: Restore
         run: |
-          npm install
+          npm ci
           npm run restore
         working-directory: src/Raven.Studio
 

--- a/.github/workflows/studioConventions.yml
+++ b/.github/workflows/studioConventions.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet build
 
     - name: Install npm dependencies
-      run: npm install
+      run: npm ci
       working-directory: ./src/Raven.Studio
   
     - name: Restore Studio

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -18,6 +18,6 @@ RUN dotnet build ./src/Raven.Server/Raven.Server.csproj && \
 COPY tools/ ./tools
 RUN dotnet build ./tools/TypingsGenerator/TypingsGenerator.csproj \
     && cd src/Raven.Studio \
-    && npm install && npm run gulp restore && npm run gulp compile
+    && npm ci && npm run gulp restore && npm run gulp compile
 
 ENTRYPOINT [ "dotnet", "./src/Raven.Server/bin/Debug/net8.0/Raven.Server.dll" ]

--- a/scripts/buildProjects.ps1
+++ b/scripts/buildProjects.ps1
@@ -130,7 +130,7 @@ function NpmInstall () {
 
     foreach ($i in 1..3) {
         try {
-            exec { npm install }
+            exec { npm ci }
             CheckLastExitCode
             return
         }

--- a/src/Raven.Studio/Raven.Studio.csproj
+++ b/src/Raven.Studio/Raven.Studio.csproj
@@ -27,7 +27,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
   </ItemGroup>
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
-    <Exec Command="npm install" />
+    <Exec Command="npm ci" />
     <Exec Command="dotnet bundle" />
   </Target>
   <ItemGroup>

--- a/src/Raven.Studio/aceBuild/README.txt
+++ b/src/Raven.Studio/aceBuild/README.txt
@@ -3,7 +3,7 @@ The overriding files are stored under the 'addons' dir.
 
 To run:
     * Go to 'src\Raven.Studio\aceBuild' folder
-    * Run 'npm install'
+    * Run 'npm ci'
     * Run 'node Makefile.dryice.js' to build
 
     The Ace sources and addons will be copied to the build dir 'src\Raven.Studio\aceBuild\build'.


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24690/Use-npm-ci-instead-of-npm-install-in-RavenDB-repo

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
