### PR TITLE
RavenDB-24700 AI Agent: disable identifier when editing ai agent

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/EditAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/EditAiAgent.tsx
@@ -44,6 +44,8 @@ export default function EditAiAgent({ queryParams }: ReactQueryParamsProps<Query
     const isTestOpen = useAppSelector(editAiAgentSelectors.isTestOpen);
     const isCommunityLicense = useAppSelector(licenseSelectors.licenseType) === "Community";
 
+    const isEditAiAgent = !!queryParams?.id && !queryParams.isClone;
+
     const form = useForm<EditAiAgentFormData>({
         defaultValues: async () => {
             const isDocumentExpirationEnabled = await dispatch(
@@ -129,7 +131,7 @@ export default function EditAiAgent({ queryParams }: ReactQueryParamsProps<Query
                                         <LoadingView />
                                     ) : (
                                         <>
-                                            <EditAiAgentBasicSection />
+                                            <EditAiAgentBasicSection isEditAiAgent={isEditAiAgent} />
                                             <EditAiAgentPersistenceSection />
                                             <EditAiAgentParametersSection />
                                             <EditAiAgentToolsSection />

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentBasicSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentBasicSection.tsx
@@ -20,7 +20,11 @@ import { useAsync } from "react-async-hook";
 import Button from "react-bootstrap/Button";
 import InputGroup from "react-bootstrap/InputGroup";
 
-export default function EditAiAgentBasicSection() {
+interface EditAiAgentBasicSectionProps {
+    isEditAiAgent: boolean;
+}
+
+export default function EditAiAgentBasicSection({ isEditAiAgent }: EditAiAgentBasicSectionProps) {
     const { control, setValue } = useFormContext<EditAiAgentFormData>();
 
     const formValues = useWatch({
@@ -95,12 +99,14 @@ export default function EditAiAgentBasicSection() {
                         name="identifier"
                         type="text"
                         placeholder="e.g. customer-service-agent"
+                        disabled={isEditAiAgent}
                         addon={
                             <Button
                                 variant="link"
                                 className="text-reset px-0"
                                 onClick={handleGenerateIdentifier}
                                 title="Click to generate the identifier from the task name"
+                                disabled={isEditAiAgent}
                             >
                                 <Icon icon="refresh" />
                                 Regenerate


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24700/AI-Agent-disable-identifier-when-editing-ai-agent

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
