### PR TITLE
RavenDB-24775 AI Agent: disable message input when tool action is not submitted

### DIFF
--- a/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
+++ b/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
@@ -65,7 +65,7 @@ export default function SampleObjectAndSchemaFields<
                     "The sample object has been modified. Please regenerate the JSON schema to ensure it matches the new sample object structure.",
             });
         } else {
-            clearErrors([jsonSchemaName as TFieldValues[TName]])
+            clearErrors([jsonSchemaName as TFieldValues[TName]]);
         }
     }, [sampleObject, jsonSchema, canRegenerateSchema]);
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -37,6 +37,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
     const document = useAppSelector(chatAiAgentSelectors.document);
     const runChatState = useAppSelector(chatAiAgentSelectors.runChatState);
     const isLoading = useAppSelector(chatAiAgentSelectors.isLoading);
+    const isWaitingForActionToolSubmit = useAppSelector(chatAiAgentSelectors.isWaitingForActionToolSubmit);
 
     // Get data on load
     useEffect(() => {
@@ -109,6 +110,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
         dispatch(chatAiAgentActions.conversationIdSet(null));
         dispatch(chatAiAgentActions.messagesSet([]));
         dispatch(chatAiAgentActions.documentSet(null));
+        dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(false));
         setValue("prompt", "");
     };
 
@@ -169,6 +171,9 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
                                         toolQueries={config.data?.Queries}
                                         toolActions={config.data?.Actions}
                                         handleSaveParameters={(toolCallParameters) => runChat(toolCallParameters)}
+                                        setIsWaitingForActionToolSubmit={(value: boolean) =>
+                                            dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(value))
+                                        }
                                     />
                                 )}
                                 {isRawData && document.data && (
@@ -202,7 +207,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
                                                 handleSubmit(handleSend)();
                                             }
                                         }}
-                                        disabled={isLoading}
+                                        disabled={isLoading || isWaitingForActionToolSubmit}
                                     />
                                     {formValues.prompt && (
                                         <ButtonWithSpinner
@@ -210,7 +215,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
                                             variant="secondary"
                                             icon="arrow-up"
                                             isSpinning={runChatState === "loading"}
-                                            disabled={isLoading}
+                                            disabled={isLoading || isWaitingForActionToolSubmit}
                                             className="position-absolute rounded-pill"
                                             style={{ right: "10px", bottom: "10px", zIndex: 5 }}
                                         />

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -14,6 +14,7 @@ interface EditAiAgentState {
     conversationId: string;
     messages: AiAgentMessage[];
     isRawData: boolean;
+    isWaitingForActionToolSubmit: boolean;
 }
 
 const initialState: EditAiAgentState = {
@@ -23,6 +24,7 @@ const initialState: EditAiAgentState = {
     conversationId: "",
     messages: [],
     isRawData: false,
+    isWaitingForActionToolSubmit: false,
 };
 
 export const chatAiAgentSlice = createSlice({
@@ -40,6 +42,9 @@ export const chatAiAgentSlice = createSlice({
         },
         isRawDataSet: (state, action: PayloadAction<boolean>) => {
             state.isRawData = action.payload;
+        },
+        isWaitingForActionToolSubmitSet: (state, action: PayloadAction<boolean>) => {
+            state.isWaitingForActionToolSubmit = action.payload;
         },
         reset: () => initialState,
     },
@@ -161,4 +166,5 @@ export const chatAiAgentSelectors = {
         state.chatAiAgent.runChatState === "loading" ||
         state.chatAiAgent.config.status === "loading" ||
         state.chatAiAgent.document.status === "loading",
+    isWaitingForActionToolSubmit: (state: RootState) => state.chatAiAgent.isWaitingForActionToolSubmit,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
@@ -35,6 +35,8 @@ export default function EditAiAgentTestPanel() {
     const runTestState = useAppSelector(editAiAgentSelectors.runTestState);
     const isWaitingForActionToolSubmit = useAppSelector(editAiAgentSelectors.isWaitingForActionToolSubmit);
 
+    const isLoading = runTestState === "loading" || isWaitingForActionToolSubmit;
+
     const runTest = async (toolCallParameters?: AiAgentToolCall[]) => {
         await dispatch(editAiAgentActions.runTest({ databaseName, formValues, toolCallParameters })).unwrap();
         setValue("test.prompt", "");
@@ -164,7 +166,7 @@ export default function EditAiAgentTestPanel() {
                                 rows={3}
                                 className="rounded-2"
                                 style={{ resize: "none" }}
-                                disabled={runTestState === "loading" || isWaitingForActionToolSubmit}
+                                disabled={isLoading}
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter" && !e.shiftKey) {
                                         e.preventDefault();
@@ -177,7 +179,7 @@ export default function EditAiAgentTestPanel() {
                                     variant="secondary"
                                     icon="arrow-up"
                                     onClick={() => runTest()}
-                                    isSpinning={runTestState === "loading" || isWaitingForActionToolSubmit}
+                                    isSpinning={isLoading}
                                     className="position-absolute rounded-pill"
                                     style={{ right: "10px", bottom: "10px", zIndex: 5 }}
                                 />

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
@@ -33,6 +33,7 @@ export default function EditAiAgentTestPanel() {
     const isRawData = useAppSelector(editAiAgentSelectors.isRawData);
     const messages = useAppSelector(editAiAgentSelectors.testMessages);
     const runTestState = useAppSelector(editAiAgentSelectors.runTestState);
+    const isWaitingForActionToolSubmit = useAppSelector(editAiAgentSelectors.isWaitingForActionToolSubmit);
 
     const runTest = async (toolCallParameters?: AiAgentToolCall[]) => {
         await dispatch(editAiAgentActions.runTest({ databaseName, formValues, toolCallParameters })).unwrap();
@@ -56,6 +57,7 @@ export default function EditAiAgentTestPanel() {
     const handleNewChat = () => {
         dispatch(editAiAgentActions.testDocumentSet(null));
         dispatch(editAiAgentActions.testMessagesSet([]));
+        dispatch(editAiAgentActions.isWaitingForActionToolSubmitSet(false));
         setValue("test.prompt", "");
     };
 
@@ -125,6 +127,9 @@ export default function EditAiAgentTestPanel() {
                                 toolQueries={Queries}
                                 toolActions={Actions}
                                 handleSaveParameters={(toolCallParameters) => runTest(toolCallParameters)}
+                                setIsWaitingForActionToolSubmit={(value: boolean) =>
+                                    dispatch(editAiAgentActions.isWaitingForActionToolSubmitSet(value))
+                                }
                             />
                         )}
                         {isRawData && testDocument && (
@@ -159,7 +164,7 @@ export default function EditAiAgentTestPanel() {
                                 rows={3}
                                 className="rounded-2"
                                 style={{ resize: "none" }}
-                                disabled={runTestState === "loading"}
+                                disabled={runTestState === "loading" || isWaitingForActionToolSubmit}
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter" && !e.shiftKey) {
                                         e.preventDefault();
@@ -172,7 +177,7 @@ export default function EditAiAgentTestPanel() {
                                     variant="secondary"
                                     icon="arrow-up"
                                     onClick={() => runTest()}
-                                    isSpinning={runTestState === "loading"}
+                                    isSpinning={runTestState === "loading" || isWaitingForActionToolSubmit}
                                     className="position-absolute rounded-pill"
                                     style={{ right: "10px", bottom: "10px", zIndex: 5 }}
                                 />

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/store/editAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/store/editAiAgentSlice.ts
@@ -16,6 +16,7 @@ interface EditAiAgentState {
     testDocument: documentDto;
     isDocumentExpirationEnabled: loadableData<boolean>;
     runTestState: loadStatus;
+    isWaitingForActionToolSubmit: boolean;
 }
 
 const initialState: EditAiAgentState = {
@@ -26,6 +27,7 @@ const initialState: EditAiAgentState = {
     testDocument: null,
     isDocumentExpirationEnabled: createIdleState(),
     runTestState: "idle",
+    isWaitingForActionToolSubmit: false,
 };
 
 export const editAiAgentSlice = createSlice({
@@ -46,6 +48,9 @@ export const editAiAgentSlice = createSlice({
         },
         testDocumentSet: (state, action: PayloadAction<any>) => {
             state.testDocument = action.payload;
+        },
+        isWaitingForActionToolSubmitSet: (state, action: PayloadAction<boolean>) => {
+            state.isWaitingForActionToolSubmit = action.payload;
         },
         reset: () => initialState,
     },
@@ -127,4 +132,5 @@ export const editAiAgentSelectors = {
     testDocument: (state: RootState) => state.editAiAgent.testDocument,
     isDocumentExpirationEnabled: (state: RootState) => state.editAiAgent.isDocumentExpirationEnabled,
     runTestState: (state: RootState) => state.editAiAgent.runTestState,
+    isWaitingForActionToolSubmit: (state: RootState) => state.editAiAgent.isWaitingForActionToolSubmit,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -26,6 +26,7 @@ interface AiAgentMessagesProps {
     toolQueries: ToolQuery[];
     toolActions: ToolAction[];
     handleSaveParameters: (toolCallParameters: AiAgentToolCall[]) => void;
+    setIsWaitingForActionToolSubmit: (isWaiting: boolean) => void;
 }
 
 export default function AiAgentMessages({
@@ -33,6 +34,7 @@ export default function AiAgentMessages({
     toolQueries,
     toolActions,
     handleSaveParameters,
+    setIsWaitingForActionToolSubmit,
 }: AiAgentMessagesProps) {
     return (
         <div className="w-100 vstack gap-2 ai-agent-messages">
@@ -45,6 +47,7 @@ export default function AiAgentMessages({
                     toolQueries={toolQueries}
                     toolActions={toolActions}
                     handleSaveParameters={handleSaveParameters}
+                    setIsWaitingForActionToolSubmit={setIsWaitingForActionToolSubmit}
                 />
             ))}
         </div>
@@ -58,6 +61,7 @@ interface AiAgentMessageProps {
     toolQueries: ToolQuery[];
     toolActions: ToolAction[];
     handleSaveParameters: (toolCallParameters: AiAgentToolCall[]) => void;
+    setIsWaitingForActionToolSubmit: (isWaiting: boolean) => void;
 }
 
 function AiAgentMessage({
@@ -67,6 +71,7 @@ function AiAgentMessage({
     toolQueries,
     toolActions,
     handleSaveParameters,
+    setIsWaitingForActionToolSubmit,
 }: AiAgentMessageProps) {
     const toolName = allMessages
         .find((x) => x.toolCalls?.some((y) => y.id === message.toolCallId))
@@ -88,6 +93,7 @@ function AiAgentMessage({
                     toolQueries={toolQueries}
                     toolActions={toolActions}
                     handleSaveParameters={handleSaveParameters}
+                    setIsWaitingForActionToolSubmit={setIsWaitingForActionToolSubmit}
                 />
             )}
         </div>
@@ -219,6 +225,7 @@ interface AgentMessageProps {
     toolQueries: ToolQuery[];
     toolActions: ToolAction[];
     handleSaveParameters?: (parameters: AiAgentToolCall[]) => void;
+    setIsWaitingForActionToolSubmit: (isWaiting: boolean) => void;
 }
 
 function AgentMessage({
@@ -227,10 +234,11 @@ function AgentMessage({
     toolQueries,
     toolActions,
     handleSaveParameters,
+    setIsWaitingForActionToolSubmit,
 }: AgentMessageProps) {
     const aceRef = useRef<ReactAce>(null);
 
-    const { control, handleSubmit, reset, formState } = useForm<{ parameters: AiAgentToolCall[] }>({
+    const { control, handleSubmit, formState } = useForm<{ parameters: AiAgentToolCall[] }>({
         defaultValues: {
             parameters:
                 agentMessage.toolCalls?.map((x) => ({
@@ -246,18 +254,6 @@ function AgentMessage({
         name: "parameters",
     });
 
-    // Reset the form when the tool calls change
-    useEffect(() => {
-        reset({
-            parameters:
-                agentMessage.toolCalls?.map((x) => ({
-                    id: x.id,
-                    name: x.name,
-                    arguments: "",
-                })) ?? [],
-        });
-    }, [agentMessage.toolCalls?.length]);
-
     const handleSave: SubmitHandler<{ parameters: AiAgentToolCall[] }> = (formData) => {
         handleSaveParameters?.(formData.parameters);
     };
@@ -268,6 +264,10 @@ function AgentMessage({
 
     const isRequireParameters =
         isLastItem && isToolAction && agentMessage.toolCalls?.length > 0 && !formState.isSubmitted;
+
+    useEffect(() => {
+        setIsWaitingForActionToolSubmit(isRequireParameters);
+    }, [isRequireParameters]);
 
     const contentMode = getAceEditorMode(agentMessage.content);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24775/AI-Agent-disable-message-input-when-tool-action-is-not-submitted

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
