### PR TITLE
Fix logging for CertificateExecTimeout

### DIFF
--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -466,6 +466,7 @@ namespace Raven.Server.ServerWide
             var ms = new MemoryStream();
             var readErrors = process.StandardError.ReadToEndAsync();
             var readStdOut = process.StandardOutput.BaseStream.CopyToAsync(ms);
+            var timeoutInMs = (int)_config.CertificateExecTimeout.AsTimeSpan.TotalMilliseconds;
 
             string GetStdError()
             {
@@ -479,20 +480,20 @@ namespace Raven.Server.ServerWide
                 }
             }
 
-            if (process.WaitForExit((int)_config.CertificateExecTimeout.AsTimeSpan.TotalMilliseconds) == false)
+            if (process.WaitForExit(timeoutInMs) == false)
             {
                 process.Kill();
-                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {_config.CertificateExecTimeout} ms but the process didn't exit. Stderr: {GetStdError()}");
+                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {timeoutInMs} ms but the process didn't exit. Stderr: {GetStdError()}");
             }
 
             try
             {
-                readStdOut.Wait(_config.CertificateExecTimeout.AsTimeSpan);
-                readErrors.Wait(_config.CertificateExecTimeout.AsTimeSpan);
+                readStdOut.Wait(timeoutInMs);
+                readErrors.Wait(timeoutInMs);
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {_config.CertificateExecTimeout} ms but the process didn't exit. Stderr: {GetStdError()}", e);
+                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {timeoutInMs} ms but the process didn't exit. Stderr: {GetStdError()}", e);
             }
 
             if (Logger.IsErrorEnabled)


### PR DESCRIPTION
TimeSetting doesn't override ToString() so we can't just directly log CertificateExecTimeout

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
