### PR TITLE
RavenDB-24390 "@archive-at" is missing in the patching test results

### DIFF
--- a/src/Raven.Server/Documents/DocumentCompare.cs
+++ b/src/Raven.Server/Documents/DocumentCompare.cs
@@ -14,14 +14,16 @@ namespace Raven.Server.Documents
     {
         public readonly struct DocumentCompareOptions
         {
-            private DocumentCompareOptions(bool tryMergeMetadataConflicts, bool throwOnAttachmentModifications)
+            private DocumentCompareOptions(bool tryMergeMetadataConflicts, bool throwOnAttachmentModifications, bool compareDataArchivalMetadata = false)
             {
                 TryMergeMetadataConflicts = tryMergeMetadataConflicts;
                 ThrowOnAttachmentModifications = throwOnAttachmentModifications;
+                CompareDataArchivalMetadata = compareDataArchivalMetadata;
             }
 
             public readonly bool TryMergeMetadataConflicts;
             public readonly bool ThrowOnAttachmentModifications;
+            public readonly bool CompareDataArchivalMetadata;
 
             public static DocumentCompareOptions Default = new DocumentCompareOptions();
 
@@ -30,6 +32,9 @@ namespace Raven.Server.Documents
 
             public static DocumentCompareOptions MergeMetadataAndThrowOnAttachmentModification =
                 new DocumentCompareOptions(tryMergeMetadataConflicts: true, throwOnAttachmentModifications: true);
+            
+            public static DocumentCompareOptions  MergeMetadataAndThrowOnAttachmentModificationCompareDataArchivalMetadata =
+                new DocumentCompareOptions(tryMergeMetadataConflicts: true, throwOnAttachmentModifications: true, compareDataArchivalMetadata: true);
         }
 
         public static unsafe DocumentCompareResult IsEqualTo(BlittableJsonReaderObject original, BlittableJsonReaderObject modified, in DocumentCompareOptions options)
@@ -194,8 +199,8 @@ namespace Raven.Server.Documents
                         }
                         else if (property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false &&
                                  property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) == false &&
-                                 property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase) == false &&
-                                 property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false)
+                                 property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false &&
+                                 (options.CompareDataArchivalMetadata && property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase)) == false)
                             continue;
                     }
                     else if (property.Equals(Constants.Documents.Metadata.Key, StringComparison.OrdinalIgnoreCase))

--- a/src/Raven.Server/Documents/DocumentCompare.cs
+++ b/src/Raven.Server/Documents/DocumentCompare.cs
@@ -194,6 +194,7 @@ namespace Raven.Server.Documents
                         }
                         else if (property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false &&
                                  property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) == false &&
+                                 property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase) == false &&
                                  property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false)
                             continue;
                     }

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -197,8 +197,8 @@ namespace Raven.Server.Documents.Patch
                     {
                         try
                         {
-                            compareResult = DocumentCompare.IsEqualTo(originalDocument.Data, modifiedDoc,
-                                DocumentCompare.DocumentCompareOptions.MergeMetadataAndThrowOnAttachmentModification);
+                            compareResult = DocumentCompare.IsEqualTo(originalDocument.Data, modifiedDoc, 
+                                DocumentCompare.DocumentCompareOptions.MergeMetadataAndThrowOnAttachmentModificationCompareDataArchivalMetadata);
                         }
                         catch (InvalidOperationException ioe)
                         {

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -907,6 +907,11 @@ namespace Raven.Server.Documents.Patch
                     {
                         [Constants.Documents.Metadata.ArchiveAt] = args[1].ToString()
                     };
+                    
+                    // add @archive-at field to args[0] for correct test patch results
+                    var obj = args[0].AsObject();
+                    var meta = obj.Get(Constants.Documents.Metadata.Key).AsObject();
+                    meta.Set(Constants.Documents.Metadata.ArchiveAt, args[1].ToString());
 
                     using (var updated = _docsCtx.ReadObject(doc.Data, archivedDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                     {

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -891,36 +891,23 @@ namespace Raven.Server.Documents.Patch
                 GetDateArg(args[1].ToString(), "archiveAt(doc, utcDateTimeString)", "utcDateTimeString");
                 
                 var archivedDocId = GetIdFromArg(args[0], _unarchiveSignature);
-                using (var doc = _database.DocumentsStorage.Get(_docsCtx, archivedDocId, DocumentFields.Data, throwOnConflict: true))
+                var boi = (BlittableObjectInstance)args[0].AsObject();
+                
+                if(boi.DocumentFlags != null && boi.DocumentFlags.Value.HasFlag(DocumentFlags.Archived))
                 {
-                    if (doc.TryGetMetadata(out var metadata) == false)
-                    {
-                        throw new InvalidOperationException($"Failed to fetch the metadata of document '{archivedDocId}'");
-                    }
-                    
-                    if(doc.Flags.HasFlag(DocumentFlags.Archived))
-                    {
-                        return JsValue.Undefined; // no-op, document already archived
-                    }
-                    // add @archive-at field
-                    metadata.Modifications = new DynamicJsonValue(metadata)
-                    {
-                        [Constants.Documents.Metadata.ArchiveAt] = args[1].ToString()
-                    };
-                    
-                    // add @archive-at field to args[0] for correct test patch results
-                    var obj = args[0].AsObject();
-                    var meta = obj.Get(Constants.Documents.Metadata.Key).AsObject();
-                    meta.Set(Constants.Documents.Metadata.ArchiveAt, args[1].ToString());
-
-                    using (var updated = _docsCtx.ReadObject(doc.Data, archivedDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                    {
-                         _database.DocumentsStorage.Put(_docsCtx, archivedDocId, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction));
-                    }
+                    return JsValue.Undefined; // no-op, document already archived
                 }
                 
+                if(boi.TryGetValue(Constants.Documents.Metadata.Key, out var metadataJs) == false)
+                {
+                    throw new InvalidOperationException($"Failed to fetch the metadata of document '{archivedDocId}'");
+                }
+                
+                // add @archive-at field
+                var metadata = metadataJs.AsObject();
+                metadata.Set(Constants.Documents.Metadata.ArchiveAt, args[1].ToString());
+                
                 return JsValue.Undefined;
-
             }
 
             private JsValue UnarchiveDoc(JsValue self, JsValue[] args)

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Queries;
 using Raven.Client.Util;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -279,6 +280,37 @@ public class DataArchivalPatchingTests : RavenTestBase
                 // Make sure that the company is skipped while indexing
                 var companies = await session.Query<Company>().Where(x => x.Name == "Company Name").ToListAsync();
                 Assert.Equal(0, companies.Count);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Patching)]
+    public void CanTestPatches()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Post { Title = "Post 1", Comments = new Post[] { } });
+
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var command = new PatchOperation.PatchCommand(store.Conventions,
+                    commands.Context,
+                    "posts/1-A",
+                    null,
+                    new PatchRequest { Script = "archived.archiveAt(this, \"2025-06-08T10:21:00.0000000Z\");"},
+                    patchIfMissing: null,
+                    skipPatchIfChangeVectorMismatch: false,
+                    returnDebugInformation: false,
+                    test: true);
+
+                commands.RequestExecutor.Execute(command, commands.Context);
+                var metadata = command.Result.ModifiedDocument[Constants.Documents.Metadata.Key] as BlittableJsonReaderObject;
+                Assert.True(metadata.TryGet(Constants.Documents.Metadata.ArchiveAt, out object _));
             }
         }
     }

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
@@ -285,7 +285,7 @@ public class DataArchivalPatchingTests : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Patching)]
-    public void CanTestPatches()
+    public void ArchiveAtPatchTestResultShouldContainArchiveAtFlag()
     {
         using (var store = GetDocumentStore())
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24390/archive-at-is-missing-in-the-patching-test-results

### Additional description

The test patch treats the patch argument as a result (which can be modified inside), whereas we don't really update it inside the ArchiveAt method - we load it by id and put to the DocumentStorage again, but modified.
This PR modifies the Jint document (argument) to reflect the changes made to the document.

There was also an issue with detecting changes, so I've updated the `ComparePropertiesExceptStartingWithAt` method.
Added passing test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
