### PR TITLE
RavenDB-24713 AI Agent: double closing the tool call in the test chat is buggy

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -16,6 +16,7 @@ import { getCoreRowModel, getFilteredRowModel, getSortedRowModel, useReactTable 
 import VirtualTable from "components/common/virtualTable/VirtualTable";
 import document from "models/database/documents/document";
 import Badge from "react-bootstrap/Badge";
+import AccordionCollapse from "react-bootstrap/AccordionCollapse";
 
 type ToolQuery = Raven.Client.Documents.Operations.AI.Agents.AiAgentToolQuery;
 type ToolAction = Raven.Client.Documents.Operations.AI.Agents.AiAgentToolAction;
@@ -412,9 +413,11 @@ function ToolCall({ toolCall, toolQueries, toolActions }: ToolCallProps) {
                         <div className="text-truncate">Tool call: {toolCall.name}</div>
                     </div>
                 </Accordion.Header>
-                <Accordion.Body className="panel-bg-3 rounded-2">
-                    <ToolCallBody tool={toolQuery ?? toolAction} toolCall={toolCall} />
-                </Accordion.Body>
+                <AccordionCollapse eventKey={id} mountOnEnter unmountOnExit>
+                    <Accordion.Body className="panel-bg-3 rounded-2">
+                        <ToolCallBody tool={toolQuery ?? toolAction} toolCall={toolCall} />
+                    </Accordion.Body>
+                </AccordionCollapse>
             </Accordion.Item>
         </Accordion>
     );


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24713

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
