### PR TITLE
RavenDB-24719 - Conversation ID prefix is not a dropdown

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentPersistenceSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentPersistenceSection.tsx
@@ -1,6 +1,4 @@
-import { FormDurationPicker, FormGroup, FormLabel, FormSelectAutocomplete, FormSwitch } from "components/common/Form";
-import { SelectOption } from "components/common/select/Select";
-import { collectionsTrackerSelectors } from "components/common/shell/collectionsTrackerSlice";
+import { FormDurationPicker, FormGroup, FormInput, FormLabel, FormSwitch } from "components/common/Form";
 import { useAppSelector } from "components/store";
 import { useFormContext, useWatch } from "react-hook-form";
 import { EditAiAgentFormData } from "../utils/editAiAgentValidation";
@@ -16,11 +14,6 @@ export default function EditAiAgentPersistenceSection() {
 
     const isDocumentExpirationEnabled = useAppSelector(editAiAgentSelectors.isDocumentExpirationEnabled);
 
-    const collectionOptions: SelectOption[] = useAppSelector(collectionsTrackerSelectors.collectionNames).map((x) => ({
-        value: x,
-        label: x,
-    }));
-
     return (
         <>
             <h3 className="m-0 mt-3">Set chat persistence</h3>
@@ -28,10 +21,11 @@ export default function EditAiAgentPersistenceSection() {
             <div className="panel-bg-1 p-3 rounded-2 border border-secondary">
                 <FormGroup>
                     <FormLabel>Conversation ID prefix</FormLabel>
-                    <FormSelectAutocomplete
+                    <FormInput
                         control={control}
                         name="persistenceConversationIdPrefix"
-                        options={collectionOptions}
+                        type="text"
+                        placeholder="e.g. Chats/"
                     />
                 </FormGroup>
                 {isDocumentExpirationEnabled.status === "success" && !isDocumentExpirationEnabled.data && (


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24719

### Additional description

<img width="1334" height="1170" alt="image" src="https://github.com/user-attachments/assets/586b81de-1492-4b61-b4c2-44d27d555c7e" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
