### PR TITLE
RavenDB-24725 new connection string for AI - Model selection dropdown does not fetch available models

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -75,7 +75,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
     internal ChatCompletionClient(IMemoryContextPool contextPool, string baseUri, string apiKey, string model, string organizationId, string projectId, bool? think = null, DocumentConventions conventions = null)
     {
-        _model = model ?? throw new ArgumentNullException(nameof(model));
+        _model = model;
         _organizationId = organizationId;
         _projectId = projectId;
         _think = think;
@@ -192,6 +192,9 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
     public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, List<BlittableJsonReaderObject> tools, bool useTools, string schema)
     {
+        if (_model is null)
+            throw new ArgumentNullException(nameof(_model));
+
         var content = new BlittableJsonContent(async stream =>
         {
             await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
@@ -51,6 +51,7 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                 ConnectorType: "Ollama",
                 OllamaSettings: {
                     Uri: uri,
+                    Think: formValues.ollamaSettings.think,
                 },
             };
 
@@ -61,7 +62,7 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                 return [];
             }
         },
-        [formValues.ollamaSettings.uri],
+        [formValues.ollamaSettings.uri, formValues.ollamaSettings.think],
         300
     );
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1109,6 +1109,6 @@ type AiConnectionStringsSettings =
 interface AiModelsRequestDto {
     ConnectorType: Extract<Raven.Client.Documents.Operations.AI.AiConnectorType, "Ollama" | "OpenAi" | "AzureOpenAi">;
     AzureOpenAiSettings?: Pick<Raven.Client.Documents.Operations.AI.AzureOpenAiSettings, "Endpoint", "ApiKey">;
-    OllamaSettings?: Pick<Raven.Client.Documents.Operations.AI.OllamaSettings, "Uri">;
+    OllamaSettings?: Pick<Raven.Client.Documents.Operations.AI.OllamaSettings, "Uri" | "Think">;
     OpenAiSettings?: Pick<Raven.Client.Documents.Operations.AI.OpenAiSettings, "Endpoint" | "ApiKey" | "OrganizationId" | "ProjectId">;
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24725/new-connection-string-for-AI-Model-selection-dropdown-does-not-fetch-available-models

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
