### PR TITLE
RavenDB-22767 Revert .ConfigureAwait(false) from Raven.Server that were added in 6.x

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -52,18 +52,16 @@ public static class SettingsZipFileHelper
                     {
                         var export = parameters.CompleteClusterConfigurationResult.ClientCert.Export(X509ContentType.Pfx);
                         if (parameters.Token != CancellationToken.None)
-                            await entryStream.WriteAsync(export, parameters.Token)
-                                             .ConfigureAwait(false);
+                            await entryStream.WriteAsync(export, parameters.Token);
                         else
-                            await entryStream.WriteAsync(export, CancellationToken.None)
-                                             .ConfigureAwait(false);
+                            await entryStream.WriteAsync(export, CancellationToken.None);
                     }
 
                     await LetsEncryptCertificateUtil.WriteCertificateAsPemToZipArchiveAsync(
                         $"admin.client.certificate.{parameters.CompleteClusterConfigurationResult.Domain}",
                         parameters.CompleteClusterConfigurationResult.CertBytes,
-                        null, archive)
-                        .ConfigureAwait(false);
+                        null,
+                        archive);
                 }
                 catch (Exception e)
                 {
@@ -76,8 +74,7 @@ public static class SettingsZipFileHelper
                     string settingsPath = parameters.OnSettingsPath.Invoke();
                     await using (var fs = SafeFileStream.Create(settingsPath, FileMode.Open, FileAccess.Read))
                     {
-                        settingsJson = await context.ReadForMemoryAsync(fs, "settings-json")
-                                                    .ConfigureAwait(false);
+                        settingsJson = await context.ReadForMemoryAsync(fs, "settings-json");
                     }
                 }
                 else
@@ -87,8 +84,7 @@ public static class SettingsZipFileHelper
                         ms2.WriteByte((byte)'{');
                         ms2.WriteByte((byte)'}');
                         ms2.Position = 0;
-                        settingsJson = await context.ReadForMemoryAsync(ms2, "settings-json")
-                                                    .ConfigureAwait(false);
+                        settingsJson = await context.ReadForMemoryAsync(ms2, "settings-json");
                     }
                 }
 
@@ -108,8 +104,7 @@ public static class SettingsZipFileHelper
                         await using (var entryStream = entry.Open())
                         await using (var writer = new StreamWriter(entryStream))
                         {
-                            await writer.WriteAsync(licenseString)
-                                        .ConfigureAwait(false);
+                            await writer.WriteAsync(licenseString);
                         }
                     }
                     catch (Exception e)
@@ -128,8 +123,7 @@ public static class SettingsZipFileHelper
                 if (parameters.SetupInfo.Environment != StudioConfiguration.StudioEnvironment.None)
                 {
                     if (parameters.OnPutServerWideStudioConfigurationValues != null && parameters.ZipOnly == false)
-                        await parameters.OnPutServerWideStudioConfigurationValues(parameters.SetupInfo.Environment)
-                                        .ConfigureAwait(false);
+                        await parameters.OnPutServerWideStudioConfigurationValues(parameters.SetupInfo.Environment);
                 }
 
                 var certificateFileName = $"cluster.server.certificate.{parameters.CompleteClusterConfigurationResult.Domain}.pfx";
@@ -140,8 +134,7 @@ public static class SettingsZipFileHelper
                 {
                     await using (var certFile = SafeFileStream.Create(certPath, FileMode.Create))
                     {
-                        await certFile.WriteAsync(parameters.CompleteClusterConfigurationResult.ServerCertBytes, parameters.Token)
-                                      .ConfigureAwait(false);
+                        await certFile.WriteAsync(parameters.CompleteClusterConfigurationResult.ServerCertBytes, parameters.Token);
                     } // we'll be flushing the directory when we'll write the settings.json
 
                     if (PlatformDetails.RunningOnPosix)

--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents
 
                 // let it propagate the exception to the client first and do
                 // the internal failure handling e.g. Index.HandleIndexCorruption
-                await Task.Delay(TimeToWaitBeforeUnloadingDatabase).ConfigureAwait(false);
+                await Task.Delay(TimeToWaitBeforeUnloadingDatabase); 
 
                 stats.NumberOfUnloads++;
                 stats.LastUnloadTime = DateTime.UtcNow;

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -173,7 +173,7 @@ namespace Raven.Server.Documents
                             , rateGate, token,
                             batchSize: OperationBatchSize);
 
-                        await Database.TxMerger.Enqueue(command).ConfigureAwait(false);
+                        await Database.TxMerger.Enqueue(command);
 
                         progress.Processed += command.Processed;
 

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -128,12 +128,12 @@ namespace Raven.Server.Documents.Handlers.Batches
         public async Task<bool> IsClusterTransaction(Stream stream, UnmanagedJsonParser parser, JsonOperationContext.MemoryBuffer buffer, JsonParserState state)
         {
             while (parser.Read() == false)
-                await RefillParserBuffer(stream, buffer, parser).ConfigureAwait(false);
+                await RefillParserBuffer(stream, buffer, parser);
 
             if (ReadClusterTransactionProperty(state))
             {
                 while (parser.Read() == false)
-                    await RefillParserBuffer(stream, buffer, parser).ConfigureAwait(false);
+                    await RefillParserBuffer(stream, buffer, parser);
 
                 return GetStringPropertyValue(state) == nameof(TransactionMode.ClusterWide);
             }
@@ -167,7 +167,7 @@ namespace Raven.Server.Documents.Handlers.Batches
             while (true)
             {
                 while (parser.Read() == false)
-                    await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                    await RefillParserBuffer(stream, buffer, parser, token);
 
                 if (state.CurrentTokenType == JsonParserToken.EndObject)
                 {
@@ -183,7 +183,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                 {
                     case CommandPropertyName.Type:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType != JsonParserToken.String)
                         {
                             ThrowUnexpectedToken(JsonParserToken.String, state);
@@ -193,7 +193,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Id:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
 
                         switch (state.CurrentTokenType)
                         {
@@ -219,14 +219,14 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                         CommandParsingObserver?.OnIdsStart(parser);
 
-                        commandData.Ids = await ReadJsonArray(ctx, stream, parser, state, buffer, token).ConfigureAwait(false);
+                        commandData.Ids = await ReadJsonArray(ctx, stream, parser, state, buffer, token);
 
                         CommandParsingObserver?.OnIdsEnd(parser);
                         break;
 
                     case CommandPropertyName.Name:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -245,7 +245,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.DestinationId:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -263,7 +263,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.From:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -279,7 +279,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.To:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -295,7 +295,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.DestinationName:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -314,7 +314,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.ContentType:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -333,8 +333,8 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Document:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
-                        commandData.Document = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
+                        commandData.Document = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.SeenAttachments = modifier.SeenAttachments;
                         commandData.SeenCounters = modifier.SeenCounters;
                         commandData.SeenTimeSeries = modifier.SeenTimeSeries;
@@ -343,23 +343,23 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Patch:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
-                        var patch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
+                        var patch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.Patch = PatchRequest.Parse(patch, out commandData.PatchArgs);
                         break;
 
                     case CommandPropertyName.JsonPatch:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
-                        var jsonPatch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
+                        var jsonPatch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.JsonPatchCommands = JsonPatchCommand.Parse(jsonPatch);
                         break;
 
                     case CommandPropertyName.TimeSeries:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
 
-                        using (var timeSeriesOperations = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false))
+                        using (var timeSeriesOperations = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token))
                         {
                             commandData.TimeSeries = commandData.Type == CommandType.TimeSeriesBulkInsert ?
                                 TimeSeriesOperation.ParseForBulkInsert(timeSeriesOperations) :
@@ -370,20 +370,20 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.CreateIfMissing:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
-                        var createIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
+                        var createIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.CreateIfMissing = createIfMissing;
                         break;
                     case CommandPropertyName.PatchIfMissing:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
-                        var patchIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
+                        var patchIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.PatchIfMissing = PatchRequest.Parse(patchIfMissing, out commandData.PatchIfMissingArgs);
                         break;
 
                     case CommandPropertyName.ChangeVector:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
                             commandData.ChangeVector = null;
@@ -402,7 +402,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.OriginalChangeVector:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
                             commandData.OriginalChangeVector = null;
@@ -421,7 +421,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Index:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType != JsonParserToken.Integer)
                         {
                             ThrowUnexpectedToken(JsonParserToken.Integer, state);
@@ -432,7 +432,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.IdPrefixed:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
 
                         if (state.CurrentTokenType != JsonParserToken.True && state.CurrentTokenType != JsonParserToken.False)
                         {
@@ -444,7 +444,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.ReturnDocument:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
 
                         if (state.CurrentTokenType != JsonParserToken.True && state.CurrentTokenType != JsonParserToken.False)
                         {
@@ -456,15 +456,15 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Counters:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
 
-                        var counterOps = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                        var counterOps = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.Counters = DocumentCountersOperation.Parse(counterOps);
                         break;
 
                     case CommandPropertyName.FromEtl:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
 
                         if (state.CurrentTokenType != JsonParserToken.True && state.CurrentTokenType != JsonParserToken.False)
                         {
@@ -476,7 +476,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.AttachmentType:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
                             commandData.AttachmentType = AttachmentType.Document;
@@ -494,7 +494,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.ContentLength:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType != JsonParserToken.Integer)
                         {
                             ThrowUnexpectedToken(JsonParserToken.Integer, state);
@@ -505,17 +505,17 @@ namespace Raven.Server.Documents.Handlers.Batches
                     case CommandPropertyName.NoSuchProperty:
                         // unknown command - ignore it
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType == JsonParserToken.StartObject ||
                             state.CurrentTokenType == JsonParserToken.StartArray)
                         {
-                            await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
+                            await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         }
                         break;
 
                     case CommandPropertyName.ForceRevisionCreationStrategy:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                            await RefillParserBuffer(stream, buffer, parser, token);
                         if (state.CurrentTokenType != JsonParserToken.String)
                         {
                             ThrowUnexpectedToken(JsonParserToken.String, state);
@@ -627,8 +627,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                 {
                     if (builder.Read())
                         break;
-
-                    await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                    await RefillParserBuffer(stream, buffer, parser, token);
                 }
 
                 builder.FinalizeDocument();
@@ -655,8 +654,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                 {
                     if (builder.Read())
                         break;
-
-                    await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                    await RefillParserBuffer(stream, buffer, parser, token);
                 }
                 builder.FinalizeDocument();
                 reader = builder.CreateReader();
@@ -1022,7 +1020,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
             // Although we using here WithCancellation and passing the token,
             // the stream will stay open even after the cancellation until the entire server will be disposed.
-            var read = await stream.ReadAsync(buffer.Memory.Memory, token).ConfigureAwait(false);
+            var read = await stream.ReadAsync(buffer.Memory.Memory, token);
             if (read == 0)
                 ThrowUnexpectedEndOfStream();
             parser.SetBuffer(buffer, 0, read);

--- a/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
@@ -33,13 +33,13 @@ public sealed class DatabaseBatchCommandsReader : AbstractBatchCommandsReader<Me
             Stream = AttachmentStreamsTempFile.StartNewStream()
         };
         attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(context, input, attachmentStream.Stream, token);
-        await attachmentStream.Stream.FlushAsync(token).ConfigureAwait(false);
+        await attachmentStream.Stream.FlushAsync(token);
         AttachmentStreams.Add(attachmentStream);
     }
 
     public override async ValueTask<MergedBatchCommand> GetCommandAsync(DocumentsOperationContext context)
     {
-        await ExecuteGetIdentitiesAsync().ConfigureAwait(false);
+        await ExecuteGetIdentitiesAsync();
 
         return new MergedBatchCommand(_database)
         {

--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -86,6 +86,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.TotalAllocatedSize)] = new Size(lowLevelTransaction.TotalAllocatedInBytes, SizeUnit.Bytes).ToString(),
                 [nameof(TxInfoResult.DecompressedBufferSize)] = new Size(lowLevelTransaction.DecompressedBufferBytes, SizeUnit.Bytes).ToString(),
                 [nameof(TxInfoResult.TotalEncryptionBufferSize)] = lowLevelTransaction.TotalEncryptionBufferInBytes.ToString(),
+                [nameof(TxInfoResult.IsDisposed)] = lowLevelTransaction.IsDisposed,
             };
         }
     }
@@ -106,5 +107,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public string TotalAllocatedSize;
         public string DecompressedBufferSize;
         public string TotalEncryptionBufferSize;
+        public bool IsDisposed;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForHead(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGetDocSize(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGet(HttpMethod.Get, this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGet(HttpMethod.Post, this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForDelete(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -71,7 +71,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForPut(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForPatch(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGenerateClassFromDocument(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
@@ -74,12 +74,12 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                 if (contentType == null ||
                     contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
                 {
-                    await commandsReader.BuildCommandsAsync(context, RequestHandler.RequestBodyStream(), GetIdentityPartsSeparator(), token.Token).ConfigureAwait(false);
+                    await commandsReader.BuildCommandsAsync(context, RequestHandler.RequestBodyStream(), GetIdentityPartsSeparator(), token.Token);
                 }
                 else if (contentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
                          contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                 {
-                    await commandsReader.ParseMultipart(context, RequestHandler.RequestBodyStream(), HttpContext.Request.ContentType, GetIdentityPartsSeparator(), token.Token).ConfigureAwait(false);
+                    await commandsReader.ParseMultipart(context, RequestHandler.RequestBodyStream(), HttpContext.Request.ContentType, GetIdentityPartsSeparator(), token.Token);
                 }
                 else
                     ThrowNotSupportedType(contentType);
@@ -94,16 +94,16 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                 }
             }
 
-            using (var command = await commandsReader.GetCommandAsync(context).ConfigureAwait(false))
+            using (var command = await commandsReader.GetCommandAsync(context))
             {
                 if (command.IsClusterTransaction)
                 {
                     var processor = GetClusterTransactionRequestProcessor();
-                    var result = await processor.ProcessAsync(context, command, token.Token).ConfigureAwait(false);
+                    var result = await processor.ProcessAsync(context, command, token.Token);
 
                     RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
 
-                    await using (AsyncBlittableJsonTextWriter.Create(context, RequestHandler.ResponseBodyStream(), out var writer))
+                    await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), token.Token))
                     {
                         context.Write(writer, new DynamicJsonValue
                         {
@@ -121,21 +121,21 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                 if (parameters.NoReply.HasValue)
                     command.IncludeReply = parameters.NoReply.Value == false;
 
-                var results = await HandleTransactionAsync(context, command, indexBatchOptions, replicationBatchOptions).ConfigureAwait(false);
+                var results = await HandleTransactionAsync(context, command, indexBatchOptions, replicationBatchOptions);
 
                 if (replicationBatchOptions != null)
                 {
-                    await WaitForReplicationAsync(context, replicationBatchOptions, command.LastChangeVector).ConfigureAwait(false);
+                    await WaitForReplicationAsync(context, replicationBatchOptions, command.LastChangeVector);
                 }
 
                 if (indexBatchOptions != null)
                 {
-                    await WaitForIndexesAsync(indexBatchOptions, command.LastChangeVector, command.LastTombstoneEtag, command.ModifiedCollections).ConfigureAwait(false);
+                    await WaitForIndexesAsync(indexBatchOptions, command.LastChangeVector, command.LastTombstoneEtag, command.ModifiedCollections);
                 }
 
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
 
-                await using (AsyncBlittableJsonTextWriter.Create(context, RequestHandler.ResponseBodyStream(), out var writer))
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), token.Token))
                 {
                     context.Write(writer, new DynamicJsonValue
                     {

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -195,8 +195,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         QueryStringParameters parameters, RevisionIncludeField revisions, HashSet<AbstractTimeSeriesRange> timeSeries, string etag)
     {
         var clusterWideTx = parameters.TxMode == TransactionMode.ClusterWide;
-        var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag)
-                                .AsTask();
+        var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag);
 
         if (result.StatusCode == HttpStatusCode.NotFound)
         {
@@ -217,8 +216,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
         HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + result.Etag + "\"";
 
-        return await WriteDocumentsByIdResultAsync(context, parameters.MetadataOnly, clusterWideTx, result)
-                        .AsTask();
+        return await WriteDocumentsByIdResultAsync(context, parameters.MetadataOnly, clusterWideTx, result);
     }
 
     private async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsByIdResultAsync(
@@ -226,7 +224,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
     {
         long numberOfResults;
         long totalDocumentsSizeInBytes;
-        await using (AsyncBlittableJsonTextWriter.Create(context, RequestHandler.ResponseBodyStream(), out var writer))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), CancellationToken))
         {
             writer.WriteStartObject();
 
@@ -236,23 +234,20 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
             writer.WriteComma();
 
-            await WriteIncludesAsync(writer, context, nameof(GetDocumentsResult.Includes), result.Includes, CancellationToken)
-                    .ConfigureAwait(false);
+            await WriteIncludesAsync(writer, context, nameof(GetDocumentsResult.Includes), result.Includes, CancellationToken);
 
             if (result.CounterIncludes?.Count > 0)
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.CounterIncludes));
-                await result.CounterIncludes.WriteIncludesAsync(writer, context, CancellationToken)
-                                            .ConfigureAwait(false);
+                await result.CounterIncludes.WriteIncludesAsync(writer, context, CancellationToken);
             }
 
             if (result.TimeSeriesIncludes?.Count > 0)
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.TimeSeriesIncludes));
-                await result.TimeSeriesIncludes.WriteIncludesAsync(writer, context, CancellationToken)
-                                               .ConfigureAwait(false);
+                await result.TimeSeriesIncludes.WriteIncludesAsync(writer, context, CancellationToken);
             }
 
             if (result.RevisionIncludes?.Count > 0)
@@ -260,8 +255,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.RevisionIncludes));
                 writer.WriteStartArray();
-                await result.RevisionIncludes.WriteIncludesAsync(writer, context, CancellationToken)
-                                             .ConfigureAwait(false);
+                await result.RevisionIncludes.WriteIncludesAsync(writer, context, CancellationToken);
                 writer.WriteEndArray();
             }
 
@@ -269,8 +263,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.CompareExchangeValueIncludes));
-                await writer.WriteCompareExchangeValuesAsync(result.CompareExchangeIncludes, CancellationToken)
-                                .ConfigureAwait(false);
+                await writer.WriteCompareExchangeValuesAsync(result.CompareExchangeIncludes, CancellationToken);
             }
 
             writer.WriteEndObject();
@@ -317,20 +310,18 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         long numberOfResults;
         long totalDocumentsSizeInBytes;
 
-        await using (AsyncBlittableJsonTextWriter.Create(context, RequestHandler.ResponseBodyStream(), out var writer))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), CancellationToken))
         {
             writer.WriteStartObject();
             writer.WritePropertyName("Results");
 
             if (result.DocumentsAsync != null)
             {
-                (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.DocumentsAsync, metadataOnly, CancellationToken)
-                                                                         .ConfigureAwait(false);
+                (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.DocumentsAsync, metadataOnly, CancellationToken);
             }
             else
             {
-                (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken)
-                                                                        .ConfigureAwait(false);
+                (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
             }
 
             if (result.ContinuationToken != null)

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForPut.cs
@@ -23,7 +23,7 @@ internal abstract class AbstractDocumentHandlerProcessorForPut
             // and the identity generation needs to take into account that the identity
             // generation can fail and will leave the reading task hanging if we abort
             // easier to just do in synchronously
-            var doc = await context.ReadForDiskAsync(RequestHandler.RequestBodyStream(), id).ConfigureAwait(false);
+            var doc = await context.ReadForDiskAsync(RequestHandler.RequestBodyStream(), id);
 
             if (id[^1] == '|')
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -57,7 +57,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
         if (counters.Count > 0)
         {
-            if (counters is [Constants.Counters.All])
+            if (counters.Count == 1 && counters[0] == Constants.Counters.All)
                 counters = Array.Empty<string>();
 
             includeCounters = new IncludeCountersCommand(RequestHandler.Database, context, counters);
@@ -112,7 +112,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
                         Debug.Assert(includeCompareExchangeValues != null, nameof(includeCompareExchangeValues) + " != null");
                         if (includeCompareExchangeValues.TryGetCompareExchange(ClusterWideTransactionHelper.GetAtomicGuardKey(id), lastModifiedIndex, out var index, out _))
                         {
-                            var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, RequestHandler.Database.ClusterTransactionId, index, changeVector);
+                            var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, RequestHandler.Database.ClusterTransactionId,
+                                index, changeVector);
                             Debug.Assert(isValid, "ChangeVector didn't have ClusterTransactionId tag but now does?!");
                             document.ChangeVector = cv;
                         }
@@ -162,20 +163,20 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
     protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token).ConfigureAwait(false);
+        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
     }
 
     protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IAsyncEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token).ConfigureAwait(false);
+        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
     }
 
     protected override async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName, List<Document> includes, CancellationToken token)
     {
         writer.WritePropertyName(propertyName);
 
-        await writer.WriteIncludesAsync(context, includes, token).ConfigureAwait(false);
+        await writer.WriteIncludesAsync(context, includes, token);
     }
 
     protected override ValueTask<DocumentsResult> GetDocumentsImplAsync(DocumentsOperationContext context, long? etag, StartsWithParams startsWith, string changeVector)

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -175,7 +175,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
                             (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentQueryResultAsync(context, result, parameters.MetadataOnly,
                                 WriteAdditionalData(indexQuery, parameters.IncludeServerSideQuery), token.Token);
-                            await writer.MaybeOuterFlushAsync();
+                            await writer.MaybeFlushAsync(token.Token);
                         }
 
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetDocs.cs
@@ -23,8 +23,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
             {
                 await GetDocumentsAndWriteAsync(context, RequestHandler.GetStart(), RequestHandler.GetPageSize(), RequestHandler.GetStringQueryString("startsWith", required: false),
                     RequestHandler.GetStringQueryString("excludes", required: false), RequestHandler.GetStringQueryString("matches", required: false),
-                    RequestHandler.GetStringQueryString("startAfter", required: false), RequestHandler.GetStringQueryString("format", required: false), token)
-                    .ConfigureAwait(false);
+                    RequestHandler.GetStringQueryString("startAfter", required: false), RequestHandler.GetStringQueryString("format", required: false), token);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                     var fromDocument = RequestHandler.GetStringQueryString("fromDocument", false);
                     if (string.IsNullOrEmpty(fromDocument) == false)
                     {
-                        var docData = await GetDocumentDataAsync(context, fromDocument).ConfigureAwait(false);
+                        var docData = await GetDocumentDataAsync(context, fromDocument);
                         if (docData == null)
                         {
                             throw new DocumentDoesNotExistException($"Was request to stream a query taken from {fromDocument} document, but it does not exist.");
@@ -148,8 +148,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 else
                 {
                     await using var stream = RequestHandler.TryGetRequestFromStream("ExportOptions") ?? RequestHandler.RequestBodyStream();
-                    var queryJson = await context.ReadForMemoryAsync(stream, "index/query")
-                                                 .ConfigureAwait(false);
+                    var queryJson = await context.ReadForMemoryAsync(stream, "index/query");
                     query = IndexQueryServerSide.Create(HttpContext, queryJson, GetQueryMetadataCache(), tracker);
                 }
                 query.IsStream = true;
@@ -173,8 +172,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 {
                     if (string.Equals(debug, "entries", StringComparison.OrdinalIgnoreCase))
                     {
-                        await ExecuteAndWriteIndexQueryStreamEntriesAsync(context, query, format, propertiesArray, fileNamePrefix, ignoreLimit, token)
-                                    .ConfigureAwait(false);
+                        await ExecuteAndWriteIndexQueryStreamEntriesAsync(context, query, format, propertiesArray, fileNamePrefix, ignoreLimit, token);
                     }
                     else
                     {
@@ -183,8 +181,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 }
                 else
                 {
-                    await ExecuteAndWriteQueryStreamAsync(context, query, format, propertiesArray, fileNamePrefix, token)
-                                .ConfigureAwait(false);
+                    await ExecuteAndWriteQueryStreamAsync(context, query, format, propertiesArray, fileNamePrefix, token);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -11,35 +11,35 @@ namespace Raven.Server.Documents.Handlers
         public async Task Post()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForGet(this, HttpMethod.Post))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/queries", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
         public async Task Get()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForGet(this, HttpMethod.Get))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/queries", "PATCH", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task Patch()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForPatch(this)) 
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/queries/test", "PATCH", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task PatchTest()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForPatchTest(this))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/queries", "DELETE", AuthorizationStatus.ValidUser, EndpointType.Write)]
         public async Task Delete()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForDelete(this))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Handlers
                 GetCsvWriter().WriteField(o?.ToString());
             }
 
-            await GetCsvWriter().NextRecordAsync().ConfigureAwait(false);
+            await GetCsvWriter().NextRecordAsync();
         }
 
         public StreamCsvBlittableQueryResultWriter(HttpResponse response, Stream stream, string[] properties = null,

--- a/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
@@ -88,10 +88,10 @@ namespace Raven.Server.Documents.Handlers
         public async ValueTask DisposeAsync()
         {
             if (_csvWriter != null)
-                await _csvWriter.DisposeAsync().ConfigureAwait(false);
+                await _csvWriter.DisposeAsync();
 
             if (_writer != null)
-                await _writer.DisposeAsync().ConfigureAwait(false);
+                await _writer.DisposeAsync();
         }
 
         public void StartResponse()
@@ -154,12 +154,12 @@ namespace Raven.Server.Documents.Handlers
 
         public async ValueTask WriteErrorAsync(Exception e)
         {
-            await _writer.WriteLineAsync(e.ToString()).ConfigureAwait(false);
+            await _writer.WriteLineAsync(e.ToString());
         }
 
         public async ValueTask WriteErrorAsync(string error)
         {
-            await _writer.WriteLineAsync(error).ConfigureAwait(false);
+            await _writer.WriteLineAsync(error);
         }
 
         public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
         public async Task StreamDocsGet()
         {
             using (var processor = new StreamingHandlerProcessorForGetDocs(this))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/streams/timeseries", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
         {
             using (var processor = new StreamingHandlerProcessorForGetTimeSeries(this))
             {
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
             }
         }
 
@@ -33,14 +33,14 @@ namespace Raven.Server.Documents.Handlers.Streaming
         public async Task StreamQueryGet()
         {
             using (var processor = new StreamingHandlerProcessorForGetStreamQuery(this, HttpMethod.Get))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/databases/*/streams/queries", "POST", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
         public async Task StreamQueryPost()
         {
             using (var processor = new StreamingHandlerProcessorForGetStreamQuery(this, HttpMethod.Post))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
@@ -60,7 +60,7 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
 
     public abstract Task<SuggestionQueryResult> ExecuteSuggestionQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token);
 
-    protected async Task<SuggestionQueryResult> ExecuteSuggestion(
+    protected Task<SuggestionQueryResult> ExecuteSuggestion(
         IndexQueryServerSide query,
         Index index,
         QueryOperationContext queryContext,
@@ -90,10 +90,10 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
         {
             var etag = index.GetIndexEtag(queryContext, query.Metadata);
             if (etag == existingResultEtag.Value)
-                return SuggestionQueryResult.NotModifiedResult;
+                return Task.FromResult(SuggestionQueryResult.NotModifiedResult);
         }
 
-        return await index.SuggestionQuery(query, queryContext, token).ConfigureAwait(false);
+        return index.SuggestionQuery(query, queryContext, token);
     }
 
     protected Task<IOperationResult> ExecuteDelete(IndexQueryServerSide query, Index index, QueryOperationOptions options, QueryOperationContext queryContext,
@@ -161,7 +161,7 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
 
         try
         {
-            var results = await index.IdQuery(query, queryContext, progress, onProgress, token).ConfigureAwait(false);
+            var results = await index.IdQuery(query, queryContext, progress, onProgress, token);
             if (options.AllowStale == false && results.IsStale)
                 throw new InvalidOperationException("Cannot perform bulk operation. Index is stale.");
 
@@ -193,7 +193,7 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
                     }, rateGate, token,
                     batchSize: batchSize);
 
-                await Database.TxMerger.Enqueue(command).ConfigureAwait(false);
+                await Database.TxMerger.Enqueue(command);
                 progress.Processed += command.Processed;
                 onProgress(progress);
 

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -91,7 +91,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -105,8 +105,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    await GetRunner(query).ExecuteStreamQuery(query, queryContext, response, writer, token)
-                                          .ConfigureAwait(false);
+                    await GetRunner(query).ExecuteStreamQuery(query, queryContext, response, writer, token);
                     return;
                 }
                 catch (ObjectDisposedException e)
@@ -116,7 +115,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -128,7 +127,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -144,8 +143,7 @@ namespace Raven.Server.Documents.Queries
                 try
                 {
                     queryContext.CloseTransaction();
-                    await GetRunner(query).ExecuteStreamIndexEntriesQuery(query, queryContext, response, writer, ignoreLimit, token)
-                                          .ConfigureAwait(false);
+                    await GetRunner(query).ExecuteStreamIndexEntriesQuery(query, queryContext, response, writer, ignoreLimit, token);
                     return;
                 }
                 catch (ObjectDisposedException e)
@@ -155,7 +153,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -167,7 +165,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -194,7 +192,7 @@ namespace Raven.Server.Documents.Queries
                         if (scope == null)
                             sw = Stopwatch.StartNew();
 
-                        result = await _static.ExecuteFacetedQuery(query, existingResultEtag, queryContext, token).ConfigureAwait(false);
+                        result = await _static.ExecuteFacetedQuery(query, existingResultEtag, queryContext, token);
                     }
 
                     result.DurationInMs = sw != null ? (long)sw.Elapsed.TotalMilliseconds : (long)scope.Duration.TotalMilliseconds;
@@ -208,7 +206,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -220,7 +218,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -285,8 +283,7 @@ namespace Raven.Server.Documents.Queries
                         if (scope == null)
                             sw = Stopwatch.StartNew();
 
-                        result = await GetRunner(query).ExecuteSuggestionQuery(query, queryContext, existingResultEtag, token)
-                                                       .ConfigureAwait(false);
+                        result = await GetRunner(query).ExecuteSuggestionQuery(query, queryContext, existingResultEtag, token);
                     }
 
                     result.DurationInMs = sw != null ? (long)sw.Elapsed.TotalMilliseconds : (long)scope.Duration.TotalMilliseconds;
@@ -300,7 +297,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -312,7 +309,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -326,8 +323,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    return await GetRunner(query).ExecuteIndexEntriesQuery(query, queryContext, ignoreLimit, existingResultEtag, token)
-                                                 .ConfigureAwait(false);
+                    return await GetRunner(query).ExecuteIndexEntriesQuery(query, queryContext, ignoreLimit, existingResultEtag, token);
                 }
                 catch (ObjectDisposedException e)
                 {
@@ -336,7 +332,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -348,7 +344,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -362,8 +358,7 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    return await GetRunner(query).ExecuteDeleteQuery(query, options, queryContext, onProgress, token)
-                                                 .ConfigureAwait(false);
+                    return await GetRunner(query).ExecuteDeleteQuery(query, options, queryContext, onProgress, token);
                 }
                 catch (ObjectDisposedException e)
                 {
@@ -372,7 +367,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -384,7 +379,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 
@@ -401,8 +396,7 @@ namespace Raven.Server.Documents.Queries
                     if (Database.ForTestingPurposes?.DelayQueryByPatch != null)
                         await Database.ForTestingPurposes.DelayQueryByPatch.WaitAsync(token.Token);
 
-                    return await GetRunner(query).ExecutePatchQuery(query, options, patch, patchArgs, queryContext, onProgress, token)
-                                                 .ConfigureAwait(false);
+                    return await GetRunner(query).ExecutePatchQuery(query, options, patch, patchArgs, queryContext, onProgress, token);
                 }
                 catch (ObjectDisposedException e)
                 {
@@ -411,7 +405,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
                 catch (OperationCanceledException e)
                 {
@@ -423,7 +417,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
+                    await WaitForIndexBeingLikelyReplacedDuringQuery();
                 }
             }
 

--- a/src/Raven.Server/Documents/Queries/StreamBlittableDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamBlittableDocumentQueryResultWriter.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Queries
             }
 
             Writer.WriteObject(res);
-            await Writer.MaybeFlushAsync(token).ConfigureAwait(false);
+            await Writer.MaybeFlushAsync(token);
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/StreamJsonDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonDocumentQueryResultWriter.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Queries
             }
             
             Writer.WriteDocument(Context, res, metadataOnly: false);
-            await Writer.MaybeFlushAsync(token).ConfigureAwait(false);
+            await Writer.MaybeFlushAsync(token);
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Queries
             _writer.WriteEndObject();
 
             _writer.WriteNewLine();
-            await _writer.MaybeFlushAsync(token).ConfigureAwait(false);
+            await _writer.MaybeFlushAsync(token);
         }
 
         public void EndResponse()
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents.Queries
 
             _writer.WriteNewLine();
 
-            await _writer.FlushAsync().ConfigureAwait(false);
+            await _writer.FlushAsync();
         }
 
         public async ValueTask WriteErrorAsync(string error)
@@ -73,7 +73,7 @@ namespace Raven.Server.Documents.Queries
 
             _writer.WriteNewLine();
 
-            await _writer.FlushAsync().ConfigureAwait(false);
+            await _writer.FlushAsync();
         }
 
         public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)

--- a/src/Raven.Server/Documents/Queries/StreamQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamQueryResult.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Documents.Queries
             _anyExceptions = true;
 
             _writer.EndResults();
-            await _writer.WriteErrorAsync(e).ConfigureAwait(false);
+            await _writer.WriteErrorAsync(e);
 
             throw e;
         }

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.TransactionMerger
 
             try
             {
-                await cmd.TaskCompletionSource.Task;
+                await cmd.TaskCompletionSource.Task.ConfigureAwait(false);
             }
             finally
             {

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.TransactionMerger
 
             try
             {
-                await cmd.TaskCompletionSource.Task.ConfigureAwait(false);
+                await cmd.TaskCompletionSource.Task;
             }
             finally
             {

--- a/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
+++ b/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
@@ -79,12 +79,12 @@ namespace Raven.Server.Https
         public async Task OnConnectionAsync(ConnectionContext context, Func<Task> next)
         {
             if (_server.ServerStore.Initialized == false)
-                await _server.ServerStore.InitializationCompleted.WaitAsync().ConfigureAwait(false);
+                await _server.ServerStore.InitializationCompleted.WaitAsync();
 
             var tlsConnectionFeature = context.Features.Get<ITlsConnectionFeature>();
             X509Certificate2 certificate = null;
             if (tlsConnectionFeature != null)
-                certificate = await tlsConnectionFeature.GetClientCertificateAsync(context.ConnectionClosed).ConfigureAwait(false);
+                certificate = await tlsConnectionFeature.GetClientCertificateAsync(context.ConnectionClosed);
 
             var httpConnectionFeature = context.Features.Get<IHttpConnectionFeature>();
             var authenticationStatus = _server.AuthenticateConnectionCertificate(certificate, httpConnectionFeature);
@@ -92,7 +92,7 @@ namespace Raven.Server.Https
             // build the token
             context.Features.Set<IHttpAuthenticationFeature>(authenticationStatus);
 
-            await next().ConfigureAwait(false);
+            await next();
         }
 
         internal static X509Certificate2 ConvertToX509Certificate2(X509Certificate certificate)

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -450,8 +450,7 @@ namespace Raven.Server.Json
                 writer.WriteComma();
             }
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token)
-                                                                                  .ConfigureAwait(false);
+            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
 
             writer.WriteEndObject();
 
@@ -477,8 +476,7 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            var (numberOfResults, _) = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token)
-                                                        .ConfigureAwait(false);
+            var (numberOfResults, _) = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
 
             writer.WriteEndObject();
 
@@ -734,8 +732,7 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token)
-                        .ConfigureAwait(false);
+            await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
 
             writer.WriteEndObject();
         }
@@ -773,8 +770,7 @@ namespace Raven.Server.Json
             writer.WriteArray(nameof(result.IncludedPaths), result.IncludedPaths);
             writer.WriteComma();
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token)
-                                                                                  .ConfigureAwait(false);
+            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token);
 
             if (result.Highlightings != null)
             {
@@ -832,8 +828,7 @@ namespace Raven.Server.Json
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.RevisionIncludes));
                 writer.WriteStartArray();
-                await revisionIncludes.WriteIncludesAsync(writer, context, token)
-                                      .ConfigureAwait(false);
+                await revisionIncludes.WriteIncludesAsync(writer, context, token);
                 writer.WriteEndArray();
             }
 
@@ -842,8 +837,7 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CounterIncludes));
-                await counters.WriteIncludesAsync(writer, context, token)
-                              .ConfigureAwait(false);
+                await counters.WriteIncludesAsync(writer, context, token);
 
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.IncludedCounterNames));
@@ -855,8 +849,7 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.TimeSeriesIncludes));
-                await timeSeries.WriteIncludesAsync(writer, context, token)
-                                .ConfigureAwait(false);
+                await timeSeries.WriteIncludesAsync(writer, context, token);
             }
 
             if (result.TimeSeriesFields != null)
@@ -870,8 +863,7 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CompareExchangeValueIncludes));
-                await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, token)
-                            .ConfigureAwait(false);
+                await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, token);
             }
 
             var spatialProperties = result.SpatialProperties;
@@ -962,15 +954,13 @@ namespace Raven.Server.Json
             if (results is List<Document> documents)
             {
                 writer.WritePropertyName(nameof(result.Results));
-                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, documents, metadataOnly, token)
-                                                                           .ConfigureAwait(false);
+                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, documents, metadataOnly, token);
                 writer.WriteComma();
             }
             else if (results is List<BlittableJsonReaderObject> objects)
             {
                 writer.WritePropertyName(nameof(result.Results));
-                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteObjectsAsync(context, objects, token)
-                                                                           .ConfigureAwait(false);
+                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteObjectsAsync(context, objects, token);
                 writer.WriteComma();
             }
             else if (results is List<FacetResult> facets)
@@ -978,16 +968,14 @@ namespace Raven.Server.Json
                 numberOfResults = facets.Count;
                 writer.WriteArray(context, nameof(result.Results), facets, (w, c, facet) => w.WriteFacetResult(c, facet));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token)
-                            .ConfigureAwait(false);
+                await writer.MaybeFlushAsync(token);
             }
             else if (results is List<SuggestionResult> suggestions)
             {
                 numberOfResults = suggestions.Count;
                 writer.WriteArray(context, nameof(result.Results), suggestions, (w, c, suggestion) => w.WriteSuggestionResult(c, suggestion));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token)
-                            .ConfigureAwait(false);
+                await writer.MaybeFlushAsync(token);
             }
             else
                 throw new NotSupportedException($"Cannot write query result of '{typeof(TResult)}' type in '{result.GetType()}'.");
@@ -996,15 +984,13 @@ namespace Raven.Server.Json
             if (includes is List<Document> includeDocuments)
             {
                 writer.WritePropertyName(nameof(result.Includes));
-                await writer.WriteIncludesAsync(context, includeDocuments, token)
-                            .ConfigureAwait(false);
+                await writer.WriteIncludesAsync(context, includeDocuments, token);
                 writer.WriteComma();
             }
             else if (includes is List<BlittableJsonReaderObject> includeObjects)
             {
                 writer.WritePropertyName(nameof(result.Includes));
-                await writer.WriteIncludesAsync(includeObjects, token)
-                            .ConfigureAwait(false);
+                await writer.WriteIncludesAsync(includeObjects, token);
                 writer.WriteComma();
             }
             else
@@ -1914,8 +1900,7 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, documents.Current, metadataOnly);
-                await writer.MaybeFlushAsync(token)
-                            .ConfigureAwait(false);
+                await writer.MaybeFlushAsync(token);
             }
 
             writer.WriteEndArray();
@@ -1948,8 +1933,7 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, document, metadataOnly);
-                await writer.FlushAsync(token)
-                            .ConfigureAwait(false); // we must flush here because we dispose the document
+                await writer.FlushAsync(token); // we must flush here because we dispose the document
             }
 
             writer.WriteEndArray();
@@ -2008,15 +1992,13 @@ namespace Raven.Server.Json
                 {
                     writer.WritePropertyName(conflict.Id);
                     WriteConflict(writer, conflict);
-                    await writer.MaybeFlushAsync(token)
-                                .ConfigureAwait(false);
+                    await writer.MaybeFlushAsync(token);
                     continue;
                 }
 
                 writer.WritePropertyName(document.Id);
                 WriteDocument(writer, context, metadataOnly: false, document: document);
-                await writer.MaybeFlushAsync(token)
-                            .ConfigureAwait(false);
+                await writer.MaybeFlushAsync(token);
             }
 
             writer.WriteEndObject();
@@ -2048,8 +2030,7 @@ namespace Raven.Server.Json
                 else
                     writer.WriteObject(includeDoc);
 
-                await writer.MaybeOuterFlushAsync()
-                            .ConfigureAwait(false);
+                await writer.MaybeOuterFlushAsync();
             }
 
             writer.WriteEndObject();
@@ -2106,7 +2087,7 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token).ConfigureAwait(false);
+                    var writtenBytes = await writer.MaybeFlushAsync(token);
 
                     if (o.HasParent)
                     {
@@ -2149,7 +2130,7 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token).ConfigureAwait(false);
+                    var writtenBytes = await writer.MaybeFlushAsync(token);
 
                     if (o.HasParent)
                     {
@@ -2236,7 +2217,7 @@ namespace Raven.Server.Json
                 if (counter == null)
                 {
                     writer.WriteNull();
-                    await writer.MaybeFlushAsync(token).ConfigureAwait(false);
+                    await writer.MaybeFlushAsync(token);
                     continue;
                 }
 
@@ -2255,7 +2236,7 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token).ConfigureAwait(false);
+                await writer.MaybeFlushAsync(token);
             }
 
             writer.WriteEndArray();
@@ -2297,7 +2278,7 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token).ConfigureAwait(false);
+                await writer.MaybeFlushAsync(token);
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -2030,7 +2030,7 @@ namespace Raven.Server.Json
                 else
                     writer.WriteObject(includeDoc);
 
-                await writer.MaybeOuterFlushAsync();
+                await writer.MaybeFlushAsync(token);
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Platform/Posix/LimitsReader.cs
+++ b/src/Raven.Server/Platform/Posix/LimitsReader.cs
@@ -66,12 +66,12 @@ namespace Raven.Server.Platform.Posix
             if (PlatformDetails.RunningOnPosix == false)
                 throw new InvalidOperationException("Cannot read Current Limits because it requires POSIX");
 
-            if (await _lock.WaitAsync(0).ConfigureAwait(false) == false)
+            if (await _lock.WaitAsync(0) == false)
                 return LimitsInfo.Current;
 
             try
             {
-                LimitsInfo.Current.MapCountCurrent = await GetCurrentMapCountAsync().ConfigureAwait(false);
+                LimitsInfo.Current.MapCountCurrent = await GetCurrentMapCountAsync();
                 LimitsInfo.Current.ThreadsCurrent = GetCurrentThreadsCount();
                 LimitsInfo.Current.SetValues();
             }
@@ -145,8 +145,7 @@ namespace Raven.Server.Platform.Posix
             long currentMapCount;
             await using (FileStream stream = File.OpenRead(CurrentMapCountFilePath))
             {
-                currentMapCount = await GetEolCountAsync(stream).ConfigureAwait(false);
-                ;
+                currentMapCount = await GetEolCountAsync(stream);
             }
 
             return currentMapCount;
@@ -158,8 +157,7 @@ namespace Raven.Server.Platform.Posix
             long eolCount = 0L;
             while (true)
             {
-                var result = await reader.ReadAsync().ConfigureAwait(false);
-                ;
+                var result = await reader.ReadAsync();
                 var buffer = result.Buffer;
 
                 while (TryReadLine(ref buffer))

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1315,8 +1315,7 @@ namespace Raven.Server
                         // to nudge all the nodes in the cluster to check the replacement state.
                         // If a node confirmed but failed with the actual replacement (e.g. file permissions)
                         // this will make sure it will try again in the next round (1 hour).
-                        await ServerStore.SendToLeaderAsync(new RecheckStatusOfServerCertificateCommand())
-                            .ConfigureAwait(false);
+                        await ServerStore.SendToLeaderAsync(new RecheckStatusOfServerCertificateCommand());
                         return null;
                     }
 
@@ -1327,8 +1326,7 @@ namespace Raven.Server
                     {
                         // This is for the case where all nodes confirmed they received the replacement cert but
                         // not all nodes have made the actual change yet.
-                        await ServerStore.SendToLeaderAsync(new RecheckStatusOfServerCertificateReplacementCommand())
-                                         .ConfigureAwait(false);
+                        await ServerStore.SendToLeaderAsync(new RecheckStatusOfServerCertificateReplacementCommand());
                     }
 
                     return null;
@@ -1522,7 +1520,7 @@ namespace Raven.Server
                 });
                 var content = new StringContent(licensePayload, Encoding.UTF8, "application/json");
 
-                response = await ApiHttpClient.PostAsync("/api/v1/dns-n-cert/user-domains", content).ConfigureAwait(false);
+                response = await ApiHttpClient.PostAsync("/api/v1/dns-n-cert/user-domains", content);
 
                 response.EnsureSuccessStatusCode();
             }
@@ -2023,8 +2021,7 @@ namespace Raven.Server
             {
                 try
                 {
-                    await ServerStore.SendToLeaderAsync(new PutCertificateWithSamePinningHashCommand(certificate.Thumbprint, newCertDef, RaftIdGenerator.NewId()))
-                        .ConfigureAwait(false);
+                    await ServerStore.SendToLeaderAsync(new PutCertificateWithSamePinningHashCommand(certificate.Thumbprint, newCertDef, RaftIdGenerator.NewId()));
                 }
                 catch (Exception e)
                 {
@@ -2245,7 +2242,7 @@ namespace Raven.Server
         {
             Task.Factory.StartNew(async () =>
             {
-                var tcpClient = await AcceptTcpClientAsync(listener).ConfigureAwait(false);
+                var tcpClient = await AcceptTcpClientAsync(listener);
                 if (tcpClient == null)
                     return;
 
@@ -2253,8 +2250,7 @@ namespace Raven.Server
                 ListenToNewTcpConnection(listener);
 
                 if (ServerStore.Initialized == false)
-                    await ServerStore.InitializationCompleted.WaitAsync()
-                                                             .ConfigureAwait(false);
+                    await ServerStore.InitializationCompleted.WaitAsync();
 
                 EndPoint remoteEndPoint = null;
                 X509Certificate2 cert = null;
@@ -2278,7 +2274,7 @@ namespace Raven.Server
 
                     try
                     {
-                        (stream, cert) = await AuthenticateAsServerIfSslNeeded(stream).ConfigureAwait(false);
+                        (stream, cert) = await AuthenticateAsServerIfSslNeeded(stream);
                     }
                     catch (Exception e)
                     {
@@ -2310,7 +2306,7 @@ namespace Raven.Server
 
                             try
                             {
-                                header = await NegotiateOperationVersion(stream, buffer, tcpClient, tcpAuditLog, cert, tcp).ConfigureAwait(false);
+                                header = await NegotiateOperationVersion(stream, buffer, tcpClient, tcpAuditLog, cert, tcp);
                             }
                             catch (Exception e)
                             {
@@ -2331,7 +2327,7 @@ namespace Raven.Server
                                 tcp.Stream = stream;
                             }
 
-                            await DispatchTcpConnection(header, tcp, buffer, cert).ConfigureAwait(false);
+                            await DispatchTcpConnection(header, tcp, buffer, cert);
 
                             if (TrafficWatchManager.HasRegisteredClients)
                                 DispatchTcpMessageToTrafficWatch(remoteEndPoint, header, cert);
@@ -2344,7 +2340,7 @@ namespace Raven.Server
                             if (_tcpLogger.IsInfoEnabled)
                                 _tcpLogger.Info("Failed to process TCP connection run", e);
 
-                            await SendErrorIfPossible(tcp, e).ConfigureAwait(false);
+                            await SendErrorIfPossible(tcp, e);
                             try
                             {
                                 tcp?.Dispose();
@@ -2393,13 +2389,13 @@ namespace Raven.Server
                 return;
             }
 
-            if (await DispatchServerWideTcpConnection(tcp, header, buffer).ConfigureAwait(false))
+            if (await DispatchServerWideTcpConnection(tcp, header, buffer))
             {
                 tcp = null; //do not keep reference -> tcp will be disposed by server-wide connection handlers
                 return;
             }
 
-            await DispatchDatabaseTcpConnection(tcp, header, buffer, certificate).ConfigureAwait(false);
+            await DispatchDatabaseTcpConnection(tcp, header, buffer, certificate);
         }
 
         private async Task<TcpConnectionHeaderMessage> NegotiateOperationVersion(
@@ -2428,7 +2424,7 @@ namespace Raven.Server
                         // we don't want to allow external (and anonymous) users to send us unlimited data
                         // a maximum of 2 KB for the header is big enough to include any valid header that
                         // we can currently think of
-                        maxSize: 1024 * 2).ConfigureAwait(false))
+                        maxSize: 1024 * 2))
                     {
                         if (count++ > maxRetries)
                         {
@@ -2486,7 +2482,7 @@ namespace Raven.Server
                             $"Didn't agree on {header.Operation} protocol version: {header.OperationVersion} will request to use version: {supported}.");
                     }
 
-                    await RespondToTcpConnection(stream, context, $"Not supporting version {header.OperationVersion} for {header.Operation}", TcpConnectionStatus.TcpVersionMismatch, supported).ConfigureAwait(false);
+                    await RespondToTcpConnection(stream, context, $"Not supporting version {header.OperationVersion} for {header.Operation}", TcpConnectionStatus.TcpVersionMismatch, supported);
                 }
 
                 bool authSuccessful = TryAuthorize(Configuration, tcp.Stream, header, tcpClient, out var err, out TcpConnectionStatus statusResult);
@@ -2500,7 +2496,7 @@ namespace Raven.Server
 
                 await RespondToTcpConnection(stream, context, err,
                     authSuccessful ? TcpConnectionStatus.Ok : statusResult,
-                    supported, licensedFeatures: header.LicensedFeatures).ConfigureAwait(false);
+                    supported, licensedFeatures: header.LicensedFeatures);
 
                 tcp.ProtocolVersion = supported;
 
@@ -2540,7 +2536,7 @@ namespace Raven.Server
             {
                 try
                 {
-                    return await listener.AcceptTcpClientAsync().ConfigureAwait(false);
+                    return await listener.AcceptTcpClientAsync();
                 }
                 catch (ObjectDisposedException)
                 {
@@ -2570,7 +2566,7 @@ namespace Raven.Server
 
                     try
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(backoffSecondsDelay), ServerStore.ServerShutdown).ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromSeconds(backoffSecondsDelay), ServerStore.ServerShutdown);
                     }
                     catch (OperationCanceledException)
                     {
@@ -2647,7 +2643,7 @@ namespace Raven.Server
                         ["Message"] = e.Message
                     });
 
-                    await errorWriter.FlushAsync().ConfigureAwait(false);
+                    await errorWriter.FlushAsync();
                 }
 
             }
@@ -2693,8 +2689,7 @@ namespace Raven.Server
             if (tcp.Operation == TcpConnectionHeaderMessage.OperationTypes.Cluster)
             {
                 var tcpClient = tcp.TcpClient.Client;
-                await ServerStore.ClusterAcceptNewConnectionAsync(tcp, header, tcp.Dispose, tcpClient.RemoteEndPoint)
-                                 .ConfigureAwait(false);
+                await ServerStore.ClusterAcceptNewConnectionAsync(tcp, header, tcp.Dispose, tcpClient.RemoteEndPoint);
                 return true;
             }
 
@@ -2707,7 +2702,7 @@ namespace Raven.Server
                     "maintenance-heartbeat-header",
                     BlittableJsonDocumentBuilder.UsageMode.None,
                     buffer
-                ).ConfigureAwait(false))
+                ))
                 {
                     var maintenanceHeader = JsonDeserializationRachis<ClusterMaintenanceSupervisor.ClusterMaintenanceConnectionHeader>.Deserialize(headerJson);
 
@@ -2800,7 +2795,7 @@ namespace Raven.Server
                     {
                         var shardedReplicationLoader = tcp.DatabaseContext.Replication;
 
-                        await shardedReplicationLoader.AcceptIncomingConnectionAsync(tcp, header, bufferToCopy).ConfigureAwait(false);
+                        await shardedReplicationLoader.AcceptIncomingConnectionAsync(tcp, header, bufferToCopy);
                         break;
                     }
 
@@ -3013,8 +3008,7 @@ namespace Raven.Server
                     await ServerStore.SendToLeaderAsync(new RegisterReplicationHubAccessCommand(database, hub, access, certificate, RaftIdGenerator.NewId())
                     {
                         RegisteringSamePublicKeyPinningHash = true
-                    })
-                        .ConfigureAwait(false);
+                    });
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -96,7 +96,7 @@ namespace Raven.Server
         {
             if (RoutesAllowedInUnsafeMode.Contains(context.Request.Path.Value))
             {
-                await RequestHandler(context).ConfigureAwait(false);
+                await RequestHandler(context);
                 return;
             }
 
@@ -105,9 +105,7 @@ namespace Raven.Server
             if (IsHtmlAcceptable(context))
             {
                 context.Response.Headers[Constants.Headers.ContentType] = "text/html; charset=utf-8";
-
-                await context.Response.WriteAsync(HtmlUtil.RenderUnsafePage())
-                                      .ConfigureAwait(false);
+                await context.Response.WriteAsync(HtmlUtil.RenderUnsafePage());
                 return;
             }
 
@@ -131,9 +129,6 @@ namespace Raven.Server
                 }
                 writer.WriteEndArray();
                 writer.WriteEndObject();
-
-                await writer.FlushAsync()
-                            .ConfigureAwait(false);
             }
         }
 
@@ -182,12 +177,10 @@ namespace Raven.Server
                 context.Response.Headers[Constants.Headers.ContentType] = ContentTypeHeaderValue;
 
                 if (_server.ServerStore.Initialized == false)
-                    await _server.ServerStore.InitializationCompleted.WaitAsync()
-                                                                     .ConfigureAwait(false);
+                    await _server.ServerStore.InitializationCompleted.WaitAsync();
 
                 sp = Stopwatch.StartNew();
-                await _router.HandlePath(requestHandlerContext)
-                             .ConfigureAwait(false);
+                await _router.HandlePath(requestHandlerContext);
                 sp.Stop();
             }
             catch (Exception e)

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -158,8 +158,7 @@ namespace Raven.Server.Routing
                 }
 
 
-                await UnlikelyFailAuthorizationAsync(context, databaseName, feature, route.AuthorizationStatus)
-                            .ConfigureAwait(false);
+                await UnlikelyFailAuthorizationAsync(context, databaseName, feature, route.AuthorizationStatus);
                 return (false, feature.Status, feature.Certificate?.Thumbprint);
             }
 
@@ -173,8 +172,7 @@ namespace Raven.Server.Routing
 
                 feature.WaitingForTwoFactorAuthentication();
 
-                await UnlikelyFailAuthorizationAsync(context, databaseName, feature, route.AuthorizationStatus)
-                            .ConfigureAwait(false);
+                await UnlikelyFailAuthorizationAsync(context, databaseName, feature, route.AuthorizationStatus);
 
                 return (false, AuthenticationStatus.TwoFactorAuthFromInvalidLimit, feature.Certificate?.Thumbprint);
             }
@@ -279,7 +277,7 @@ namespace Raven.Server.Routing
             reqCtx.CheckForChanges = tryMatch.Value.CheckForChanges;
 
             var tuple = tryMatch.Value.TryGetHandler(reqCtx);
-            var handler = tuple.Item1 ?? await tuple.Item2.ConfigureAwait(false);
+            var handler = tuple.Item1 ?? await tuple.Item2;
 
             reqCtx.DatabaseMetrics?.Requests.RequestsPerSec.Mark();
             _serverMetrics.Requests.RequestsPerSec.Mark();
@@ -336,7 +334,7 @@ namespace Raven.Server.Routing
                 {
                     if (_ravenServer.Configuration.Security.AuthenticationEnabled && skipAuthorization == false)
                     {
-                        var (authorized, authorizationStatus, thumbprint) = await TryAuthorizeAsync(tryMatch.Value, context, reqCtx.DatabaseName).ConfigureAwait(false);
+                        var (authorized, authorizationStatus, thumbprint) = await TryAuthorizeAsync(tryMatch.Value, context, reqCtx.DatabaseName);
                         status = authorizationStatus;
                         certificateThumbprint = thumbprint;
 
@@ -397,7 +395,7 @@ namespace Raven.Server.Routing
                     if (tryMatch.Value.DisableOnCpuCreditsExhaustion &&
                         _ravenServer.CpuCreditsBalance.FailoverAlertRaised.IsRaised())
                     {
-                        await RejectRequestBecauseOfCpuThresholdAsync(context).ConfigureAwait(false);
+                        await RejectRequestBecauseOfCpuThresholdAsync(context);
                         return;
                     }
 
@@ -413,7 +411,7 @@ namespace Raven.Server.Routing
                                 sp = Stopwatch.StartNew();
                             }
 
-                            await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted).ConfigureAwait(false);
+                            await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted);
 
                             if (RequestLogger.IsInfoEnabled && sp != null)
                             {
@@ -421,12 +419,12 @@ namespace Raven.Server.Routing
                             }
                         }
 
-                        await handler(reqCtx).ConfigureAwait(false);
+                        await handler(reqCtx);
                     }
                 }
                 else
                 {
-                    await handler(reqCtx).ConfigureAwait(false);
+                    await handler(reqCtx);
                 }
             }
             finally
@@ -445,7 +443,7 @@ namespace Raven.Server.Routing
                 var requestBody = context.Request.Body;
                 while (true)
                 {
-                    var read = await requestBody.ReadAsync(buffer.Memory.Memory).ConfigureAwait(false);
+                    var read = await requestBody.ReadAsync(buffer.Memory.Memory);
                     if (read == 0)
                         break;
                 }

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -206,18 +206,18 @@ namespace Raven.Server.Routing
             DatabasesLandlord databasesLandlord, StringSegment databaseName)
         {
             var time = databasesLandlord.DatabaseLoadTimeout;
-            if (await database.DatabaseShutdownCompleted.WaitAsync(time).ConfigureAwait(false) == false)
+            if (await database.DatabaseShutdownCompleted.WaitAsync(time) == false)
             {
                 ThrowDatabaseUnloadTimeout(databaseName, databasesLandlord.DatabaseLoadTimeout);
             }
-            await CreateDatabase(context).ConfigureAwait(false);
+            await CreateDatabase(context);
         }
 
         private async Task UnlikelyWaitForDatabaseToLoad(RequestHandlerContext context, Task<DocumentDatabase> database,
             DatabasesLandlord databasesLandlord, StringSegment databaseName)
         {
             var time = databasesLandlord.DatabaseLoadTimeout;
-            await Task.WhenAny(database, Task.Delay(time)).ConfigureAwait(false);
+            await Task.WhenAny(database, Task.Delay(time));
             if (database.IsCompleted == false)
             {
                 if (databasesLandlord.InitLog.TryGetValue(databaseName.Value, out var initLogQueue))
@@ -230,7 +230,7 @@ namespace Raven.Server.Routing
                 }
                 ThrowDatabaseLoadTimeout(databaseName, databasesLandlord.DatabaseLoadTimeout);
             }
-            context.Database = await database.ConfigureAwait(false);
+            context.Database = await database;
             if (context.Database == null)
                 DatabaseDoesNotExistException.Throw(databaseName.Value);
         }
@@ -280,7 +280,7 @@ namespace Raven.Server.Routing
 
         private async Task<HandleRequest> WaitForDb(Task databaseLoading)
         {
-            await databaseLoading.ConfigureAwait(false);
+            await databaseLoading;
 
             return _request;
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1150,13 +1150,13 @@ namespace Raven.Server.ServerWide
             }
             while (tasks.Count != 0)
             {
-                var completedTask = await Task.WhenAny(tasks.Values).ConfigureAwait(false);
+                var completedTask = await Task.WhenAny(tasks.Values);
                 var name = tasks.Single(t => t.Value == completedTask).Key;
                 tasks.Remove(name);
                 try
                 {
-                    var database = await completedTask.ConfigureAwait(false);
-                    await database.RefreshFeaturesAsync().ConfigureAwait(false);
+                    var database = await completedTask;
+                    await database.RefreshFeaturesAsync();
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Web.System
         public async Task Databases()
         {
             using (var processor = new DatabasesHandlerProcessorForGet(this))
-                await processor.ExecuteAsync().ConfigureAwait(false);
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/admin/databases/topology/modify", "POST", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -40,8 +40,7 @@ namespace Raven.Server.Web.System
             var remoteTask = GetStringQueryString("remote-task");
             var tag = GetStringQueryString("tag", false);
 
-            var authResult = await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask).ConfigureAwait(false);
-            if (authResult == false)
+            if (await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask) == false)
                 return;
 
             if (ServerStore.IdleDatabases.TryGetValue(database, out _) && (tag == ReplicationLoader.PullReplicationAsSinkTag || string.IsNullOrEmpty(tag)))
@@ -111,8 +110,7 @@ namespace Raven.Server.Web.System
                 }
             }
 
-            var authResult = await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask).ConfigureAwait(false);
-            if (authResult == false)
+            if (await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask) == false)
                 return;
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -142,13 +140,11 @@ namespace Raven.Server.Web.System
                     if (feature.CanAccess(database, requireAdmin: false, requireWrite: false))
                         return true;
 
-                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess)
-                                       .ConfigureAwait(false);
+                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess);
                     return false;
 
                 case RavenServer.AuthenticationStatus.UnfamiliarIssuer:
-                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess)
-                                       .ConfigureAwait(false);
+                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess);
                     return false;
 
                 case RavenServer.AuthenticationStatus.UnfamiliarCertificate:
@@ -166,8 +162,7 @@ namespace Raven.Server.Web.System
                                 return true;
                         }
 
-                        await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess)
-                                           .ConfigureAwait(false);
+                        await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess);
                         return false;
                     }
 

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -17,35 +17,6 @@ namespace Sparrow.Json
             _cancellationToken = cancellationToken;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ValueTask<int> MaybeOuterFlushAsync()
-        {
-            var innerStream = _stream as MemoryStream;
-            if (innerStream == null)
-                ThrowInvalidTypeException(_stream?.GetType());
-            if (innerStream.Length * 2 <= innerStream.Capacity)
-                return new ValueTask<int>(0);
-
-            FlushInternal();
-            return new ValueTask<int>(OuterFlushAsync());
-        }
-
-        public async Task<int> OuterFlushAsync()
-        {
-            var innerStream = _stream as MemoryStream;
-            if (innerStream == null)
-                ThrowInvalidTypeException(_stream?.GetType());
-
-            FlushInternal();
-            innerStream.TryGetBuffer(out var bytes);
-            var bytesCount = bytes.Count;
-            if (bytesCount == 0)
-                return 0;
-            await _outputStream.WriteAsync(bytes.Array, bytes.Offset, bytesCount, _cancellationToken).ConfigureAwait(false);
-            innerStream.SetLength(0);
-            return bytesCount;
-        }
-
         public async ValueTask WriteStreamAsync(Stream stream, CancellationToken token = default)
         {
             await FlushAsync(token).ConfigureAwait(false);

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -17,13 +17,6 @@ namespace Sparrow.Json
             _cancellationToken = cancellationToken;
         }
 
-
-        public static ConfiguredAsyncDisposable Create(JsonOperationContext context, Stream stream, out AsyncBlittableJsonTextWriter writer, CancellationToken cancellationToken = default)
-        {
-            writer = new AsyncBlittableJsonTextWriter(context, stream, cancellationToken);
-            return writer.ConfigureAwait(false);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<int> MaybeOuterFlushAsync()
         {

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -182,7 +182,7 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeOuterFlushAsync().ConfigureAwait(false);
+                await writer.MaybeFlushAsync().ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }
@@ -201,7 +201,7 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeOuterFlushAsync().ConfigureAwait(false);
+                await writer.MaybeFlushAsync().ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -971,7 +971,7 @@ namespace Sparrow.Json
         public async ValueTask WriteAsync(Stream stream, BlittableJsonReaderObject json, CancellationToken token = default)
         {
             EnsureNotDisposed();
-            await using (AsyncBlittableJsonTextWriter.Create(this, stream, out var writer))
+            await using (var writer = new AsyncBlittableJsonTextWriter(this, stream))
             {
                 writer.WriteObject(json);
                 await writer.FlushAsync(token).ConfigureAwait(false);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -211,8 +211,7 @@ namespace Voron
                 // the reference to storage environment won't be copied to the state-machine produced by await TimeoutManager.WaitFor() call
                 // otherwise the reference is hold and that prevents from running the finalizer of the environment
 
-                var result = await IdleFlushTimerInternal(weakRef)
-                                            .ConfigureAwait(false);
+                var result = await IdleFlushTimerInternal(weakRef);
                 switch (result)
                 {
                     case true:
@@ -220,8 +219,7 @@ namespace Voron
                     case false:
                         return;
                     case null:
-                        await TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(1000), token)
-                                            .ConfigureAwait(false);
+                        await TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(1000), token);
                         break;
                 }
             }
@@ -237,9 +235,7 @@ namespace Voron
 
                 try
                 {
-                    var result = await env._writeTransactionRunning.WaitAsync(TimeSpan.FromMilliseconds(env.Options.IdleFlushTimeout))
-                                                                       .ConfigureAwait(false);     
-                    if (result == false)
+                    if (await env._writeTransactionRunning.WaitAsync(TimeSpan.FromMilliseconds(env.Options.IdleFlushTimeout)) == false)
                     {
                         if (env.Journal.Applicator.ShouldFlush)
                             GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(env);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767

### Additional description

RavenDB-22767 is an intermittent issue that we’ve seen from time to time since almost a year. We see it only on 6.x instances, including those upgrading from 5.4. The number of users affected by this issues is increasing.

While the original https://github.com/ravendb/ravendb/pull/18136 doesn't seem to be wrong, and there is reasonable performance motivation for it, we decided to revert it since the  the only notable lead suggests a potential connection to the async/await machinery (see comment: https://issues.hibernatingrhinos.com/issue/RavenDB-22767/Scratch-buffers-arent-released#focus=Comments-67-1064615.0-0). We built a few custom builds where removing `.ConfigureAwait(false)` in a few places seemed to yield positive results.

Since https://github.com/ravendb/ravendb/pull/18136 did not provide a significant performance benefit, we are reverting it in the upcoming stable build as part of our troubleshooting efforts to determine if this resolves the issue for affected users.


### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
