### PR TITLE
RavenDB-24734 create different schema for tools and structured output

### DIFF
--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -387,11 +387,16 @@ namespace Raven.Server.Web
             return value[0];
         }
 
-        internal T GetEnumQueryString<T>(string name) where T : struct
+        internal T GetEnumQueryString<T>(string name, bool required = true) where T : struct
         {
             var val = HttpContext.Request.Query[name];
             if (val.Count == 0 || string.IsNullOrWhiteSpace(val[0]))
-                ThrowRequiredMember(name);
+            {
+                if (required)
+                    ThrowRequiredMember(name);
+
+                return default;
+            }
 
             var value = val[0];
             if (Enum.TryParse(typeof(T), value, true, out var result) == false)

--- a/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
@@ -347,11 +347,24 @@ namespace Raven.Server.Web.Studio
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
+                var type = GetEnumQueryString<SchemaType>("type", required: false);
                 var sampleObj = await context.ReadForMemoryAsync(RequestBodyStream(), "convert-to-json-schema");
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
-                    var schema = ChatCompletionClient.GetSchemaFromSampleObject(sampleObj.ToString());
+                    string schema;
+                    switch (type)
+                    {
+                        case SchemaType.Default:
+                        case SchemaType.StructureOutput:
+                            schema = ChatCompletionClient.GetSchemaForRequest(schema: null, sampleObj.ToString());
+                            break;
+                        case SchemaType.ToolParameters:
+                            schema = ChatCompletionClient.GetSchemaForTool(schema: null, sampleObj.ToString());
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException($"The type '{type}' is missing");
+                    }
 
                     writer.WriteStartObject();
                     writer.WritePropertyName("Result");
@@ -383,6 +396,13 @@ namespace Raven.Server.Web.Studio
             Database,
             Script,
             ElasticSearchIndex
+        }
+
+        public enum SchemaType
+        {
+            Default,
+            StructureOutput,
+            ToolParameters,
         }
     }
 }

--- a/src/Raven.Studio/typescript/commands/database/tasks/getJsonSchemaFromSampleObjectCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getJsonSchemaFromSampleObjectCommand.ts
@@ -2,12 +2,19 @@ import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
 
 class getJsonSchemaFromSampleObjectCommand extends commandBase {
-    constructor(private payload: object) {
+    constructor(
+        private payload: object,
+        private schemaType?: Raven.Server.Web.Studio.StudioTasksHandler.SchemaType
+    ) {
         super();
     }
 
     execute(): JQueryPromise<{ Result: string }> {
-        const url = endpoints.global.studioTasks.studioTasksConvertToJsonSchema;
+        const args = {
+            type: this.schemaType,
+        };
+
+        const url = endpoints.global.studioTasks.studioTasksConvertToJsonSchema + this.urlEncodeArgs(args);
 
         return this.post<{ Result: string }>(url, JSON.stringify(this.payload)).fail((response: JQueryXHR) => {
             this.reportError(

--- a/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
+++ b/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
@@ -21,6 +21,7 @@ interface SampleObjectAndSchemaFieldsProps<TFieldValues extends FieldValues, TNa
     jsonSchemaLabel?: ReactNode;
     jsonSchema: string;
     jsonSchemaSyntaxHelp: React.ReactNode;
+    schemaType?: Raven.Server.Web.Studio.StudioTasksHandler.SchemaType;
 }
 
 export default function SampleObjectAndSchemaFields<
@@ -37,6 +38,7 @@ export default function SampleObjectAndSchemaFields<
     jsonSchemaLabel = "JSON schema",
     jsonSchema,
     jsonSchemaSyntaxHelp,
+    schemaType,
 }: SampleObjectAndSchemaFieldsProps<TFieldValues, TName>) {
     const sampleObjectRef = useRef<ReactAce>(null);
     const jsonSchemaRef = useRef<ReactAce>(null);
@@ -46,7 +48,7 @@ export default function SampleObjectAndSchemaFields<
     const [lastSampleObjectForGenerate, setLastSampleObjectForGenerate] = useState<string>("");
 
     const asyncGenerateSchema = useAsyncCallback(async () => {
-        const result = await tasksService.getJsonSchemaFromSampleObject(JSON.parse(sampleObject));
+        const result = await tasksService.getJsonSchemaFromSampleObject(JSON.parse(sampleObject), schemaType);
         setValue(jsonSchemaName, result.Result as TFieldValues[TName], { shouldValidate: true });
         setLastSampleObjectForGenerate(sampleObject);
     });

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentToolsSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentToolsSection.tsx
@@ -247,6 +247,7 @@ function QueryField({ index, remove, save, edit, cancelEdit }: QueryFieldProps) 
                 jsonSchemaLabel="Parameters JSON schema"
                 jsonSchema={queryItem.parametersSchema}
                 jsonSchemaSyntaxHelp={<div>TODO</div>}
+                schemaType="ToolParameters"
             />
         </div>
     );
@@ -342,6 +343,7 @@ function ActionField({ index, remove, save, edit, cancelEdit }: ActionFieldProps
                 jsonSchemaLabel="Parameters JSON schema"
                 jsonSchema={actionItem.parametersSchema}
                 jsonSchemaSyntaxHelp={<div>TODO</div>}
+                schemaType="ToolParameters"
             />
         </div>
     );

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -486,6 +486,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(NodeId));
             scripter.AddType(typeof(ModifyOngoingTaskResult));
             scripter.AddType(typeof(Transformation));
+            scripter.AddType(typeof(SchemaType));
 
             // ongoing tasks - replication
             scripter.AddType(typeof(OngoingTaskReplication));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24734

### Additional description

Creating schema for structured output is slightly different from the schema for the tools.
So we need to separate the two.
Relevant only for studio. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
