### PR TITLE
RavenDB-24714 - AI Agent: add link to the query page in the tool query

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentToolsSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentToolsSection.tsx
@@ -9,6 +9,10 @@ import useRqlLanguageService from "components/hooks/useRqlLanguageService";
 import { useRef } from "react";
 import ReactAce from "react-ace";
 import { FormGroup, FormLabel } from "components/common/Form";
+import queryCriteria from "models/database/query/queryCriteria";
+import savedQueriesStorage from "common/storage/savedQueriesStorage";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
 export default function EditAiAgentToolsSection() {
     const { control } = useFormContext<EditAiAgentFormData>();
@@ -152,6 +156,7 @@ interface QueryFieldProps {
 
 function QueryField({ index, remove, save, edit, cancelEdit }: QueryFieldProps) {
     const { control, setValue, trigger } = useFormContext<EditAiAgentFormData>();
+    const dbName = useAppSelector(databaseSelectors.activeDatabaseName);
 
     const queryAceRef = useRef<ReactAce>(null);
 
@@ -190,6 +195,19 @@ function QueryField({ index, remove, save, edit, cancelEdit }: QueryFieldProps) 
         );
     }
 
+    const linkToQuery = () => {
+        const query = queryCriteria.empty();
+
+        query.queryText(queryItem.query);
+        query.queryParameters(queryItem.parametersSampleObject);
+        query.name(queryItem.query);
+        query.recentQuery(true);
+        const queryDto = query.toStorageDto();
+        savedQueriesStorage.saveAndNavigate(dbName, queryDto, {
+            newWindow: true,
+        });
+    };
+
     return (
         <div className="well p-2 rounded-2 border border-secondary mt-2">
             <div className="hstack justify-content-between">
@@ -224,7 +242,12 @@ function QueryField({ index, remove, save, edit, cancelEdit }: QueryFieldProps) 
                 />
             </FormGroup>
             <FormGroup>
-                <FormLabel>Query</FormLabel>
+                <div className="d-flex mb-1 justify-content-between">
+                    <FormLabel className="mb-0">Query</FormLabel>
+                    <Button variant="link" className="m-0 p-0" onClick={linkToQuery}>
+                        Query page link
+                    </Button>
+                </div>
                 <FormAceEditor
                     aceRef={queryAceRef}
                     control={control}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentToolsSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentToolsSection.tsx
@@ -197,10 +197,15 @@ function QueryField({ index, remove, save, edit, cancelEdit }: QueryFieldProps) 
 
     const linkToQuery = () => {
         const query = queryCriteria.empty();
+        const queryText = queryItem.query;
 
-        query.queryText(queryItem.query);
-        query.queryParameters(queryItem.parametersSampleObject);
-        query.name(queryItem.query);
+        const regexToFind$: RegExp = /\$\w+/g;
+        const matches = queryText.match(regexToFind$) || [];
+        const parameters: Record<string, string> = Object.fromEntries(matches.map((match) => [match, "undefined"]));
+
+        query.queryText(queryText);
+        query.queryParameters(parameters);
+        query.name(queryText);
         query.recentQuery(true);
         const queryDto = query.toStorageDto();
         savedQueriesStorage.saveAndNavigate(dbName, queryDto, {
@@ -245,7 +250,7 @@ function QueryField({ index, remove, save, edit, cancelEdit }: QueryFieldProps) 
                 <div className="d-flex mb-1 justify-content-between">
                     <FormLabel className="mb-0">Query</FormLabel>
                     <Button variant="link" className="m-0 p-0" onClick={linkToQuery}>
-                        Query page link
+                        Test query
                     </Button>
                 </div>
                 <FormAceEditor

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -11,6 +11,7 @@ class queryCriteria {
     ignoreIndexQueryLimit = ko.observable<boolean>(false);
     
     queryText = ko.observable<string>("");
+    queryParameters = ko.observable<string>("");
     metadataOnly = ko.observable<boolean>(false);
     recentQuery = ko.observable<boolean>(false);
     graphOutput = ko.observable<boolean>(false);
@@ -54,6 +55,15 @@ class queryCriteria {
                 this.ignoreIndexQueryLimit(false);
             }
         });
+
+        /* parameters should be in JSON format.
+        e.g. {"query": ["term or phrase to search in the catalog"]}
+        */
+        this.queryParameters.subscribe(queryParameters => {
+            if (queryParameters) {
+                this.queryText(this.queryText() + "\r\n\r\n" + queryParameters);
+            }
+        })
 
         this.queryText.subscribe(queryText => {
             if (queryUtil.isDynamicQuery(queryText)) {

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -11,7 +11,7 @@ class queryCriteria {
     ignoreIndexQueryLimit = ko.observable<boolean>(false);
     
     queryText = ko.observable<string>("");
-    queryParameters = ko.observable<string>("");
+    queryParameters = ko.observable<Record<string, string>>({});
     metadataOnly = ko.observable<boolean>(false);
     recentQuery = ko.observable<boolean>(false);
     graphOutput = ko.observable<boolean>(false);
@@ -56,12 +56,9 @@ class queryCriteria {
             }
         });
 
-        /* parameters should be in JSON format.
-        e.g. {"query": ["term or phrase to search in the catalog"]}
-        */
         this.queryParameters.subscribe(queryParameters => {
             if (queryParameters) {
-                this.queryText(this.queryText() + "\r\n\r\n" + queryParameters);
+                this.queryText(this.formatQueryParameters(queryParameters) + "\r\n\r\n" + this.queryText());
             }
         })
 
@@ -72,6 +69,11 @@ class queryCriteria {
                 this.ignoreIndexQueryLimit(false);
             }
         })
+    }
+    
+    private formatQueryParameters(params: Record<string, string>): string {
+        return Object.entries(params).map(([key, value]) => `${key} = "${value}"`)
+            .join("\n")
     }
 
     updateUsing(storedQuery: storedQueryDto): void {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24714

### Additional description
When we define values in the query using variables prefixed with `$` (e.g. `$query`, `$similarity`), clicking **Test query** redirects us to the query page. In that view, the query is pre-filled and all the `$` variables are displayed at the top.

eg. 1
<img width="1068" height="1123" alt="image" src="https://github.com/user-attachments/assets/8da70f1a-51d4-4dc5-adc0-7d5a9b129796" />

<img width="2293" height="324" alt="image" src="https://github.com/user-attachments/assets/74eb41ed-3304-4fd4-ae99-dae32b9462f1" />

e.g. 2
<img width="1016" height="809" alt="image" src="https://github.com/user-attachments/assets/a24f392e-17d8-4e36-bfae-7e11ab16a6fa" />


<img width="2310" height="311" alt="image" src="https://github.com/user-attachments/assets/a2242038-9a3b-46b7-9e64-be2de74e5a2b" />



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
