### PR TITLE
RavenDB-24759 tests are missing RavenServiceRequirement and failing with connectivity exception

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22426.cs
+++ b/test/SlowTests/Issues/RavenDB-22426.cs
@@ -29,7 +29,7 @@ public class RavenDB_22426 : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Etl)]
+    [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.MsSql)]
     public void TestOldFactoryName()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -309,7 +309,7 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [RavenFact(RavenTestCategory.Logging)]
+        [RavenFact(RavenTestCategory.Logging, Requires = RavenServiceRequirement.MsSql)]
         public void ConnectionStringsAuditJsonDoesntIncludeCredentials()
         {
             var sqlConnectionString = new SqlConnectionString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24759

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
