### PR TITLE
RavenDB-24715 -  tool name regex '^[a-zA-Z0-9_-]+$'

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
@@ -37,7 +37,10 @@ const schema = yup.object({
     isToolsAdvancedSettings: yup.boolean(),
     queries: yup.array().of(
         yup.object({
-            name: yup.string().required(),
+            name: yup
+                .string()
+                .required()
+                .matches(/^[a-zA-Z0-9_-]+$/, "Tool name can only contain letters, numbers, underscores and hyphens"),
             description: yup.string().required(),
             query: yup.string().required(),
             parametersSampleObject: yup.string(),
@@ -56,7 +59,10 @@ const schema = yup.object({
     ),
     actions: yup.array().of(
         yup.object({
-            name: yup.string().required(),
+            name: yup
+                .string()
+                .required()
+                .matches(/^[a-zA-Z0-9_-]+$/, "Tool name can only contain letters, numbers, underscores and hyphens"),
             description: yup.string().required(),
             parametersSampleObject: yup.string(),
             parametersSchema: yup


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24715

### Additional description

i have added validation also to tool actions.
<img width="768" height="410" alt="image" src="https://github.com/user-attachments/assets/888e5448-f603-4478-bdc1-23b7030ed5a4" />

<img width="778" height="443" alt="image" src="https://github.com/user-attachments/assets/d5ca59a5-5494-4690-a7ea-e8dd7250b43b" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
