### PR TITLE
RavenDB-24590 Debugging enhancements for Corax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -59,6 +59,7 @@ using Raven.Server.ServerWide.Memory;
 using Raven.Server.Storage.Layout;
 using Raven.Server.Storage.Schema;
 using Raven.Server.Utils;
+using Raven.Server.Utils.Debugging;
 using Raven.Server.Utils.Enumerators;
 using Raven.Server.Utils.Metrics;
 using Sparrow;
@@ -2435,6 +2436,7 @@ namespace Raven.Server.Documents.Indexes
 
             bool mightBeMore = false;
 
+            using (CreateBatchRunningFileMarkerIfDebuggingEnabled())
             using (DocumentDatabase.PreventFromUnloadingByIdleOperations())
             using (CultureHelper.EnsureInvariantCulture())
             using (var context = QueryOperationContext.Allocate(DocumentDatabase, this))
@@ -5486,6 +5488,21 @@ namespace Raven.Server.Documents.Indexes
 
                 return files.Length;
             }
+        }
+
+        private IDisposable CreateBatchRunningFileMarkerIfDebuggingEnabled()
+        {
+            if (RavenDebugVariables.Indexing.ShouldPutBatchRunningFileMarker(SearchEngineType) == false)
+                return null;
+
+            var batchRunningMarkerFile = _environment.Options.BasePath.Combine("indexing-batch.marker").FullPath;
+
+            if (File.Exists(batchRunningMarkerFile))
+                File.Delete(batchRunningMarkerFile);
+
+            File.Create(batchRunningMarkerFile!).Dispose();
+
+            return new DisposableAction(() => File.Delete(batchRunningMarkerFile));
         }
 
         internal TestingStuff _forTestingPurposes;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -45,6 +46,8 @@ namespace Raven.Server.Documents.Replication
 {
     public class ReplicationLoader : AbstractReplicationLoader<DocumentsContextPool, DocumentsOperationContext>, ITombstoneAware
     {
+        const string ReplicationDisabledByMarkerFile = "Replication is disabled because there is disable.replication.marker file in the database data directory";
+
         private readonly Timer _reconnectAttemptTimer;
         private long _reconnectInProgress;
         private readonly ReaderWriterLockSlim _locker = new ReaderWriterLockSlim();
@@ -78,6 +81,7 @@ namespace Raven.Server.Documents.Replication
         public ConflictSolver ConflictSolverConfig;
         private readonly CancellationToken _shutdownToken;
         private HubInfoForCleaner _hubInfoForCleaner;
+        private bool _replicationDisabledByMarker;
         private readonly ConcurrentQueue<TaskCompletionSource<object>> _waitForReplicationTasks = new ConcurrentQueue<TaskCompletionSource<object>>();
         private readonly ConcurrentDictionary<ReplicationNode, LastEtagPerDestination> _lastSendEtagPerDestination = new ConcurrentDictionary<ReplicationNode, LastEtagPerDestination>();
 
@@ -386,6 +390,9 @@ namespace Raven.Server.Documents.Replication
             X509Certificate2 certificate,
             JsonOperationContext.MemoryBuffer buffer)
         {
+            if (_replicationDisabledByMarker)
+                throw new InvalidOperationException(ReplicationDisabledByMarkerFile);
+
             var supportedVersions = GetSupportedVersions(tcpConnectionOptions);
             var initialRequest = GetReplicationInitialRequest(tcpConnectionOptions, supportedVersions, buffer);
 
@@ -766,6 +773,19 @@ namespace Raven.Server.Documents.Replication
             ConflictResolver = new ResolveConflictOnReplicationConfigurationChange(this, _logger);
             Task.Run(() => ConflictResolver.RunConflictResolversOnce(record.ConflictSolverConfig, index));
             _isInitialized.Raise();
+
+            if (Database.Configuration.Core.RunInMemory == false)
+            {
+                string disableMarkerPath = Database.Configuration.Core.DataDirectory.Combine("disable.replication.marker").FullPath;
+                
+                if (File.Exists(disableMarkerPath))
+                {
+                    _replicationDisabledByMarker = true;
+
+                    if (_logger.IsOperationsEnabled) 
+                        _logger.Operations(ReplicationDisabledByMarkerFile);
+                }
+            }
         }
 
         public void HandleDatabaseRecordChange(DatabaseRecord newRecord, long index)
@@ -822,7 +842,7 @@ namespace Raven.Server.Documents.Replication
         private void HandleTopologyChange(DatabaseRecord newRecord)
         {
             var instancesToDispose = new List<IDisposable>();
-            if (newRecord == null || _server.IsPassive())
+            if (newRecord == null || _server.IsPassive() || _replicationDisabledByMarker)
             {
                 DropOutgoingConnections(Destinations, instancesToDispose);
                 DropIncomingConnections(Destinations, instancesToDispose);
@@ -830,6 +850,10 @@ namespace Raven.Server.Documents.Replication
                 _externalDestinations.Clear();
                 _destinations.Clear();
                 DisposeConnections(instancesToDispose);
+
+                if (_replicationDisabledByMarker && _logger.IsInfoEnabled) 
+                    _logger.Info(ReplicationDisabledByMarkerFile);
+
                 return;
             }
 

--- a/src/Raven.Server/Utils/Debugging/RavenDebugVariables.cs
+++ b/src/Raven.Server/Utils/Debugging/RavenDebugVariables.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Raven.Client.Documents.Indexes;
+
+namespace Raven.Server.Utils.Debugging;
+
+public static class RavenDebugVariables
+{
+    public static class Indexing
+    {
+        static Indexing()
+        {
+            string searchEngineToDebug = Environment.GetEnvironmentVariable("RAVEN_DEBUG_INDEXING_SEARCH_ENGINE");
+
+            if (string.IsNullOrEmpty(searchEngineToDebug) == false)
+            {
+                if (Enum.TryParse<SearchEngineType>(searchEngineToDebug, true, out var engineType)) 
+                    SearchEngineToDebug = engineType;
+            }
+
+            string batchingFileMarkers = Environment.GetEnvironmentVariable("RAVEN_DEBUG_INDEXING_BATCHING_FILE_MARKERS");
+
+            if (string.IsNullOrEmpty(batchingFileMarkers) == false)
+            {
+                BatchingFileMarkers = batchingFileMarkers;
+            }
+        }
+
+        public static SearchEngineType? SearchEngineToDebug { get; private set; }
+
+        public static string BatchingFileMarkers { get; private set; }
+
+        public static bool ShouldPutBatchRunningFileMarker(SearchEngineType searchEngine)
+        {
+            if (string.IsNullOrEmpty(BatchingFileMarkers))
+                return false;
+
+            if (SearchEngineToDebug == null)
+            {
+                // enable for any index regardless search engine type since it was not set
+                return true;
+            }
+
+            return searchEngine == SearchEngineToDebug.Value;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24590

### Additional description

Two debugging enhancements to improve troubleshooting of Corax issues:

1. Ability to disable replication (incoming / outgoing) via `disable.replication.marker` file put in a database data directory. 
 - This is needed to prevent from accepting incoming changes to documents which often made that an issue in Corax index was no longer reproducible after some time even if we managed to get index data.

2. Ability to create `indexing-batch.marker` file during an index batch run. 

- It can be configured via env variable:

```
RAVEN_DEBUG_INDEXING_BATCHING_FILE_MARKERS=true
```
- In order to do it selectively only for Corax you can do:

```
RAVEN_DEBUG_INDEXING_SEARCH_ENGINE=Corax
```

-  Together with `RAVEN_Indexing_MaxNumberOfConcurrentlyRunningIndexes=1`, it will give better isolation and discoverability of a problematic index


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
