### PR TITLE
RavenDB-24718 AI Agent: submit to a tool action is free text

### DIFF
--- a/src/Raven.Studio/typescript/components/common/ace/actions/AceEditorFormatAction.tsx
+++ b/src/Raven.Studio/typescript/components/common/ace/actions/AceEditorFormatAction.tsx
@@ -8,14 +8,19 @@ const beautify = ace.require("ace/ext/beautify").beautify;
 export default function AceEditorFormatAction() {
     const reactAce = useAceEditorContext();
 
+    const handleFormat = () => {
+        try {
+            const value = reactAce?.current.editor.session.getValue();
+            const parsed = JSON.parse(value);
+            const formatted = JSON.stringify(parsed, null, 2);
+            reactAce?.current.editor.session.setValue(formatted);
+        } catch {
+            beautify(reactAce?.current.editor.session);
+        }
+    };
+
     return (
-        <Button
-            variant="link"
-            onClick={() => beautify(reactAce?.current.editor.session)}
-            className="p-0 text-reset"
-            size="sm"
-            title="Format"
-        >
+        <Button variant="link" onClick={handleFormat} className="p-0 text-reset" size="sm" title="Format">
             <Icon icon="indent" margin="m-0" />
         </Button>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -109,6 +109,7 @@ function ToolMessage({ message, type }: ToolMessageProps) {
         () => (isTable ? JSON.parse(message.content).map((x: any) => new document(x)) : []),
         [message.content, isTable]
     );
+    const contentMode = getAceEditorMode(message.content);
 
     const { columnDefs } = useDocumentColumnsProvider({
         documents: tableData,
@@ -147,7 +148,7 @@ function ToolMessage({ message, type }: ToolMessageProps) {
                     aceRef={aceRef}
                     value={message.content}
                     readOnly
-                    mode="json"
+                    mode={contentMode}
                     height="150px"
                     actions={[{ component: <AceEditor.FullScreenAction /> }, { component: <AceEditor.FormatAction /> }]}
                 />
@@ -320,11 +321,14 @@ function AgentMessage({
                                 value={agentMessage.content}
                                 readOnly
                                 mode={contentMode}
-                                actions={[{ component: <AceEditor.FullScreenAction /> }]}
+                                actions={[
+                                    { component: <AceEditor.FullScreenAction /> },
+                                    { component: <AceEditor.FormatAction /> },
+                                ]}
                                 height={getAgentAceEditorHeight(agentMessage.content)}
-                                wrapEnabled
+                                wrapEnabled={contentMode === "text" ? true : false}
                                 setOptions={{
-                                    indentedSoftWrap: false,
+                                    indentedSoftWrap: contentMode === "text" ? true : false,
                                 }}
                             />
                         </div>
@@ -378,7 +382,7 @@ function ParameterField({ idx, name, control }: ParameterFieldProps) {
                 aceRef={aceRef}
                 control={control}
                 name={`parameters.${idx}.arguments`}
-                mode="json"
+                mode="text"
                 height="150px"
                 actions={[{ component: <AceEditor.FullScreenAction /> }, { component: <AceEditor.FormatAction /> }]}
             />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24718/AI-Agent-submit-to-a-tool-action-is-free-text
https://issues.hibernatingrhinos.com/issue/RavenDB-24770/Format-sample-object-does-not-work

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is neededx

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
