### PR TITLE
RavenDB-24720 Ai Agents Expire in -> should have a toggle

### DIFF
--- a/src/Raven.Studio/typescript/components/common/DurationPicker.tsx
+++ b/src/Raven.Studio/typescript/components/common/DurationPicker.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React, { ChangeEvent, useEffect, useState } from "react";
 import Form from "react-bootstrap/Form";
 import FormGroup from "react-bootstrap/FormGroup";
-import FormLabel from "react-bootstrap/FormLabel";
+import InputGroup from "react-bootstrap/InputGroup";
 
 interface Duration {
     days: number;
@@ -54,50 +54,58 @@ export default function DurationPicker(props: DurationPickerProps) {
         <div className={classNames("d-flex gap-1", { "flex-grow-1": isFlexGrow })}>
             {showDays && (
                 <FormGroup controlId="days" className={classNames({ "flex-grow-1": isFlexGrow })}>
-                    <FormLabel className="small-label">Days</FormLabel>
-                    <Form.Control
-                        type="number"
-                        min={0}
-                        value={days ?? ""}
-                        placeholder={placeholder?.days}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => setDays(getInputValue(e))}
-                        disabled={disabled}
-                    />
+                    <InputGroup>
+                        <Form.Control
+                            type="number"
+                            min={0}
+                            value={days ?? ""}
+                            placeholder={placeholder?.days}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => setDays(getInputValue(e))}
+                            disabled={disabled}
+                        />
+                        <InputGroup.Text>Days</InputGroup.Text>
+                    </InputGroup>
                 </FormGroup>
             )}
             <FormGroup controlId="hours" className={classNames({ "flex-grow-1": isFlexGrow })}>
-                <FormLabel className="small-label">Hours</FormLabel>
-                <Form.Control
-                    type="number"
-                    min={0}
-                    value={hours ?? ""}
-                    placeholder={placeholder?.hours}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setHours(getInputValue(e))}
-                    disabled={disabled}
-                />
-            </FormGroup>
-            <FormGroup controlId="minutes" className={classNames({ "flex-grow-1": isFlexGrow })}>
-                <FormLabel className="small-label">Minutes</FormLabel>
-                <Form.Control
-                    type="number"
-                    min={0}
-                    value={minutes ?? ""}
-                    placeholder={placeholder?.minutes}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setMinutes(getInputValue(e))}
-                    disabled={disabled}
-                />
-            </FormGroup>
-            {showSeconds && (
-                <FormGroup controlId="seconds" className={classNames({ "flex-grow-1": isFlexGrow })}>
-                    <FormLabel className="small-label">Seconds</FormLabel>
+                <InputGroup>
                     <Form.Control
                         type="number"
                         min={0}
-                        value={seconds ?? ""}
-                        placeholder={placeholder?.seconds}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => setSeconds(getInputValue(e))}
+                        value={hours ?? ""}
+                        placeholder={placeholder?.hours}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setHours(getInputValue(e))}
                         disabled={disabled}
                     />
+                    <InputGroup.Text>Hours</InputGroup.Text>
+                </InputGroup>
+            </FormGroup>
+            <FormGroup controlId="minutes" className={classNames({ "flex-grow-1": isFlexGrow })}>
+                <InputGroup>
+                    <Form.Control
+                        type="number"
+                        min={0}
+                        value={minutes ?? ""}
+                        placeholder={placeholder?.minutes}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => setMinutes(getInputValue(e))}
+                        disabled={disabled}
+                    />
+                    <InputGroup.Text>Minutes</InputGroup.Text>
+                </InputGroup>
+            </FormGroup>
+            {showSeconds && (
+                <FormGroup controlId="seconds" className={classNames({ "flex-grow-1": isFlexGrow })}>
+                    <InputGroup>
+                        <Form.Control
+                            type="number"
+                            min={0}
+                            value={seconds ?? ""}
+                            placeholder={placeholder?.seconds}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => setSeconds(getInputValue(e))}
+                            disabled={disabled}
+                        />
+                        <InputGroup.Text>Seconds</InputGroup.Text>
+                    </InputGroup>
                 </FormGroup>
             )}
         </div>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentPersistenceSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentPersistenceSection.tsx
@@ -43,10 +43,20 @@ export default function EditAiAgentPersistenceSection() {
                 )}
                 {(formValues.isEnableDocumentExpiration || isDocumentExpirationEnabled.data) && (
                     <FormGroup>
-                        <FormLabel>
-                            Expire in <OptionalLabel />
-                        </FormLabel>
-                        <FormDurationPicker control={control} name="persistenceExpiresInSeconds" showDays isFlexGrow />
+                        <div className="d-flex mb-3 gap-2 align-items-center">
+                            <FormSwitch name="isDocumentExpireInCustomizeEnabled" control={control} />
+                            <FormLabel className="mb-0">
+                                Expire in <OptionalLabel />
+                            </FormLabel>
+                        </div>
+                        {formValues.isDocumentExpireInCustomizeEnabled && (
+                            <FormDurationPicker
+                                control={control}
+                                name="persistenceExpiresInSeconds"
+                                showDays
+                                isFlexGrow
+                            />
+                        )}
                     </FormGroup>
                 )}
             </div>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentPersistenceSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentPersistenceSection.tsx
@@ -5,7 +5,6 @@ import { useAppSelector } from "components/store";
 import { useFormContext, useWatch } from "react-hook-form";
 import { EditAiAgentFormData } from "../utils/editAiAgentValidation";
 import { editAiAgentSelectors } from "../store/editAiAgentSlice";
-import OptionalLabel from "components/common/OptionalLabel";
 
 export default function EditAiAgentPersistenceSection() {
     const { control } = useFormContext<EditAiAgentFormData>();
@@ -43,12 +42,9 @@ export default function EditAiAgentPersistenceSection() {
                 )}
                 {(formValues.isEnableDocumentExpiration || isDocumentExpirationEnabled.data) && (
                     <FormGroup>
-                        <div className="d-flex mb-3 gap-2 align-items-center">
-                            <FormSwitch name="isDocumentExpireInCustomizeEnabled" control={control} />
-                            <FormLabel className="mb-0">
-                                Expire in <OptionalLabel />
-                            </FormLabel>
-                        </div>
+                        <FormSwitch name="isDocumentExpireInCustomizeEnabled" control={control}>
+                            Set expiration
+                        </FormSwitch>
                         {formValues.isDocumentExpireInCustomizeEnabled && (
                             <FormDurationPicker
                                 control={control}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
@@ -15,6 +15,7 @@ function mapFromDto(
             sampleObject: "",
             outputSchema: "",
             isEnableDocumentExpiration: !isDocumentExpirationEnabled,
+            isDocumentExpireInCustomizeEnabled: false,
             persistenceConversationIdPrefix: "",
             persistenceExpiresInSeconds: TimeInSeconds.Day * 30,
             parameterInput: "",
@@ -49,6 +50,7 @@ function mapFromDto(
         sampleObject: dto.SampleObject,
         outputSchema: dto.OutputSchema,
         isEnableDocumentExpiration: !isDocumentExpirationEnabled,
+        isDocumentExpireInCustomizeEnabled: !!dto.Persistence.ConversationExpirationInSec,
         persistenceConversationIdPrefix: dto.Persistence.ConversationIdPrefix,
         persistenceExpiresInSeconds: dto.Persistence.ConversationExpirationInSec,
         parameterInput: "",
@@ -125,7 +127,8 @@ function mapToDto(
         Persistence: {
             ConversationIdPrefix: formData.persistenceConversationIdPrefix,
             ConversationExpirationInSec:
-                isDocumentExpirationEnabled || formData.isEnableDocumentExpiration
+                (isDocumentExpirationEnabled || formData.isEnableDocumentExpiration) &&
+                formData.isDocumentExpireInCustomizeEnabled
                     ? formData.persistenceExpiresInSeconds
                     : null,
         },

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
@@ -20,6 +20,7 @@ const schema = yup.object({
             }
         ),
     isEnableDocumentExpiration: yup.boolean(),
+    isDocumentExpireInCustomizeEnabled: yup.boolean(),
     persistenceConversationIdPrefix: yup.string().required(),
     persistenceExpiresInSeconds: yup.number().nullable().positive().integer(),
     parameterInput: yup.string().test("unique-parameter", "Parameter name must be unique", function (value) {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -117,7 +117,7 @@ export default function EditRevision(props: EditRevisionProps) {
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
     return (
-        <Modal show onHide={toggle} contentClassName="modal-border bulge-info">
+        <Modal size="lg" show onHide={toggle} contentClassName="modal-border bulge-info">
             <Form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
                 <Modal.Body className="vstack gap-3">
                     <h4>{getTitle(taskType, configType)}</h4>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24720

### Additional description

<img width="1368" height="1162" alt="image" src="https://github.com/user-attachments/assets/980b16f9-fab2-4e25-85a8-91aade3eb0d1" />

<img width="1342" height="1122" alt="image" src="https://github.com/user-attachments/assets/ff2d10e4-e7a1-44fd-8e02-f72258de11ab" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
