### PR TITLE
RavenDB-24717 AI Agent: different view for the tool call

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.scss
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.scss
@@ -20,4 +20,13 @@
         padding: sizes.$gutter-xxs !important;
         background-color: colors.$panel-bg-3 !important;
     }
+
+    .tool-call-details {
+        .accordion-button {
+            border-radius: sizes.$gutter-sm !important;
+            font-size: sizes.$font-size-sm !important;
+            padding: sizes.$gutter-xxs !important;
+            background-color: colors.$panel-bg-2 !important;
+        }
+    }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -430,32 +430,53 @@ function ToolCallBody({ tool, toolCall }: ToolCallBodyProps) {
     const prettifiedArguments = aiAgentsUtils.getPrettifiedContent(toolCall?.arguments);
     const argumentsMode = getAceEditorMode(prettifiedArguments);
 
+    const id = useUniqueId("tool-call-details");
+
     return (
         <div className="vstack gap-2">
             {tool && (
-                <>
-                    <small className="text-muted">Description</small>
-                    <div>{tool.Description}</div>
-                    <hr className="my-1" />
-                    {tool.ParametersSampleObject && (
-                        <div>
-                            <small className="text-muted">Parameters</small>
-                            <AceEditor value={tool.ParametersSampleObject} readOnly mode="json" height="100px" />
-                        </div>
-                    )}
-                    {tool.ParametersSchema && (
-                        <div>
-                            <small className="text-muted">Parameters schema</small>
-                            <AceEditor value={tool.ParametersSchema} readOnly mode="json" height="100px" />
-                        </div>
-                    )}
-                    {"Query" in tool && tool.Query && (
-                        <div>
-                            <small className="text-muted">Query</small>
-                            <AceEditor value={tool.Query} readOnly mode="text" height="100px" />
-                        </div>
-                    )}
-                </>
+                <Accordion className="tool-call-details border border-secondary rounded-2 panel-bg-2">
+                    <Accordion.Item eventKey={id} className="panel-bg-2">
+                        <Accordion.Header className="p-2">
+                            <Icon icon="settings" />
+                            See details
+                        </Accordion.Header>
+                        <Accordion.Collapse eventKey={id} mountOnEnter unmountOnExit>
+                            <Accordion.Body className="panel-bg-2 rounded-2">
+                                {tool.Description && (
+                                    <div>
+                                        <small className="text-muted">Description</small>
+                                        <div>{tool.Description}</div>
+                                        <hr className="my-1" />
+                                    </div>
+                                )}
+                                {tool.ParametersSampleObject && (
+                                    <div>
+                                        <small className="text-muted">Parameters</small>
+                                        <AceEditor
+                                            value={tool.ParametersSampleObject}
+                                            readOnly
+                                            mode="json"
+                                            height="100px"
+                                        />
+                                    </div>
+                                )}
+                                {tool.ParametersSchema && (
+                                    <div>
+                                        <small className="text-muted">Parameters schema</small>
+                                        <AceEditor value={tool.ParametersSchema} readOnly mode="json" height="100px" />
+                                    </div>
+                                )}
+                                {"Query" in tool && tool.Query && (
+                                    <div>
+                                        <small className="text-muted">Query</small>
+                                        <AceEditor value={tool.Query} readOnly mode="text" height="100px" />
+                                    </div>
+                                )}
+                            </Accordion.Body>
+                        </Accordion.Collapse>
+                    </Accordion.Item>
+                </Accordion>
             )}
             <div>
                 <small className="text-muted">Arguments</small>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24717/AI-Agent-different-view-for-the-tool-call

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
