### PR TITLE
RavenDB-23788 Add wait to test ResponsibleNodeForBackup_CurrentRespon…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -141,8 +141,10 @@ namespace SlowTests.Issues
                     DeletePrevious = false, RunInMemory = false, DataDirectory = result.DataDirectory, CustomSettings = settings
                 });
                 nodes.Add(server);
-                var val = await WaitForValueAsync(async () => await GetMembersCount(store), clusterSize);
-                Assert.Equal(clusterSize, val);
+
+                await WaitAndAssertForValueAsync(async () => await GetClusterSize(store), clusterSize);
+                await WaitAndAssertForValueAsync(async () => await GetRehabCount(store), 0);
+                await WaitAndAssertForValueAsync(async () => await GetMembersCount(store), clusterSize);
 
                 await WaitForValueAsync(async () =>
                 {
@@ -223,6 +225,7 @@ namespace SlowTests.Issues
                     DeletePrevious = false, RunInMemory = false, DataDirectory = result.DataDirectory, CustomSettings = settings
                 });
                 nodes.Add(server);
+
                 var val = await WaitForValueAsync(async () => await GetMembersCount(store), clusterSize);
                 Assert.Equal(clusterSize, val);
 
@@ -369,6 +372,25 @@ namespace SlowTests.Issues
                 return -1;
             }
             return res.Topology.Members.Count;
+        }
+        protected static async Task<int> GetRehabCount(IDocumentStore store, string databaseName = null)
+        {
+            var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName ?? store.Database));
+            if (res == null)
+            {
+                return -1;
+            }
+            return res.Topology.Rehabs.Count;
+        }
+
+        protected static async Task<int> GetClusterSize(IDocumentStore store, string databaseName = null)
+        {
+            var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName ?? store.Database));
+            if (res == null)
+            {
+                return -1;
+            }
+            return res.Topology.Count;
         }
 
         private static void CheckDecisionLog(RavenServer leaderServer, string reasonForDecisionLog, string info = "")


### PR DESCRIPTION
…sibleNodeNotResponding

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23788

### Additional description

Can't reproduce the failure. Added changes to the test that may help prevent it.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
