### PR TITLE
RavenDB-24366 "@archived: true" should be removed when testing the "unarchive" method in the "Test Patch" view

### DIFF
--- a/src/Raven.Server/Documents/DocumentCompare.cs
+++ b/src/Raven.Server/Documents/DocumentCompare.cs
@@ -120,6 +120,17 @@ namespace Raven.Server.Documents
             throw new InvalidOperationException("Illegal modifications of '@attachments' detected");
         }
 
+        private static bool ShouldIgnoreMetadataProperty(string property, in DocumentCompareOptions options)
+        {
+            // ignore the change unless it's collection, expiration, or refresh metadata
+            // ignore the change unless it's archived metadata, but only if CompareDataArchivalMetadata is set `true`
+            return property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false &&
+                   property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) == false &&
+                   property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false &&
+                   (options.CompareDataArchivalMetadata && (property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase) ||
+                                                            property.Equals(Constants.Documents.Metadata.Archived, StringComparison.OrdinalIgnoreCase))) == false;
+        }
+
         private static DocumentCompareResult ComparePropertiesExceptStartingWithAt(
             BlittableJsonReaderObject current,
             BlittableJsonReaderObject modified,
@@ -197,10 +208,7 @@ namespace Raven.Server.Documents
                                 continue;
                             }
                         }
-                        else if (property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false &&
-                                 property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) == false &&
-                                 property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false &&
-                                 (options.CompareDataArchivalMetadata && property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase)) == false)
+                        else if (ShouldIgnoreMetadataProperty(property, options))
                             continue;
                     }
                     else if (property.Equals(Constants.Documents.Metadata.Key, StringComparison.OrdinalIgnoreCase))

--- a/src/Raven.Server/Documents/DocumentCompare.cs
+++ b/src/Raven.Server/Documents/DocumentCompare.cs
@@ -119,16 +119,25 @@ namespace Raven.Server.Documents
         {
             throw new InvalidOperationException("Illegal modifications of '@attachments' detected");
         }
-
-        private static bool PatchResultMetadataPropertyDoesntContainImpactfulChange(string property, in DocumentCompareOptions options)
+        
+        private static bool IsSignificantMetadataProperty(string property, in DocumentCompareOptions options)
         {
-            // Don't ignore collection, expiration, or refresh metadata
-            // Don't ignore archived metadata only when DocumentCompareOptions.CompareDataArchivalMetadata equals `true`
-            return property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false &&
-                   property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) == false &&
-                   property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false &&
-                   (options.CompareDataArchivalMetadata && (property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase) ||
-                                                            property.Equals(Constants.Documents.Metadata.Archived, StringComparison.OrdinalIgnoreCase))) == false;
+            if (property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) ||
+                property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) ||
+                property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // Archival properties are significant only when the option is enabled
+            if (options.CompareDataArchivalMetadata &&
+                (property.Equals(Constants.Documents.Metadata.ArchiveAt, StringComparison.OrdinalIgnoreCase) ||
+                 property.Equals(Constants.Documents.Metadata.Archived, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static DocumentCompareResult ComparePropertiesExceptStartingWithAt(
@@ -208,7 +217,7 @@ namespace Raven.Server.Documents
                                 continue;
                             }
                         }
-                        else if (PatchResultMetadataPropertyDoesntContainImpactfulChange(property, options))
+                        else if (IsSignificantMetadataProperty(property, options) == false)
                             continue;
                     }
                     else if (property.Equals(Constants.Documents.Metadata.Key, StringComparison.OrdinalIgnoreCase))

--- a/src/Raven.Server/Documents/DocumentCompare.cs
+++ b/src/Raven.Server/Documents/DocumentCompare.cs
@@ -120,10 +120,10 @@ namespace Raven.Server.Documents
             throw new InvalidOperationException("Illegal modifications of '@attachments' detected");
         }
 
-        private static bool ShouldIgnoreMetadataProperty(string property, in DocumentCompareOptions options)
+        private static bool PatchResultMetadataPropertyDoesntContainImpactfulChange(string property, in DocumentCompareOptions options)
         {
-            // ignore the change unless it's collection, expiration, or refresh metadata
-            // ignore the change unless it's archived metadata, but only if CompareDataArchivalMetadata is set `true`
+            // Don't ignore collection, expiration, or refresh metadata
+            // Don't ignore archived metadata only when DocumentCompareOptions.CompareDataArchivalMetadata equals `true`
             return property.Equals(Constants.Documents.Metadata.Collection, StringComparison.OrdinalIgnoreCase) == false &&
                    property.Equals(Constants.Documents.Metadata.Expires, StringComparison.OrdinalIgnoreCase) == false &&
                    property.Equals(Constants.Documents.Metadata.Refresh, StringComparison.OrdinalIgnoreCase) == false &&
@@ -208,7 +208,7 @@ namespace Raven.Server.Documents
                                 continue;
                             }
                         }
-                        else if (ShouldIgnoreMetadataProperty(property, options))
+                        else if (PatchResultMetadataPropertyDoesntContainImpactfulChange(property, options))
                             continue;
                     }
                     else if (property.Equals(Constants.Documents.Metadata.Key, StringComparison.OrdinalIgnoreCase))

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -209,6 +209,13 @@ namespace Raven.Server.Documents.Patch
                     if (shouldUpdateMetadata || compareResult != DocumentCompareResult.Equal)
                     {
                         Debug.Assert(originalDocument != null);
+                        
+                        if (run.UnarchiveCalled)
+                        {
+                            originalDocument.Flags &= ~DocumentFlags.Archived;
+                            nonPersistentFlags |= NonPersistentDocumentFlags.Unarchive;
+                        }
+                        
                         if (_isTest == false || run.PutOrDeleteCalled)
                         {
                             putResult = _database.DocumentsStorage.Put(

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -235,6 +235,7 @@ namespace Raven.Server.Documents.Patch
             public bool DebugMode;
             public List<string> DebugOutput;
             public bool PutOrDeleteCalled;
+            public bool UnarchiveCalled;
             public HashSet<string> Includes;
             public HashSet<string> IncludeRevisionsChangeVectors;
             public DateTime? IncludeRevisionByDateTimeBefore;
@@ -922,29 +923,23 @@ namespace Raven.Server.Documents.Patch
                     throw new InvalidOperationException("unarchive(doc) must take document object as the first argument");
                 
                 var archivedDocId = GetIdFromArg(args[0], _unarchiveSignature);
-                using (var doc = _database.DocumentsStorage.Get(_docsCtx, archivedDocId, DocumentFields.Data, throwOnConflict: true))
+                
+                var boi = (BlittableObjectInstance)args[0].AsObject();
+                if (boi.DocumentFlags.HasValue == false || boi.DocumentFlags.Value.HasFlag(DocumentFlags.Archived) == false)
                 {
-                    if (doc.Flags.HasFlag(DocumentFlags.Archived) == false)
-                    {
-                        return JsValue.Undefined;
-                    }
-                    
-                    if (doc.TryGetMetadata(out var metadata) == false)
-                    {
-                        throw new InvalidOperationException($"Failed to fetch the metadata of document '{archivedDocId}'");
-                    }
-                    
-                    // Remove archived metadata marker, remove archived document flag
-                    metadata.Modifications = new DynamicJsonValue(metadata);
-                    metadata.Modifications.Remove(Constants.Documents.Metadata.Archived);
-                    doc.Flags = doc.Flags.Strip(DocumentFlags.Archived);
-        
-                    using (var updated = _docsCtx.ReadObject(doc.Data, archivedDocId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                    {
-                         _database.DocumentsStorage.Put(_docsCtx, archivedDocId, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction), nonPersistentFlags: NonPersistentDocumentFlags.Unarchive);
-                    }
+                    return JsValue.Undefined; // no-op, document has no Archived flag
                 }
 
+                if (boi.TryGetValue(Constants.Documents.Metadata.Key, out var metadataJs) == false)
+                {
+                    throw new InvalidOperationException($"Failed to fetch the metadata of document '{archivedDocId}'");
+                }
+                
+                // Remove archived metadata marker, mark UnarchiveCalled (we can't set flags here, removed later)
+                var metadata = metadataJs.AsObject();
+                metadata.Delete(Constants.Documents.Metadata.Archived);
+                UnarchiveCalled = true;
+                
                 return JsValue.Undefined;
             }
 
@@ -2199,6 +2194,7 @@ namespace Raven.Server.Documents.Patch
                 DocumentCountersToUpdate?.Clear();
                 DocumentTimeSeriesToUpdate?.Clear();
                 PutOrDeleteCalled = false;
+                UnarchiveCalled= false;
                 OriginalDocumentId = null;
                 RefreshOriginalDocument = false;
                 ScriptEngine.Advanced.ResetCallStack();

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -2194,7 +2194,7 @@ namespace Raven.Server.Documents.Patch
                 DocumentCountersToUpdate?.Clear();
                 DocumentTimeSeriesToUpdate?.Clear();
                 PutOrDeleteCalled = false;
-                UnarchiveCalled= false;
+                UnarchiveCalled = false;
                 OriginalDocumentId = null;
                 RefreshOriginalDocument = false;
                 ScriptEngine.Advanced.ResetCallStack();

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
@@ -233,6 +233,65 @@ public class DataArchivalPatchingTests : RavenTestBase
             }
         }
     }
+    
+    [RavenFact(RavenTestCategory.Patching)]
+    public async Task UnarchivePatchTestResultShouldntContainArchivedFlag()
+    {
+        using (var store = GetDocumentStore())
+        {
+            // Insert document with archive time before activating the archival
+            var company = new Company { Name = "Company Name" };
+            var retires = SystemTime.UtcNow.AddMinutes(5);
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company);
+                var metadata = session.Advanced.GetMetadataFor(company);
+                metadata[Constants.Documents.Metadata.ArchiveAt] = retires.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                await session.SaveChangesAsync();
+            }
+
+            // Activate the archival
+            await SetupDataArchival(store);
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+            var documentsArchiver = database.DataArchivist;
+            await documentsArchiver.ArchiveDocs();
+
+            await Indexes.WaitForIndexingAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var archivedCompany = await session.LoadAsync<Company>(company.Id);
+                var metadata = session.Advanced.GetMetadataFor(archivedCompany);
+                Assert.DoesNotContain(Constants.Documents.Metadata.ArchiveAt, metadata.Keys);
+                Assert.Contains(Constants.Documents.Metadata.Collection, metadata.Keys);
+                Assert.Contains(Constants.Documents.Metadata.Archived, metadata.Keys);
+                Assert.Equal(true, metadata[Constants.Documents.Metadata.Archived]);
+
+                // Make sure that the company is skipped while indexing (auto map index)
+                var companies = await session.Query<Company>().Where(x => x.Name == "Company Name").ToListAsync();
+                Assert.Equal(0, companies.Count);
+            }
+
+            using (var commands = store.Commands())
+            {
+                var command = new PatchOperation.PatchCommand(store.Conventions,
+                    commands.Context,
+                    "companies/1-A",
+                    null,
+                    new PatchRequest { Script = "archived.unarchive(this)"},
+                    patchIfMissing: null,
+                    skipPatchIfChangeVectorMismatch: false,
+                    returnDebugInformation: false,
+                    test: true);
+
+                commands.RequestExecutor.Execute(command, commands.Context);
+                var metadata = command.Result.ModifiedDocument[Constants.Documents.Metadata.Key] as BlittableJsonReaderObject;
+                Assert.False(metadata.TryGet(Constants.Documents.Metadata.Archived, out object _));
+            }
+        }
+    }
 
 
     [RavenFact(RavenTestCategory.Patching)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24366/archived-true-should-be-removed-when-testing-the-unarchive-method-in-the-Test-Patch-view-Fix-the-Before-document-that-shows

### Additional description

Dropped redundant DocumentStore calls, which can be handled in a much cleaner way, which is much closer to the Patch & ScriptRunner design. As we cannot modify BlittableObjectInstance Flags within ScriptRunner, introduced the flag `UnarchiveCalled` that works similarly to the already existing flags. 

Also, extracted a large `if` statement body in `DocumentCompare.isEqual` to a separate `ShouldIgnoreMetadataProperty` method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
