### PR TITLE
RavenDB-24765 Make bge-micro-v2 initialization Lazy to prevent server spin-up crash

### DIFF
--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -1,6 +1,7 @@
 #pragma warning disable SKEXP0070
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -30,7 +31,7 @@ public static class GenerateEmbeddings
     // Dimensions (buffer size) from internals of SmartComponents.
     public const int F32Size = 1536;
 
-    private static SessionOptions OnnxSessionOptions;
+    private static Lazy<SessionOptions> OnnxSessionOptions = new(() => null);
 
     internal static readonly Lazy<IEmbeddingGenerator<string, Embedding<float>>> Embedder = new(() => CreateTextEmbeddingGenerationService());
 
@@ -42,6 +43,33 @@ public static class GenerateEmbeddings
             throw new InvalidOperationException($"Could not find constructor for {typeof(BertOnnxTextEmbeddingGenerationService)}.");
 #pragma warning restore CS0618 // Type or member is obsolete
     }
+    
+    private static bool RunningOnCortexA53()
+    {
+        // Only Linux exposes MIDR registers through sysfs
+        if (PlatformDetails.RunningOnLinux == false)
+            return false;
+
+        const string midrPath =
+            "/sys/devices/system/cpu/cpu0/regs/identification/midr_el1";
+
+        try
+        {
+            string text = File.ReadAllText(midrPath).Trim();   // e.g. "410fd034"
+            if (ulong.TryParse(text, NumberStyles.HexNumber,
+                    CultureInfo.InvariantCulture, out ulong midr))
+            {
+                // ARM implementer 0x41 (A), part 0xD03 ⇒ Cortex‑A53
+                return (midr & 0xFFF000u) == 0x41D030u;
+            }
+        }
+        catch (Exception)  // file missing, permission, etc.
+        {
+            /* ignore – fall through and report false */
+        }
+
+        return false;
+    }
 
     public static void Configure(RavenConfiguration configuration)
     {
@@ -50,7 +78,13 @@ public static class GenerateEmbeddings
 
         try
         {
-            OnnxSessionOptions = new SessionOptions { IntraOpNumThreads = configuration.Indexing.MaxNumberOfThreadsForLocalEmbeddingsGeneration };
+            OnnxSessionOptions = new Lazy<SessionOptions>(valueFactory: () =>
+            {
+                if (RunningOnCortexA53())
+                    throw new IncorrectDllException("Could not initialize 'ONNX Runtime'. Cortex A53 is not supported by ONNX Runtime.");
+                
+                return new SessionOptions { IntraOpNumThreads = configuration.Indexing.MaxNumberOfThreadsForLocalEmbeddingsGeneration };
+            });
         }
         catch (TypeInitializationException e) when (PlatformDetails.RunningOnWindows)
         {
@@ -270,7 +304,7 @@ public static class GenerateEmbeddings
             var modelBytes = new MemoryStream();
             onnxModelStream.CopyTo(modelBytes);
 
-            var onnxSession = new InferenceSession(modelBytes.Length == modelBytes.GetBuffer().Length ? modelBytes.GetBuffer() : modelBytes.ToArray(), OnnxSessionOptions ?? new SessionOptions());
+            var onnxSession = new InferenceSession(modelBytes.Length == modelBytes.GetBuffer().Length ? modelBytes.GetBuffer() : modelBytes.ToArray(), OnnxSessionOptions.Value ?? new SessionOptions());
             dimensions ??= onnxSession.OutputMetadata.First().Value.Dimensions.Last();
 
             var tokenizer = new BertTokenizer();

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -43,33 +43,6 @@ public static class GenerateEmbeddings
             throw new InvalidOperationException($"Could not find constructor for {typeof(BertOnnxTextEmbeddingGenerationService)}.");
 #pragma warning restore CS0618 // Type or member is obsolete
     }
-    
-    private static bool RunningOnCortexA53()
-    {
-        // Only Linux exposes MIDR registers through sysfs
-        if (PlatformDetails.RunningOnLinux == false)
-            return false;
-
-        const string midrPath =
-            "/sys/devices/system/cpu/cpu0/regs/identification/midr_el1";
-
-        try
-        {
-            string text = File.ReadAllText(midrPath).Trim();   // e.g. "410fd034"
-            if (ulong.TryParse(text, NumberStyles.HexNumber,
-                    CultureInfo.InvariantCulture, out ulong midr))
-            {
-                // ARM implementer 0x41 (A), part 0xD03 ⇒ Cortex‑A53
-                return (midr & 0xFFF000u) == 0x41D030u;
-            }
-        }
-        catch (Exception)  // file missing, permission, etc.
-        {
-            /* ignore – fall through and report false */
-        }
-
-        return false;
-    }
 
     public static void Configure(RavenConfiguration configuration)
     {
@@ -80,8 +53,8 @@ public static class GenerateEmbeddings
         {
             OnnxSessionOptions = new Lazy<SessionOptions>(valueFactory: () =>
             {
-                if (RunningOnCortexA53())
-                    throw new IncorrectDllException("Could not initialize 'ONNX Runtime'. Cortex A53 is not supported by ONNX Runtime.");
+                if (PlatformDetails.RunningOnCortexA53)
+                    throw new IncorrectDllException("Could not initialize 'ONNX Runtime'. Your CPU, the Cortex A53, is not supported by ONNX Runtime: https://github.com/microsoft/onnxruntime/issues/25472");
                 
                 return new SessionOptions { IntraOpNumThreads = configuration.Indexing.MaxNumberOfThreadsForLocalEmbeddingsGeneration };
             });

--- a/src/Sparrow/Platform/PlatformDetails.cs
+++ b/src/Sparrow/Platform/PlatformDetails.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
@@ -35,6 +36,7 @@ namespace Sparrow.Platform
 #endif
         public static readonly bool RunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+        public static readonly bool RunningOnCortexA53 = RunningOnLinux && CheckIfRunningOnCortexA53();
         public static readonly bool CanPrefetch;
         public static readonly bool CanDiscardMemory;
         internal static readonly bool CanUseHttp2;
@@ -84,6 +86,31 @@ namespace Sparrow.Platform
             {
                 return false;
             }
+        }
+
+        private static bool CheckIfRunningOnCortexA53()
+        {
+            const string midrPath = "/sys/devices/system/cpu/cpu0/regs/identification/midr_el1";
+
+            if (File.Exists(midrPath) == false)
+                return false;
+
+            try
+            {
+                string text = File.ReadAllText(midrPath).Trim(); // e.g. "410fd034"
+                if (ulong.TryParse(text, NumberStyles.HexNumber,
+                        CultureInfo.InvariantCulture, out ulong midr))
+                {
+                    // ARM implementer 0x41 (A), part 0xD03 ⇒ Cortex‑A53
+                    return (midr & 0xFFF000u) == 0x41D030u;
+                }
+            }
+            catch (Exception) // file missing, permission, etc.
+            {
+                // ignore – fall through and report false
+            }
+
+            return false;
         }
 
         internal static string GetVcRedistLink()

--- a/src/Sparrow/Platform/PlatformDetails.cs
+++ b/src/Sparrow/Platform/PlatformDetails.cs
@@ -98,14 +98,19 @@ namespace Sparrow.Platform
             try
             {
                 string text = File.ReadAllText(midrPath).Trim(); // e.g. "410fd034"
-                if (ulong.TryParse(text, NumberStyles.HexNumber,
-                        CultureInfo.InvariantCulture, out ulong midr))
+                if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                    text = text.Substring(2);
+
+                if (ulong.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ulong midr))
                 {
+                    ulong implementer = (midr >> 24) & 0xFF;
+                    ulong partNumber = (midr >> 4) & 0xFFF;
+
                     // ARM implementer 0x41 (A), part 0xD03 ⇒ Cortex‑A53
-                    return (midr & 0xFFF000u) == 0x41D030u;
+                    return implementer == 0x41 && partNumber == 0xD03;
                 }
             }
-            catch (Exception) // file missing, permission, etc.
+            catch (Exception)
             {
                 // ignore – fall through and report false
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24765/Make-bge-micro-v2-initialization-Lazy-to-prevent-server-spin-up-crash

### Additional description

Also added a check for Cortex A53, which is problematic. More details [here](https://github.com/microsoft/onnxruntime/issues/25472)

The PR is *draft* - I need some time to check on CortexA53.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No (the Cortex check is only for **Linux** though)

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
