### PR TITLE
RavenDB-24642 - GenAI support for images & documents - missing attachment

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -27,6 +27,7 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Raven.Server.Documents.AI;
@@ -157,7 +158,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         return new AiResponse(AiResponseType.Result) { Result = result, Message = msg};
     }
 
-    public async Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, CancellationToken token)
+    public async Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, List<GenAiAttachment> contextOutputAttachments, CancellationToken token)
     {
         if (_forTestingPurposes?.SimulateFailureAsync != null)
             await _forTestingPurposes.SimulateFailureAsync(userPrompt);
@@ -172,7 +173,11 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         var msg2 = new DynamicJsonValue
         {
             [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
-            [Constants.RequestFields.Content] = userPrompt
+            [Constants.RequestFields.Content] = contextOutputAttachments switch
+            {
+                null => userPrompt,
+                _ => CreateContentWithAttachments(userPrompt, contextOutputAttachments)
+            }
         };
 
         var messages = new List<BlittableJsonReaderObject>() { ctx.ReadObject(msg1, "system/msg"), ctx.ReadObject(msg2, "user/msg") };
@@ -182,6 +187,52 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
         return (results.Result.ToString(), usage);
     }
+
+
+    private DynamicJsonArray CreateContentWithAttachments(string context, List<GenAiAttachment> attachments)
+    {
+        var content = new DynamicJsonArray
+        {
+            new DynamicJsonValue
+            {
+                ["type"] = "text",
+                ["text"] = context
+            }
+        };
+
+        foreach (var attachment in attachments)
+        {
+            content.Add(attachment.Type switch
+            {
+                "text/plain" => new DynamicJsonValue
+                {
+                    ["type"] = "text",
+                    ["text"] = attachment.Data
+                },
+                "application/pdf" => new DynamicJsonValue
+                {
+                    ["type"] = "file",
+                    ["file"] = new DynamicJsonValue
+                    {
+                        ["filename"] = attachment.Name,
+                        ["file_data"] = "data:application/pdf;base64," + attachment.Data
+                    }
+                },
+                "image/jpeg" or "image/png" or "image/gif" or "image/webp" => new DynamicJsonValue
+                {
+                    ["type"] = "image_url",
+                    ["image_url"] = new DynamicJsonValue
+                    {
+                        ["url"] = "data:" + attachment.Type + ";base64," + attachment.Data
+                    }
+                },
+                _ => throw new InvalidOperationException("Unknown attachment type: " + attachment.Type)
+            });
+        }
+
+        return content;
+    }
+
     public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, string schema) => CreateCompletionRequest(ctx, messages, tools: null, useTools: false, schema);
 
     public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, List<BlittableJsonReaderObject> tools, bool useTools, string schema)

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -149,7 +149,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             _ = choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal) || msg.TryGet(Constants.ResponseFields.Refusal, out refusal);
 
             //TODO: full output if we get here?
-            throw new RefusedToAnswerException("The request was refused by the model")
+            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}'")
             {
                 Refusal = refusal, FinishReason = finishReason, RequestId = GetRequestId(response.Headers)
             };

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -146,7 +146,8 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         if (string.IsNullOrEmpty(content))
         {
             choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
-            choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal); 
+            _ = choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal) || msg.TryGet(Constants.ResponseFields.Refusal, out refusal);
+
             //TODO: full output if we get here?
             throw new RefusedToAnswerException("The request was refused by the model")
             {

--- a/src/Raven.Server/Documents/AI/IChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/IChatCompletionClient.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI;
@@ -15,7 +17,9 @@ public interface IChatCompletionClient : IDisposable
         @"(?<value>\d+(?:\.\d+)?)(?<unit>ns|us|µs|ms|s|m|h)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant
     );
-    Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, CancellationToken token);
+    Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, List<GenAiAttachment> contextOutputAttachments,
+        CancellationToken token);
+    
     Task<BlittableJsonReaderObject> GetResponseContentAsync(JsonOperationContext context, HttpResponseMessage response, CancellationToken token);
 }
 

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.ETL
 
             DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo, new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo, LoadToFunctionTranslator));
 
-            foreach (var collection in LoadToDestinations)
+            foreach (var collection in LoadToDestinations ?? [])
             {
                 var name = Transformation.LoadTo + collection;
                 DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -140,22 +140,31 @@ namespace Raven.Server.Documents.ETL
 
             var attachmentName = args[0].AsString();
             var loadAttachmentReference = CreateLoadAttachmentReference(attachmentName);
-
+            Attachment attachment = null;
             if ((Current.Document.Flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
             {
-                var attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(Context, Current.DocumentId, attachmentName, AttachmentType.Document, null);
+                attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(Context, Current.DocumentId, attachmentName, AttachmentType.Document, null);
 
                 if (attachment == null)
-                    return JsValue.Null;
-
-                AddLoadedAttachment(loadAttachmentReference, attachmentName, attachment);
+                    UpdateEmptyAttachmentInfo();
             }
             else
             {
-                return JsValue.Null;
+                UpdateEmptyAttachmentInfo();
             }
 
+            AddLoadedAttachment(loadAttachmentReference, attachmentName, attachment);
+
             return loadAttachmentReference;
+
+            void UpdateEmptyAttachmentInfo()
+            {
+                loadAttachmentReference = (JsNull)Activator.CreateInstance(typeof(JsNull), true);
+                attachment = new Attachment()
+                {
+                    Name = Context.GetLazyString(attachmentName)
+                };
+            }
         }
 
         private static JsValue CreateLoadAttachmentReference(string attachmentName)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Operations.AI;
+using System.Linq;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Server.Documents.AI;
 using Sparrow.Json;
@@ -47,10 +48,17 @@ public class ContextOutput
     public bool IsCached { get; set; }
     public string AiHash { get; set; }
 
-    public DynamicJsonValue ToJson() => new()
+    public DynamicJsonValue ToJson()
     {
-        [nameof(Context)] = Context, 
-        [nameof(IsCached)] = IsCached, 
-        [nameof(AiHash)] = AiHash
-    };
+        var json = new DynamicJsonValue
+        {
+            [nameof(Context)] = Context, 
+            [nameof(IsCached)] = IsCached, 
+            [nameof(AiHash)] = AiHash
+        };
+        if (Attachments != null)
+            json[nameof(Attachments)] = new DynamicJsonArray(Attachments.Select(x => x.ToJson()));
+
+        return json;
+    }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
@@ -42,6 +42,8 @@ public class ModelOutput
 public class ContextOutput
 {
     public BlittableJsonReaderObject Context { get; set; }
+    
+    public List<GenAiAttachment> Attachments;
     public bool IsCached { get; set; }
     public string AiHash { get; set; }
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
@@ -1,5 +1,11 @@
-﻿using Sparrow.Json;
+﻿using System.Collections.Generic;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
 
-public record GenAiScriptResult(string DocumentId, BlittableJsonReaderObject Context, string AiHash, bool IsCached);
+public record GenAiAttachment(string Name, string Type, string Data);
+
+public record GenAiScriptResult(string DocumentId, BlittableJsonReaderObject Context, string AiHash, bool IsCached)
+{
+    public List<GenAiAttachment> Attachments;
+}

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
@@ -1,9 +1,38 @@
 ﻿using System.Collections.Generic;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
 
-public record GenAiAttachment(string Name, string Type, string Data);
+public class GenAiAttachment
+{
+    public string Name { get; set; }
+    public string Type { get; set; }
+    public string Data { get; set; }
+
+    public GenAiAttachment()
+    {
+        // for deserialization
+    }
+    public GenAiAttachment(string name, string type, string data)
+    {
+        Name = name;
+        Type = type;
+        Data = data;
+    }
+
+    public DynamicJsonValue ToJson()
+    {
+        var json = new DynamicJsonValue
+        {
+            [nameof(Name)] = Name,
+            [nameof(Type)] = Type,
+            [nameof(Data)] = Data
+        };
+
+        return json;
+    }
+}
 
 public record GenAiScriptResult(string DocumentId, BlittableJsonReaderObject Context, string AiHash, bool IsCached)
 {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -29,13 +29,13 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
     private readonly GenAiConfiguration _configuration;
     private byte[] _configurationPartialHash;
     private List<GenAiScriptResult> _currentRun;
-    private Dictionary<string, Attachment> _attachments;
+    private Dictionary<JsValue, Attachment> _attachments;
     private readonly GenAiStatsScope _stats;
 
     private static readonly string JavaScriptApi = @"
 class AIContextItem {
   #withAttachment(type, data) {
-    if (typeof type !== 'string' || typeof data !== 'string') {
+    if (typeof type !== 'string' || (typeof data !== 'string' && data !== null)) {
         throw new Error('both type and data must be strings');
     }
     this.attachments.push({ type, data });
@@ -119,7 +119,7 @@ var ai = new AI();
     protected override void AddLoadedAttachment(JsValue reference, string name, Attachment attachment)
     {
         _attachments ??= [];
-        _attachments.Add(reference.AsString(), attachment);
+        _attachments.Add(reference, attachment);
     }
 
     protected override void AddLoadedCounter(JsValue reference, string name, long value)
@@ -178,8 +178,14 @@ var ai = new AI();
                 attachmentsHashes ??= [];
                 
                 var attachmentObj = current.AsObject();
-                var data = attachmentObj.GetOwnProperty("data").Value.AsString();
-                attachmentsHashes.Add(_attachments?.TryGetValue(data, out var attachment) is true ? attachment.Base64Hash.ToString() : data);
+                var data = attachmentObj.GetOwnProperty("data").Value;
+                if (data.IsNull())
+                    attachmentsHashes.Add(string.Empty);
+                else
+                {
+                    attachmentsHashes.Add(_attachments?.TryGetValue(data, out var attachment) is true ? attachment?.Base64Hash.ToString() : data.AsString());
+                }
+
                 attachmentsHashes.Add(attachmentObj.GetOwnProperty("type").Value.AsString());
             }
             
@@ -199,29 +205,39 @@ var ai = new AI();
                     foreach (var current in ctxObj.GetOwnProperty("attachments").Value.AsArray())
                     {
                         var attachmentObj = current.AsObject();
-                        var data = attachmentObj.GetOwnProperty("data").Value.AsString();
+                        var reference = attachmentObj.GetOwnProperty("data").Value;
+                        var data = string.Empty;
                         string type = attachmentObj.GetOwnProperty("type").Value.AsString();
                         string filename = "unknown.name";
 
                         // TODO: we aren't being really efficient here in terms of allocations / memory
                         // but the problem is that the API itself may require large BASE64 strings, annoying 
-                        if (_attachments?.TryGetValue(data, out var attachment) is true)
+                        if (_attachments?.TryGetValue(reference, out var attachment) is true)
                         {
                             filename = attachment.Name.ToString(CultureInfo.InvariantCulture);
-                            using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
-                            if (type == "text/plain")
+                            if (reference.IsNull())
                             {
-                                attachment.Stream.CopyTo(memoryStream);
+                                data = $"File '{filename}' (of type '{type}') could not be loaded: file not found";
+                                filename = "file.not.found";
+                                type = "text/plain";
                             }
-                            else // anything but text is using BASE64
+                            else
                             {
-                                using var transform = new ToBase64Transform();
-                                using var cryptoStream = new CryptoStream(attachment.Stream, transform, CryptoStreamMode.Read);
-                                cryptoStream.CopyTo(memoryStream);
-                            }
+                                using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+                                if (type == "text/plain")
+                                {
+                                    attachment.Stream.CopyTo(memoryStream);
+                                }
+                                else // anything but text is using BASE64
+                                {
+                                    using var transform = new ToBase64Transform();
+                                    using var cryptoStream = new CryptoStream(attachment.Stream, transform, CryptoStreamMode.Read);
+                                    cryptoStream.CopyTo(memoryStream);
+                                }
 
-                            Span<byte> readOnlySpan = memoryStream.GetBuffer();
-                            data = Encoding.ASCII.GetString(readOnlySpan[..(int)memoryStream.Length]);
+                                Span<byte> readOnlySpan = memoryStream.GetBuffer();
+                                data = Encoding.ASCII.GetString(readOnlySpan[..(int)memoryStream.Length]);
+                            }
                         }
 
                         result.Attachments.Add(new GenAiAttachment(filename, type, data));

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
 using Jint;
 using Jint.Native;
+using Jint.Native.Function;
 using Jint.Native.Object;
-using Jint.Runtime.Descriptors;
-using Jint.Runtime.Interop;
 using Raven.Client;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ETL;
@@ -16,6 +18,7 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Platform;
 
@@ -25,38 +28,98 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
 {
     private readonly GenAiConfiguration _configuration;
     private byte[] _configurationPartialHash;
-    private readonly PatchRequest _mainScript;
     private List<GenAiScriptResult> _currentRun;
+    private Dictionary<string, Attachment> _attachments;
     private readonly GenAiStatsScope _stats;
 
-    public GenAiScriptTransformer(DocumentDatabase database, DocumentsOperationContext context, Transformation transformation, PatchRequest behaviorFunctions, GenAiConfiguration configuration, GenAiStatsScope stats) : base(database, context, null, behaviorFunctions)
+    private static readonly string JavaScriptApi = @"
+class AIContextItem {
+  #withAttachment(type, data) {
+    if (typeof type !== 'string' || typeof data !== 'string') {
+        throw new Error('both type and data must be strings');
+    }
+    this.attachments.push({ type, data });
+    return this;
+  }
+
+  constructor(ctx) {
+    if (ctx !== null && (typeof ctx !== 'object' || Array.isArray(ctx))) {
+      throw new Error('ctx must be an object');
+    }
+    this.ctx = ctx;
+    this.attachments = [];
+  }
+
+  withText(data) {
+    return this.#withAttachment('text/plain', data);
+  }
+
+  withJpeg(data) {
+    return this.#withAttachment('image/jpeg', data);
+  }
+
+  withPng(data) {
+    return this.#withAttachment('image/png', data);
+  }
+
+  withWebp(data) {
+    return this.#withAttachment('image/webp', data);
+  }
+
+  withGif(data) {
+    return this.#withAttachment('image/gif', data);
+  }
+
+  withPdf(data) {
+    return this.#withAttachment('application/pdf', data);
+  }
+}
+
+class AI {
+  #allContexts = [];
+
+  __retrieveContexts() {
+     const ctxs = this.#allContexts;
+     this.#allContexts = [];
+     return ctxs;
+  }
+
+  genContext(...args) {
+    if (args.length !== 1) {
+      throw new Error('Invalid number of arguments for ai.genContext(ctx)');
+    }
+    const ctx = new AIContextItem(args[0]);
+    this.#allContexts.push(ctx);
+    return ctx;
+  }
+}
+
+var ai = new AI();
+"; 
+
+    public GenAiScriptTransformer(DocumentDatabase database, DocumentsOperationContext context, Transformation transformation, PatchRequest behaviorFunctions, GenAiConfiguration configuration, GenAiStatsScope stats) 
+        : base(database, context, new PatchRequest(transformation.Script, PatchRequestType.GenAi), behaviorFunctions)
     {
         _configuration = configuration;
         _stats = stats.For(EtlOperations.Transform, start: false);
-        _mainScript = new PatchRequest(transformation.Script, PatchRequestType.GenAi);
     }
 
     public override void Initialize(bool debugMode)
     {
-        ReturnMainRun = Database.Scripts.GetScriptRunner(_mainScript, true, out DocumentScript);
-
-        if (DocumentScript == null)
-            return;
-
-        if (debugMode)
-            DocumentScript.DebugMode = true;
-
-        var contextFunc = new ClrFunction(DocumentScript.ScriptEngine, "genContext", AddContext);
-        ObjectInstance aiObject = new JsObject(DocumentScript.ScriptEngine);
-        aiObject.FastSetProperty("genContext", new PropertyDescriptor(contextFunc, false, false, false));
-        DocumentScript.ScriptEngine.SetValue("ai", aiObject);
-
         _configurationPartialHash = GetInitialHash(_configuration);
+
+        base.Initialize(debugMode);
+        JsValue aiAlreadyExists = DocumentScript.ScriptEngine.GetValue("ai");
+        if (aiAlreadyExists.IsNull() || aiAlreadyExists.IsUndefined())
+        {
+            DocumentScript.ScriptEngine.Execute(JavaScriptApi);
+        }
     }
 
     protected override void AddLoadedAttachment(JsValue reference, string name, Attachment attachment)
     {
-        throw new NotSupportedException("Attachment are not supported in GenAI Task");
+        _attachments ??= [];
+        _attachments.Add(reference.AsString(), attachment);
     }
 
     protected override void AddLoadedCounter(JsValue reference, string name, long value)
@@ -91,35 +154,84 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
             Debug.Assert(item.IsDelete is false);
 
             DocumentScript.Run(Context, Context, "execute", [Current.Document]);
+            ProcessScriptResults();
+        }
+    }
+
+    private void ProcessScriptResults()
+    {
+        ObjectInstance ai = DocumentScript.ScriptEngine.GetValue("ai").AsObject();
+        Function retrieveContexts = ai.Prototype!.GetOwnProperty("__retrieveContexts").Value.AsFunctionInstance();
+        JsArray contexts = retrieveContexts.Call(ai, []).AsArray();
+        List<string> attachmentsHashes = null;
+        foreach (var ctx in contexts)
+        {
+            attachmentsHashes?.Clear();
+            
+            ObjectInstance ctxObj = ctx.AsObject();
+            ObjectInstance userSpecificCtx = ctxObj.GetOwnProperty("ctx").Value.AsObject();
+            var context = JsBlittableBridge.Translate(Context, DocumentScript.ScriptEngine, userSpecificCtx);
+            _stats.NumberOfContextObjects++;
+
+            foreach (var current in ctxObj.GetOwnProperty("attachments").Value.AsArray())
+            {
+                attachmentsHashes ??= [];
+                
+                var attachmentObj = current.AsObject();
+                var data = attachmentObj.GetOwnProperty("data").Value.AsString();
+                attachmentsHashes.Add(_attachments?.TryGetValue(data, out var attachment) is true ? attachment.Base64Hash.ToString() : data);
+                attachmentsHashes.Add(attachmentObj.GetOwnProperty("type").Value.AsString());
+            }
+            
+            string hash = CalculateHash(context, attachmentsHashes);
+            var isCached = ShouldSendContext(hash, _configuration.Identifier, Current.Document) == false;
+
+            if (isCached)
+                _stats.TotalCachedContexts++;
+
+            using (context)
+            {
+                var result = new GenAiScriptResult(Current.DocumentId, context.CloneOnTheSameContext(), hash, isCached);
+                if (attachmentsHashes?.Count > 0)
+                {
+                    result.Attachments = [];
+                    
+                    foreach (var current in ctxObj.GetOwnProperty("attachments").Value.AsArray())
+                    {
+                        var attachmentObj = current.AsObject();
+                        var data = attachmentObj.GetOwnProperty("data").Value.AsString();
+                        string type = attachmentObj.GetOwnProperty("type").Value.AsString();
+                        string filename = "unknown.name";
+
+                        // TODO: we aren't being really efficient here in terms of allocations / memory
+                        // but the problem is that the API itself may require large BASE64 strings, annoying 
+                        if (_attachments?.TryGetValue(data, out var attachment) is true)
+                        {
+                            filename = attachment.Name.ToString(CultureInfo.InvariantCulture);
+                            using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+                            if (type == "text/plain")
+                            {
+                                attachment.Stream.CopyTo(memoryStream);
+                            }
+                            else // anything but text is using BASE64
+                            {
+                                using var transform = new ToBase64Transform();
+                                using var cryptoStream = new CryptoStream(attachment.Stream, transform, CryptoStreamMode.Read);
+                                cryptoStream.CopyTo(memoryStream);
+                            }
+
+                            Span<byte> readOnlySpan = memoryStream.GetBuffer();
+                            data = Encoding.ASCII.GetString(readOnlySpan[..(int)memoryStream.Length]);
+                        }
+
+                        result.Attachments.Add(new GenAiAttachment(filename, type, data));
+                    }
+                }
+                _currentRun.Add(result);
+            }
         }
     }
     
-    private JsValue AddContext(JsValue self, JsValue[] args)
-    {
-        const string methodDecl = "ai.genContext(ctx);";
-        if (args.Length != 1)
-            throw new InvalidOperationException($"Invalid number of arguments for {methodDecl}, got {args.Length} but expected 1.");
-
-        if (args[0].IsObject() is false)
-            throw new ArgumentException("Expected 'ctx' to be an object, but was: " + args[0].Type + ", " + args[0]);
-
-        var context = JsBlittableBridge.Translate(Context, DocumentScript.ScriptEngine, args[0].AsObject());
-        _stats.NumberOfContextObjects++;
-
-        string hash = CalculateHash(context);
-        var isCached = ShouldSendContext(hash, _configuration.Identifier, Current.Document) == false;
-
-        if (isCached)
-            _stats.TotalCachedContexts++;
-
-        using (context)
-        {
-            _currentRun.Add(new GenAiScriptResult(Current.DocumentId, context.CloneOnTheSameContext(), hash, isCached));
-        }
-
-        return JsValue.Null;
-    }
-
     private static bool ShouldSendContext(string hash, string taskIdentifier, Document doc)
     {
         if (doc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
@@ -129,7 +241,8 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
 
         foreach (var h in existingHashes)
         {
-            if (string.Equals(hash, h?.ToString(), StringComparison.OrdinalIgnoreCase))
+            // those are base 64 values, they are case _sensitive_
+            if (string.Equals(hash, h?.ToString(), StringComparison.Ordinal))
                 return false; // already sent
         }
 
@@ -165,13 +278,22 @@ internal sealed class GenAiScriptTransformer : EtlTransformer<GenAiItem, GenAiSc
     }
 
     [SkipLocalsInit]
-    private unsafe string CalculateHash(BlittableJsonReaderObject contextObj)
+    private unsafe string CalculateHash(BlittableJsonReaderObject contextObj, List<string> attachmentsHashes)
     {
         var state = stackalloc byte[_configurationPartialHash.Length];
         _configurationPartialHash.CopyTo(new Span<byte>(state, _configurationPartialHash.Length));
 
         if (Sodium.crypto_generichash_update(state, contextObj.BasePointer, (ulong)contextObj.Size) != 0)
             ComputeHttpEtags.ThrowFailedToUpdateHash();
+
+        foreach (string attachmentsHash in attachmentsHashes ?? [])
+        {
+            fixed(char* p = attachmentsHash)
+            {
+                if (Sodium.crypto_generichash_update(state, (byte*)p, (ulong)(sizeof(char) * attachmentsHash.Length)) != 0)
+                    ComputeHttpEtags.ThrowFailedToUpdateHash();
+            }
+        }
 
         var hash = stackalloc byte[Sodium.GenericHashSize];
         if (Sodium.crypto_generichash_final(state, hash, Sodium.GenericHashSize) != 0)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -179,12 +179,8 @@ var ai = new AI();
                 
                 var attachmentObj = current.AsObject();
                 var data = attachmentObj.GetOwnProperty("data").Value;
-                if (data.IsNull())
-                    attachmentsHashes.Add(string.Empty);
-                else
-                {
+                if (data.IsNull() == false)
                     attachmentsHashes.Add(_attachments?.TryGetValue(data, out var attachment) is true ? attachment?.Base64Hash.ToString() : data.AsString());
-                }
 
                 attachmentsHashes.Add(attachmentObj.GetOwnProperty("type").Value.AsString());
             }
@@ -217,8 +213,7 @@ var ai = new AI();
                             filename = attachment.Name.ToString(CultureInfo.InvariantCulture);
                             if (reference.IsNull())
                             {
-                                data = $"File '{filename}' (of type '{type}') could not be loaded: file not found";
-                                filename = "file.not.found";
+                                data = $"File '{filename}' (of type '{type}') could not be loaded: attachment not found";
                                 type = "text/plain";
                             }
                             else

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -197,7 +197,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 Task<(string Result, AiUsage Usage)> task;
                 try
                 {
-                    task = _chatCompletionClient.CompleteAsync(Configuration.Prompt, json, Schema, CancellationToken);
+                    task = _chatCompletionClient.CompleteAsync(Configuration.Prompt, json,Schema,  item.ContextOutput.Attachments, CancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -513,7 +513,8 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 {
                     Context = scriptResult.Context,
                     IsCached = scriptResult.IsCached,
-                    AiHash = scriptResult.AiHash
+                    AiHash = scriptResult.AiHash,
+                    Attachments = scriptResult.Attachments
                 }
             };
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -333,7 +333,20 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         {
             case TestStage.CreateContextObjects:
             case TestStage.ApplyUpdateScript:
-                if (testGenAiScript.Document != null)
+
+                if (testGenAiScript.Document == null && string.IsNullOrEmpty(testGenAiScript.DocumentId))
+                    throw new InvalidOperationException("Document or DocumentId must be provided to run GenAI test");
+
+                if (testGenAiScript.Document != null && string.IsNullOrEmpty(testGenAiScript.DocumentId) == false)
+                {
+                    context.OpenReadTransaction();
+                    document = context.DocumentDatabase.DocumentsStorage.Get(context, testGenAiScript.DocumentId, DocumentFields.Id | DocumentFields.LowerId | DocumentFields.ChangeVector);
+                    if (document == null)
+                        throw new InvalidOperationException($"Document {testGenAiScript.DocumentId} does not exist");
+
+                    document.Data = testGenAiScript.Document;
+                }
+                else if (testGenAiScript.Document != null)
                 {
                     document = new Document
                     {
@@ -344,9 +357,6 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 }
                 else
                 {
-                    if (string.IsNullOrEmpty(testGenAiScript.DocumentId))
-                        throw new InvalidOperationException("Document or DocumentId must be provided to run GenAI test");
-
                     context.OpenReadTransaction();
                     document = context.DocumentDatabase.DocumentsStorage.Get(context, testGenAiScript.DocumentId)?.Clone(context);
                     if (document == null)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/GenAiTestScriptResult.cs
@@ -23,6 +23,11 @@ public class GenAiTestScriptResult : TestEtlScriptResult
 
     public PatchStatus Status;
 
+    public GenAiTestScriptResult()
+    {
+        // for deserialization
+    }
+
     public override DynamicJsonValue ToJson(JsonOperationContext context)
     {
         var json = base.ToJson(context);

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/TestGenAiScript.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/TestGenAiScript.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Documents.ETL.Providers.AI.GenAi.Test
 
         public BlittableJsonReaderObject Document { get; set; }
 
-        public DynamicJsonValue ToJson()
+        public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
             json[nameof(TestStage)] = TestStage;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/TestGenAiScript.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/Test/TestGenAiScript.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.ETL.Test;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.ETL.Providers.AI.GenAi.Test
 {
@@ -12,6 +14,18 @@ namespace Raven.Server.Documents.ETL.Providers.AI.GenAi.Test
         public TestStage TestStage { get; set; }
 
         public BlittableJsonReaderObject Document { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(TestStage)] = TestStage;
+            json[nameof(Document)] = Document;
+
+            if (Input != null)
+                json[nameof(Input)] = new DynamicJsonArray(Input.Select(x => x.ToJson()));
+
+            return json;
+        }
     }
 
     public enum TestStage

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Handlers/Processors/AiEtlHandlerProcessorForTestAiConnectionBase.cs
@@ -98,7 +98,7 @@ internal class AiIntegrationHandlerProcessorForTestAiConnection<TRequestHandler,
                         using (var client = ChatCompletionClient.CreateChatCompletionClient( ServerStore.ContextPool, aiConnectionString))
                         {
                             var schema = ChatCompletionClient.GetSchemaFromSampleObject("{}");
-                            await client.CompleteAsync("foo", "bar", schema, HttpContext.RequestAborted);
+                            await client.CompleteAsync("foo", "bar", schema, null, HttpContext.RequestAborted);
                         }
 
                         break;

--- a/src/Raven.Server/Documents/ETL/Test/TestEtlScript.cs
+++ b/src/Raven.Server/Documents/ETL/Test/TestEtlScript.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Documents.ETL.Test
         public TConfiguration Configuration;
 
 
-        public DynamicJsonValue ToJson() => new DynamicJsonValue()
+        public virtual DynamicJsonValue ToJson() => new DynamicJsonValue()
         {
             [nameof(DocumentId)] = DocumentId,
             [nameof(IsDelete)] = IsDelete,

--- a/src/Raven.Server/Documents/ETL/Test/TestEtlScript.cs
+++ b/src/Raven.Server/Documents/ETL/Test/TestEtlScript.cs
@@ -1,5 +1,6 @@
 ﻿using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.ETL.Test
 {
@@ -12,5 +13,13 @@ namespace Raven.Server.Documents.ETL.Test
         public bool IsDelete;
 
         public TConfiguration Configuration;
+
+
+        public DynamicJsonValue ToJson() => new DynamicJsonValue()
+        {
+            [nameof(DocumentId)] = DocumentId,
+            [nameof(IsDelete)] = IsDelete,
+            [nameof(Configuration)] = Configuration.ToJson()
+        };
     }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/hooks/useEditGenAiTaskTests.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/hooks/useEditGenAiTaskTests.ts
@@ -54,6 +54,7 @@ export function useEditGenAiTaskTests() {
                         Context: JSON.parse(x.value),
                         AiHash: formValues.isForceSendingCachedObjects ? null : x.aiHash,
                         IsCached: formValues.isForceSendingCachedObjects ? false : x.isCached,
+                        Attachments: [], // FIXME
                     },
                     DebugActions: null,
                     DebugOutput: [],
@@ -108,6 +109,7 @@ export function useEditGenAiTaskTests() {
                         IsCached: formValues.isForceSendingCachedObjects
                             ? false
                             : formValues.playgroundContexts[idx].isCached,
+                        Attachments: [],//FIXME
                     },
                     DebugActions: null,
                     DebugOutput: [],

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -712,6 +712,7 @@ namespace Orders
                         },
                         IsCached: true,
                         AiHash: "MWoEsxOgGzl1OZarcxjlIki5ELBagYJjX/uIPHEFcxA=",
+                        Attachments: [], //FIXME
                     },
                     ModelOutput: null,
                 },
@@ -724,6 +725,7 @@ namespace Orders
                         },
                         IsCached: true,
                         AiHash: "tDRYDLQP/Q7sNmY6ZCRCcMUwwGdD1Lp05/Evybr7C0s=",
+                        Attachments: [], //FIXME
                     },
                     ModelOutput: null,
                 },
@@ -765,6 +767,7 @@ namespace Orders
                         },
                         IsCached: true,
                         AiHash: "MWoEsxOgGzl1OZarcxjlIki5ELBagYJjX/uIPHEFcxA=",
+                        Attachments: [], //FIXME
                     },
                     ModelOutput: {
                         Usage: {
@@ -788,6 +791,7 @@ namespace Orders
                         },
                         IsCached: true,
                         AiHash: "tDRYDLQP/Q7sNmY6ZCRCcMUwwGdD1Lp05/Evybr7C0s=",
+                        Attachments: [], //FIXME
                     },
                     ModelOutput: {
                         Usage: {
@@ -849,6 +853,7 @@ namespace Orders
                         },
                         IsCached: true,
                         AiHash: "MWoEsxOgGzl1OZarcxjlIki5ELBagYJjX/uIPHEFcxA=",
+                        Attachments: [], //FIXME
                     },
                     ModelOutput: {
                         Usage: {
@@ -872,6 +877,7 @@ namespace Orders
                         },
                         IsCached: true,
                         AiHash: "tDRYDLQP/Q7sNmY6ZCRCcMUwwGdD1Lp05/Evybr7C0s=",
+                        Attachments: [], //FIXME
                     },
                     ModelOutput: {
                         Usage: {

--- a/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
@@ -59,7 +59,7 @@ public class ChatCompletionClientTests : RavenTestBase
             var context =
                 "{\"Text\":\"Surefire investment property in caiman islands, win $$$$ for sure, qucik!\",\"Author\":\"homepage\",\"Id\":\"2236672c-b941-4855-999e-5374f41cbddd\"}";
 
-            var res = await client.CompleteAsync(prompt, context, defaultJsonSchema, default);
+            var res = await client.CompleteAsync(prompt, context, defaultJsonSchema, null, default);
             var answer = JsonConvert.DeserializeObject<AiCommentResult>(res.Result); // check if it can be parsed to json, if cannot parse it throws
             Assert.NotNull(answer.Blocked);
             Assert.False(string.IsNullOrEmpty(answer.Reason));
@@ -91,7 +91,7 @@ public class ChatCompletionClientTests : RavenTestBase
             configuration.Connection.OpenAiSettings.ApiKey += "xyz"; // wrong api key
             using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
             {
-                var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, default));
+                var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, null, default));
                 Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
             }
             configuration.Connection.OpenAiSettings.ApiKey = 
@@ -103,7 +103,7 @@ public class ChatCompletionClientTests : RavenTestBase
         {
             using var cts = new CancellationTokenSource();
             await cts.CancelAsync();
-            await Assert.ThrowsAsync<TaskCanceledException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, cts.Token));
+            await Assert.ThrowsAsync<TaskCanceledException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, null, cts.Token));
         }
 
         using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
@@ -117,14 +117,14 @@ public class ChatCompletionClientTests : RavenTestBase
                 writer.WriteEndObject();
             };
 
-            var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, default));
+            var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, null, default));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
         SetModel("gpt-4kabcdefg", out var originalModel); // wrong model name
         using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
         {
-            var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, default));
+            var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, null, default));
             Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
         }
         SetModel(originalModel, out _); // back to the original model name
@@ -156,7 +156,7 @@ public class ChatCompletionClientTests : RavenTestBase
                  <p><b>404.</b> <ins>That's an error.</ins>
                  <p>The requested URL <code>/v1/chat/completions</code> was not found on this server.  <ins>That's all we know.</ins>
              */
-            await Assert.ThrowsAsync<InvalidDataException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, default));
+            await Assert.ThrowsAsync<InvalidDataException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, null, default));
         }
 
 
@@ -219,14 +219,14 @@ public class ChatCompletionClientTests : RavenTestBase
             // Should throw at least once
             await Assert.ThrowsAsync<RefusedToAnswerException>(async () =>
             {
-                await client.CompleteAsync(promptA, context1A, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(promptA, context2A, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(prompt0B, contextB, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(prompt1B, contextB, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(prompt2B, contextB, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(prompt3B, contextB, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(prompt4B, contextB, jsonSchemaForRefusing, default);
-                await client.CompleteAsync(prompt5B, contextB, jsonSchemaForRefusing, default);
+                await client.CompleteAsync(promptA, context1A, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(promptA, context2A, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(prompt0B, contextB, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(prompt1B, contextB, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(prompt2B, contextB, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(prompt3B, contextB, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(prompt4B, contextB, jsonSchemaForRefusing, null, default);
+                await client.CompleteAsync(prompt5B, contextB, jsonSchemaForRefusing, null, default);
             });
         }
     }

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24621.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24621.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_24621(ITestOutputHelper output) : RavenTestBase(output)
+{
+    public record Item(ImageDescription[] ImageDescriptions = null);
+    
+    public record ImageDescription(string Description, bool SafeForWork, string[] Tags);
+    
+    const string HeartPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=";
+
+    // TODO: Things to test
+    //  - missing attachment
+    //  - updating attachment - see that it updates
+    //  - removing an attachment - what does it do?
+    //  - pdf reading
+    //  - jpeg / gif as well
+    //  - need specific model for vision? 
+    //  - test with multiple attachments
+    //  - withJpeg('image.jpg') <-- should validate that this is an error (not base64)
+    //  - withJpeg(this.ImageBase64) <-- should work
+    
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task CanUseModelToDescribeImages(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images";
+        config.Collection = "Items";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            ImageDescriptions = new[]
+            {
+                new {
+                    Description = "Detailed description of the image", 
+                    SafeForWork = true,
+                    Tags = new[]{"matching tags for the image"}
+                }
+            }
+        });
+        config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+ai.genContext({})
+    .withPng(loadAttachment('image.png'));
+"
+        };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Item(null), "items/1");
+            session.Advanced.Attachments.Store("items/1", "image.png", new MemoryStream(Convert.FromBase64String(HeartPngBase64)));
+            await session.SaveChangesAsync();
+        }
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120 )));
+        using (var session = store.OpenAsyncSession())
+        {
+            var item = await session.LoadAsync<Item>("items/1");
+            Assert.NotNull(item.ImageDescriptions);
+        }
+    }
+    
+    
+    private record Summary(string Category, decimal TotalSpent, int TransactionCount, string Notes);
+
+    private record Transaction(string User, DateTime Date, string Location, Summary[] Summary = null);
+    
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task CanAttachTextFile(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Categorize the expenses in the associated file";
+        config.Collection = "Transactions";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            Summary = new[]
+            {
+                new {
+                    Category = "Expense category (food | entertainment | utilities | education)", 
+                    TotalSpent = 10m,
+                    TransctionCount = 5,
+                    Notes = "General observations on this expense category based on the actual expenses (spend too much on takeout or fees are high on utility, etc)"
+                }
+            }
+        });
+        config.UpdateScript = @"this.Summary = $output.Summary;";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+ai.genContext({
+    Date: this.Date,
+    Location: this.Location,
+})
+    .withText(loadAttachment('transactions.csv'));
+"
+        };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Transaction("users/1", new DateTime(2025, 1, 1), "New York"), "txs/2025-01-01");
+            session.Advanced.Attachments.Store("txs/2025-01-01", "transactions.csv", new MemoryStream(Csv.ToArray()));
+            await session.SaveChangesAsync();
+        }
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120 )));
+        using (var session = store.OpenAsyncSession())
+        {
+            Transaction tx = await session.LoadAsync<Transaction>("txs/2025-01-01");
+            Assert.NotNull(tx.Summary);
+        }
+
+    }
+
+    private static ReadOnlySpan<byte> Csv => @"Date,Description,Category,Amount
+2025-01-01,Grocery Store,Food,45.32
+2025-01-02,Utility Bill,Utilities,120.75
+2025-01-03,Online Shopping,Retail,89.99
+2025-01-04,Gas Station,Transportation,35.50
+2025-01-05,Restaurant,Food,62.10
+2025-01-06,Internet Bill,Utilities,79.99
+2025-01-07,Pharmacy,Health,22.45
+2025-01-08,Streaming Service,Entertainment,14.99
+2025-01-09,Gym Membership,Fitness,40.00
+2025-01-10,Clothing Store,Retail,75.20
+2025-01-11,Coffee Shop,Food,8.75
+2025-01-12,Car Insurance,Transportation,95.00
+2025-01-13,Home Depot,Home,130.25
+2025-01-14,Pet Supplies,Pet Care,28.60
+2025-01-15,Doctor Visit,Health,50.00
+2025-01-16,Grocery Store,Food,53.80
+2025-01-17,Movie Theater,Entertainment,22.00
+2025-01-18,Phone Bill,Utilities,65.30
+2025-01-19,Bookstore,Retail,19.95
+2025-01-20,Auto Repair,Transportation,210.50
+2025-01-21,Fast Food,Food,12.65
+2025-01-22,Charity Donation,Miscellaneous,25.00
+2025-01-23,Hair Salon,Personal Care,45.00
+2025-01-24,Grocery Store,Food,60.15
+2025-01-25,Online Subscription,Entertainment,9.99"u8;
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_24642(ITestOutputHelper output) : RavenTestBase(output)
+{
+
+    public record Item(ImageDescription[] ImageDescriptions = null);
+
+    public record ImageDescription(string Description, bool SafeForWork, string[] Tags);
+
+    private const string HeartPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=";
+
+    private const string PngScript = @"
+ai.genContext({})
+    .withPng(loadAttachment('image.png'));
+";
+
+    public const string PngScriptWithoutNull = @"
+const img1 = loadAttachment('image.png');
+if (!img1) {
+    return;
+}
+
+ai.genContext({}).withPng(img1);
+";
+
+    private const string NonEmptyAnswerHint = " ;Always provide a valid structured response matching the schema (if you have an empty answer - please return default values instead)";
+
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
+        Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
+        Data = new object[] { false })]
+    public async Task CanProcessNonExistedImageAttachment(Options options, GenAiConfiguration config, bool withNullAttachments)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images." + NonEmptyAnswerHint;
+        config.Collection = "Items";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            ImageDescriptions = new[]
+            {
+                new { 
+                    Description = "Detailed description of the image", 
+                    SafeForWork = true, 
+                    Tags = new[]
+                    {
+                        "matching tags for the image"
+                    }
+                }
+            }
+        });
+        config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
+        config.GenAiTransformation = new GenAiTransformation { Script = withNullAttachments ? PngScript : PngScriptWithoutNull };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var noneDescription = "None" + Guid.NewGuid();
+        var none = new ImageDescription[] { new ImageDescription(noneDescription, false, new string[] { "None" }) };
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Item(none), "items/1");
+            await session.StoreAsync(new Item(none), "items/2");
+            var doc3 = new Item(none);
+            await session.StoreAsync(doc3, "Doc/3");
+            session.Advanced.GetMetadataFor(doc3)["@collection"] = "Docs"; // store doc3 in another collection
+
+            using var file1 = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            using var file2 = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+
+            session.Advanced.Attachments.Store("items/1", "image.png", file1);
+            session.Advanced.Attachments.Store("Doc/3", "image.png", file2);
+            await session.SaveChangesAsync();
+        }
+
+         Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+        await WaitForAssertionAsync(async () =>
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var item1 = await session.LoadAsync<Item>("items/1");
+                var item2 = await session.LoadAsync<Item>("items/2");
+                var doc3 = await session.LoadAsync<Item>("Doc/3");
+                Assert.NotNull(item1.ImageDescriptions);
+                Assert.NotNull(item2.ImageDescriptions);
+                Assert.NotNull(doc3.ImageDescriptions);
+                Assert.True(doc3.ImageDescriptions.Any(d => d.Description == noneDescription)); // shouldn't change - because it's not in 'Items' collection
+
+                Assert.False(item1.ImageDescriptions.Any(d => d.Description == noneDescription));
+                var item2Changed = item2.ImageDescriptions.Any(d => d.Description == noneDescription) == false;
+                if (withNullAttachments)
+                    Assert.True(item2Changed || ValidateRefusalNotification(db));
+                else
+                    Assert.False(item2Changed);
+            }
+        }, TimeSpan.FromSeconds(15));
+    }
+
+    private static bool ValidateRefusalNotification(DocumentDatabase db)
+    {
+        using (db.NotificationCenter.GetStored(out var actions))
+        {
+            var jsonAlerts = actions.ToList();
+            if (jsonAlerts.Count == 0)
+                return false;
+            var bjro = jsonAlerts.First().Json;
+
+            return bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
+                details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
+                errors.Length > 0 &&
+                errors.First().ToString()!.Contains("The request was refused by the model");
+        }
+    }
+
+    private record Summary(string Category, decimal TotalSpent, int TransactionCount, string Notes);
+
+    private record Transaction(string User, DateTime Date, string Location, Summary[] Summary = null);
+
+
+    private const string Script =
+        @"
+ai.genContext({
+    Date: this.Date,
+    Location: this.Location,
+})
+    .withText(loadAttachment('transactions.csv'));
+";
+
+    public const string ScriptWithoutNull = @"
+const file = loadAttachment('transactions.csv');
+if (!file) {
+    return;
+}
+
+ai.genContext({
+    Date: this.Date,
+    Location: this.Location,
+}).withText(file);
+";
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
+        Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
+        Data = new object[] { false })]
+    public async Task CanProcessNonExistedTextAttachment(Options options, GenAiConfiguration config, bool withNullAttachments)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Categorize the expenses in the associated file. " + NonEmptyAnswerHint;
+        config.Collection = "Transactions";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            Summary = new[]
+            {
+                new {
+                    Category = "Expense category (food | entertainment | utilities | education)",
+                    TotalSpent = 10m,
+                    TransctionCount = 5,
+                    Notes = "General observations on this expense category based on the actual expenses (spend too much on takeout or fees are high on utility, etc)"
+                }
+            }
+        });
+        config.UpdateScript = @"this.Summary = $output.Summary;";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = withNullAttachments ? Script : ScriptWithoutNull
+        };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var noneNotes = "None" + Guid.NewGuid();
+        var none = new Summary[] { new Summary("None", 0, 0, noneNotes) };
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Transaction("Transaction/1", new DateTime(2025, 1, 1), "New York", none), "Transaction/1");
+            await session.StoreAsync(new Transaction("Transaction/2", new DateTime(2025, 1, 2), "New York", none), "Transaction/2");
+            var doc3 = new Transaction("doc/3", new DateTime(2025, 1, 1), "New York", none);
+            await session.StoreAsync(doc3, "Doc/3");
+            session.Advanced.GetMetadataFor(doc3)["@collection"] = "Docs"; // store doc3 in another collection
+
+            using var file1 = new MemoryStream(Csv.ToArray());
+            using var file2 = new MemoryStream(Csv.ToArray());
+
+            session.Advanced.Attachments.Store("Transaction/1", "transactions.csv", file1);
+            session.Advanced.Attachments.Store("Doc/3", "transactions.csv", file2);
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+        await WaitForAssertionAsync(async () =>
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var transaction1 = await session.LoadAsync<Transaction>("Transaction/1");
+                var transaction2 = await session.LoadAsync<Transaction>("Transaction/2");
+                var doc3 = await session.LoadAsync<Transaction>("Doc/3");
+                Assert.NotNull(transaction1.Summary);
+                Assert.NotNull(transaction2.Summary);
+                Assert.NotNull(doc3.Summary);
+                Assert.True(doc3.Summary.Any(d => d.Notes == noneNotes)); // shouldn't change - because it's not in 'Transaction' collection
+
+                Assert.False(transaction1.Summary.Any(d => d.Notes == noneNotes));
+                var transaction2Changed = transaction2.Summary.Any(d => d.Notes == noneNotes) == false;
+                if (withNullAttachments)
+                    Assert.True(transaction2Changed || ValidateRefusalNotification(db));
+                else
+                    Assert.False(transaction2Changed);
+            }
+        }, TimeSpan.FromSeconds(15));
+
+
+    }
+
+    private static ReadOnlySpan<byte> Csv => @"Date,Description,Category,Amount
+2025-01-01,Grocery Store,Food,45.32
+2025-01-02,Utility Bill,Utilities,120.75
+2025-01-03,Online Shopping,Retail,89.99
+2025-01-04,Gas Station,Transportation,35.50
+2025-01-05,Restaurant,Food,62.10
+2025-01-06,Internet Bill,Utilities,79.99
+2025-01-07,Pharmacy,Health,22.45
+2025-01-08,Streaming Service,Entertainment,14.99
+2025-01-09,Gym Membership,Fitness,40.00
+2025-01-10,Clothing Store,Retail,75.20
+2025-01-11,Coffee Shop,Food,8.75
+2025-01-12,Car Insurance,Transportation,95.00
+2025-01-13,Home Depot,Home,130.25
+2025-01-14,Pet Supplies,Pet Care,28.60
+2025-01-15,Doctor Visit,Health,50.00
+2025-01-16,Grocery Store,Food,53.80
+2025-01-17,Movie Theater,Entertainment,22.00
+2025-01-18,Phone Bill,Utilities,65.30
+2025-01-19,Bookstore,Retail,19.95
+2025-01-20,Auto Repair,Transportation,210.50
+2025-01-21,Fast Food,Food,12.65
+2025-01-22,Charity Donation,Miscellaneous,25.00
+2025-01-23,Hair Salon,Personal Care,45.00
+2025-01-24,Grocery Store,Food,60.15
+2025-01-25,Online Subscription,Entertainment,9.99"u8;
+
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
@@ -1,12 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
+using Raven.Client;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Json;
 using Raven.Server.Documents;
 using Sparrow.Json;
 using Tests.Infrastructure;
@@ -22,7 +26,11 @@ public class RavenDB_24642(ITestOutputHelper output) : RavenTestBase(output)
 
     public record ImageDescription(string Description, bool SafeForWork, string[] Tags);
 
-    private const string HeartPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=";
+    private const string HeartPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=";
+
+    private const string StarPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAB59JREFUeJzdmweMFVUUhn+asPQmrNKbiKhEKZoooCuyGFA6xEAgsqi0xJAgGMQQUZqAgpSIIgQCBgKIoC4QkCZSDIIgVRBW2lKUtvR2PP/cebNv+2N35t3ISb7kheybe/43d+5pA2DHyikNLK0ddcuv9FJGKEUs+xIVK6/MVzYrtS37EhV7Ubmk3FVet+xL4JZP+UQRl2+UB6x6FLBVUDYhVfA+3OeHV4JyPl8+SMGCjuCbynDLPgVqPyhSty6keXPvLm+H2er3ncUoF/Pnh/TrBxk5ElK4sCP4tvKQZd8CsTaKVK0KWbUKsmcPpH597y6/ifvsLpdRvlakQwfI1auQO3cgffp4ghOVylY99NkaKn8rMnkyRMSwYIF3eDEuv2TXRX/tXUXq1IHs2pUq+PBhSNOm3l0eb9lH36ys8pMigwdDrlxJFXzrFmTCBE/wNqWGVU99sleVk4qsXp0qNgTvOIzgCzBFxf/eZipStizk9u2Mgknt2p7o7y37mmdj+ZfM2NuzZ+ZiyaBBkEKFHMEpSmnLPufJmihSrhxk3rysBa9cCalSxbvLr1j2OddWWBmtOGnkhQtZC755E9KmjSd4ulLCque5tCeVvSwUxozJWmyI6dMhBQo4go8pz1r2PVfWU7lbvjxk48acBe/YAalRw7vL71j2PYMx7+WWZYytqtRVnlaaKfFKJ2WLIv37Q1JSchZ8/Tpk2DBP8O9KB5juCM+Bx9112B6KyavztV1HWyrtle7KW8pAZZgySpmkzIDpUCxVVis/u6JY3v2h7FcOw2zJ0zC1rixdCrl7N2fBZP16TzC/e0pJUv5U9rjrbFU2KquU71x/vlA+VT5WBiv9lTeUjjAH4AswjwjT20cpuLOSjNQuhG8UKQI5fz4yseTaNUipUr77cQcmqTmEsGYDt83a8D+sXBnSpIk5YVu3hnTpYmIptyhTxOHDIePGQaZNg8yaBVm4EJKYCFm7FrJtG2TvXsjx45GLDXH0KGTnTsjmzSZcLVkCmTvXrDN+PGTECBO3WVPTn/btIfHxJidv0MDk6xUrZhDNVlI7hJWgBWCew8TQVqxXD7JsGeTIEciJE5AzZ8zdYi7MMBLpNg2CGzcgly8bf06dghw7ZgqRffsgy5dD2rZNc3cPKs8ji2YhOw8/hn6Zdu0g+/fbE3avJCdD+vb1srZQQdIiM6HhVlzprVznl8qUMVkSKxvbgrKCu42PAbspYdv4I+XBnMSGjDkw2y48cSU2FjJjhtlGtsVltr35nPO8cYX+q0xVSkYqNmScATE8OaVdhQqQsWPtC0zP7NmQmjU9seycfODu0lxbFZi4x9GIcyImJdkXykN06FAIU1dX7BHlCfjUDKyjLFFusAfVqRNk+3Z7Yg8cgPTuDSle3GvzroFJnHy1msocRVjfNmxo5wQ/dw4SF+c1/8hyBDiu4XZhG+YsFytZEjJzZtadDD/hSbx4sZlauEIvKp8rBYMSGzIG8LdhUjWpVg0yalTa5pzfMCSyvRsm9oQyBOZNgqhYIZiqiEWCMzLh6CQI0ayiGHaKFfPEXlW6woeqKTcWC3dARnr1MhMFP7fxgAHmzHDXWKc8Y0NouLHwYArnJPN+59gJCZ5YlqAsY63PoFhj7lBk4kT/tzSfXRjBu5R6VpW6xkL7TtGikC1b/Be8davJ8mASn06WtTrGToOT3rGW9Vswr9mypXeXR1rW6uTbnBY4jQKeqH4LZnEwZIgnmAdk4HE3O+NMlwW2TJ3qv9gQK1Z4grmW1RYuF09hP/ngweAEnzzp9axZDfW1Kbif4oxJInWecZrFOrmXmF2pkneXv7Qp+Dcg+0FZOGzs9ehhMjPCz+xDRfLd7t3TbGsrxvbJDaZ8kyZl7yxTzjVrII0aeW/uOLU1PzdubPrRfO8ju2twcB4T4/Wsy9oQHEenOR7ZsCFrRy9dMglJ2HSQDq9TNrifnQJkypTsW0j8wfh37jWaRVssiwcn/rZqZUJHegfZyuWd4w8S1pXga4etYcIZeQ1mmuD8DXvKmzZl3jBkk75FC+86bKhHNTxVgulhOzEyvXNMFlg91aqV5nUGdkweSecoPzNdXAZzAjslIBvuPJnTX3fgQO96HLPERlEvGsEdz8yfnzGEcFLBMYvrHEtIzqiye+54Hnyo/MPvME3t2BFy9mzaa8+Z412Tr0A9FajCdMaBlZPj8o06OsPnj9M/TvuRWrd+C/MGbaQWGgRcg9seHj06dT7FUBb2PkiCz5qyNU4SnVnO6dOQ3bsh3bpBSpTwnOEkcZDycC6uzS7p+8pfvFbp0qZpeOiQmSx07uytMcUnLTkaOw2/cNGuXSGLFplw4zrBcHMAJgPLy6HCNhJnw0nudZ1cnXMjng3uv3H4VywPa0RsrH85u3XCRFj3kB3/PkpRH9cqBbNT2MNy4nb16t56nIrE+7hWlsYXzW4hdYbD543/YYPD5yD+lwrv4svKTrhx24Wzr/cCWC+DfRa2KIV/BdOoD9rYe16AtD/2gqAXZcLBnjS7/b8qz8EkENEyngvsofFQ5HnBkBdoj4tJApMI3uXHglwoB6NovtLIuF01yIV4SDAGR+V0zMH40jnL07h7+dJ/6BKDgg9Udu4AAAAASUVORK5CYII=";
 
     private const string PngScript = @"
 ai.genContext({})
@@ -38,7 +46,8 @@ if (!img1) {
 ai.genContext({}).withPng(img1);
 ";
 
-    private const string NonEmptyAnswerHint = " ;Always provide a valid structured response matching the schema (if you have an empty answer - please return default values instead)";
+    private const string NonEmptyAnswerHint =
+        " ;Always provide a valid structured response matching the schema (if you have no answer or an empty answer - please return default values instead)";
 
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -57,14 +66,7 @@ ai.genContext({}).withPng(img1);
         {
             ImageDescriptions = new[]
             {
-                new { 
-                    Description = "Detailed description of the image", 
-                    SafeForWork = true, 
-                    Tags = new[]
-                    {
-                        "matching tags for the image"
-                    }
-                }
+                new { Description = "Detailed description of the image", SafeForWork = true, Tags = new[] { "matching tags for the image" } }
             }
         });
         config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
@@ -72,16 +74,16 @@ ai.genContext({}).withPng(img1);
 
         await store.Maintenance.SendAsync(new AddGenAiOperation(config));
 
-        var noneDescription = "None" + Guid.NewGuid();
-        var none = new ImageDescription[] { new ImageDescription(noneDescription, false, new string[] { "None" }) };
+        var marker = new ImageDescription("None" + Guid.NewGuid(), false, new string[] { "None" });
+        var markerArr = new ImageDescription[] { marker };
 
         var etl = Etl.WaitForEtlToComplete(store);
 
         using (var session = store.OpenAsyncSession())
         {
-            await session.StoreAsync(new Item(none), "items/1");
-            await session.StoreAsync(new Item(none), "items/2");
-            var doc3 = new Item(none);
+            await session.StoreAsync(new Item(markerArr), "items/1");
+            await session.StoreAsync(new Item(markerArr), "items/2");
+            var doc3 = new Item(markerArr);
             await session.StoreAsync(doc3, "Doc/3");
             session.Advanced.GetMetadataFor(doc3)["@collection"] = "Docs"; // store doc3 in another collection
 
@@ -93,52 +95,35 @@ ai.genContext({}).withPng(img1);
             await session.SaveChangesAsync();
         }
 
-         Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
-        await WaitForAssertionAsync(async () =>
+        using (var session = store.OpenAsyncSession())
         {
-            using (var session = store.OpenAsyncSession())
-            {
-                var item1 = await session.LoadAsync<Item>("items/1");
-                var item2 = await session.LoadAsync<Item>("items/2");
-                var doc3 = await session.LoadAsync<Item>("Doc/3");
-                Assert.NotNull(item1.ImageDescriptions);
-                Assert.NotNull(item2.ImageDescriptions);
-                Assert.NotNull(doc3.ImageDescriptions);
-                Assert.True(doc3.ImageDescriptions.Any(d => d.Description == noneDescription)); // shouldn't change - because it's not in 'Items' collection
+            var item1 = await session.LoadAsync<Item>("items/1");
+            var item2 = await session.LoadAsync<Item>("items/2");
+            var doc3 = await session.LoadAsync<Item>("Doc/3");
+            Assert.NotNull(item1.ImageDescriptions);
+            Assert.NotNull(item2.ImageDescriptions);
+            Assert.NotNull(doc3.ImageDescriptions);
+            Assert.True(doc3.ImageDescriptions.Any(d => d.Description == marker.Description)); // shouldn't change - because it's not in 'Items' collection
 
-                Assert.False(item1.ImageDescriptions.Any(d => d.Description == noneDescription));
-                var item2Changed = item2.ImageDescriptions.Any(d => d.Description == noneDescription) == false;
-                if (withNullAttachments)
-                    Assert.True(item2Changed || ValidateRefusalNotification(db));
-                else
-                    Assert.False(item2Changed);
-            }
-        }, TimeSpan.FromSeconds(15));
-    }
-
-    private static bool ValidateRefusalNotification(DocumentDatabase db)
-    {
-        using (db.NotificationCenter.GetStored(out var actions))
-        {
-            var jsonAlerts = actions.ToList();
-            if (jsonAlerts.Count == 0)
-                return false;
-            var bjro = jsonAlerts.First().Json;
-
-            return bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
-                details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
-                errors.Length > 0 &&
-                errors.First().ToString()!.Contains("The request was refused by the model");
+            Assert.False(item1.ImageDescriptions.Any(d => d.Description == marker.Description));
+            var item2Changed = item2.ImageDescriptions.Any(d => d.Description == marker.Description) == false;
+            if (withNullAttachments)
+                Assert.True(item2Changed || ValidateRefusalNotification(db));
+            else
+                Assert.False(item2Changed);
         }
+
+        // Update/delete - Assert hashes
+        await AssertHashes<Item>(store, "items/1", "items/2", "image.png", () => new MemoryStream(Convert.FromBase64String(StarPngBase64)), withNullAttachments);
     }
 
     private record Summary(string Category, decimal TotalSpent, int TransactionCount, string Notes);
 
     private record Transaction(string User, DateTime Date, string Location, Summary[] Summary = null);
-
 
     private const string Script =
         @"
@@ -160,88 +145,6 @@ ai.genContext({
     Location: this.Location,
 }).withText(file);
 ";
-
-    [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
-        Data = new object[] { true })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
-        Data = new object[] { false })]
-    public async Task CanProcessNonExistedTextAttachment(Options options, GenAiConfiguration config, bool withNullAttachments)
-    {
-        using var store = GetDocumentStore(options);
-        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
-
-        config.Prompt = "Categorize the expenses in the associated file. " + NonEmptyAnswerHint;
-        config.Collection = "Transactions";
-        config.SampleObject = JsonConvert.SerializeObject(new
-        {
-            Summary = new[]
-            {
-                new {
-                    Category = "Expense category (food | entertainment | utilities | education)",
-                    TotalSpent = 10m,
-                    TransctionCount = 5,
-                    Notes = "General observations on this expense category based on the actual expenses (spend too much on takeout or fees are high on utility, etc)"
-                }
-            }
-        });
-        config.UpdateScript = @"this.Summary = $output.Summary;";
-        config.GenAiTransformation = new GenAiTransformation
-        {
-            Script = withNullAttachments ? Script : ScriptWithoutNull
-        };
-
-        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
-
-        var noneNotes = "None" + Guid.NewGuid();
-        var none = new Summary[] { new Summary("None", 0, 0, noneNotes) };
-
-        var etl = Etl.WaitForEtlToComplete(store);
-
-        using (var session = store.OpenAsyncSession())
-        {
-            await session.StoreAsync(new Transaction("Transaction/1", new DateTime(2025, 1, 1), "New York", none), "Transaction/1");
-            await session.StoreAsync(new Transaction("Transaction/2", new DateTime(2025, 1, 2), "New York", none), "Transaction/2");
-            var doc3 = new Transaction("doc/3", new DateTime(2025, 1, 1), "New York", none);
-            await session.StoreAsync(doc3, "Doc/3");
-            session.Advanced.GetMetadataFor(doc3)["@collection"] = "Docs"; // store doc3 in another collection
-
-            using var file1 = new MemoryStream(Csv.ToArray());
-            using var file2 = new MemoryStream(Csv.ToArray());
-
-            session.Advanced.Attachments.Store("Transaction/1", "transactions.csv", file1);
-            session.Advanced.Attachments.Store("Doc/3", "transactions.csv", file2);
-            await session.SaveChangesAsync();
-        }
-
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
-
-        var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-
-        await WaitForAssertionAsync(async () =>
-        {
-            using (var session = store.OpenAsyncSession())
-            {
-                var transaction1 = await session.LoadAsync<Transaction>("Transaction/1");
-                var transaction2 = await session.LoadAsync<Transaction>("Transaction/2");
-                var doc3 = await session.LoadAsync<Transaction>("Doc/3");
-                Assert.NotNull(transaction1.Summary);
-                Assert.NotNull(transaction2.Summary);
-                Assert.NotNull(doc3.Summary);
-                Assert.True(doc3.Summary.Any(d => d.Notes == noneNotes)); // shouldn't change - because it's not in 'Transaction' collection
-
-                Assert.False(transaction1.Summary.Any(d => d.Notes == noneNotes));
-                var transaction2Changed = transaction2.Summary.Any(d => d.Notes == noneNotes) == false;
-                if (withNullAttachments)
-                    Assert.True(transaction2Changed || ValidateRefusalNotification(db));
-                else
-                    Assert.False(transaction2Changed);
-            }
-        }, TimeSpan.FromSeconds(15));
-
-
-    }
-
     private static ReadOnlySpan<byte> Csv => @"Date,Description,Category,Amount
 2025-01-01,Grocery Store,Food,45.32
 2025-01-02,Utility Bill,Utilities,120.75
@@ -269,4 +172,409 @@ ai.genContext({
 2025-01-24,Grocery Store,Food,60.15
 2025-01-25,Online Subscription,Entertainment,9.99"u8;
 
+    private static ReadOnlySpan<byte> Csv2 => @"Date,Description,Category,Amount
+2025-01-01,Grocery Store,Food,45.32
+2025-01-02,Utility Bill,Utilities,120.75
+2025-01-03,Online Shopping,Retail,89.99
+2025-01-04,Gas Station,Transportation,35.50
+2025-01-05,Restaurant,Food,62.10
+2025-01-06,Internet Bill,Utilities,79.99"u8;
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
+        Data = new object[] { true })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false,
+        Data = new object[] { false })]
+    public async Task CanProcessNonExistedTextAttachment(Options options, GenAiConfiguration config, bool withNullAttachments)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Categorize the expenses in the associated file. " + NonEmptyAnswerHint;
+        config.Collection = "Transactions";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            Summary = new[]
+            {
+                new
+                {
+                    Category = "Expense category (food | entertainment | utilities | education)",
+                    TotalSpent = 10m,
+                    TransctionCount = 5,
+                    Notes =
+                        "General observations on this expense category based on the actual expenses (spend too much on takeout or fees are high on utility, etc)"
+                }
+            }
+        });
+        config.UpdateScript = @"this.Summary = $output.Summary;";
+        config.GenAiTransformation = new GenAiTransformation { Script = withNullAttachments ? Script : ScriptWithoutNull };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var marker = new Summary("None", 0, 0, "None" + Guid.NewGuid());
+        var markerArray = new Summary[] { marker };
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Transaction("Transaction/1", new DateTime(2025, 1, 1), "New York", markerArray), "Transaction/1");
+            await session.StoreAsync(new Transaction("Transaction/2", new DateTime(2025, 1, 2), "New York", markerArray), "Transaction/2");
+            var doc3 = new Transaction("doc/3", new DateTime(2025, 1, 1), "New York", markerArray);
+            await session.StoreAsync(doc3, "Doc/3");
+            session.Advanced.GetMetadataFor(doc3)["@collection"] = "Docs"; // store doc3 in another collection
+
+            using var file1 = new MemoryStream(Csv.ToArray());
+            using var file2 = new MemoryStream(Csv.ToArray());
+
+            session.Advanced.Attachments.Store("Transaction/1", "transactions.csv", file1);
+            session.Advanced.Attachments.Store("Doc/3", "transactions.csv", file2);
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var transaction1 = await session.LoadAsync<Transaction>("Transaction/1");
+            var transaction2 = await session.LoadAsync<Transaction>("Transaction/2");
+            var doc3 = await session.LoadAsync<Transaction>("Doc/3");
+            Assert.NotNull(transaction1.Summary);
+            Assert.NotNull(transaction2.Summary);
+            Assert.NotNull(doc3.Summary);
+            Assert.True(doc3.Summary.Any(d => d.Notes == marker.Notes)); // shouldn't change - because it's not in 'Transaction' collection
+
+            Assert.False(transaction1.Summary.Any(d => d.Notes == marker.Notes));
+            var transaction2Changed = transaction2.Summary.Any(d => d.Notes == marker.Notes) == false;
+            if (withNullAttachments)
+                Assert.True(transaction2Changed || ValidateRefusalNotification(db));
+            else
+                Assert.False(transaction2Changed);
+        }
+
+        // Update/delete - Assert hashes
+        await AssertHashes<Item>(store, "Transaction/1", "Transaction/2", "transactions.csv", () => new MemoryStream(Csv2.ToArray()), withNullAttachments);
+    }
+
+    public record Doc(FileDescription[] FileDescriptions = null);
+
+    public record FileDescription(string Description, bool SafeForWork, string[] Tags);
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task GenAiDifferentAttachmentsPerContexts(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = @"You are an assistant that receives a list of files and returns structured information about each file.
+For each file in the input list:
+- Always return one object, in the same order as input.
+- If the file is readable and can be processed:
+  - Provide a detailed ""Description"" of its contents.
+  - Set ""SafeForWork"" to true if the file is appropriate for work, otherwise false.
+  - Provide a list of relevant ""Tags"".
+- If a file is missing, unreadable, unsupported, or failed to load:
+  - Return:
+    new { Description = ""Image doesn't exist"", SafeForWork = true, Tags = new[] { ""image doesn't exist"" } }
+
+Your full response should be in this format:
+
+FileDescriptions = new[]
+{
+    // One object per file
+    // Always present all files, even unreadable ones
+}
+Never skip a file. Return default values for anything unknown or inaccessible.
+" + NonEmptyAnswerHint;
+        config.Collection = "Docs";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            FileDescriptions = new[]
+            {
+                new { Description = "Detailed description of the first file", SafeForWork = true, Tags = new[] { "tag1", "tag2" } },
+                new { Description = "Detailed description of the second file", SafeForWork = false, Tags = new[] { "tag3" } },
+                new { Description = "Image doesn't exist", SafeForWork = true, Tags = new[] { "image doesn't exist" } }
+            }
+        });
+        config.UpdateScript = @"this.FileDescriptions = $output.FileDescriptions;";
+        config.GenAiTransformation = new GenAiTransformation { Script = @"
+ai.genContext({})
+    .withPng(loadAttachment('heart.png'))
+    .withPng(loadAttachment('star.png'))
+    .withText(loadAttachment('transactions.csv'));
+" };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var marker = new FileDescription("None" + Guid.NewGuid(), false, new string[] { "None" });
+        var markerArray = new FileDescription[] { marker };
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Doc(markerArray), "Docs/1");
+            await session.StoreAsync(new Doc(markerArray), "Docs/2");
+
+            using var heart1 = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            using var star = new MemoryStream(Convert.FromBase64String(StarPngBase64));
+            using var text1 = new MemoryStream(Csv.ToArray());
+
+            using var heart2 = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            using var text2 = new MemoryStream(Csv.ToArray());
+
+
+            session.Advanced.Attachments.Store("Docs/1", "heart.png", heart1);
+            session.Advanced.Attachments.Store("Docs/1", "star.png", star);
+            session.Advanced.Attachments.Store("Docs/1", "transactions.csv", text1);
+
+            session.Advanced.Attachments.Store("Docs/2", "heart.png", heart2);
+            session.Advanced.Attachments.Store("Docs/2", "transactions.csv", text2);
+
+            await session.SaveChangesAsync();
+
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var item1 = await session.LoadAsync<Doc>("Docs/1");
+            var item2 = await session.LoadAsync<Doc>("Docs/2");
+            Assert.NotNull(item1.FileDescriptions);
+            Assert.NotNull(item2.FileDescriptions);
+
+            Assert.False(item1.FileDescriptions.Any(d => d.Description == marker.Description));
+            var item2Changed = item2.FileDescriptions.Any(d => d.Description == marker.Description) == false;
+            Assert.True(item2Changed || ValidateRefusalNotification(db));
+        }
+    }
+
+    public record Post(string Content, Comment[] Comments = null);
+    public record Comment(string Id, string Author, string Content, string AuthorDescription, string ProfileImage);
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false)]
+    public async Task GenAiMultipleAttachment(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images." + NonEmptyAnswerHint;
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(
+            new { PhotoDescription = "Description of the photo" });
+
+        config.UpdateScript = @"    
+const comment = this.Comments.find(c => c.Id == $input.Id);
+comment.AuthorDescription = $output.PhotoDescription;
+";
+
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    let img = loadAttachment(comment.ProfileImage);
+    if(!img)
+        continue;
+    ai.genContext({Id: comment.Id}).withPng(img);
+}"
+        };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        var marker = "None" + Guid.NewGuid();
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var p1 = new Post("Hello World!",
+                new Comment[]
+                {
+                    new Comment(Id: "Comment1", Author: "Shahar Heart", AuthorDescription: marker, Content: "Hey!", ProfileImage: "heart.png"),
+                    new Comment(Id: "Comment2", Author: "Omer Star", AuthorDescription: marker, Content: "Hello!", ProfileImage: "star.png"),
+                    new Comment(Id: "Comment3", Author: "Aviv Rachmany", AuthorDescription: marker, Content: "Hello", ProfileImage: "none.png")
+                });
+            await session.StoreAsync(p1, "Post/1");
+
+            using var heart = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            using var star = new MemoryStream(Convert.FromBase64String(StarPngBase64));
+
+            session.Advanced.Attachments.Store("Post/1", "heart.png", heart);
+            session.Advanced.Attachments.Store("Post/1", "star.png", star);
+
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var p1 = await session.LoadAsync<Post>("Post/1");
+            var comments = p1.Comments;
+            Assert.NotEqual(marker, comments[0].AuthorDescription);
+            Assert.NotEqual(marker, comments[1].AuthorDescription);
+            Assert.Equal(marker, comments[2].AuthorDescription);
+        }
+
+        var hashes = (await GetHashes<Post>(store, "Post/1")).ToList();
+        Assert.Equal(2, hashes.Count);
+
+        // Changing attachment
+        etl = Etl.WaitForEtlToComplete(store);
+        var db = await GetDatabase(store.Database);
+        using (var session = store.OpenAsyncSession())
+        {
+            using var heart = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            session.Advanced.Attachments.Store("Post/1", "star.png", heart); // changing star to be heart
+            await session.SaveChangesAsync();
+        }
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        await WaitForAssertionAsync(async () =>
+        {
+            var hashesAfterChange = (await GetHashes<Post>(store, "Post/1")).ToList();
+            Assert.Equal(2, hashesAfterChange.Count);
+            Assert.Equal(hashes[0], hashesAfterChange[0]);
+            Assert.NotEqual(hashes[1], hashesAfterChange[1]);
+        });
+
+        // Delete attachment
+        etl = Etl.WaitForEtlToComplete(store);
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Advanced.Attachments.Delete("Post/1", "star.png");
+            await session.SaveChangesAsync();
+        }
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        await WaitForAssertionAsync(async () =>
+        {
+            var hashesAfterDelete = (await GetHashes<Post>(store, "Post/1")).ToList();
+            Assert.Equal(1, hashesAfterDelete.Count);
+            Assert.Equal(hashes[0], hashesAfterDelete[0]);
+        });
+    }
+
+
+    private async Task AssertHashes<T>(DocumentStore store,
+        string docId1,
+        string docId2,
+        string fileName,
+        Func<MemoryStream> fileStreamFactory,
+        bool withNullAttachments)
+    {
+        // Update/delete - Assert hashes
+
+        var oldHash1 = await GetHash<T>(store, docId1); // doc1 - attachment exist (Heart)
+        var oldHash2 = await GetHash<T>(store, docId2); // doc2 - attachment doesn't exist
+        Assert.NotNull(oldHash1);
+        if (withNullAttachments)
+            Assert.NotNull(oldHash2);
+        else
+            Assert.Null(oldHash2);
+
+        var etl = Etl.WaitForEtlToComplete(store);
+        using (var session = store.OpenAsyncSession())
+        {
+            using var file1 = fileStreamFactory();
+            using var file2 = fileStreamFactory();
+
+            session.Advanced.Attachments.Store(docId1, fileName, file1); // change
+            session.Advanced.Attachments.Store(docId2, fileName, file2); // add new
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        var hash1 = string.Empty;
+        var hash2 = string.Empty;
+        await WaitForAssertionAsync(async () =>
+        {
+            hash1 = await GetHash<T>(store, docId1); // doc1 - attachment exist (Star)
+            hash2 = await GetHash<T>(store, docId2); // doc2 - attachment exist (Star)
+            Assert.NotNull(hash1);
+            Assert.NotNull(hash2);
+            Assert.NotEqual(oldHash1, hash1);
+            Assert.NotEqual(oldHash2, hash1);
+        });
+
+
+        etl = Etl.WaitForEtlToComplete(store);
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Advanced.Attachments.Delete(docId1, fileName);
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        await WaitForAssertionAsync(async () =>
+        {
+            var newHash1 = await GetHash<T>(store, docId1);
+        if (withNullAttachments)
+            Assert.NotEqual(hash1, newHash1); // doc1 - hash of 'non-existed image.png'
+        else
+            Assert.Equal(hash1, newHash1); // doc1 - hasn't changed - etl didn't process this doc
+        });
+    }
+
+    private static async Task<string> GetHash<T>(DocumentStore store, string id)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<T>(id);
+            var metadata = session.Advanced.GetMetadataFor(doc);
+            if (metadata.TryGetValue(Constants.Documents.Metadata.GenAiHashes, out object hashesSectionObj) &&
+                hashesSectionObj is MetadataAsDictionary hashesSection &&
+                hashesSection.TryGetValue("openai-aiintegrationtask", out object hashesObj)
+                && hashesObj is IEnumerable<object> hashesArr && hashesArr.First() is string hash)
+            {
+                return hash;
+            }
+
+            return null;
+        }
+    }
+
+    private static async Task<IEnumerable<string>> GetHashes<T>(DocumentStore store, string id)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<T>(id);
+            var metadata = session.Advanced.GetMetadataFor(doc);
+            if (metadata.TryGetValue(Constants.Documents.Metadata.GenAiHashes, out object hashesSectionObj) &&
+                hashesSectionObj is MetadataAsDictionary hashesSection &&
+                hashesSection.TryGetValue("openai-aiintegrationtask", out object hashesObj)
+                && hashesObj is IEnumerable<object> hashesArr)
+            {
+                return hashesArr.Select(o => o as string);
+            }
+
+            return null;
+        }
+    }
+
+    private static bool ValidateRefusalNotification(DocumentDatabase db)
+    {
+        using (db.NotificationCenter.GetStored(out var actions))
+        {
+            var jsonAlerts = actions.ToList();
+            if (jsonAlerts.Count == 0)
+                return false;
+            var bjro = jsonAlerts.First().Json;
+
+            return bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
+                   details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
+                   errors.Length > 0 &&
+                   errors.First().ToString()!.Contains("The request was refused by the model");
+        }
+    }
 }

--- a/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
@@ -1,0 +1,467 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi;
+
+public class RavenDB_24648(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const string HeartPngBase64 =
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=";
+
+    private const string StarPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAB59JREFUeJzdmweMFVUUhn+asPQmrNKbiKhEKZoooCuyGFA6xEAgsqi0xJAgGMQQUZqAgpSIIgQCBgKIoC4QkCZSDIIgVRBW2lKUtvR2PP/cebNv+2N35t3ISb7kheybe/43d+5pA2DHyikNLK0ddcuv9FJGKEUs+xIVK6/MVzYrtS37EhV7Ubmk3FVet+xL4JZP+UQRl2+UB6x6FLBVUDYhVfA+3OeHV4JyPl8+SMGCjuCbynDLPgVqPyhSty6keXPvLm+H2er3ncUoF/Pnh/TrBxk5ElK4sCP4tvKQZd8CsTaKVK0KWbUKsmcPpH597y6/ifvsLpdRvlakQwfI1auQO3cgffp4ghOVylY99NkaKn8rMnkyRMSwYIF3eDEuv2TXRX/tXUXq1IHs2pUq+PBhSNOm3l0eb9lH36ys8pMigwdDrlxJFXzrFmTCBE/wNqWGVU99sleVk4qsXp0qNgTvOIzgCzBFxf/eZipStizk9u2Mgknt2p7o7y37mmdj+ZfM2NuzZ+ZiyaBBkEKFHMEpSmnLPufJmihSrhxk3rysBa9cCalSxbvLr1j2OddWWBmtOGnkhQtZC755E9KmjSd4ulLCque5tCeVvSwUxozJWmyI6dMhBQo4go8pz1r2PVfWU7lbvjxk48acBe/YAalRw7vL71j2PYMx7+WWZYytqtRVnlaaKfFKJ2WLIv37Q1JSchZ8/Tpk2DBP8O9KB5juCM+Bx9112B6KyavztV1HWyrtle7KW8pAZZgySpmkzIDpUCxVVis/u6JY3v2h7FcOw2zJ0zC1rixdCrl7N2fBZP16TzC/e0pJUv5U9rjrbFU2KquU71x/vlA+VT5WBiv9lTeUjjAH4AswjwjT20cpuLOSjNQuhG8UKQI5fz4yseTaNUipUr77cQcmqTmEsGYDt83a8D+sXBnSpIk5YVu3hnTpYmIptyhTxOHDIePGQaZNg8yaBVm4EJKYCFm7FrJtG2TvXsjx45GLDXH0KGTnTsjmzSZcLVkCmTvXrDN+PGTECBO3WVPTn/btIfHxJidv0MDk6xUrZhDNVlI7hJWgBWCew8TQVqxXD7JsGeTIEciJE5AzZ8zdYi7MMBLpNg2CGzcgly8bf06dghw7ZgqRffsgy5dD2rZNc3cPKs8ji2YhOw8/hn6Zdu0g+/fbE3avJCdD+vb1srZQQdIiM6HhVlzprVznl8qUMVkSKxvbgrKCu42PAbspYdv4I+XBnMSGjDkw2y48cSU2FjJjhtlGtsVltr35nPO8cYX+q0xVSkYqNmScATE8OaVdhQqQsWPtC0zP7NmQmjU9seycfODu0lxbFZi4x9GIcyImJdkXykN06FAIU1dX7BHlCfjUDKyjLFFusAfVqRNk+3Z7Yg8cgPTuDSle3GvzroFJnHy1msocRVjfNmxo5wQ/dw4SF+c1/8hyBDiu4XZhG+YsFytZEjJzZtadDD/hSbx4sZlauEIvKp8rBYMSGzIG8LdhUjWpVg0yalTa5pzfMCSyvRsm9oQyBOZNgqhYIZiqiEWCMzLh6CQI0ayiGHaKFfPEXlW6woeqKTcWC3dARnr1MhMFP7fxgAHmzHDXWKc8Y0NouLHwYArnJPN+59gJCZ5YlqAsY63PoFhj7lBk4kT/tzSfXRjBu5R6VpW6xkL7TtGikC1b/Be8davJ8mASn06WtTrGToOT3rGW9Vswr9mypXeXR1rW6uTbnBY4jQKeqH4LZnEwZIgnmAdk4HE3O+NMlwW2TJ3qv9gQK1Z4grmW1RYuF09hP/ngweAEnzzp9axZDfW1Kbif4oxJInWecZrFOrmXmF2pkneXv7Qp+Dcg+0FZOGzs9ehhMjPCz+xDRfLd7t3TbGsrxvbJDaZ8kyZl7yxTzjVrII0aeW/uOLU1PzdubPrRfO8ju2twcB4T4/Wsy9oQHEenOR7ZsCFrRy9dMglJ2HSQDq9TNrifnQJkypTsW0j8wfh37jWaRVssiwcn/rZqZUJHegfZyuWd4w8S1pXga4etYcIZeQ1mmuD8DXvKmzZl3jBkk75FC+86bKhHNTxVgulhOzEyvXNMFlg91aqV5nUGdkweSecoPzNdXAZzAjslIBvuPJnTX3fgQO96HLPERlEvGsEdz8yfnzGEcFLBMYvrHEtIzqiye+54Hnyo/MPvME3t2BFy9mzaa8+Z412Tr0A9FajCdMaBlZPj8o06OsPnj9M/TvuRWrd+C/MGbaQWGgRcg9seHj06dT7FUBb2PkiCz5qyNU4SnVnO6dOQ3bsh3bpBSpTwnOEkcZDycC6uzS7p+8pfvFbp0qZpeOiQmSx07uytMcUnLTkaOw2/cNGuXSGLFplw4zrBcHMAJgPLy6HCNhJnw0nudZ1cnXMjng3uv3H4VywPa0RsrH85u3XCRFj3kB3/PkpRH9cqBbNT2MNy4nb16t56nIrE+7hWlsYXzW4hdYbD543/YYPD5yD+lwrv4svKTrhx24Wzr/cCWC+DfRa2KIV/BdOoD9rYe16AtD/2gqAXZcLBnjS7/b8qz8EkENEyngvsofFQ5HnBkBdoj4tJApMI3uXHglwoB6NovtLIuF01yIV4SDAGR+V0zMH40jnL07h7+dJ/6BKDgg9Udu4AAAAASUVORK5CYII=";
+
+    private const string NonEmptyAnswerHint =
+        " ;Always provide a valid structured response matching the schema (if you have no answer or an empty answer - please return default values instead)";
+
+    private class Post
+    {
+        public string Content { get; set; }
+        public Comment[] Comments { get; set; }
+        public Post(){ }
+        public Post(string content, Comment[] comments)
+        {
+            Content = content;
+            Comments = comments;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is not Post other)
+                return false;
+
+            if (Content != other.Content)
+                return false;
+
+            if (Comments == other.Comments)
+                return true;
+
+            if (Comments == null || other.Comments == null || Comments.Length != other.Comments.Length)
+                return false;
+
+            for (int i = 0; i < Comments.Length; i++)
+            {
+                if (!Equals(Comments[i], other.Comments[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = Content?.GetHashCode() ?? 0;
+            if (Comments != null)
+            {
+                foreach (var comment in Comments)
+                    hash = HashCode.Combine(hash, comment?.GetHashCode() ?? 0);
+            }
+
+            return hash;
+        }
+    }
+
+    private class Comment
+    {
+        public string Id { get; set; }
+        public string Author { get; set; }
+        public string Content { get; set; }
+        public string AuthorDescription { get; set; }
+        public string ProfileImage { get; set; }
+
+        public Comment() { }
+
+        public Comment(string id, string author, string content, string authorDescription, string profileImage)
+        {
+            Id = id;
+            Author = author;
+            Content = content;
+            AuthorDescription = authorDescription;
+            ProfileImage = profileImage;
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            return obj is Comment other &&
+                   Id == other.Id &&
+                   Author == other.Author &&
+                   Content == other.Content &&
+                   AuthorDescription == other.AuthorDescription &&
+                   ProfileImage == other.ProfileImage;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, Author, Content, AuthorDescription, ProfileImage);
+        }
+
+
+    }
+
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task GenAiTestModeWithAttachments(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images." + NonEmptyAnswerHint;
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(
+            new { PhotoDescription = "Description of the photo" });
+
+        config.UpdateScript = @"    
+const comment = this.Comments.find(c => c.Id == $input.Id);
+comment.AuthorDescription = $output.PhotoDescription;
+";
+
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    let img = loadAttachment(comment.ProfileImage);
+    if(!img)
+        continue;
+    ai.genContext({Id: comment.Id}).withPng(img);
+}"
+        };
+
+        var marker = "None" + Guid.NewGuid();
+        var post1 = new Post("Hello World!",
+            new Comment[]
+            {
+                new Comment(id: "Comment1", author: "Shahar Heart", authorDescription: marker, content: "Hey!", profileImage: "heart.png"),
+                new Comment(id: "Comment2", author: "Omer Star", authorDescription: marker, content: "Hello!", profileImage: "star.png"),
+                new Comment(id: "Comment3", author: "Aviv Rachmany", authorDescription: marker, content: "Hello", profileImage: "none.png")
+            });
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(post1, "Post/1");
+
+            using var heart = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            using var star = new MemoryStream(Convert.FromBase64String(StarPngBase64));
+
+            session.Advanced.Attachments.Store("Post/1", "heart.png", heart);
+            session.Advanced.Attachments.Store("Post/1", "star.png", star);
+
+            await session.SaveChangesAsync();
+        }
+
+        var database = await GetDocumentDatabaseInstanceFor(store);
+        using var _ = database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
+
+        // Stage 1 : Create Gen Ai Contexts
+        // test-doc (sending new doc - doesn't exist)
+        var document = store.Conventions.Serialization.DefaultConverter.ToBlittable(post1, context);
+        var createCtx2 = await store.Maintenance.SendAsync(context, new TestCreateGenAiContextOperation(document, config));
+        Assert.Equal(0, createCtx2.Results.Count);
+
+
+        // Existing doc with attachments
+        var createCtx = await store.Maintenance.SendAsync(context, new TestCreateGenAiContextOperation("Post/1", config));
+        var genAiContexts = createCtx.Results;
+        Assert.Equal(2, genAiContexts.Count);
+        Assert.NotNull(genAiContexts[0].ContextOutput.Context);
+        Assert.NotNull(genAiContexts[1].ContextOutput.Context);
+        Assert.Equal(1, genAiContexts[0].ContextOutput.Attachments.Count);
+        Assert.Equal(1, genAiContexts[1].ContextOutput.Attachments.Count);
+        Assert.Equal("heart.png", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.Equal("star.png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.Equal("image/png", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Type);
+        Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
+        Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
+        Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
+
+        // Stage 2 : Send to model
+        var sendToModel = await store.Maintenance.SendAsync(context, new TestGenAiSendToModelOperation(genAiContexts, config));
+        var contextsAndOutputs = sendToModel.Results;
+        Assert.Equal(2, contextsAndOutputs.Count);
+        Assert.NotNull(contextsAndOutputs[0].ContextOutput.Context);
+        Assert.NotNull(contextsAndOutputs[1].ContextOutput.Context);
+        Assert.Equal(1, contextsAndOutputs[0].ContextOutput.Attachments.Count);
+        Assert.Equal(1, contextsAndOutputs[1].ContextOutput.Attachments.Count);
+        Assert.Equal("heart.png", contextsAndOutputs[0].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.Equal("star.png", contextsAndOutputs[1].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.NotNull(contextsAndOutputs[0].ModelOutput?.Output);
+        Assert.NotNull(contextsAndOutputs[1].ModelOutput?.Output);
+        
+        // Stage 3 : Update Script
+        // doc id
+        var updateScriptRes = await store.Maintenance.SendAsync(context, new TestGenAiUpdateScriptOperation("Post/1", contextsAndOutputs, config));
+        var inputDoc = ToPost(updateScriptRes.InputDocument);
+        Assert.Equal(post1, inputDoc);
+        var outputDoc = ToPost(updateScriptRes.OutputDocument);
+        Assert.NotEqual(marker, outputDoc.Comments[0].AuthorDescription);
+        Assert.NotEqual(marker, outputDoc.Comments[1].AuthorDescription);
+        outputDoc.Comments[0].AuthorDescription = marker;
+        outputDoc.Comments[1].AuthorDescription = marker;
+        Assert.Equal(post1, outputDoc);
+        
+        // doc
+        updateScriptRes = await store.Maintenance.SendAsync(context, new TestGenAiUpdateScriptOperation(document, contextsAndOutputs, config));
+        inputDoc = ToPost(updateScriptRes.InputDocument);
+        Assert.Equal(post1, inputDoc);
+        outputDoc = ToPost(updateScriptRes.OutputDocument);
+        Assert.NotEqual(marker, outputDoc.Comments[0].AuthorDescription);
+        Assert.NotEqual(marker, outputDoc.Comments[1].AuthorDescription);
+        outputDoc.Comments[0].AuthorDescription = marker;
+        outputDoc.Comments[1].AuthorDescription = marker;
+        Assert.Equal(post1, outputDoc);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task GenAiTestModeEditedDocWithAttachments(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images." + NonEmptyAnswerHint;
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(
+            new { PhotoDescription = "Description of the photo" });
+
+        config.UpdateScript = @"    
+const comment = this.Comments.find(c => c.Id == $input.Id);
+comment.AuthorDescription = $output.PhotoDescription;
+";
+
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    let img = loadAttachment(comment.ProfileImage);
+    if(!img)
+        continue;
+    ai.genContext({Id: comment.Id}).withPng(img);
+}"
+        };
+
+        var marker = "None" + Guid.NewGuid();
+        var post1 = new Post("Hello World!",
+            new Comment[]
+            {
+                new Comment(id: "Comment1", author: "Shahar Heart", authorDescription: marker, content: "Hey!", profileImage: "heart.png"),
+                new Comment(id: "Comment2", author: "Omer Star", authorDescription: marker, content: "Hello!", profileImage: "star.png"),
+                new Comment(id: "Comment3", author: "Aviv Rachmany", authorDescription: marker, content: "Hello", profileImage: "none.png")
+            });
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(post1, "Post/1");
+
+            using var heart = new MemoryStream(Convert.FromBase64String(HeartPngBase64));
+            using var star = new MemoryStream(Convert.FromBase64String(StarPngBase64));
+
+            session.Advanced.Attachments.Store("Post/1", "heart.png", heart);
+            session.Advanced.Attachments.Store("Post/1", "star.png", star);
+
+            await session.SaveChangesAsync();
+        }
+
+        var database = await GetDocumentDatabaseInstanceFor(store);
+        using var _ = database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
+
+        // Stage 1 : Create Gen Ai Contexts
+        // existing doc with edit
+        var editedPost1 = new Post() { Content = "Shahar", Comments = post1.Comments };
+        var document = store.Conventions.Serialization.DefaultConverter.ToBlittable(editedPost1, context);
+        var createCtx3 = await store.Maintenance.SendAsync(context, new TestCreateGenAiContextOperation("Post/1", document, config));
+        var genAiContexts = createCtx3.Results;
+        Assert.Equal(2, genAiContexts.Count);
+        Assert.NotNull(genAiContexts[0].ContextOutput.Context);
+        Assert.NotNull(genAiContexts[1].ContextOutput.Context);
+        Assert.Equal(1, genAiContexts[0].ContextOutput.Attachments.Count);
+        Assert.Equal(1, genAiContexts[1].ContextOutput.Attachments.Count);
+        Assert.Equal("heart.png", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.Equal("star.png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.Equal("image/png", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Type);
+        Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
+        Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
+        Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
+
+
+        // Stage 2 : Send to model
+        var sendToModel = await store.Maintenance.SendAsync(context, new TestGenAiSendToModelOperation(genAiContexts, config));
+        var contextsAndOutputs = sendToModel.Results;
+        Assert.Equal(2, contextsAndOutputs.Count);
+        Assert.NotNull(contextsAndOutputs[0].ContextOutput.Context);
+        Assert.NotNull(contextsAndOutputs[1].ContextOutput.Context);
+        Assert.Equal(1, contextsAndOutputs[0].ContextOutput.Attachments.Count);
+        Assert.Equal(1, contextsAndOutputs[1].ContextOutput.Attachments.Count);
+        Assert.Equal("heart.png", contextsAndOutputs[0].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.Equal("star.png", contextsAndOutputs[1].ContextOutput.Attachments.FirstOrDefault()?.Name);
+        Assert.NotNull(contextsAndOutputs[0].ModelOutput?.Output);
+        Assert.NotNull(contextsAndOutputs[1].ModelOutput?.Output);
+
+        // Stage 3 : Update Script
+        // doc id
+        var updateScriptRes = await store.Maintenance.SendAsync(context, new TestGenAiUpdateScriptOperation("Post/1", contextsAndOutputs, config));
+        var inputDoc = ToPost(updateScriptRes.InputDocument);
+        Assert.Equal(post1, inputDoc);
+        var outputDoc = ToPost(updateScriptRes.OutputDocument);
+        Assert.NotEqual(marker, outputDoc.Comments[0].AuthorDescription);
+        Assert.NotEqual(marker, outputDoc.Comments[1].AuthorDescription);
+        outputDoc.Comments[0].AuthorDescription = marker;
+        outputDoc.Comments[1].AuthorDescription = marker;
+        Assert.Equal(post1, outputDoc);
+
+        // doc
+        updateScriptRes = await store.Maintenance.SendAsync(context, new TestGenAiUpdateScriptOperation(document, contextsAndOutputs, config));
+        inputDoc = ToPost(updateScriptRes.InputDocument);
+        Assert.Equal(editedPost1, inputDoc);
+        outputDoc = ToPost(updateScriptRes.OutputDocument);
+        Assert.NotEqual(marker, outputDoc.Comments[0].AuthorDescription);
+        Assert.NotEqual(marker, outputDoc.Comments[1].AuthorDescription);
+        outputDoc.Comments[0].AuthorDescription = marker;
+        outputDoc.Comments[1].AuthorDescription = marker;
+        Assert.Equal(editedPost1, outputDoc);
+    }
+
+    private static readonly Func<BlittableJsonReaderObject, Post> ToPost = JsonDeserializationClient.GenerateJsonDeserializationRoutine<Post>();
+
+    private class TestCreateGenAiContextOperation : IMaintenanceOperation<GenAiTestScriptResult>
+    {
+        private readonly TestGenAiScript _testGenAiScript;
+
+        public TestCreateGenAiContextOperation(string docId, GenAiConfiguration config)
+        {
+            _testGenAiScript = new TestGenAiScript
+            {
+                DocumentId = docId,
+                Configuration = config,
+                TestStage = TestStage.CreateContextObjects
+            };
+        }
+
+        public TestCreateGenAiContextOperation(BlittableJsonReaderObject doc, GenAiConfiguration config)
+        {
+            _testGenAiScript = new TestGenAiScript
+            {
+                Document = doc,
+                Configuration = config,
+                TestStage = TestStage.CreateContextObjects
+            };
+        }
+
+        public TestCreateGenAiContextOperation(string docId, BlittableJsonReaderObject doc, GenAiConfiguration config)
+        {
+            _testGenAiScript = new TestGenAiScript
+            {
+                DocumentId = docId,
+                Document = doc,
+                Configuration = config,
+                TestStage = TestStage.CreateContextObjects
+            };
+        }
+
+        public RavenCommand<GenAiTestScriptResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new TestGenAiCommand(_testGenAiScript, conventions);
+        }
+    }
+
+    private class TestGenAiSendToModelOperation : IMaintenanceOperation<GenAiTestScriptResult>
+    {
+        private readonly TestGenAiScript _testGenAiScript;
+
+        public TestGenAiSendToModelOperation(List<GenAiResultItem> genAiContexts, GenAiConfiguration config)
+        {
+            _testGenAiScript = new TestGenAiScript
+            {
+                Input = genAiContexts,
+                Configuration = config,
+                TestStage = TestStage.SendToModel
+            };
+        }
+
+        public RavenCommand<GenAiTestScriptResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new TestGenAiCommand(_testGenAiScript, conventions);
+        }
+    }
+
+    private class TestGenAiUpdateScriptOperation : IMaintenanceOperation<GenAiTestScriptResult>
+    {
+        private readonly TestGenAiScript _testGenAiScript;
+
+        public TestGenAiUpdateScriptOperation(string docId, List<GenAiResultItem> genAiContextsAndModelOutputs, GenAiConfiguration config)
+        {
+            _testGenAiScript = new TestGenAiScript
+            {
+                DocumentId = docId,
+                Input = genAiContextsAndModelOutputs,
+                Configuration = config,
+                TestStage = TestStage.ApplyUpdateScript
+            };
+        }
+
+        public TestGenAiUpdateScriptOperation(BlittableJsonReaderObject doc, List<GenAiResultItem> genAiContextsAndModelOutputs, GenAiConfiguration config)
+        {
+            _testGenAiScript = new TestGenAiScript
+            {
+                Document = doc,
+                Input = genAiContextsAndModelOutputs,
+                Configuration = config,
+                TestStage = TestStage.ApplyUpdateScript
+            };
+        }
+
+        public RavenCommand<GenAiTestScriptResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new TestGenAiCommand(_testGenAiScript, conventions);
+        }
+    }
+
+    private class TestGenAiCommand(TestGenAiScript testGenAiScript, DocumentConventions conventions) : RavenCommand<GenAiTestScriptResult>
+    {
+        private readonly TestGenAiScript _testGenAiScript = testGenAiScript;
+        private readonly DocumentConventions _conventions = conventions;
+
+        public override bool IsReadRequest { get; } = true;
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/admin/ai/gen-ai/test";
+            // var bjro = _conventions.Serialization.DefaultConverter.ToBlittable(_testGenAiScript, ctx);
+            var bjro = ctx.ReadObject(_testGenAiScript.ToJson(), "TestGenAiCommand_payload");
+            return new HttpRequestMessage
+            {
+                Method = HttpMethods.Post,
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, bjro).ConfigureAwait(false), _conventions)
+            };
+        }
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            Result = DeserializeToTestEtlScriptResult(response);
+        }
+
+        private static readonly Func<BlittableJsonReaderObject, GenAiTestScriptResult> DeserializeToTestEtlScriptResult = JsonDeserializationClient.GenerateJsonDeserializationRoutine<GenAiTestScriptResult>();
+
+    }
+}

--- a/test/StressTests/GenAi/ChatCompletionClientStressTests.cs
+++ b/test/StressTests/GenAi/ChatCompletionClientStressTests.cs
@@ -68,7 +68,7 @@ public class ChatCompletionClientStressTests : RavenTestBase
 
             context = sb.ToString();
 
-            await Assert.ThrowsAsync<TooManyTokensException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, default));
+            await Assert.ThrowsAsync<TooManyTokensException>(() => client.CompleteAsync(prompt, context, defaultJsonSchema, null, default));
         }
     }
 
@@ -89,7 +89,7 @@ public class ChatCompletionClientStressTests : RavenTestBase
             var tasks = new List<Task>();
             for (int i = 0; i < 20_000; i++)
             {
-                var t = client.CompleteAsync(prompt, context, defaultJsonSchema, default);
+                var t = client.CompleteAsync(prompt, context, defaultJsonSchema, null, default);
                 tasks.Add(t);
             }
             await Task.WhenAll(tasks);

--- a/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
@@ -181,7 +181,7 @@ public abstract class AbstractGenAiConnectorForTesting<T> : BaseAiConnectorForTe
         using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
         {
             logger = null;
-            var result = client.CompleteAsync(systemPrompt: "Reply with exact word only: raven", "", schema, token).GetAwaiter().GetResult();
+            var result = client.CompleteAsync(systemPrompt: "Reply with exact word only: raven", "", schema, null, token).GetAwaiter().GetResult();
 
             return true;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24642/GenAI-support-for-images-documents-missing-attachment
https://issues.hibernatingrhinos.com/issue/RavenDB-24648/GenAI-support-for-images-documents-server-side-test-mode

### Additional description

Let the user decide how to handle missing attachments (`loadAttachment` returns `null`).
If the user explicitly passes a non-existent attachment using (ex: `.withPng(null)`), the system will send a stub message to the model indicating the file was not found:
```
{ type: 'text': 'content': 'File 'image.png' (of type 'image\png') could not be loaded: file not found' }
```
You cant include here the name of the missing attachment. 
The only way to do that is by returning it from loadAttachment.
But then you're not returning null when the attachment is not found,
which prevents the user from deciding how to handle a non-found attachment,
and also changes the existing behavior for all transformers.

- Gen-Ai test mode now support attachments, look at the test in `RavenDB-24642.cs`
Required Studio Changes:
- if you want to use attachments on the test mode, on the first stage (`CreateContextObjects`), you need to send also the doc id.
- Also the class `ContextOutput` now has `Attachments` property of type `GenAiAttachment`:
```
public class ContextOutput
{
    public BlittableJsonReaderObject Context { get; set; }
    
    public List<GenAiAttachment> Attachments;
    public bool IsCached { get; set; }
    public string AiHash { get; set; }

...
}

public class GenAiAttachment
{
    public string Name { get; set; }
    public string Type { get; set; }
    public string Data { get; set; }

...
}
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
