### PR TITLE
RavenDB-24708 changing the sample object should invalidate the json schema

### DIFF
--- a/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
+++ b/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
@@ -4,10 +4,11 @@ import AceEditor from "../ace/AceEditor";
 import ButtonWithSpinner from "../ButtonWithSpinner";
 import { FormAceEditor, FormGroup, FormLabel } from "../Form";
 import PopoverWithHoverWrapper from "../PopoverWithHoverWrapper";
-import { Control, FieldPath, FieldValues, UseFormSetValue } from "react-hook-form";
+import { Control, FieldPath, FieldValues, useFormContext, UseFormSetValue } from "react-hook-form";
 import ReactAce from "react-ace";
-import { ReactNode, useRef, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { useServices } from "components/hooks/useServices";
+import { EditAiAgentFormData } from "components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation";
 import { useAsyncCallback } from "react-async-hook";
 
 interface SampleObjectAndSchemaFieldsProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> {
@@ -41,6 +42,7 @@ export default function SampleObjectAndSchemaFields<
     const sampleObjectRef = useRef<ReactAce>(null);
     const jsonSchemaRef = useRef<ReactAce>(null);
 
+    const { setError, clearErrors } = useFormContext<EditAiAgentFormData>();
     const { tasksService } = useServices();
 
     const [lastSampleObjectForGenerate, setLastSampleObjectForGenerate] = useState<string>("");
@@ -52,6 +54,18 @@ export default function SampleObjectAndSchemaFields<
     });
 
     const canRegenerateSchema = !!sampleObject && !!jsonSchema && lastSampleObjectForGenerate !== sampleObject;
+
+    useEffect(() => {
+        if (canRegenerateSchema) {
+            setError(jsonSchemaName as TFieldValues[TName], {
+                type: "value",
+                message:
+                    "The sample object has been modified. Please regenerate the JSON schema to ensure it matches the new sample object structure.",
+            });
+        } else {
+            clearErrors([jsonSchemaName as TFieldValues[TName]])
+        }
+    }, [sampleObject, jsonSchema, canRegenerateSchema]);
 
     return (
         <div>
@@ -180,7 +194,7 @@ export default function SampleObjectAndSchemaFields<
                                 <ButtonWithSpinner
                                     className="rounded-pill position-absolute z-1"
                                     style={{
-                                        bottom: "20px",
+                                        top: "150px",
                                         right: "54px",
                                     }}
                                     variant="primary"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24708

### Additional description

<img width="1502" height="812" alt="image" src="https://github.com/user-attachments/assets/24b6b57d-8b85-429d-bfbd-9d8f13c7e81c" />

<img width="1490" height="773" alt="image" src="https://github.com/user-attachments/assets/83996c78-0dc4-49cf-a239-57aaea6e6eb3" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
