### PR TITLE
RavenDB-25323: Ensure we cannot mix container ids and entry ids.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
+++ b/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Sparrow.Server.Utils.VxSort;
 using Voron;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Util;
 
@@ -19,14 +20,14 @@ public partial class IndexWriter
         private readonly IndexWriter _writer;
         private ContextBoundNativeList<long> _entriesForTermsRemovalsBuffer;
         private NativeList<long> _entriesForTermsAdditionsBufferEntryId;
-        private NativeList<long> _entriesForTermsAdditionsBufferTermId;
+        private NativeList<ContainerEntryId> _entriesForTermsAdditionsBufferTermId;
         private readonly List<long> _additionsForTerm, _removalsForTerm;
         private readonly HashSet<long> _entriesAlreadyAdded;
-        private long _termContainerId;
+        private ContainerEntryId _termContainerId;
         
         public EntriesToTermsTracker(IndexWriter writer)
         {
-            _termContainerId = Constants.IndexWriter.InvalidPageId;
+            _termContainerId = ContainerEntryId.Invalid;
             _writer = writer;
             _entriesForTermsRemovalsBuffer = new(writer._entriesAllocator);
             _entriesForTermsAdditionsBufferEntryId.Initialize(_writer._entriesAllocator);
@@ -39,9 +40,9 @@ public partial class IndexWriter
         /// <summary>
         /// Gathers all entry IDs to be processed with the term.
         /// </summary>
-        public void InsertEntries(in EntriesModifications entries, long termContainerId)
+        public void InsertEntries(in EntriesModifications entries, ContainerEntryId termContainerId)
         {
-            Debug.Assert(_termContainerId == Constants.IndexWriter.InvalidPageId);
+            Debug.Assert(_termContainerId == ContainerEntryId.Invalid);
             _termContainerId = termContainerId;
 
             SetRange(_additionsForTerm, entries.Additions);
@@ -99,7 +100,7 @@ public partial class IndexWriter
                 _entriesForTermsAdditionsBufferTermId.AddUnsafe(_termContainerId);
             }
 
-            _termContainerId = Constants.IndexWriter.InvalidPageId;
+            _termContainerId = ContainerEntryId.Invalid;
         }
         
         /// <summary>
@@ -133,7 +134,7 @@ public partial class IndexWriter
                 {
                     Int64LookupKey key = entriesIds[idX];
                     entriesToTermsTree.TryGetNextValue(ref key, out _);
-                    entriesToTermsTree.AddOrSetAfterGetNext(ref key, entriesTerms[idX]);
+                    entriesToTermsTree.AddOrSetAfterGetNext(ref key, (long)entriesTerms[idX]);
                 }
             }
         }

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -421,7 +421,7 @@ public partial class IndexWriter
                 out Span<byte> space);
             term.CopyTo(space);
 
-            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, termId);
+            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, (long)termId);
             
             if (entryTerms.TryAdd(recordedTerm) == false)
             {

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -421,7 +421,7 @@ public partial class IndexWriter
                 out Span<byte> space);
             term.CopyTo(space);
 
-            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, (long)termId);
+            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, termId);
             
             if (entryTerms.TryAdd(recordedTerm) == false)
             {
@@ -441,7 +441,7 @@ public partial class IndexWriter
             ref var entryTerms = ref _parent.GetEntryTerms(_termPerEntryIndex);
 
             _parent.InitializeFieldRootPage(field);
-            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, field.FieldRootPage);
+            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, new ContainerEntryId(field.FieldRootPage));
             
             if (entryTerms.TryAdd(recordedTerm) == false)
             {

--- a/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
@@ -120,7 +120,7 @@ public partial class IndexWriter
         {
             bool termFound = postingListId != Constants.IndexSearcher.InvalidId;
             Debug.Assert(termFound || entries.Removals.Count == 0, "Cannot remove entries from term that isn't already there");
-            _writer._entriesToTermsTracker.InsertEntries(entries, key.ToLong());
+            _writer._entriesToTermsTracker.InsertEntries(entries, new ContainerEntryId(key.ToLong()));
             LookupTreeOperationJob result;
             if (entries.HasChanges)
             {

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -136,7 +136,7 @@ public unsafe partial class IndexWriter
                         ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[offset]);
                         var job = ProcessSingleEntry(ref entries, isNullTerm: false,
                             sortedTerms[offset], postingListIds[offset],
-                            keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
+                            (long)keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
                         totalLengthOfTerm += totalLengthOfTermDelta;
                         entries.Dispose(_writer._entriesAllocator);
                         _jobs[offset] = job;
@@ -386,7 +386,7 @@ public unsafe partial class IndexWriter
                     out var listSpace);
 
                 processingBuffer.Slice(0, processingBufferPosition).CopyTo(listSpace);
-                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, listContainerId);
+                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, (long)listContainerId);
 
                 fieldTerms.Dispose(_writer._entriesAllocator);
                 if (entryTerms.TryAdd(recordedTerm) == false)
@@ -477,7 +477,7 @@ public unsafe partial class IndexWriter
                 var term = sortedTerms[i];
 
                 var key = buffers.Keys[i].Key ??= llt.AcquireCompactKey();
-                buffers.Keys[i].ContainerId = Container.InvalidId;
+                buffers.Keys[i].ContainerId = ContainerEntryId.Invalid;
                 key.Set(term.AsSpan());
                 key.ChangeDictionary(fieldTree.DictionaryId);
                 key.EncodedWithCurrent(out _);
@@ -504,11 +504,11 @@ public unsafe partial class IndexWriter
                 return *((long, long)*)entry.Reader.Base;
             }
 
-            long setId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
+            long setId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
 
             _writer.InitializeFieldRootPage(_indexedField);
 
-            long nullMarkerId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
+            long nullMarkerId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
                 1, _indexedField.FieldRootPage, out var nullBuffer);
             nullBuffer.Clear();
 

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -136,7 +136,7 @@ public unsafe partial class IndexWriter
                         ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[offset]);
                         var job = ProcessSingleEntry(ref entries, isNullTerm: false,
                             sortedTerms[offset], postingListIds[offset],
-                            (long)keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
+                            keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
                         totalLengthOfTerm += totalLengthOfTermDelta;
                         entries.Dispose(_writer._entriesAllocator);
                         _jobs[offset] = job;
@@ -166,11 +166,11 @@ public unsafe partial class IndexWriter
 
         private void HandleSpecialTerm(Span<int> termsOffsets, Span<Slice> sortedTerms, int termIndex, Tree tree, ref long totalLengthOfTerm)
         {
-            (long postingListId, long termContainerId) = GetOrCreateSpecialPostingList(tree);
+            (var postingListId, var termContainerId) = GetOrCreateSpecialPostingList(tree);
             ref var entries = ref _indexedField.Storage.GetAsRef(termsOffsets[termIndex]);
             var nullLookup = new CompactTree.CompactKeyLookup(CompactKey.NullInstance);
             var job = ProcessSingleEntry(ref entries, isNullTerm: true,
-                sortedTerms[termIndex], postingListId, termContainerId, termsOffsets[termIndex], out var totalLengthOfTermDelta);
+                sortedTerms[termIndex], (long)postingListId, termContainerId, termsOffsets[termIndex], out var totalLengthOfTermDelta);
             totalLengthOfTerm += totalLengthOfTermDelta;
             ProcessCompactTreeOperation(job, ref nullLookup, _fieldTree.CheckTreeStructureChanges(), pageOffset: -1, sortedTerms[termIndex]);
         }
@@ -214,7 +214,7 @@ public unsafe partial class IndexWriter
             }
         }
         
-        private LookupTreeOperationJob ProcessSingleEntry(ref EntriesModifications entries, bool isNullTerm, Slice term, long postListId, long termContainerId, int storageLocation, out int totalLengthOfTermDelta)
+        private LookupTreeOperationJob ProcessSingleEntry(ref EntriesModifications entries, bool isNullTerm, Slice term, long postListId, ContainerEntryId termContainerId, int storageLocation, out int totalLengthOfTermDelta)
         {
             UpdateEntriesForTerm(ref _entriesForTerm, in entries);
             if (_indexedField.Spatial == null) // For spatial, we handle this in InsertSpatialField, so we skip it here
@@ -277,7 +277,7 @@ public unsafe partial class IndexWriter
             {
                 Debug.Assert(_virtualTermIdToTermContainerId[storageLocation] == Constants.IndexedField.Invalid,
                     "virtualMapping[entries.StorageLocation] == Constants.IndexedField.Invalid, Term was already set! Persisted: {_virtualTermIdToTermContainerId[storageLocation]}, new: {termContainerId}");
-                _virtualTermIdToTermContainerId[storageLocation] = termContainerId;
+                _virtualTermIdToTermContainerId[storageLocation] = (long)termContainerId;
             }
 
             return lookupTreeOperationJob;
@@ -386,7 +386,7 @@ public unsafe partial class IndexWriter
                     out var listSpace);
 
                 processingBuffer.Slice(0, processingBufferPosition).CopyTo(listSpace);
-                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, (long)listContainerId);
+                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, listContainerId);
 
                 fieldTerms.Dispose(_writer._entriesAllocator);
                 if (entryTerms.TryAdd(recordedTerm) == false)
@@ -413,7 +413,7 @@ public unsafe partial class IndexWriter
             }
         }
 
-        private void RecordTermsForEntries(in EntriesModifications entries, long termContainerId)
+        private void RecordTermsForEntries(in EntriesModifications entries, ContainerEntryId termContainerId)
         {
             foreach (var entry in _entriesForTerm)
             {
@@ -424,14 +424,14 @@ public unsafe partial class IndexWriter
 
                 ref var recordedTerm = ref recordedTermList.AddByRefUnsafe();
 
-                Debug.Assert((termContainerId & 0b111) == 0); // ensure that the three bottom bits are cleared
+                Debug.Assert(((long)termContainerId & 0b111) == 0); // ensure that the three bottom bits are cleared
 
                 long recordedTermContainerId = entry.Frequency switch
                 {
-                    > 1 => termContainerId << Constants.IndexWriter.TermFrequencyShift | // note, bottom 3 are cleared, so we have 11 bits to play with
+                    > 1 => (long)termContainerId << Constants.IndexWriter.TermFrequencyShift | // note, bottom 3 are cleared, so we have 11 bits to play with
                            EntryIdEncodings.FrequencyQuantization(entry.Frequency) << 3 |
                            0b100, // marker indicating that we have a term frequency here
-                    _ => termContainerId
+                    _ => (long)termContainerId
                 };
 
                 Debug.Assert(entry.InserterMode is not InserterMode.Ignore);
@@ -491,7 +491,7 @@ public unsafe partial class IndexWriter
             pageOffsets = new Span<int>(buffers.PageOffsets, 0, max);
         }
 
-        private (long NonExistingTermListId, long NonExistingTermId) GetOrCreateSpecialPostingList(Tree tree)
+        private (ContainerEntryId NonExistingTermListId, ContainerEntryId NonExistingTermId) GetOrCreateSpecialPostingList(Tree tree)
         {
             // In the case where the field does not have any null values, we will create a *large* posting list (an empty one)
             // then we'll insert data to it as if it was any other term
@@ -501,29 +501,30 @@ public unsafe partial class IndexWriter
             {
                 Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
                 Debug.Assert(entry.Reader.Length == sizeof((long, long)));
-                return *((long, long)*)entry.Reader.Base;
+                var tuple = *((long, long)*)entry.Reader.Base;
+                return (new ContainerEntryId(tuple.Item1), new ContainerEntryId(tuple.Item2));
             }
 
-            long setId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
+            var setId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
 
             _writer.InitializeFieldRootPage(_indexedField);
 
-            long nullMarkerId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
+            var nullMarkerId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
                 1, _indexedField.FieldRootPage, out var nullBuffer);
             nullBuffer.Clear();
 
             // we need to account for the size of the posting lists, once a term has been switch to a posting list
             // it will always be in this model, so we don't need to do any cleanup
             _writer._largePostingListSet ??= _writer._transaction.OpenPostingList(Constants.IndexWriter.LargePostingListsSetSlice);
-            _writer._largePostingListSet.Add(setId);
+            _writer._largePostingListSet.Add((long)setId);
 
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
             PostingList.Create(_writer._transaction.LowLevelTransaction, ref postingListState);
-            var encodedPostingListId = EntryIdEncodings.Encode(setId, 0, TermIdMask.PostingList);
+            var encodedPostingListId = new ContainerEntryId(EntryIdEncodings.Encode((long)setId, 0, TermIdMask.PostingList));
 
             using (tree.DirectAdd(_indexedField.Name, sizeof((long, long)), out var p))
             {
-                *((long, long)*)p = (encodedPostingListId, nullMarkerId);
+                *((long, long)*)p = ((long)encodedPostingListId, (long)nullMarkerId);
             }
 
             return (encodedPostingListId, nullMarkerId);
@@ -548,6 +549,8 @@ public unsafe partial class IndexWriter
                 if ((cur & (long)TermIdMask.EnsureIsSingleMask) == 0)
                     continue;
 
+                // Decoding the posting list id yields the container root that stores the posting list. We keep it as
+                // ContainerId so later steps talk to the correct root instead of a payload slot.
                 long containerId = EntryIdEncodings.GetContainerId(cur);
                 postingListPagesProcessingBuffer.Add(containerId / Voron.Global.Constants.Storage.PageSize);
             }

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -77,9 +77,9 @@ namespace Corax.Indexing
         private Dictionary<Slice, IndexedField> _dynamicFieldsTerms;
         private FieldsCache _fieldsCache;
 
-        private long _postingListContainerId;
-        private long _storedFieldsContainerId;
-        private long _entriesTermsContainerId;
+        private ContainerId _postingListContainerId;
+        private ContainerId _storedFieldsContainerId;
+        private ContainerId _entriesTermsContainerId;
         private Lookup<Int64LookupKey> _entryIdToLocation;
         private IndexFieldsMapping _dynamicFieldsMapping;
         private PostingList _largePostingListSet;
@@ -132,6 +132,9 @@ namespace Corax.Indexing
         /// we need to keep track of how many documents we actually deleted
         /// (e.g., when we perform a delete operation not by 'primary key,'
         /// we might end up in a situation where we try to remove the same document twice, and we need to detect it).
+        ///
+        /// Note: This stores document entry IDs (index-level identifiers), not ContainerEntryId (storage-level identifiers).
+        /// While both are represented as long, they are semantically different concepts and should not be confused.
         /// </summary>
         private readonly HashSet<long> _deletedEntries = new();
 
@@ -563,11 +566,12 @@ namespace Corax.Indexing
             foreach (var entryToDelete in _entriesToDelete)
             {
                 _termsPerEntryId.EnsureCapacityFor(_entriesAllocator, 1);
-                if (_entryIdToLocation.TryRemove(entryToDelete, out var entryTermsId) == false)
+                if (_entryIdToLocation.TryRemove(entryToDelete, out var entryTermsIdLong) == false)
                     ThrowUnableToLocateEntry(entryToDelete);
 
                 RemoveDocumentBoost(entryToDelete);
-                var entryTerms = Container.Get(_transaction.LowLevelTransaction, entryTermsId);
+                ContainerEntryId entryTermsId = (ContainerEntryId)entryTermsIdLong;
+                Container.Get(_transaction.LowLevelTransaction, entryTermsId, out var entryTerms);
                 var termsPerEntryIndex = InsertTermsPerEntry(entryToDelete);
                 RecordTermDeletionsForEntry(entryTerms, _transaction.LowLevelTransaction, _fieldsByRootPage, _nullTermsMarkers, _nonExistingTermsMarkers,
                     _compactTreeDictionaryId, entryToDelete, termsPerEntryIndex);
@@ -600,7 +604,7 @@ namespace Corax.Indexing
                     vectorIndexer.Remove(entryToDelete, reader.StoredField.Value.ToSpan());
                 }
 
-                Container.Delete(llt, _storedFieldsContainerId, reader.TermId);
+                Container.Delete(llt, _storedFieldsContainerId, new ContainerEntryId(reader.TermId));
             }
 
             reader.Reset();
@@ -933,13 +937,13 @@ namespace Corax.Indexing
 
             var countOfAlreadyDeletedEntries = _deletedEntries.Count;
             setsAreDisjoint = true;
-            var containerId = EntryIdEncodings.GetContainerId(postingListId);
+            var containerEntryId = (ContainerEntryId)EntryIdEncodings.GetContainerId(postingListId);
 
             if ((postingListId & (long)TermIdMask.EnsureIsSingleMask) == (long)TermIdMask.Single)
             {
-                singleDocumentEntryId = containerId;
+                singleDocumentEntryId = (long)containerEntryId;
                 Debug.Assert(singleDocumentEntryId > 0);
-                var isNewDocument = _deletedEntries.Add(containerId);
+                var isNewDocument = _deletedEntries.Add((long)containerEntryId);
                 if (isNewDocument)
                     _entriesToDelete.Add(singleDocumentEntryId);
                 setsAreDisjoint &= isNewDocument;
@@ -956,7 +960,7 @@ namespace Corax.Indexing
             singleDocumentEntryId = Constants.IndexSearcher.InvalidId;
             if ((postingListId & (long)TermIdMask.PostingList) != 0)
             {
-                var setSpace = Container.GetMutable(_transaction.LowLevelTransaction, containerId);
+                var setSpace = Container.GetMutable(_transaction.LowLevelTransaction, containerEntryId);
                 ref var setState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
                 using var set = new PostingList(_transaction.LowLevelTransaction, Slices.Empty, setState);
@@ -968,7 +972,7 @@ namespace Corax.Indexing
 
             if ((postingListId & (long)TermIdMask.SmallPostingList) != 0)
             {
-                var smallSet = Container.Get(_transaction.LowLevelTransaction, containerId);
+                Container.Get(_transaction.LowLevelTransaction, containerEntryId, out var smallSet);
                 // combine with existing value
                 _ = VariableSizeEncoding.Read<int>(smallSet.Address, out var pos);
                 _pforDecoder.Init(smallSet.Address + pos, smallSet.Length - pos);
@@ -1177,10 +1181,10 @@ namespace Corax.Indexing
 
                 int size = writer.Encode(termsRef);
 
-                long entryTermsId = Container.Allocate(_transaction.LowLevelTransaction, _entriesTermsContainerId, size, out var space);
+                ContainerEntryId entryTermsId = Container.Allocate(_transaction.LowLevelTransaction, _entriesTermsContainerId, size, out var space);
                 writer.Write(space);
 
-                _entryIdToLocation.Add(termsPerEntryIds[i], entryTermsId);
+                _entryIdToLocation.Add(termsPerEntryIds[i], (long)entryTermsId);
             }
         }
 
@@ -1267,7 +1271,7 @@ namespace Corax.Indexing
             var containerId = EntryIdEncodings.GetContainerId(idInTree);
 
             var llt = _transaction.LowLevelTransaction;
-            Container.GetMutable(llt, containerId, out var item);
+            Container.GetMutable(llt, new ContainerEntryId(containerId), out var item);
 
             Debug.Assert(entries.Removals.ToSpan().ToArray().Distinct().Count() == entries.Removals.Count, $"Removals list is not distinct.");
 
@@ -1304,7 +1308,7 @@ namespace Corax.Indexing
 
             if (_smallPostingListWorkingBuffer.Count == 0)
             {
-                Container.Delete(llt, _postingListContainerId, containerId);
+                Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
                 termIdInTree = Constants.IndexSearcher.InvalidId;
                 return AddEntriesToTermResult.RemoveTermId;
             }
@@ -1326,7 +1330,7 @@ namespace Corax.Indexing
                 return AddEntriesToTermResult.NothingToDo;
             }
 
-            Container.Delete(llt, _postingListContainerId, containerId);
+            Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
 
             termIdInTree = AllocatedSpaceForSmallSet(encoded, llt, out Span<byte> space);
 
@@ -1337,7 +1341,7 @@ namespace Corax.Indexing
 
         private long AllocatedSpaceForSmallSet(Span<byte> encoded, LowLevelTransaction llt, out Span<byte> space)
         {
-            long termIdInTree = Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
+            long termIdInTree = (long)Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
 
             return EntryIdEncodings.Encode(termIdInTree, 0, TermIdMask.SmallPostingList);
         }
@@ -1424,7 +1428,7 @@ namespace Corax.Indexing
         {
             var containerId = EntryIdEncodings.GetContainerId(id);
             var llt = _transaction.LowLevelTransaction;
-            var setSpace = Container.GetMutable(llt, containerId);
+            var setSpace = Container.GetMutable(llt, new ContainerEntryId(containerId));
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
             entries.GetEncodedAdditionsAndRemovals(_entriesAllocator, out var additions, out var removals);
@@ -1436,12 +1440,12 @@ namespace Corax.Indexing
 
             if (numberOfEntries == 0)
             {
-                if (isNullTerm) // we don't want to remove the null term posting list 
+                if (isNullTerm) // we don't want to remove the null term posting list
                     return AddEntriesToTermResult.NothingToDo;
 
                 llt.FreePage(postingListState.RootPage);
 
-                Container.Delete(llt, _postingListContainerId, containerId);
+                Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
                 RemovePostingListFromLargePostingListsSet(containerId);
 
                 return AddEntriesToTermResult.RemoveTermId;
@@ -1512,7 +1516,7 @@ namespace Corax.Indexing
 
         private void AddNewTermToSet(out long termId)
         {
-            long setId = Container.Allocate(_transaction.LowLevelTransaction, _postingListContainerId, sizeof(PostingListState), out var setSpace);
+            long setId = (long)Container.Allocate(_transaction.LowLevelTransaction, _postingListContainerId, sizeof(PostingListState), out var setSpace);
 
             // we need to account for the size of the posting lists, once a term has been switch to a posting list
             // it will always be in this model, so we don't need to do any cleanup

--- a/src/Corax/Indexing/RecordedTerm.cs
+++ b/src/Corax/Indexing/RecordedTerm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Utils;
+using Voron.Data.Containers;
 using Voron.Util;
 
 namespace Corax.Indexing;
@@ -52,17 +53,17 @@ public struct RecordedTerm : IComparable<RecordedTerm>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static RecordedTerm CreateForStored<T>(in NativeList<T> fieldTerms, in StoredFieldType storedFieldType, in long listContainerId)
+    public static RecordedTerm CreateForStored<T>(in NativeList<T> fieldTerms, in StoredFieldType storedFieldType, in ContainerEntryId listContainerId)
         where T : unmanaged
     {
         return new RecordedTerm
         (
-            // why: entryTerms.Count << 8 
+            // why: entryTerms.Count << 8
             // we put entries count here because we are sorting the entries afterward
             // this ensure that stored values are then read using the same order we have for writing them
             // which is important for storing arrays
             termContainerId: fieldTerms.Count << Constants.IndexWriter.TermFrequencyShift | (int)storedFieldType | 0b110, // marker for stored field
-            @long: listContainerId
+            @long: (long)listContainerId
         );
     }
 }

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -171,7 +171,7 @@ public partial class IndexSearcher
         else if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
         {
             var smallSetId = EntryIdEncodings.GetContainerId(containerId);
-            Container.Get(_transaction.LowLevelTransaction, smallSetId, out var small);
+            Container.Get(_transaction.LowLevelTransaction, new ContainerEntryId(smallSetId), out var small);
             matches = TermMatch.YieldSmall(this, Allocator, small, termRatioToWholeCollection, field.HasBoost);
         }
         else
@@ -185,7 +185,7 @@ public partial class IndexSearcher
     public PostingList GetPostingList(long containerId)
     {
         var setId = EntryIdEncodings.GetContainerId(containerId);
-        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, setId);
+        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(setId));
 
         ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
         var set = new PostingList(_transaction.LowLevelTransaction, Slices.Empty, setState);
@@ -257,7 +257,7 @@ public partial class IndexSearcher
         if ((containerId & (long)TermIdMask.PostingList) != 0)
         {
             var setId = EntryIdEncodings.GetContainerId(containerId);
-            var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, setId);
+        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(setId));
             ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             return setState.NumberOfEntries;
         }
@@ -265,7 +265,7 @@ public partial class IndexSearcher
         if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
         {
             var smallSetId = EntryIdEncodings.GetContainerId(containerId);
-            var small = Container.GetReadOnly(_transaction.LowLevelTransaction, smallSetId);
+            var small = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(smallSetId));
             var itemsCount = VariableSizeEncoding.Read<int>(small, out _);
 
             return itemsCount;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -157,11 +157,11 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     public EntryTermsReader GetEntryTermsReader(long id, ref Page p)
     {
-        if (_entryIdToLocation.TryGetValue(id, out var loc) == false)
+        if (_entryIdToLocation.TryGetValue(id, out var locLong) == false)
             throw new InvalidOperationException("Unable to find entry id: " + id);
 
         InitializeSpecialTermsMarkers();
-        
+        ContainerEntryId loc = (ContainerEntryId)locLong;
         var item = Container.MaybeGetFromSamePage(_transaction.LowLevelTransaction, ref p, loc);
         return new EntryTermsReader(_transaction.LowLevelTransaction, _nullTermsMarkers, _nonExistingTermsMarkers, item.Address, item.Length, _dictionaryId, _vectorFieldsMarkers);
     }

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -109,27 +109,27 @@ public unsafe struct TermsReader : IDisposable
     
     public bool TryGetRawTermFor(long id, out UnmanagedSpan term)
     {
-        if (_lookup.TryGetValue(id, out var termContainerId) == false)
+        if (_lookup.TryGetValue(id, out var termEntryId) == false)
         {
             term = default;
             return false;
         }
 
-        Container.Get(_llt, termContainerId, out var item);
+        Container.Get(_llt, new ContainerEntryId(termEntryId), out var item);
         term = item.ToUnmanagedSpan();
         return true;
     }
     
     public bool TryGetTermFor(long id, out string term)
     {
-        if (_lookup == null || 
-            _lookup.TryGetValue(id, out var termContainerId) == false)
+        if (_lookup == null ||
+            _lookup.TryGetValue(id, out var termEntryId) == false)
         {
             term = null;
             return false;
         }
 
-        Container.Get(_llt, termContainerId, out var item);
+        Container.Get(_llt, new ContainerEntryId(termEntryId), out var item);
         Set(_xKeyScope.Key, item, _dictionaryId);
         term = _xKeyScope.Key.ToString();
         return true;
@@ -186,7 +186,7 @@ public unsafe struct TermsReader : IDisposable
         UnmanagedSpan term = UnmanagedSpan.Empty;
         if (hasValue)
         {
-            var item = Container.MaybeGetFromSamePage(_llt, ref _lastPage, termId);
+            var item = Container.MaybeGetFromSamePage(_llt, ref _lastPage, new ContainerEntryId(termId));
             term = item.ToUnmanagedSpan();
         }
 

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -252,7 +252,7 @@ public unsafe struct EntryTermsReader
         IsNonExisting = _nonExistingTermsMarkers.Contains(TermId);
         IsVectorHash = false;
         
-        Container.Get(_llt, TermId, out var termItem);
+        Container.Get(_llt, new ContainerEntryId(TermId), out var termItem);
         FieldRootPage = termItem.PageLevelMetadata;
         
         if (IsNull == false && IsNonExisting == false)
@@ -310,7 +310,7 @@ public unsafe struct EntryTermsReader
                         FieldRootPage = val;
                         break;
                     case StoredFieldType.Term:
-                        Container.Get(_llt, val, out var termItem);
+                        Container.Get(_llt, new ContainerEntryId(val), out var termItem);
                         TermId = val;
                         FieldRootPage = termItem.PageLevelMetadata;
                         StoredField = termItem.ToUnmanagedSpan();

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -55,7 +55,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                     {
                         for (int i = 0; i < read; i++)
                         {
-                            Container.Get(tx.LowLevelTransaction, buffer[i], out var item);
+                            Container.Get(tx.LowLevelTransaction, new ContainerEntryId(buffer[i]), out var item);
                             var state = (PostingListState*)item.Address;
                             var pl = new PostingList(tx.LowLevelTransaction, Constants.IndexWriter.LargePostingListsSetSlice, *state);
                             list.AddRange(pl.AllPages());

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -5235,7 +5235,7 @@ namespace Raven.Server.Documents.Indexes
                     {
                         for (int i = 0; i < read; i++)
                         {
-                            Container.Get(llt, buffer[i], out var item);
+                            Container.Get(llt, new ContainerEntryId(buffer[i]), out var item);
                             var state = (PostingListState*)item.Address;
                             report.BranchPages += state->BranchPages;
                             report.LeafPages += state->LeafPages;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -50,6 +50,12 @@ public sealed partial class CompactTree : IPrepareForCommit
             ContainerId = ContainerEntryId.Invalid;
         }
 
+        public CompactKeyLookup(ContainerEntryId entryId)
+        {
+            ContainerId = entryId;
+            Key = null;
+        }
+
         public CompactKeyLookup(long keyData)
         {
             ContainerId = (ContainerEntryId)keyData;
@@ -195,7 +201,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (!IsValid)
+            if (IsValid == false)
             {
                 return -1;
             }
@@ -316,7 +322,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         Add(scope.Key, value);
     }
 
-    public long Add(ReadOnlySpan<byte> key, long value)
+    public ContainerEntryId Add(ReadOnlySpan<byte> key, long value)
     {
         using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
         return Add(scope.Key, value);
@@ -326,22 +332,22 @@ public sealed partial class CompactTree : IPrepareForCommit
     {
     }
 
-    public long Add(CompactKey key, long value)
+    public ContainerEntryId Add(CompactKey key, long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
         var lookup = new CompactKeyLookup(key);
         CompactTreeDumper.WriteAddition(this, ref lookup, value);
         _inner.Add(ref lookup, value);
 
-        return (long)lookup.ContainerId;
+        return lookup.ContainerId;
     }
-    
-    public long Add(CompactKeyLookup key, long value)
+
+    public ContainerEntryId Add(CompactKeyLookup key, long value)
     {
         Debug.Assert(key.Key.Dictionary == _inner.State.DictionaryId);
         CompactTreeDumper.WriteAddition(this, ref key, value);
         _inner.Add(ref key, value);
-        return (long)key.ContainerId;
+        return key.ContainerId;
     }
 
     public void PrepareForCommit()
@@ -389,7 +395,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             }
 
             var containerId = Container.Create(llt);
-            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, (long)containerId);
+            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, containerId);
         }
         else
         {
@@ -431,12 +437,12 @@ public sealed partial class CompactTree : IPrepareForCommit
         return _inner.TryGetValue(new CompactKeyLookup(scope.Key), out value);
     }
     
-    public bool TryGetValue(ReadOnlySpan<byte> key, out long termContainerId, out long value)
+    public bool TryGetValue(ReadOnlySpan<byte> key, out ContainerEntryId termContainerId, out long value)
     {
         using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
         var ckl = new CompactKeyLookup(scope.Key);
         var found = _inner.TryGetValue(ref ckl, out value);
-        termContainerId = (long)ckl.ContainerId;
+        termContainerId = ckl.ContainerId;
         return found;
     }
 
@@ -447,7 +453,7 @@ public sealed partial class CompactTree : IPrepareForCommit
     /// <param name="value">The value stored under the CompactKey.</param>
     /// <param name="key">The underlying value of the CompactKey.</param>
     /// <returns>True if the value exists; otherwise, false.</returns>
-    public bool TryGetValue(long termContainerId, out long value, out ReadOnlySpan<byte> key)
+    public bool TryGetValue(ContainerEntryId termContainerId, out long value, out ReadOnlySpan<byte> key)
     {
         var containerId = new CompactKeyLookup(termContainerId);
         var found = _inner.TryGetValue(ref containerId, out value);
@@ -467,12 +473,12 @@ public sealed partial class CompactTree : IPrepareForCommit
         return _inner.TryGetTermContainerId(new CompactKeyLookup(key), out value);
     }
 
-    public bool TryGetValue(CompactKey key, out long termContainerId, out long value)
+    public bool TryGetValue(CompactKey key, out ContainerEntryId termContainerId, out long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
         CompactKeyLookup compactKeyLookup = new(key);
         var result = _inner.TryGetValue(ref compactKeyLookup, out value);
-        termContainerId = (long)compactKeyLookup.ContainerId;
+        termContainerId = compactKeyLookup.ContainerId;
         return result;
     }
     
@@ -517,13 +523,13 @@ public sealed partial class CompactTree : IPrepareForCommit
         _inner.InitializeCursorState();
     }
 
-    public bool TryGetNextValue(CompactKey key, out long termContainerId, out long value,out CompactKeyLookup lookup)
+    public bool TryGetNextValue(CompactKey key, out ContainerEntryId termContainerId, out long value,out CompactKeyLookup lookup)
     {
         key.ChangeDictionary(DictionaryId);
         key.EncodedWithCurrent(out _);
         lookup = new CompactKeyLookup(key);
         var result = _inner.TryGetNextValue(ref lookup, out value);
-        termContainerId = (long)lookup.ContainerId;
+        termContainerId = lookup.ContainerId;
         return result;
     }
     

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -39,38 +39,41 @@ public sealed partial class CompactTree : IPrepareForCommit
     public unsafe struct CompactKeyLookup : ILookupKey
     {
         public CompactKey Key;
-        public long ContainerId;
+        public ContainerEntryId ContainerId;
+
+        public bool IsValid => ContainerId.IsValid;
+        public bool IsEmpty => ContainerId.IsEmpty;
 
         public CompactKeyLookup(CompactKey key)
         {
             Key = key;
-            ContainerId = -1;
+            ContainerId = ContainerEntryId.Invalid;
         }
 
-        public CompactKeyLookup(long containerId)
+        public CompactKeyLookup(long keyData)
         {
-            ContainerId = containerId;
+            ContainerId = (ContainerEntryId)keyData;
             Key = null;
         }
 
         public void Reset()
         {
-            ContainerId = -1;
+            ContainerId = ContainerEntryId.Invalid;
         }
 
         public long ToLong()
         {
-            return ContainerId;
+            return (long)ContainerId;
         }
 
-        public static T FromLong<T>(long l)
+        public static T FromLong<T>(long keyData)
         {
             if (typeof(T) != typeof(CompactKeyLookup))
             {
                 throw new NotSupportedException(typeof(T).FullName);
             }
 
-            return (T)(object)new CompactKeyLookup(l);
+            return (T)(object)new CompactKeyLookup(keyData);
         }
 
         public static long MinValue => 0;
@@ -83,7 +86,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
             byte* keyPtr;
             int keyLenInBits;
-            if (ContainerId == 0)
+            if (IsEmpty)
             {
                 keyPtr = null;
                 keyLenInBits = 0;
@@ -105,7 +108,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
             byte* keyPtr;
             int keyLenInBits;
-            if (ContainerId == 0)
+            if (IsEmpty)
             {
                 keyPtr = null;
                 keyLenInBits = 0;
@@ -123,38 +126,39 @@ public sealed partial class CompactTree : IPrepareForCommit
             GetKey(parent);
         }
 
-        public int CompareTo<T>(Lookup<T> parent, long currentKeyId) where T : struct, ILookupKey
+        /// <summary>
+        /// Compares this CompactKeyLookup with key data from storage.
+        /// The keyData parameter contains a ContainerEntryId stored as a long for interface compatibility.
+        /// </summary>
+        public int CompareTo<T>(Lookup<T> parent, long keyData) where T : struct, ILookupKey
         {
             var llt = parent.Llt;
 
             byte* keyPtr;
             int keyLengthInBits;
-            if (currentKeyId == 0)
+            if (keyData == 0)
             {
                 keyPtr = null;
                 keyLengthInBits = 0;
             }
             else
             {
-                GetEncodedKey(llt, currentKeyId, out keyLengthInBits, out keyPtr);
+                GetEncodedKey(llt, (ContainerEntryId)keyData, out keyLengthInBits, out keyPtr);
             }
 
             var k = GetKey(parent);
-            if (ReferenceEquals(k, CompactKey.NullInstance))
-                return -1; // null is smallest
-            
             var match = k.CompareEncodedWithCurrent(keyPtr, keyLengthInBits);
             if (match == 0)
             {
-                ContainerId = currentKeyId;
+                ContainerId = (ContainerEntryId)keyData;
             }
 
             return match;
         }
 
-        private static void GetEncodedKey(LowLevelTransaction llt, long l, out int encodedKeyLengthInBits, out byte* encodedKeyPtr) 
+        private static void GetEncodedKey(LowLevelTransaction llt, ContainerEntryId entryId, out int encodedKeyLengthInBits, out byte* encodedKeyPtr)
         {
-            Container.Get(llt, l, out var keyItem);
+            Container.Get(llt, entryId, out var keyItem);
             int remainderInBits = *keyItem.Address >> 4;
             var encodedKeyLen = keyItem.Length - 1;
             encodedKeyLengthInBits = encodedKeyLen * 8 - remainderInBits;
@@ -170,16 +174,16 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public void CreateTermInContainer<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (ContainerId == -1) // need to save this in the external terms container
+            if (ContainerId == ContainerEntryId.Invalid) // need to save this in the external terms container
             {
                 var encodedKey = Key.EncodedWithCurrent(out int encodedKeyLengthInBits);
-                ContainerId = WriteTermToContainer(encodedKey, encodedKeyLengthInBits, ref parent.State, parent.Llt);
+                ContainerId = (ContainerEntryId)WriteTermToContainer(encodedKey, encodedKeyLengthInBits, ref parent.State, parent.Llt);
             }
         }
 
         public void OnKeyRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (ContainerId == 0)
+            if (IsEmpty)
                 return; // the empty key is not stored and cannot be referenced
             DecrementTermReferenceCount(parent.Llt, ContainerId, ref parent.State);
         }
@@ -191,12 +195,12 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (ContainerId < 0)
+            if (!IsValid)
             {
                 return -1;
             }
 
-            var term = Container.Get(parent.Llt, ContainerId);
+            Container.Get(parent.Llt, ContainerId, out var term);
             return term.ToSpan()[0] & 0xF;
         }
 
@@ -207,7 +211,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             var llt = parent.Llt;
             byte* keyPtr;
             int keyLenInBits;
-            if (ContainerId == 0)
+            if (IsEmpty)
             {
                 keyPtr = null;
                 keyLenInBits = 0;
@@ -228,7 +232,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             return Key?.ToString() ?? "ContainerId: " + ContainerId;
         }
 
-        private void DecrementTermReferenceCount(LowLevelTransaction llt, long keyContainerId, ref LookupState state)
+        private void DecrementTermReferenceCount(LowLevelTransaction llt, ContainerEntryId keyContainerId, ref LookupState state)
         {
             var term = Container.GetMutable(llt, keyContainerId);
             int termRefCount = term[0] & 0xF;
@@ -244,7 +248,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         }
 
 
-        private void IncrementTermReferenceCount(LowLevelTransaction llt, long keyContainerId)
+        private void IncrementTermReferenceCount(LowLevelTransaction llt, ContainerEntryId keyContainerId)
         {
             var term = Container.GetMutable(llt, keyContainerId);
             int termRefCount = term[0] & 0xF;
@@ -260,7 +264,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         }
 
 
-        private static long WriteTermToContainer(ReadOnlySpan<byte> encodedKey, int encodedKeyLengthInBits, ref LookupState state, LowLevelTransaction llt)
+        private static ContainerEntryId WriteTermToContainer(ReadOnlySpan<byte> encodedKey, int encodedKeyLengthInBits, ref LookupState state, LowLevelTransaction llt)
         {
             // the term in the container is:  [ metadata -1 byte ] [ term bytes ]
             // the metadata is composed of two nibbles - the first says the *remainder* of bits in the last byte in the term
@@ -329,7 +333,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         CompactTreeDumper.WriteAddition(this, ref lookup, value);
         _inner.Add(ref lookup, value);
 
-        return lookup.ContainerId;
+        return (long)lookup.ContainerId;
     }
     
     public long Add(CompactKeyLookup key, long value)
@@ -337,7 +341,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         Debug.Assert(key.Key.Dictionary == _inner.State.DictionaryId);
         CompactTreeDumper.WriteAddition(this, ref key, value);
         _inner.Add(ref key, value);
-        return key.ContainerId;
+        return (long)key.ContainerId;
     }
 
     public void PrepareForCommit()
@@ -384,8 +388,8 @@ public sealed partial class CompactTree : IPrepareForCommit
                 dictionaryId = ((PersistentDictionaryRootHeader*)existingDictionary)->PageNumber;
             }
 
-            long containerId = Container.Create(llt);
-            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, containerId);
+            var containerId = Container.Create(llt);
+            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, (long)containerId);
         }
         else
         {
@@ -432,7 +436,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
         var ckl = new CompactKeyLookup(scope.Key);
         var found = _inner.TryGetValue(ref ckl, out value);
-        termContainerId = ckl.ContainerId;
+        termContainerId = (long)ckl.ContainerId;
         return found;
     }
 
@@ -468,7 +472,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         key.ChangeDictionary(_inner.State.DictionaryId);
         CompactKeyLookup compactKeyLookup = new(key);
         var result = _inner.TryGetValue(ref compactKeyLookup, out value);
-        termContainerId = compactKeyLookup.ContainerId;
+        termContainerId = (long)compactKeyLookup.ContainerId;
         return result;
     }
     
@@ -519,7 +523,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         key.EncodedWithCurrent(out _);
         lookup = new CompactKeyLookup(key);
         var result = _inner.TryGetNextValue(ref lookup, out value);
-        termContainerId = lookup.ContainerId;
+        termContainerId = (long)lookup.ContainerId;
         return result;
     }
     
@@ -547,13 +551,13 @@ public sealed partial class CompactTree : IPrepareForCommit
         #if DEBUG
         for (int i = 0; i < keys.Length; i++)
         {
-            Debug.Assert(keys[i].ContainerId == -1, "keys[i].ContainerId == -1");
+            Debug.Assert(keys[i].ContainerId == ContainerEntryId.Invalid, "keys[i].ContainerId == ContainerEntryId.Invalid");
         }
         #endif
         var read = _inner.BulkUpdateStart(keys, values, offsets, out pageNum);
         for (int i = 0; i < read; i++)
         {
-            if (keys[i].ContainerId == -1)
+            if (keys[i].ContainerId == ContainerEntryId.Invalid)
             {
                 keys[i].CreateTermInContainer(_inner);
             }

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -29,7 +29,53 @@ namespace Voron.Data.Containers
         [FieldOffset(1)]
         public long ContainerId;
     }
-    
+
+    [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
+    public readonly struct ContainerId(long id) : IEquatable<ContainerId>
+    {
+        [FieldOffset(0)]
+        private readonly long _id = id;
+
+        public static readonly ContainerId Invalid = new(-1);
+
+        public bool IsValid => _id > 0;
+        public bool IsEmpty => _id == 0;
+
+        public static explicit operator long(ContainerId containerId) => containerId._id;
+        public static explicit operator ContainerId(long id) => new(id);
+
+        public bool Equals(ContainerId other) => _id == other._id;
+        public override bool Equals(object obj) => obj is ContainerId other && Equals(other);
+        public override int GetHashCode() => _id.GetHashCode();
+        public override string ToString() => $"ContainerId({_id})";
+
+        public static bool operator ==(ContainerId left, ContainerId right) => left._id == right._id;
+        public static bool operator !=(ContainerId left, ContainerId right) => left._id != right._id;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
+    public readonly struct ContainerEntryId(long id) : IEquatable<ContainerEntryId>
+    {
+        [FieldOffset(0)]
+        private readonly long _id = id;
+
+        public static readonly ContainerEntryId Invalid = new(-1);
+
+        public bool IsValid => _id > 0;
+        public bool IsEmpty => _id == 0;
+
+        public static explicit operator long(ContainerEntryId entryId) => entryId._id;
+        public static explicit operator ContainerEntryId(long id) => new(id);
+
+        public bool Equals(ContainerEntryId other) => _id == other._id;
+        public override bool Equals(object obj) => obj is ContainerEntryId other && Equals(other);
+        public override int GetHashCode() => _id.GetHashCode();
+        public override string ToString() => $"ContainerEntryId({_id})";
+
+        public static bool operator ==(ContainerEntryId left, ContainerEntryId right) => left._id == right._id;
+        public static bool operator !=(ContainerEntryId left, ContainerEntryId right) => left._id != right._id;
+    }
+
     public readonly unsafe ref struct Container
     {
         public const int InvalidId = -1;
@@ -47,9 +93,9 @@ namespace Voron.Data.Containers
 
             public Dictionary<long, long> LastFreePageByPageLevelMetadata = new();
 
-            public long ContainerId;
+            public ContainerId ContainerId;
 
-            public TransactionState(long containerId)
+            public TransactionState(ContainerId containerId)
             {
                 ContainerId = containerId;
             }
@@ -61,7 +107,7 @@ namespace Voron.Data.Containers
                 if (_allPages != null)
                     return _allPages;
                 
-                var rootContainer = new Container(llt.GetPage(ContainerId));
+                var rootContainer = new Container(llt.GetPage((long)ContainerId));
                 ref var allPagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.AllPagesOffset));
                 _allPages = Lookup<Int64LookupKey>.Open(llt, allPagesState);
                 return _allPages;
@@ -72,7 +118,7 @@ namespace Voron.Data.Containers
                 if (_freePages != null)
                     return _freePages;
                 
-                var rootContainer = new Container(llt.GetPage(ContainerId));
+                var rootContainer = new Container(llt.GetPage((long)ContainerId));
                 ref var allPagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.FreeListOffset));
                 _freePages = Lookup<Int64LookupKey>.Open(llt, allPagesState);
                 return _freePages;
@@ -131,7 +177,7 @@ namespace Voron.Data.Containers
                         freePages.TryRemoveExistingValue(ref key, out _);
                 }
                 
-                var rootContainer = new Container(tx.LowLevelTransaction.ModifyPage(ContainerId));
+                var rootContainer = new Container(tx.LowLevelTransaction.ModifyPage((long)ContainerId));
                 
                 ref var allPagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.AllPagesOffset));
                 allPagesState = allPages.State;
@@ -609,14 +655,14 @@ namespace Voron.Data.Containers
             Header = ref Unsafe.AsRef<ContainerPageHeader>(page.Pointer);
         }
 
-        public static long Create(LowLevelTransaction llt)
+        public static ContainerId Create(LowLevelTransaction llt)
         {
             var page = AllocateContainerPage(llt);
 
             var root = new Container(page);
             root.Header.NumberOfOverflowPages = 0;
             root.Header.PageLevelMetadata = -1;
-            
+
             root.Allocate(sizeof(LookupState), ContainerPageHeader.FreeListOffset, out var freeListStateBuf);
             root.Allocate(sizeof(LookupState), ContainerPageHeader.AllPagesOffset, out var allPagesStateBuf);
             root.Allocate(sizeof(long), ContainerPageHeader.NumberOfEntriesOffset, out var numberOfEntriesBuffer);
@@ -629,11 +675,11 @@ namespace Voron.Data.Containers
             Lookup<Int64LookupKey>.Create(llt, out freeListState);
             ref var allPagesListState = ref MemoryMarshal.AsRef<LookupState>(allPagesStateBuf);
             Lookup<Int64LookupKey>.Create(llt, out allPagesListState);
-            
+
             var list = Lookup<Int64LookupKey>.Open(llt, allPagesListState);
             list.Add(page.PageNumber, 0);
             allPagesListState = list.State;
-            return page.PageNumber;
+            return (ContainerId)page.PageNumber;
         }
 
         private static Page AllocateContainerPage( LowLevelTransaction llt )
@@ -690,7 +736,7 @@ namespace Voron.Data.Containers
             Memory.Copy(_page.Pointer, tmpPtr, Constants.Storage.PageSize);
         }
 
-        public static long Allocate(LowLevelTransaction llt, long containerId, int size, out Span<byte> allocatedSpace)
+        public static ContainerEntryId Allocate(LowLevelTransaction llt, ContainerId containerId, int size, out Span<byte> allocatedSpace)
         {
             return Allocate(llt, containerId, size, pageLevelMetadata: -1, out allocatedSpace);
         }
@@ -702,9 +748,9 @@ namespace Voron.Data.Containers
         ///
         /// If the current page isn't a match to the pageLevelMetadata value passed, we'll allocate a *new* page for that purpose.
         /// </summary>
-        public static long Allocate(LowLevelTransaction llt, long containerId, int size, long pageLevelMetadata, out Span<byte> allocatedSpace)
+        public static ContainerEntryId Allocate(LowLevelTransaction llt, ContainerId containerId, int size, long pageLevelMetadata, out Span<byte> allocatedSpace)
         {
-            long AllocateOverflowPageUnlikely(Container rootContainer, out Span<byte> allocatedSpace)
+            ContainerEntryId AllocateOverflowPageUnlikely(Container rootContainer, out Span<byte> allocatedSpace)
             {
                 // The space to allocate is big enough to be allocated in a dedicated overflow page.
                 // We will figure out how many pages we will need to store it.
@@ -718,7 +764,7 @@ namespace Voron.Data.Containers
                 AddToAllPagesList(llt, rootContainer, overflowPage.PageNumber);
 
                 allocatedSpace = overflowPage.AsSpan(PageHeader.SizeOf, size);
-                return overflowPage.PageNumber * Constants.Storage.PageSize;
+                return new ContainerEntryId(overflowPage.PageNumber * Constants.Storage.PageSize);
             }
 
             // This method will return the allocated space inside the container and also the entry internal id to 
@@ -727,7 +773,7 @@ namespace Voron.Data.Containers
             if(size <= 0)
                 throw new ArgumentOutOfRangeException(nameof(size));
             
-            var rootContainer = new Container(llt.ModifyPage(containerId));
+            var rootContainer = new Container(llt.ModifyPage((long)containerId));
             rootContainer.UpdateNumberOfEntries(1);
             
             if (size > MaxSizeInsideContainerPage)
@@ -776,7 +822,7 @@ namespace Voron.Data.Containers
             return container.Allocate(size, pos, out allocatedSpace);
         }
 
-        private long Allocate(int size, int pos, out Span<byte> allocatedSpace)
+        private ContainerEntryId Allocate(int size, int pos, out Span<byte> allocatedSpace)
         {
             Debug.Assert(pos < 1024, "pos < 1024");
             var reqSize = ComputeRequiredSize(size);
@@ -795,7 +841,7 @@ namespace Voron.Data.Containers
             allocatedSpace = _page.AsSpan(entryStartOffset, size);
 
             long id = Header.PageNumber * Constants.Storage.PageSize + IndexToOffset(pos);
-            return id;
+            return new ContainerEntryId(id);
         }
 
         private static long IndexToOffset(int pos)
@@ -815,11 +861,11 @@ namespace Voron.Data.Containers
             return (int)offset >> 3;
         }
 
-        private static Container MoveToNextPage(LowLevelTransaction llt, long containerId, long pageLevelMetadata, Container container, int size)
+        private static Container MoveToNextPage(LowLevelTransaction llt, ContainerId containerId, long pageLevelMetadata, Container container, int size)
         {
             Debug.Assert(size <= MaxSizeInsideContainerPage);
 
-            var rootPage = llt.ModifyPage(containerId);
+            var rootPage = llt.ModifyPage((long)containerId);
             var rootContainer = new Container(rootPage);
             // we'll only remove from the free list if the page level metadata matches, since it probably has space otherwise
             if (pageLevelMetadata == container.Header.PageLevelMetadata)
@@ -831,8 +877,8 @@ namespace Voron.Data.Containers
             {
                 AddToFreeList(llt, rootContainer, container._page.PageNumber, container.Header.PageLevelMetadata);
             }
-            
-        
+
+
             var txState = llt.Transaction.GetContainerState(containerId);
             if(txState.LastFreePageByPageLevelMetadata.TryGetValue(pageLevelMetadata, out var lastFreePage))
             {
@@ -976,11 +1022,11 @@ namespace Voron.Data.Containers
             return pageLevelMetadata == maybe.Header.PageLevelMetadata;
         }
 
-        public static List<long> GetAllIds(LowLevelTransaction llt, long containerId)
+        public static List<long> GetAllIds(LowLevelTransaction llt, ContainerId containerId)
         {
             var list = new List<long>();
             Span<long> items = stackalloc long[256];
-            Container rootContainer = new Container(llt.GetPage(containerId));
+            Container rootContainer = new Container(llt.GetPage((long)containerId));
             var txState = llt.Transaction.GetContainerState(containerId);
             var it = txState.GetAllPages(llt).Iterate();
             it.Reset();
@@ -995,7 +1041,7 @@ namespace Voron.Data.Containers
                 int itemsLeftOnCurrentPage = 0;
                 do
                 {
-                    int count = GetEntriesInto(containerId, ref offset, page, items, out itemsLeftOnCurrentPage);
+                    int count = GetEntriesInto((long)containerId, ref offset, page, items, out itemsLeftOnCurrentPage);
                     list.AddRange(items[..count]);
 
                     //need read to the end of page
@@ -1054,7 +1100,7 @@ namespace Voron.Data.Containers
 
         public static void AddToFreeList(LowLevelTransaction llt, in Container rootContainer, long pageNum, long pageLevelMetadata)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             ref long valRef = ref CollectionsMarshal.GetValueRefOrAddDefault(txState.FreeListAdditions, pageNum, out var exists);
             if (exists)
             {
@@ -1072,7 +1118,7 @@ namespace Voron.Data.Containers
         
         public static void RemoveFromFreeList(LowLevelTransaction llt, in Container rootContainer, long pageNum)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             txState.FreeListAdditions.Remove(pageNum);
             txState.FreeListRemovals.Add(pageNum);
             
@@ -1081,14 +1127,14 @@ namespace Voron.Data.Containers
         
         public static void AddToAllPagesList(LowLevelTransaction llt, in Container rootContainer, long pageNum)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             txState.Removals.Remove(pageNum);
             txState.Additions.Add(pageNum);
         }
         
         public static void RemoveFromAllPagesList(LowLevelTransaction llt, in Container rootContainer, long pageNum, long pageLevelMetadata)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             
             txState.FreeListAdditions.Remove(pageNum);
             txState.FreeListRemovals.Add(pageNum);
@@ -1174,11 +1220,11 @@ namespace Voron.Data.Containers
             return size + 1 + isLarge.ToInt32();
         }
 
-        public static void Delete(LowLevelTransaction llt, long containerId, long id)
+        public static void Delete(LowLevelTransaction llt, ContainerId containerId, ContainerEntryId id)
         {
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.ModifyPage(pageNum);
-            Container rootContainer = new Container(llt.ModifyPage(containerId));
+            Container rootContainer = new Container(llt.ModifyPage((long)containerId));
             rootContainer.UpdateNumberOfEntries(-1);
 
             if (page.IsOverflow)
@@ -1215,7 +1261,7 @@ namespace Voron.Data.Containers
 
             if (container.HasEntries() == false) // cannot delete root page
             {
-                Debug.Assert(pageNum != containerId);
+                Debug.Assert(pageNum != (long)containerId);
                 
                 // don't need to consider the root page, the free list & all pages
                 // entries will ensure that we never get here
@@ -1223,7 +1269,7 @@ namespace Voron.Data.Containers
                 {
                     // we delete the current free page, so we'll point to ourselves are resolve
                     // the next allocation via the free list
-                    rootContainer.UpdateNextFreePage(containerId);
+                    rootContainer.UpdateNextFreePage((long)containerId);
                 }
 
                 RemoveFromFreeList(llt, rootContainer, page.PageNumber);
@@ -1281,12 +1327,12 @@ namespace Voron.Data.Containers
             return *(long*)pagePointer;
         }
         
-        public static Span<byte> GetMutable(LowLevelTransaction llt, long id)
+        public static Span<byte> GetMutable(LowLevelTransaction llt, ContainerEntryId id)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.ModifyPage(pageNum);
 
             if (page.IsOverflow)
@@ -1304,12 +1350,12 @@ namespace Voron.Data.Containers
             return new Span<byte>(pagePointer, size);
         }
         
-        public static void GetMutable(LowLevelTransaction llt, long id, out Item item)
+        public static void GetMutable(LowLevelTransaction llt, ContainerEntryId id, out Item item)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.ModifyPage(pageNum);
 
             if (page.IsOverflow)
@@ -1326,12 +1372,12 @@ namespace Voron.Data.Containers
             item = new Item(page, pagePointer, size);
         }
 
-        public static void Get(LowLevelTransaction llt, long id, out Item item)
+        public static void Get(LowLevelTransaction llt, ContainerEntryId id, out Item item)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.GetPage(pageNum);
             if (page.IsOverflow)
             {
@@ -1348,12 +1394,12 @@ namespace Voron.Data.Containers
             item = new Item(page, pagePointer, size);
         }
 
-        public static Span<byte> GetReadOnly(LowLevelTransaction llt, long id)
+        public static Span<byte> GetReadOnly(LowLevelTransaction llt, ContainerEntryId id)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.GetPage(pageNum);
             if (page.IsOverflow)
             {
@@ -1368,19 +1414,13 @@ namespace Voron.Data.Containers
             var size = itemMetadata.Get(ref pagePointer);
             return new Span<byte>(pagePointer, size);
         }
-        
-        public static Item Get(LowLevelTransaction llt, long id)
-        {
-            Get(llt, id, out Item result);
-            return result;
-        }
 
-        public static Item MaybeGetFromSamePage(LowLevelTransaction llt, ref Page page, long id)
+        public static Item MaybeGetFromSamePage(LowLevelTransaction llt, ref Page page, ContainerEntryId id)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             if(!page.IsValid || pageNum != page.PageNumber)
                 page = llt.GetPage(pageNum);
 
@@ -1477,13 +1517,13 @@ namespace Voron.Data.Containers
             }
         }
 
-        public static (Lookup<Int64LookupKey> allPages, Lookup<Int64LookupKey> freePages) GetPagesFor(LowLevelTransaction tx, long containerId)
+        public static (Lookup<Int64LookupKey> allPages, Lookup<Int64LookupKey> freePages) GetPagesFor(LowLevelTransaction tx, ContainerId containerId)
         {
             var state = tx.Transaction.GetContainerState(containerId);
             return (state.GetAllPages(tx), state.GetFreePages(tx));
         }
-        
-        public static Lookup<Int64LookupKey>.ForwardIterator GetAllPagesIterator(LowLevelTransaction tx, long containerId)
+
+        public static Lookup<Int64LookupKey>.ForwardIterator GetAllPagesIterator(LowLevelTransaction tx, ContainerId containerId)
         {
             var state = tx.Transaction.GetContainerState(containerId);
             return state.GetAllPages(tx).Iterate();

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -6,12 +6,9 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using System.Text;
 using Sparrow;
 using Sparrow.Server;
-using Sparrow.Server.Binary;
-using Sparrow.Server.Platform.Posix;
 using Voron.Data.Lookups;
 using Voron.Exceptions;
 using Voron.Global;
@@ -30,6 +27,10 @@ namespace Voron.Data.Containers
         public long ContainerId;
     }
 
+    // Represents the root container itself (the header page that owns freelists, lookup trees, etc.).
+    // Historically both container ids and entry ids were plain longs, so ContainerEntryId == 0 meant
+    // "empty entry" while ContainerId == 0 pointed at the storage header. Mixing them up would send
+    // callers to the wrong page or reuse a root as if it were an entry. This wrapper marks "root" level.
     [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
     public readonly struct ContainerId(long id) : IEquatable<ContainerId>
     {
@@ -53,6 +54,9 @@ namespace Voron.Data.Containers
         public static bool operator !=(ContainerId left, ContainerId right) => left._id != right._id;
     }
 
+    // Represents an entry allocated inside a container (the payload slot). Value 0 means "no entry" here,
+    // which collided with ContainerId == 0 (root header) when both were longs. Passing the wrong type would
+    // make us delete or read from the root instead of the payload. The dedicated type enforces the boundary.
     [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
     public readonly struct ContainerEntryId(long id) : IEquatable<ContainerEntryId>
     {

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -72,7 +72,7 @@ public unsafe partial class Hnsw
             }
             case Constants.Graphs.VectorId.PostingList:
             {
-                var setStateSpan = Container.GetReadOnly(llt, rawPostingListId);
+                var setStateSpan = Container.GetReadOnly(llt, new ContainerEntryId(rawPostingListId));
                 ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
                 var postingList = new PostingList(llt, Slices.Empty, setState);
                 result = new long[(int)Math.Min(postingList.State.NumberOfEntries, 16)];

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -51,7 +51,7 @@ public unsafe partial class Hnsw
 
     public static long[] GetEntries(LowLevelTransaction llt,long postingListId)
     {
-        long rawPostingListId = postingListId & Constants.Graphs.VectorId.ContainerType;
+        ContainerEntryId rawPostingListId = new ContainerEntryId(postingListId & Constants.Graphs.VectorId.ContainerType);
         long[] result;
         switch (postingListId & Constants.Graphs.VectorId.EnsureIsSingleMask)
         {
@@ -59,7 +59,7 @@ public unsafe partial class Hnsw
                 result= [];
                 break;
             case Constants.Graphs.VectorId.Single:
-                result = [rawPostingListId];
+                result = [(long)rawPostingListId];
                 break;
             case Constants.Graphs.VectorId.SmallPostingList:
             {
@@ -72,7 +72,7 @@ public unsafe partial class Hnsw
             }
             case Constants.Graphs.VectorId.PostingList:
             {
-                var setStateSpan = Container.GetReadOnly(llt, new ContainerEntryId(rawPostingListId));
+                var setStateSpan = Container.GetReadOnly(llt, rawPostingListId);
                 ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
                 var postingList = new PostingList(llt, Slices.Empty, setState);
                 result = new long[(int)Math.Min(postingList.State.NumberOfEntries, 16)];

--- a/src/Voron/Data/Graphs/Hnsw.Options.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Options.cs
@@ -1,5 +1,6 @@
-﻿using System.Numerics;
+using System.Numerics;
 using System.Runtime.InteropServices;
+using Voron.Data.Containers;
 using Voron.Impl.Paging;
 
 namespace Voron.Data.Graphs;
@@ -31,10 +32,10 @@ public partial class Hnsw
         public long CountOfVectors;
 
         [FieldOffset(24)]
-        public long Container;
+        public ContainerId Container;
 
         [FieldOffset(32)]
-        public long LastUsedContainerId;
+        public ContainerId LastUsedContainerId;
 
         public int MaxLevel => BitOperations.Log2((ulong)CountOfVectors);
 

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -117,7 +117,8 @@ public partial class Hnsw
                 _nextNodeIndex++; // do not attempt to insert the first node, since it is the graph root
                 ref Node startingNode = ref _searchState.Nodes[0];
                 Span<byte> span = startingNode.Encode(ref byteBuffer);
-                entryPointNode = Container.Allocate(_searchState.Llt, _searchState.Options.Container, span.Length, out Span<byte> allocated);
+                var allocatedId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, span.Length, out Span<byte> allocated);
+                entryPointNode = (long)allocatedId;
                 span.CopyTo(allocated);
                 _searchState.RegisterNodeLocation(EntryPointId, entryPointNode);
             }

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -15,6 +15,7 @@ using Sparrow.Server.Utils;
 using Sparrow.Server.Utils.VxSort;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Data.PostingLists;
 using Voron.Global;
@@ -77,15 +78,15 @@ public unsafe partial class Hnsw
         {
             if ((vectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
             {
-                var item = Container.Get(state.Llt, vectorId);
+                Container.Get(state.Llt, new ContainerEntryId(vectorId), out var item);
                 var vectorSpan = new UnmanagedSpan(item.Address, item.Length);
                 Debug.Assert(state.Options.VectorSizeBytes == vectorSpan.Length, "state.Options.VectorSizeBytes == vectorSpan.Length");
                 return vectorSpan;
             }
-            
+
             var count = (byte)(vectorId >> 1);
             var containerId = vectorId & ~0xFFF;
-            var container = Container.Get(state.Llt, containerId);
+            Container.Get(state.Llt, new ContainerEntryId(containerId), out var container);
             var offset = count * state.Options.VectorSizeBytes;
             Debug.Assert(offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length, "offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length");
             return new UnmanagedSpan(container.Address + offset, state.Options.VectorSizeBytes);
@@ -104,17 +105,17 @@ public unsafe partial class Hnsw
 
         public bool VectorLoaded => _vectorSpan.Length > 0;
 
-        public long GetVectorContainerId()
+        public ContainerId GetVectorContainerId()
         {
             if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
-                return VectorId;
+                return new ContainerId(VectorId);
 
-            return VectorId & ~0xFFF;
+            return new ContainerId(VectorId & ~0xFFF);
         }
 
         public static NodeReader Decode(LowLevelTransaction llt, long id)
         {
-            var span = Container.Get(llt, id).ToSpan();
+            var span = Container.GetReadOnly(llt, new ContainerEntryId(id));
             return Decode(llt, span);
         }
 
@@ -209,7 +210,7 @@ public unsafe partial class Hnsw
 
         // global creation for all HNSWs in the database
         var vectorsContainerId = CreateHnswGlobalState(llt);
-        long storage = Container.Create(llt);
+        ContainerId storage = Container.Create(llt);
         tree.LookupFor<Int64LookupKey>(NodeIdToLocationSlice);
         tree.LookupFor<Int64LookupKey>(NodesByVectorIdSlice);
 
@@ -220,7 +221,7 @@ public unsafe partial class Hnsw
             VectorEmbeddingType.Binary => SimilarityMethod.HammingDistance,
             _ => throw new InvalidOperationException($"Unexpected value of {nameof(VectorEmbeddingType)}: {embeddingType}")
         };
-        
+
         var options = new Options
         {
             Version = Constants.Graphs.HnswVersion.CurrentVersion,
@@ -237,23 +238,23 @@ public unsafe partial class Hnsw
         }
     }
 
-    private static long ReadGlobalVectorsContainerId(LowLevelTransaction llt)
+    private static ContainerId ReadGlobalVectorsContainerId(LowLevelTransaction llt)
     {
         var config = llt.Transaction.ReadTree(HnswGlobalConfigSlice);
         var read = config.DirectRead(VectorsContainerIdSlice);
-        return Unsafe.Read<long>(read);
+        return new ContainerId(Unsafe.Read<long>(read));
     }
 
-    private static long CreateHnswGlobalState(LowLevelTransaction llt)
+    private static ContainerId CreateHnswGlobalState(LowLevelTransaction llt)
     {
         llt.Transaction.CompactTreeFor(VectorsIdByHashSlice);
         var config = llt.Transaction.CreateTree(HnswGlobalConfigSlice);
         var read = config.DirectRead(VectorsContainerIdSlice);
         if (read is not null)
-            return Unsafe.Read<long>(read);
+            return new ContainerId(Unsafe.Read<long>(read));
 
-        long vectorsContainerId = Container.Create(llt);
-        config.Add(VectorsContainerIdSlice, vectorsContainerId);
+        ContainerId vectorsContainerId = Container.Create(llt);
+        config.Add(VectorsContainerIdSlice, (long)vectorsContainerId);
         return vectorsContainerId;
     }
 
@@ -495,7 +496,7 @@ public unsafe partial class Hnsw
 
         public static void ReadPostingList(LowLevelTransaction llt, long rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
         {
-            var smallPostingList = Container.Get(llt, rawPostingListId);
+            Container.Get(llt, new ContainerEntryId(rawPostingListId), out var smallPostingList);
             var count = VariableSizeEncoding.Read<int>(smallPostingList.Address, out var offset);
             
             var requiredSize = Math.Max(256, 256 * (int)Math.Ceiling((count + listBuffer.Count) / 256f));
@@ -731,9 +732,9 @@ public unsafe partial class Hnsw
                    ref var n = ref _nodes[existingIdx];
                    if (n.VectorLoaded)
                        continue;
-                   nodeIndexes[vectorsToLoadIdx] = existingIdx;
-                   vectorIdsToLoad[vectorsToLoadIdx++] = n.GetVectorContainerId();
-                   continue;
+                    nodeIndexes[vectorsToLoadIdx] = existingIdx;
+                    vectorIdsToLoad[vectorsToLoadIdx++] = (long)n.GetVectorContainerId();
+                    continue;
                }
 
                var nodeIdx = AllocateNodeIndex(nodeId);
@@ -758,8 +759,8 @@ public unsafe partial class Hnsw
                    var nodeIndex = indexesOfIds[i];
                    ref var n = ref _nodes[nodeIndex];
                    reader.LoadInto(ref n);
-                   nodeIndexes[vectorsToLoadIdx] = nodeIndex;
-                   vectorIdsToLoad[vectorsToLoadIdx++] = n.GetVectorContainerId();
+                    nodeIndexes[vectorsToLoadIdx] = nodeIndex;
+                    vectorIdsToLoad[vectorsToLoadIdx++] = (long)n.GetVectorContainerId();
                }
            }
            if (vectorsToLoadIdx is 0)
@@ -792,7 +793,7 @@ public unsafe partial class Hnsw
         public Random Random;
         private readonly CompactTree _vectorsByHash;
         private readonly int _vectorBatchSizeInPages;
-        private readonly long _globalVectorsContainerId;
+        private readonly ContainerId _globalVectorsContainerId;
         private PostingList _largePostingListSet;
 
         public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
@@ -903,7 +904,7 @@ public unsafe partial class Hnsw
                 vector.Length != _searchState.Options.VectorSizeBytes,
                 $"Vector size {vector.Length} does not match expected size: {_searchState.Options.VectorSizeBytes}");
 
-            long hashContainerId;
+            ContainerId hashContainerId;
             var hashBuffer = ComputeHashFor(vector);
             ref (ByteString Hash, int NodeIndex, NativeList<long> PostingList) postingList = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorHashCache, hashBuffer, out var exists);
             if(exists)
@@ -912,18 +913,21 @@ public unsafe partial class Hnsw
                 ref var l = ref postingList.PostingList;
                 l.Add(_searchState.Llt.Allocator, entryId);
                 // key already exists in the dictionary, so can clear this 
-                var nodeIdExists = _vectorsByHash.TryGetValue(hashBuffer.ToReadOnlySpan(), out hashContainerId, out _);
+                var nodeIdExists = _vectorsByHash.TryGetValue(hashBuffer.ToReadOnlySpan(), out var hashContainerIdLong, out _);
+                hashContainerId = new ContainerId(hashContainerIdLong);
                 _searchState.Llt.Allocator.Release(ref hashBuffer);
                 Debug.Assert(nodeIdExists, $"nodeIdExists");
                 return postingList.Hash;
             }
 
             var vectorHash = hashBuffer.ToReadOnlySpan();
-            if (_vectorsByHash.TryGetValue(vectorHash, out hashContainerId, out var vectorId) is false)
+            if (_vectorsByHash.TryGetValue(vectorHash, out var hashContainerIdLong2, out var vectorId) is false)
             {
-                vectorId = RegisterVector(vector);
-                hashContainerId = _vectorsByHash.Add(vectorHash, vectorId);
+                var vectorEntryId = RegisterVector(vector);
+                vectorId = (long)vectorEntryId;
+                hashContainerIdLong2 = _vectorsByHash.Add(vectorHash, vectorId);
             }
+            hashContainerId = new ContainerId(hashContainerIdLong2);
             
             if (_nodesByVectorId.TryGetValue(vectorId, out var nodeId))
             {
@@ -948,14 +952,14 @@ public unsafe partial class Hnsw
             return list;
         }
         
-        private long RegisterVector(ReadOnlySpan<byte> vector)
+        private ContainerEntryId RegisterVector(ReadOnlySpan<byte> vector)
         {
-            if (_searchState.Options.LastUsedContainerId is 0)
+            if (_searchState.Options.LastUsedContainerId.IsEmpty)
             {
                 if (_vectorBatchSizeInPages is 1)
                 {
                     // here we allocate a small value, directly from the container
-                    var vectorId = Container.Allocate(_searchState.Llt, _globalVectorsContainerId, 
+                    var vectorId = Container.Allocate(_searchState.Llt, _globalVectorsContainerId,
                         vector.Length, out var singleVectorStorage);
 
                     vector.CopyTo(singleVectorStorage);
@@ -967,14 +971,14 @@ public unsafe partial class Hnsw
                     sizeInBytes, out var vectorStorage);
                 
                 Debug.Assert(vectorStorage.Length / _searchState.Options.VectorSizeBytes <= byte.MaxValue, "vectorStorage.Length / _searchState.Options.VectorSizeBytes <= byte.MaxValue");
-                Debug.Assert((batchId & 0xFFF) == 0, "We allocate > 1 page, so we get the full page container id");
-                _searchState.Options.LastUsedContainerId = batchId;
+                Debug.Assert(((long)batchId & 0xFFF) == 0, "We allocate > 1 page, so we get the full page container id");
+                _searchState.Options.LastUsedContainerId = new ContainerId((long)batchId);
                 _searchState.Options.VectorBatchIndex = 1;
                 vector.CopyTo(vectorStorage);
                 //container id | index    | marker
-                return GetVectorId(batchId, 0);
+                return GetVectorId(new ContainerId((long)batchId), 0);
             }
-            var span = Container.GetMutable(_searchState.Llt, _searchState.Options.LastUsedContainerId);
+            var span = Container.GetMutable(_searchState.Llt, new ContainerEntryId((long)_searchState.Options.LastUsedContainerId));
             var count = _searchState.Options.VectorBatchIndex++;
             Debug.Assert(((count) * vector.Length) < span.Length, "((count) * vector.Length) < span.Length");
             var offset = count * vector.Length;
@@ -984,16 +988,16 @@ public unsafe partial class Hnsw
             if (offset + vector.Length > span.Length)
             {
                 // no more room for the _next_ vector
-                _searchState.Options.LastUsedContainerId = 0;
+                _searchState.Options.LastUsedContainerId = new ContainerId(0);
                 _searchState.Options.VectorBatchIndex = 0;
             }
             return id;
 
-            long GetVectorId(long containerId, int index)
+            ContainerEntryId GetVectorId(ContainerId containerId, int index)
             {
-                Debug.Assert((containerId & Constants.Graphs.VectorId.EnsureIsSingleMask) == 0, $"Container id {containerId}");
+                Debug.Assert(((long)containerId & Constants.Graphs.VectorId.EnsureIsSingleMask) == 0, $"Container id {containerId}");
                 //container id | index    | marker
-                return containerId | (uint)(index << 1) | Constants.Graphs.VectorStorage.VectorContainerInternalIndexer;
+                return new ContainerEntryId((long)containerId | (uint)(index << 1) | Constants.Graphs.VectorStorage.VectorContainerInternalIndexer);
             }
         }
 
@@ -1090,10 +1094,10 @@ public unsafe partial class Hnsw
                 {
                     if (hasSmallPostingList)
                     {
-                        Container.Delete(_searchState.Llt, _searchState.Options.Container, rawPostingListId);
+                        Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(rawPostingListId));
                     }
 
-                    if (listBuffer.Count is 0) 
+                    if (listBuffer.Count is 0)
                         return 0;
                     
                     Debug.Assert((listBuffer[0] & Constants.Graphs.VectorId.PostingList) == 0, "(listBuffer[0] & 0b11) == 0");
@@ -1115,12 +1119,13 @@ public unsafe partial class Hnsw
                 Span<byte> mutable;
                 if (currentSize == byteBuffer.Count)
                 {
-                    mutable = Container.GetMutable(_searchState.Llt, rawPostingListId);
+                    mutable = Container.GetMutable(_searchState.Llt, new ContainerEntryId(rawPostingListId));
                 }
                 else
                 {
                     DeleteOldSmallPostingListIfNeeded();
-                    rawPostingListId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, byteBuffer.Count, out mutable);
+                    var allocatedId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, byteBuffer.Count, out mutable);
+                    rawPostingListId = (long)allocatedId;
                 }
                 Span<byte> span = byteBuffer.ToSpan();
                 span.CopyTo(mutable);
@@ -1133,7 +1138,7 @@ public unsafe partial class Hnsw
                 {
                     if (hasSmallPostingList)
                     {
-                        Container.Delete(_searchState.Llt, _searchState.Options.Container, rawPostingListId);
+                        Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(rawPostingListId));
                     }
                 }
             }
@@ -1146,7 +1151,7 @@ public unsafe partial class Hnsw
 
         private long UpdatePostingList(long postingListId, in NativeList<long> modifications, FastPForEncoder pForEncoder, ref FastPForDecoder pForDecoder, ref ContextBoundNativeList<long> tempListBuffer)
         {
-            var setSpace = Container.GetMutable(_searchState.Llt, postingListId);
+            var setSpace = Container.GetMutable(_searchState.Llt, new ContainerEntryId(postingListId));
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
             var lists = stackalloc long*[2];
@@ -1172,7 +1177,7 @@ public unsafe partial class Hnsw
             {
                 _largePostingListSet ??= _searchState.Llt.Transaction.OpenPostingList(Constants.PostingList.PostingListRegister);
                 _largePostingListSet.Remove(postingListId);
-                Container.Delete(_searchState.Llt, _searchState.Options.Container, postingListId);
+                Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(postingListId));
                 return 0;
             }
 
@@ -1181,14 +1186,14 @@ public unsafe partial class Hnsw
 
         private long CreateNewPostingList(FastPForEncoder pforEncoder)
         {
-            long setId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, sizeof(PostingListState), out var setSpace);
+            var setId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, sizeof(PostingListState), out var setSpace);
 
             _largePostingListSet ??= _searchState.Llt.Transaction.OpenPostingList(Constants.PostingList.PostingListRegister);
-            _largePostingListSet.Add(setId);
+            _largePostingListSet.Add((long)setId);
             
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
             PostingList.Create(_searchState.Llt, ref postingListState, pforEncoder);
-            return setId | Constants.Graphs.VectorId.PostingList;
+            return (long)setId | Constants.Graphs.VectorId.PostingList;
         }
 
 
@@ -1197,17 +1202,18 @@ public unsafe partial class Hnsw
             var encoded = node.Encode(ref byteBuffer);
             if (_searchState.TryGetLocationForNode(node.NodeId, out var locationId))
             {
-                var existing = Container.GetMutable(_searchState.Llt, locationId);
+                var existing = Container.GetMutable(_searchState.Llt, new ContainerEntryId(locationId));
                 if (existing.Length == encoded.Length)
                 {
                     encoded.CopyTo(existing);
                     return;
                 }
 
-                Container.Delete(_searchState.Llt, _searchState.Options.Container, locationId);
+                Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(locationId));
             }
 
-            locationId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, encoded.Length, out var storage);
+            var allocatedId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, encoded.Length, out var storage);
+            locationId = (long)allocatedId;
             _searchState.RegisterNodeLocation(node.NodeId, locationId);
             encoded.CopyTo(storage);
         }
@@ -1410,7 +1416,7 @@ public unsafe partial class Hnsw
                         _searchState.ReadPostingList(rawPostingListId, ref _postingListResults, ref _pforDecoder, out _);
                         continue;
                     case Constants.Graphs.VectorId.PostingList: // large posting list
-                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, rawPostingListId);
+                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, new ContainerEntryId(rawPostingListId));
                         ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
                         _postingList = new PostingList(_searchState.Llt, Slices.Empty, setState);
                         _postingListIterator = _postingList.Iterate();

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -489,14 +489,14 @@ public unsafe partial class Hnsw
             return distance;
         }
 
-        public void ReadPostingList(long rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
+        public void ReadPostingList(ContainerEntryId rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
         {
             ReadPostingList(Llt, rawPostingListId, ref listBuffer, ref pforDecoder, out postingListSize);
         }
 
-        public static void ReadPostingList(LowLevelTransaction llt, long rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
+        public static void ReadPostingList(LowLevelTransaction llt, ContainerEntryId rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
         {
-            Container.Get(llt, new ContainerEntryId(rawPostingListId), out var smallPostingList);
+            Container.Get(llt, rawPostingListId, out var smallPostingList);
             var count = VariableSizeEncoding.Read<int>(smallPostingList.Address, out var offset);
             
             var requiredSize = Math.Max(256, 256 * (int)Math.Ceiling((count + listBuffer.Count) / 256f));
@@ -904,7 +904,6 @@ public unsafe partial class Hnsw
                 vector.Length != _searchState.Options.VectorSizeBytes,
                 $"Vector size {vector.Length} does not match expected size: {_searchState.Options.VectorSizeBytes}");
 
-            ContainerId hashContainerId;
             var hashBuffer = ComputeHashFor(vector);
             ref (ByteString Hash, int NodeIndex, NativeList<long> PostingList) postingList = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorHashCache, hashBuffer, out var exists);
             if(exists)
@@ -912,22 +911,18 @@ public unsafe partial class Hnsw
                 // already added this in the current batch
                 ref var l = ref postingList.PostingList;
                 l.Add(_searchState.Llt.Allocator, entryId);
-                // key already exists in the dictionary, so can clear this 
-                var nodeIdExists = _vectorsByHash.TryGetValue(hashBuffer.ToReadOnlySpan(), out var hashContainerIdLong, out _);
-                hashContainerId = new ContainerId(hashContainerIdLong);
                 _searchState.Llt.Allocator.Release(ref hashBuffer);
-                Debug.Assert(nodeIdExists, $"nodeIdExists");
                 return postingList.Hash;
             }
 
             var vectorHash = hashBuffer.ToReadOnlySpan();
-            if (_vectorsByHash.TryGetValue(vectorHash, out var hashContainerIdLong2, out var vectorId) is false)
+            long vectorId;
+            if (_vectorsByHash.TryGetValue(vectorHash, out _, out vectorId) is false)
             {
                 var vectorEntryId = RegisterVector(vector);
                 vectorId = (long)vectorEntryId;
-                hashContainerIdLong2 = _vectorsByHash.Add(vectorHash, vectorId);
+                _vectorsByHash.Add(vectorHash, vectorId);
             }
-            hashContainerId = new ContainerId(hashContainerIdLong2);
             
             if (_nodesByVectorId.TryGetValue(vectorId, out var nodeId))
             {
@@ -1064,14 +1059,14 @@ public unsafe partial class Hnsw
                 
                 int currentSize = 0;
                 bool hasSmallPostingList = false;
-                long rawPostingListId = postingList & Constants.Graphs.VectorId.ContainerType;
-                
+                ContainerEntryId rawPostingListId = new ContainerEntryId(postingList & Constants.Graphs.VectorId.ContainerType);
+
                 switch (postingList & Constants.Graphs.VectorId.EnsureIsSingleMask)
                 {
                     case Constants.Graphs.VectorId.Tombstone: // nothing there
                         break;
                     case Constants.Graphs.VectorId.Single: // single value, just add it
-                        listBuffer.Add(rawPostingListId);
+                        listBuffer.Add((long)rawPostingListId);
                         break;
                     case Constants.Graphs.VectorId.SmallPostingList:
                         hasSmallPostingList = true;
@@ -1094,12 +1089,12 @@ public unsafe partial class Hnsw
                 {
                     if (hasSmallPostingList)
                     {
-                        Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(rawPostingListId));
+                        Container.Delete(_searchState.Llt, _searchState.Options.Container, rawPostingListId);
                     }
 
                     if (listBuffer.Count is 0)
                         return 0;
-                    
+
                     Debug.Assert((listBuffer[0] & Constants.Graphs.VectorId.PostingList) == 0, "(listBuffer[0] & 0b11) == 0");
                     return listBuffer[0] | Constants.Graphs.VectorId.Single;
                 }
@@ -1119,26 +1114,25 @@ public unsafe partial class Hnsw
                 Span<byte> mutable;
                 if (currentSize == byteBuffer.Count)
                 {
-                    mutable = Container.GetMutable(_searchState.Llt, new ContainerEntryId(rawPostingListId));
+                    mutable = Container.GetMutable(_searchState.Llt, rawPostingListId);
                 }
                 else
                 {
                     DeleteOldSmallPostingListIfNeeded();
-                    var allocatedId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, byteBuffer.Count, out mutable);
-                    rawPostingListId = (long)allocatedId;
+                    rawPostingListId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, byteBuffer.Count, out mutable);
                 }
                 Span<byte> span = byteBuffer.ToSpan();
                 span.CopyTo(mutable);
 
-                Debug.Assert((rawPostingListId & Constants.Graphs.VectorId.PostingList) == 0, "(rawPostingListId & 0b11) == 0");
-                return rawPostingListId | Constants.Graphs.VectorId.SmallPostingList;
-                
-                
+                Debug.Assert(((long)rawPostingListId & Constants.Graphs.VectorId.PostingList) == 0, "(rawPostingListId & 0b11) == 0");
+                return (long)rawPostingListId | Constants.Graphs.VectorId.SmallPostingList;
+
+
                 void DeleteOldSmallPostingListIfNeeded()
                 {
                     if (hasSmallPostingList)
                     {
-                        Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(rawPostingListId));
+                        Container.Delete(_searchState.Llt, _searchState.Options.Container, rawPostingListId);
                     }
                 }
             }
@@ -1149,9 +1143,9 @@ public unsafe partial class Hnsw
             //todo: we may wants to release the vector hash cache
         }
 
-        private long UpdatePostingList(long postingListId, in NativeList<long> modifications, FastPForEncoder pForEncoder, ref FastPForDecoder pForDecoder, ref ContextBoundNativeList<long> tempListBuffer)
+        private long UpdatePostingList(ContainerEntryId postingListId, in NativeList<long> modifications, FastPForEncoder pForEncoder, ref FastPForDecoder pForDecoder, ref ContextBoundNativeList<long> tempListBuffer)
         {
-            var setSpace = Container.GetMutable(_searchState.Llt, new ContainerEntryId(postingListId));
+            var setSpace = Container.GetMutable(_searchState.Llt, postingListId);
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
             var lists = stackalloc long*[2];
@@ -1176,12 +1170,12 @@ public unsafe partial class Hnsw
             if(numberOfEntries is 0)
             {
                 _largePostingListSet ??= _searchState.Llt.Transaction.OpenPostingList(Constants.PostingList.PostingListRegister);
-                _largePostingListSet.Remove(postingListId);
-                Container.Delete(_searchState.Llt, _searchState.Options.Container, new ContainerEntryId(postingListId));
+                _largePostingListSet.Remove((long)postingListId);
+                Container.Delete(_searchState.Llt, _searchState.Options.Container, postingListId);
                 return 0;
             }
 
-            return postingListId | Constants.Graphs.VectorId.PostingList;
+            return (long)postingListId | Constants.Graphs.VectorId.PostingList;
         }
 
         private long CreateNewPostingList(FastPForEncoder pforEncoder)
@@ -1392,7 +1386,7 @@ public unsafe partial class Hnsw
 
                 var nodeIdx = _indexes[_currentNode];
                 ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
-                var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
+                ContainerEntryId rawPostingListId = new ContainerEntryId(node.PostingListId & Constants.Graphs.VectorId.ContainerType);
                 distance = _searchState.Distance(_vector.ToSpan(), -1, nodeIdx);
 
                 if (distance > _maximumDistance)
@@ -1400,7 +1394,7 @@ public unsafe partial class Hnsw
                     _currentNode++;
                     continue;
                 }
-                
+
                 switch (node.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask)
                 {
                     case Constants.Graphs.VectorId.Tombstone: // empty
@@ -1408,7 +1402,7 @@ public unsafe partial class Hnsw
                         continue;
                     case Constants.Graphs.VectorId.Single: // single item posting list
                         distances[index] = distance;
-                        matches[index++] = rawPostingListId;
+                        matches[index++] = (long)rawPostingListId;
                         _currentNode++;
                         continue;
                     case Constants.Graphs.VectorId.SmallPostingList: // small posting list
@@ -1416,7 +1410,7 @@ public unsafe partial class Hnsw
                         _searchState.ReadPostingList(rawPostingListId, ref _postingListResults, ref _pforDecoder, out _);
                         continue;
                     case Constants.Graphs.VectorId.PostingList: // large posting list
-                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, new ContainerEntryId(rawPostingListId));
+                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, rawPostingListId);
                         ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
                         _postingList = new PostingList(_searchState.Llt, Slices.Empty, setState);
                         _postingListIterator = _postingList.Iterate();

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -8,6 +8,7 @@ using Sparrow;
 using Sparrow.Server;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
 using Voron.Debugging;
 using Voron.Global;
 using Voron.Impl;
@@ -376,7 +377,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             RootPage = newPage.PageNumber,
             NumberOfEntries = 0,
             DictionaryId = dictionaryId,
-            TermsContainerId = termsContainerId
+            TermsContainerId = new ContainerId(termsContainerId)
         };
     }
 

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -322,7 +322,12 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     public ref LookupState State => ref _state;
     public LowLevelTransaction Llt => _llt;
 
-    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId = -1, long termsContainerId = -1)
+    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId = -1)
+    {
+        return InternalCreate(parent, name, dictionaryId, ContainerId.Invalid);
+    }
+
+    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId, ContainerId termsContainerId)
     {
         var llt = parent.Llt;
 
@@ -359,7 +364,12 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         };
     }
     
-    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId = -1, long termsContainerId = -1)
+    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId = -1)
+    {
+        Create(llt, out state, dictionaryId, ContainerId.Invalid);
+    }
+
+    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId, ContainerId termsContainerId)
     {
         var newPage = llt.AllocatePage(1);
         var compactPageHeader = (LookupPageHeader*)newPage.Pointer;
@@ -377,7 +387,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             RootPage = newPage.PageNumber,
             NumberOfEntries = 0,
             DictionaryId = dictionaryId,
-            TermsContainerId = new ContainerId(termsContainerId)
+            TermsContainerId = termsContainerId
         };
     }
 

--- a/src/Voron/Data/Lookups/LookupState.cs
+++ b/src/Voron/Data/Lookups/LookupState.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
+using Voron.Data.Containers;
 
 namespace Voron.Data.Lookups
 {
@@ -24,7 +25,7 @@ namespace Voron.Data.Lookups
         [FieldOffset(40)]
         public long DictionaryId;
         [FieldOffset(48)]
-        public long TermsContainerId;
+        public ContainerId TermsContainerId;
         
 
         public override string ToString()

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -54,7 +54,7 @@ namespace Voron.Debugging
         public List<JournalFile> Journals;
         public JournalFile[] FlushedJournals { get; set; }
         public List<Table> Tables;
-        public Dictionary<Slice, long> Containers;
+        public Dictionary<Slice, ContainerId> Containers;
         public List<PostingList> PostingLists;
         public List<PersistentDictionaryRootHeader> PersistentDictionaries;
         public List<Lookup<Int64LookupKey>> NumericLookups;
@@ -117,7 +117,7 @@ namespace Voron.Debugging
                 {
                     var globalContainer = tree.DirectRead(Hnsw.VectorsContainerIdSlice);
                     if (globalContainer != null)
-                        input.Containers.Add(Hnsw.VectorContainerStorageSlice, Unsafe.Read<long>(globalContainer));
+                        input.Containers.Add(Hnsw.VectorContainerStorageSlice, Unsafe.Read<ContainerId>(globalContainer));
                 }
                 
                 if (tree.State.Header.Flags.HasFlag(TreeFlags.CompactTrees) ||
@@ -152,7 +152,7 @@ namespace Voron.Debugging
                                         string nestedReportName = treeReport.Name + "/" + nestedReport.Name;
                                         nestedReport.Name = nestedReportName +" (CompactTree)";
                                         trees.Add(nestedReport);
-                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", (long)textLookup.State.TermsContainerId, input.IncludeDetails));
+                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", textLookup.State.TermsContainerId, input.IncludeDetails));
                                     }
                                     break;
                                 case RootObjectType.EmbeddedFixedSizeTree:
@@ -510,7 +510,7 @@ namespace Voron.Debugging
             return treeReport;
         }
 
-        public TreeReport GetContainerReport(string name, long page, bool includeDetails)
+        public TreeReport GetContainerReport(string name, ContainerId page, bool includeDetails)
         {
             name += $" (Container)";
             
@@ -519,7 +519,7 @@ namespace Voron.Debugging
             if (includeDetails)
             {
                 pageDensities = new();
-                var it = Container.GetAllPagesIterator(_tx, new ContainerId(page));
+                var it = Container.GetAllPagesIterator(_tx, page);
                 while (it.MoveNext(out var pageNum))
                 {
                     // cannot use GetPageHeader since we are reading not just from the header
@@ -537,10 +537,10 @@ namespace Voron.Debugging
                 }
             }
 
-            var (allPages, freePages) = Container.GetPagesFor(_tx, new ContainerId(page));
+            var (allPages, freePages) = Container.GetPagesFor(_tx, page);
             
             // cannot use GetPageHeader since we are reading not just from the header
-            var root = new Container(_tx.GetPage(page));
+            var root = new Container(_tx.GetPage((long)page));
             double density = pageDensities?.Average() ?? -1;
             long totalPages = allPages.State.NumberOfEntries + root.Header.NumberOfOverflowPages + freePages.State.PageCount + allPages.State.PageCount;
             var treeReport = new TreeReport

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -152,7 +152,7 @@ namespace Voron.Debugging
                                         string nestedReportName = treeReport.Name + "/" + nestedReport.Name;
                                         nestedReport.Name = nestedReportName +" (CompactTree)";
                                         trees.Add(nestedReport);
-                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", textLookup.State.TermsContainerId, input.IncludeDetails));
+                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", (long)textLookup.State.TermsContainerId, input.IncludeDetails));
                                     }
                                     break;
                                 case RootObjectType.EmbeddedFixedSizeTree:
@@ -519,7 +519,7 @@ namespace Voron.Debugging
             if (includeDetails)
             {
                 pageDensities = new();
-                var it = Container.GetAllPagesIterator(_tx, page);
+                var it = Container.GetAllPagesIterator(_tx, new ContainerId(page));
                 while (it.MoveNext(out var pageNum))
                 {
                     // cannot use GetPageHeader since we are reading not just from the header
@@ -536,8 +536,8 @@ namespace Voron.Debugging
                     }
                 }
             }
-            
-            var (allPages, freePages) = Container.GetPagesFor(_tx, page);
+
+            var (allPages, freePages) = Container.GetPagesFor(_tx, new ContainerId(page));
             
             // cannot use GetPageHeader since we are reading not just from the header
             var root = new Container(_tx.GetPage(page));

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -33,7 +33,7 @@ namespace Voron.Impl
 
         public ByteStringContext Allocator => _lowLevelTransaction.Allocator;
 
-        private Dictionary<long, Container.TransactionState> _containers;
+        private Dictionary<ContainerId, Container.TransactionState> _containers;
         
         private Dictionary<Slice, PostingList> _postingLists;
         
@@ -167,7 +167,7 @@ namespace Voron.Impl
             _lowLevelTransaction.EndAsyncCommit();
         }
 
-        public long OpenContainer(string name)
+        public ContainerId OpenContainer(string name)
         {
             using (Slice.From(Allocator, name, ByteStringType.Immutable, out Slice nameSlice))
             {
@@ -187,12 +187,12 @@ namespace Voron.Impl
             return LowLevelTransaction.RootObjects.LookupFor<TKey>(name);
         }
 
-        public long OpenContainer(Slice name)
+        public ContainerId OpenContainer(Slice name)
         {
             var exists = LowLevelTransaction.RootObjects.DirectRead(name);
             if (exists != null)
             {
-                return ((ContainerRootHeader*)exists)->ContainerId;
+                return new ContainerId(((ContainerRootHeader*)exists)->ContainerId);
             }
             var id = Container.Create(LowLevelTransaction);
 
@@ -200,7 +200,7 @@ namespace Voron.Impl
                 *((ContainerRootHeader*)ptr) = new ContainerRootHeader
                 {
                     RootObjectType = RootObjectType.Container,
-                    ContainerId = id
+                    ContainerId = (long)id
                 };
             
             
@@ -320,7 +320,7 @@ namespace Voron.Impl
 
             if (_containers != null)
             {
-                foreach (var (containerId, containerState) in _containers)
+                foreach (var (_, containerState) in _containers)
                 {
                     containerState.PrepareForCommit(this);
                 }
@@ -736,9 +736,9 @@ namespace Voron.Impl
             LowLevelTransaction.RootObjects.Forget(name);
         }
 
-        public Container.TransactionState GetContainerState(long containerId)
+        public Container.TransactionState GetContainerState(ContainerId containerId)
         {
-            _containers ??= new Dictionary<long, Container.TransactionState>();
+            _containers ??= new Dictionary<ContainerId, Container.TransactionState>();
             if (_containers.TryGetValue(containerId, out var state))
                 return state;
             state = new Container.TransactionState(containerId);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1230,7 +1230,7 @@ namespace Voron
                                 }
                                 break;
                             case RootObjectType.Container:
-                                long container = (long)tx.OpenContainer(currentKey);
+                                var container = tx.OpenContainer(currentKey);
                                 RegisterContainer(container, name);
                                 break;
                             case RootObjectType.Set:
@@ -1299,14 +1299,14 @@ namespace Voron
                 }
             }
 
-            void RegisterContainer(long container, string name)
+            void RegisterContainer(ContainerId container, string name)
             {
-                r.Add(container, name);
+                r.Add((long)container, name);
                 var overflowName = $"{name}/OverflowPage";
-                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, new ContainerId(container));
+                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, container);
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");
                 RegisterPages(freePages.AllPages(), name + "/FreePagesSet");
-                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, new ContainerId(container));
+                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, container);
                 while (iterator.MoveNext(out var page))
                 {
                     var pageObject = tx.LowLevelTransaction.GetPage(page);
@@ -1326,7 +1326,7 @@ namespace Voron
                 RegisterPages(numeric.AllPages(), name);
                 if (numeric.State.TermsContainerId.IsValid)
                 {
-                    RegisterContainer((long)numeric.State.TermsContainerId, name + "/TermsContainer");
+                    RegisterContainer(numeric.State.TermsContainerId, name + "/TermsContainer");
                 }
             }
         }
@@ -1395,7 +1395,7 @@ namespace Voron
                                 detailedReportInput.Tables.Add(table);
                                 break;
                             case RootObjectType.Container:
-                                long container = (long)tx.OpenContainer(currentKey);
+                                var container = tx.OpenContainer(currentKey);
                                 detailedReportInput.Containers[currentKey] = container;
                                 break;
                             case RootObjectType.Set:

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -22,6 +22,7 @@ using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Compression;
+using Voron.Data.Containers;
 using Voron.Data.Fixed;
 using Voron.Data.Lookups;
 using Voron.Data.PostingLists;
@@ -1229,7 +1230,7 @@ namespace Voron
                                 }
                                 break;
                             case RootObjectType.Container:
-                                long container = tx.OpenContainer(currentKey);
+                                long container = (long)tx.OpenContainer(currentKey);
                                 RegisterContainer(container, name);
                                 break;
                             case RootObjectType.Set:
@@ -1302,10 +1303,10 @@ namespace Voron
             {
                 r.Add(container, name);
                 var overflowName = $"{name}/OverflowPage";
-                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, container);
+                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, new ContainerId(container));
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");
                 RegisterPages(freePages.AllPages(), name + "/FreePagesSet");
-                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, container);
+                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, new ContainerId(container));
                 while (iterator.MoveNext(out var page))
                 {
                     var pageObject = tx.LowLevelTransaction.GetPage(page);
@@ -1323,9 +1324,9 @@ namespace Voron
             void RegisterLookup(Lookup<Int64LookupKey> numeric, string name)
             {
                 RegisterPages(numeric.AllPages(), name);
-                if (numeric.State.TermsContainerId > 0)
+                if (numeric.State.TermsContainerId.IsValid)
                 {
-                    RegisterContainer(numeric.State.TermsContainerId, name + "/TermsContainer");
+                    RegisterContainer((long)numeric.State.TermsContainerId, name + "/TermsContainer");
                 }
             }
         }
@@ -1394,7 +1395,7 @@ namespace Voron
                                 detailedReportInput.Tables.Add(table);
                                 break;
                             case RootObjectType.Container:
-                                long container = tx.OpenContainer(currentKey);
+                                long container = (long)tx.OpenContainer(currentKey);
                                 detailedReportInput.Containers[currentKey] = container;
                                 break;
                             case RootObjectType.Set:

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -81,7 +81,7 @@ public class FacetIndexingRepro : StorageTest
                         Container.Allocate(wtx.LowLevelTransaction, c, items[i].Item2, out _);
                         break;
                     case '-':
-                        Container.Delete(wtx.LowLevelTransaction, c, items[i].Item2);
+                        Container.Delete(wtx.LowLevelTransaction, c, new ContainerEntryId(items[i].Item2));
                         break;
                 }
             }

--- a/test/FastTests/Corax/Bugs/RavenDB-21223.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21223.cs
@@ -27,7 +27,7 @@ namespace FastTests.Corax.Bugs
                 var rootContainer = wtx.OpenContainer("TestContainer");
                 for (int i = 0; i < 1000; i++)
                 {
-                    var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
+                    var allocatedPage = (long)Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
                     space.Fill(1);
                 }
 
@@ -40,14 +40,14 @@ namespace FastTests.Corax.Bugs
                 var rootContainer = wtx.OpenContainer("TestContainer");
                 for (int i = 0; i < 1000; i++)
                 {
-                    var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
+                    var allocatedPage = (long)Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
                     space.Fill(1);
                     toDelete.Add(allocatedPage);
                 }
                 foreach (var id in toDelete)
-                    Container.Delete(wtx.LowLevelTransaction, rootContainer, id);
+                    Container.Delete(wtx.LowLevelTransaction, rootContainer, new ContainerEntryId(id));
 
-                var newPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var allocatedSpace);
+                var newPage = (long)Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var allocatedSpace);
                 allocatedSpace.Fill(2);
 
                 wtx.Commit();

--- a/test/FastTests/Corax/Bugs/RavenDB-21272.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21272.cs
@@ -3,6 +3,7 @@ using System.Text;
 using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,7 +37,7 @@ public class RavenDB_21272 : StorageTest
                 keys[i].Key.Set(Encoding.UTF8.GetBytes(i.ToString("00000")));
                 keys[i].Key.ChangeDictionary(tree.DictionaryId);
                 keys[i].Key.EncodedWithCurrent(out _);
-                keys[i].ContainerId = -1;
+                keys[i].ContainerId = ContainerEntryId.Invalid;
                 vals[i] = 100000 + i;
             }
 
@@ -61,7 +62,7 @@ public class RavenDB_21272 : StorageTest
                     {
                         for (int j = i; j < num; j++)
                         {
-                            k[j].ContainerId = -1;
+                            k[j].ContainerId = ContainerEntryId.Invalid;
                         }
                         i++;
                         if (separatorIndex == -1)
@@ -91,7 +92,7 @@ public class RavenDB_21272 : StorageTest
             k = keys.Skip(10).Take(separatorIndex-10).Concat(new[]{keys[separatorIndex]}).ToArray();
             for (int i = 0; i < k.Length; i++)
             {
-                k[i].ContainerId = -1;
+                k[i].ContainerId = ContainerEntryId.Invalid;
             }
             v = vals;
             o = offsets;
@@ -117,7 +118,7 @@ public class RavenDB_21272 : StorageTest
                     {
                         for (int j = i; j < num; j++)
                         {
-                            k[j].ContainerId = -1;
+                            k[j].ContainerId = ContainerEntryId.Invalid;
                         }
                         break;
                     }

--- a/test/FastTests/Voron/Containers/ContainerTests.cs
+++ b/test/FastTests/Voron/Containers/ContainerTests.cs
@@ -18,14 +18,14 @@ namespace FastTests.Voron.Containers
         {
             using var wtx = Env.WriteTransaction();
 
-            var containerId = Container.Create(wtx.LowLevelTransaction);
+            var containerId = (long)Container.Create(wtx.LowLevelTransaction);
 
             Span<byte> expected = Encoding.UTF8.GetBytes("Stav");
 
-            var id = Container.Allocate(wtx.LowLevelTransaction, containerId, expected.Length, out var space);
+            var id = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), expected.Length, out var space);
             expected.CopyTo(space);
 
-            Container.Get(wtx.LowLevelTransaction, id, out var actual);
+            Container.Get(wtx.LowLevelTransaction, new ContainerEntryId(id), out var actual);
 
             Assert.Equal(expected.ToArray(), actual.ToSpan().ToArray());
         }
@@ -39,17 +39,17 @@ namespace FastTests.Voron.Containers
 
             using (var wtx = Env.WriteTransaction())
             {
-                containerId = Container.Create(wtx.LowLevelTransaction);
+                containerId = (long)Container.Create(wtx.LowLevelTransaction);
 
                 for (int i = 0; i < 1024; i++)
                 {
-                    var id = Container.Allocate(wtx.LowLevelTransaction, containerId, 8, out _);
+                    var id = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), 8, out _);
                     expected.Add(id);
                 }
 
                 for (int i = 0; i < 16; i++)
                 {
-                    var id = Container.Allocate(wtx.LowLevelTransaction, containerId, 10_000, out _);
+                    var id = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), 10_000, out _);
                     expected.Add(id);
                 }
 
@@ -60,7 +60,7 @@ namespace FastTests.Voron.Containers
 
             using (var rtx = Env.ReadTransaction())
             {
-                var actual = Container.GetAllIds(rtx.LowLevelTransaction, containerId);
+                var actual = Container.GetAllIds(rtx.LowLevelTransaction, new ContainerId(containerId));
                 actual.Sort();
                 Assert.Equal(expected.Count, actual.Count);
                 Assert.Equal(expected, actual);
@@ -73,38 +73,38 @@ namespace FastTests.Voron.Containers
         {
             using var wtx = Env.WriteTransaction();
 
-            var containerId = Container.Create(wtx.LowLevelTransaction);
+            var containerId = (long)Container.Create(wtx.LowLevelTransaction);
 
             Span<byte> expected = Encoding.UTF8.GetBytes("Stav");
             var ids = new List<long>();
 
             for (int i = 0; i < 16; i++)
             {
-                var id = Container.Allocate(wtx.LowLevelTransaction, containerId, 500, out var s);
+                var id = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), 500, out var s);
                 expected.CopyTo(s);
                 ids.Add(id);
             }
 
             for (int i = 0; i < 3; i++)
             {
-                Container.Delete(wtx.LowLevelTransaction, containerId, ids[^1]);
+                Container.Delete(wtx.LowLevelTransaction, new ContainerId(containerId), new ContainerEntryId(ids[^1]));
                 ids.RemoveAt(ids.Count - 1);
             }
 
 
             for (int i = 0; i < ids.Count; i++)
             {
-                Container.Delete(wtx.LowLevelTransaction, containerId, ids[i]);
+                Container.Delete(wtx.LowLevelTransaction, new ContainerId(containerId), new ContainerEntryId(ids[i]));
                 ids.RemoveAt(i);
             }
 
 
             // should not throw here
-            Container.Allocate(wtx.LowLevelTransaction, containerId, 750, out var space);
+            Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), 750, out var space);
 
             foreach (var itemId in ids)
             {
-                var data = Container.GetReadOnly(wtx.LowLevelTransaction, itemId);
+                var data = Container.GetReadOnly(wtx.LowLevelTransaction, new ContainerEntryId(itemId));
                 Assert.True(data.Slice(0, 4).SequenceEqual(expected));
             }
         }
@@ -114,24 +114,24 @@ namespace FastTests.Voron.Containers
         {
             using var wtx = Env.WriteTransaction();
 
-            var containerId = Container.Create(wtx.LowLevelTransaction);
+            var containerId = (long)Container.Create(wtx.LowLevelTransaction);
 
             Span<byte> expected = Encoding.UTF8.GetBytes("Stav");
             var ids = new List<long>();
 
             for (int i = 0; i < 16; i++)
             {
-                var id = Container.Allocate(wtx.LowLevelTransaction, containerId, 500, out var s);
+                var id = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), 500, out var s);
                 expected.CopyTo(s);
                 ids.Add(id);
             }
 
             // should not throw here
-            var newId = Container.Allocate(wtx.LowLevelTransaction, containerId, 750, out var space);
+            var newId = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), 750, out var space);
 
             foreach (var itemId in ids)
             {
-                var data = Container.GetReadOnly(wtx.LowLevelTransaction, itemId);
+                var data = Container.GetReadOnly(wtx.LowLevelTransaction, new ContainerEntryId(itemId));
                 Assert.True(data.Slice(0, 4).SequenceEqual(expected));
             }
         }
@@ -149,20 +149,20 @@ namespace FastTests.Voron.Containers
 
             {
                 using var wtx = Env.WriteTransaction();
-                containerId = Container.Create(wtx.LowLevelTransaction);
-                containerItemId = Container.Allocate(wtx.LowLevelTransaction, containerId, expected.Length, out var s);
+                containerId = (long)Container.Create(wtx.LowLevelTransaction);
+                containerItemId = (long)Container.Allocate(wtx.LowLevelTransaction, new ContainerId(containerId), expected.Length, out var s);
                 expected.CopyTo(s);
                 wtx.Commit();
             }
 
             {
                 using var wtx = Env.WriteTransaction();
-                var container = Container.GetMutable(wtx.LowLevelTransaction, containerItemId);
+                var container = Container.GetMutable(wtx.LowLevelTransaction, new ContainerEntryId(containerItemId));
                 (pageId, _) = Math.DivRem(containerItemId, Constants.Storage.PageSize);
                 var page = wtx.LowLevelTransaction.ModifyPage(pageId);
                 Assert.True(page.IsOverflow);
                 overflowPageCount = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(page.OverflowSize);
-                Container.Delete(wtx.LowLevelTransaction, containerId, containerItemId);
+                Container.Delete(wtx.LowLevelTransaction, new ContainerId(containerId), new ContainerEntryId(containerItemId));
                 wtx.Commit();
             }
 

--- a/test/SlowTests/Corax/DeleteTest.cs
+++ b/test/SlowTests/Corax/DeleteTest.cs
@@ -93,7 +93,7 @@ public class DeleteTest : StorageTest
             Assert.True(terms!.TryGetValue("9", out var containerId));
             Assert.NotEqual(0, containerId & (long)TermIdMask.PostingList);
             var setId = EntryIdEncodings.DecodeAndDiscardFrequency(containerId);
-            var setStateSpan = Container.GetMutable(llt, setId);
+            var setStateSpan = Container.GetMutable(llt, new ContainerEntryId(setId));
             ref var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             using var _ = Slice.From(llt.Allocator, "Content", ByteStringType.Immutable, out var fieldName);
             var set = new PostingList(llt, fieldName, in setState);

--- a/test/SlowTests/Voron/ContainerSpaceUsageCalculationTests.cs
+++ b/test/SlowTests/Voron/ContainerSpaceUsageCalculationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using FastTests.Voron;
 using FastTests.Voron.FixedSize;
@@ -38,17 +38,17 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
             for (int i = 0; i < elementsUsed; i++)
             {
                 Container.Allocate(llt: wTx.LowLevelTransaction, containerId: currentContainer, size: random.Next(17, 512), out var memory);
-                
+
                 memory.Fill((byte)random.Next(0, byte.MaxValue +1));
             }
-            
+
             wTx.Commit();
         }
 
         using (var rTx = Env.ReadTransaction())
         {
             var currentContainer = rTx.OpenContainer(nameof(ContainerSpaceUsageCalculationTests));
-            var rootPage = rTx.LowLevelTransaction.GetPage(currentContainer);
+            var rootPage = rTx.LowLevelTransaction.GetPage((long)currentContainer);
             var rootContainer = new Container(rootPage);
 
             var spaceUsedFromMethod = rootContainer.SpaceUsedInItems(rootPage.Pointer, out var usedItemsFromMethod);
@@ -74,8 +74,8 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
         if (iterations > elementsUsed)
             elementsUsed = iterations;
         
-        long[] containersToRemove = new long[elementsUsed];
-        long rootContainerPage;
+        ContainerEntryId[] containersToRemove = new ContainerEntryId[elementsUsed];
+        ContainerId rootContainerPage;
         using (var wTx = Env.WriteTransaction())
         {
             rootContainerPage = wTx.OpenContainer(nameof(ContainerSpaceUsageCalculationTests));
@@ -118,7 +118,7 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
         AssertSpaceUsedInItems(rootContainerPage, iterations);
         using (var rTx = Env.ReadTransaction())
         {
-            var rootPage = rTx.LowLevelTransaction.GetPage(rootContainerPage);
+            var rootPage = rTx.LowLevelTransaction.GetPage((long)rootContainerPage);
             var rootContainer = new Container(rootPage);
 
             var hasEntries = false;
@@ -137,11 +137,11 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
         }
     }
 
-    private unsafe void AssertSpaceUsedInItems(long rootContainerPage, int iterationIdx)
+    private unsafe void AssertSpaceUsedInItems(ContainerId rootContainerPage, int iterationIdx)
     {
         using (var rTx = Env.WriteTransaction())
         {
-            var rootPage = rTx.LowLevelTransaction.ModifyPage(rootContainerPage);
+            var rootPage = rTx.LowLevelTransaction.ModifyPage((long)rootContainerPage);
             var rootContainer = new Container(rootPage);
             var spaceUsedFromMethod = rootContainer.SpaceUsedInItems(rootPage.Pointer, out var usedItemsFromMethod);
             var sizeUsedOneByOne = SpaceUsedInItems(rootPage, ref rootContainer, out var usedItems);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24624

### Additional description

While this PR may not solve the issue found, under investigation we identified a potential issue that would involve mixing different type of container ids. This refactoring solves a whole class of bugs involving using entry ids as container ids and viceversa by forcing a binary compatible type system restriction. 

There are still some casts being performed where the binary representation is used, but those had been audited to ensure the risk of mixing them is minimal. 

This PR can be applied individually, but it would cause a lot of conflicts when trying to merge from the backport. It is better to just apply the backport and when the backport is available include this PR immediately after the merge which will fix what it is necessary for v7.0 to compile. https://github.com/ravendb/ravendb/pull/21097

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
