### PR TITLE
RavenDB-24624: Ensure we cannot mix container ids and entry ids [v6.2]

### DIFF
--- a/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
+++ b/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Sparrow.Server.Utils.VxSort;
 using Voron;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Util;
 
@@ -19,14 +20,14 @@ public partial class IndexWriter
         private readonly IndexWriter _writer;
         private ContextBoundNativeList<long> _entriesForTermsRemovalsBuffer;
         private NativeList<long> _entriesForTermsAdditionsBufferEntryId;
-        private NativeList<long> _entriesForTermsAdditionsBufferTermId;
+        private NativeList<ContainerEntryId> _entriesForTermsAdditionsBufferTermId;
         private readonly List<long> _additionsForTerm, _removalsForTerm;
         private readonly HashSet<long> _entriesAlreadyAdded;
-        private long _termContainerId;
+        private ContainerEntryId _termContainerId;
         
         public EntriesToTermsTracker(IndexWriter writer)
         {
-            _termContainerId = Constants.IndexWriter.InvalidPageId;
+            _termContainerId = ContainerEntryId.Invalid;
             _writer = writer;
             _entriesForTermsRemovalsBuffer = new(writer._entriesAllocator);
             _entriesForTermsAdditionsBufferEntryId.Initialize(_writer._entriesAllocator);
@@ -39,9 +40,9 @@ public partial class IndexWriter
         /// <summary>
         /// Gathers all entry IDs to be processed with the term.
         /// </summary>
-        public void InsertEntries(in EntriesModifications entries, long termContainerId)
+        public void InsertEntries(in EntriesModifications entries, ContainerEntryId termContainerId)
         {
-            Debug.Assert(_termContainerId == Constants.IndexWriter.InvalidPageId);
+            Debug.Assert(_termContainerId == ContainerEntryId.Invalid);
             _termContainerId = termContainerId;
 
             SetRange(_additionsForTerm, entries.Additions);
@@ -99,7 +100,7 @@ public partial class IndexWriter
                 _entriesForTermsAdditionsBufferTermId.AddUnsafe(_termContainerId);
             }
 
-            _termContainerId = Constants.IndexWriter.InvalidPageId;
+            _termContainerId = ContainerEntryId.Invalid;
         }
         
         /// <summary>
@@ -133,7 +134,7 @@ public partial class IndexWriter
                 {
                     Int64LookupKey key = entriesIds[idX];
                     entriesToTermsTree.TryGetNextValue(ref key, out _);
-                    entriesToTermsTree.AddOrSetAfterGetNext(ref key, entriesTerms[idX]);
+                    entriesToTermsTree.AddOrSetAfterGetNext(ref key, (long)entriesTerms[idX]);
                 }
             }
         }

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -396,7 +396,7 @@ public partial class IndexWriter
                 out Span<byte> space);
             term.CopyTo(space);
 
-            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, (long)termId);
+            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, termId);
             
             if (entryTerms.TryAdd(recordedTerm) == false)
             {
@@ -416,7 +416,7 @@ public partial class IndexWriter
             ref var entryTerms = ref _parent.GetEntryTerms(_termPerEntryIndex);
 
             _parent.InitializeFieldRootPage(field);
-            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, field.FieldRootPage);
+            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, new ContainerEntryId(field.FieldRootPage));
             
             if (entryTerms.TryAdd(recordedTerm) == false)
             {

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -396,7 +396,7 @@ public partial class IndexWriter
                 out Span<byte> space);
             term.CopyTo(space);
 
-            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, termId);
+            var recordedTerm = RecordedTerm.CreateForStored(entryTerms, type, (long)termId);
             
             if (entryTerms.TryAdd(recordedTerm) == false)
             {

--- a/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
@@ -120,7 +120,7 @@ public partial class IndexWriter
         {
             bool termFound = postingListId != Constants.IndexSearcher.InvalidId;
             Debug.Assert(termFound || entries.Removals.Count == 0, "Cannot remove entries from term that isn't already there");
-            _writer._entriesToTermsTracker.InsertEntries(entries, key.ToLong());
+            _writer._entriesToTermsTracker.InsertEntries(entries, new ContainerEntryId(key.ToLong()));
             LookupTreeOperationJob result;
             if (entries.HasChanges)
             {

--- a/src/Corax/Indexing/IndexWriter.Testing.cs
+++ b/src/Corax/Indexing/IndexWriter.Testing.cs
@@ -1,4 +1,5 @@
-﻿using Corax.Utils;
+using Corax.Utils;
+using System;
 using Sparrow;
 using Sparrow.Compression;
 using Sparrow.Server;
@@ -44,7 +45,7 @@ public partial class IndexWriter
                 }
 
 
-                Container.GetAll(writer._transaction.LowLevelTransaction, keysPtr[..read], containersPtr, -1, writer._transaction.LowLevelTransaction.PageLocator);
+                Container.GetAll(writer._transaction.LowLevelTransaction, keysPtr[..read], new Span<UnmanagedSpan>(containersPtr, read), -1, writer._transaction.LowLevelTransaction.PageLocator);
                 for (int i = 0; i < read; i++)
                 {
                     var currentKey = keys[i];

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -136,7 +136,7 @@ public unsafe partial class IndexWriter
                         ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[offset]);
                         var job = ProcessSingleEntry(ref entries, isNullTerm: false,
                             sortedTerms[offset], postingListIds[offset],
-                            keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
+                            (long)keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
                         totalLengthOfTerm += totalLengthOfTermDelta;
                         entries.Dispose(_writer._entriesAllocator);
                         _jobs[offset] = job;
@@ -386,7 +386,7 @@ public unsafe partial class IndexWriter
                     out var listSpace);
 
                 processingBuffer.Slice(0, processingBufferPosition).CopyTo(listSpace);
-                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, listContainerId);
+                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, (long)listContainerId);
 
                 fieldTerms.Dispose(_writer._entriesAllocator);
                 if (entryTerms.TryAdd(recordedTerm) == false)
@@ -477,7 +477,7 @@ public unsafe partial class IndexWriter
                 var term = sortedTerms[i];
 
                 var key = buffers.Keys[i].Key ??= llt.AcquireCompactKey();
-                buffers.Keys[i].ContainerId = Container.InvalidId;
+                buffers.Keys[i].ContainerId = ContainerEntryId.Invalid;
                 key.Set(term.AsSpan());
                 key.ChangeDictionary(fieldTree.DictionaryId);
                 key.EncodedWithCurrent(out _);
@@ -504,11 +504,11 @@ public unsafe partial class IndexWriter
                 return *((long, long)*)entry.Reader.Base;
             }
 
-            long setId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
+            long setId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
 
             _writer.InitializeFieldRootPage(_indexedField);
 
-            long nullMarkerId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
+            long nullMarkerId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
                 1, _indexedField.FieldRootPage, out var nullBuffer);
             nullBuffer.Clear();
 

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -136,7 +136,7 @@ public unsafe partial class IndexWriter
                         ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[offset]);
                         var job = ProcessSingleEntry(ref entries, isNullTerm: false,
                             sortedTerms[offset], postingListIds[offset],
-                            (long)keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
+                            keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
                         totalLengthOfTerm += totalLengthOfTermDelta;
                         entries.Dispose(_writer._entriesAllocator);
                         _jobs[offset] = job;
@@ -166,11 +166,11 @@ public unsafe partial class IndexWriter
 
         private void HandleSpecialTerm(Span<int> termsOffsets, Span<Slice> sortedTerms, int termIndex, Tree tree, ref long totalLengthOfTerm)
         {
-            (long postingListId, long termContainerId) = GetOrCreateSpecialPostingList(tree);
+            (var postingListId, var termContainerId) = GetOrCreateSpecialPostingList(tree);
             ref var entries = ref _indexedField.Storage.GetAsRef(termsOffsets[termIndex]);
             var nullLookup = new CompactTree.CompactKeyLookup(CompactKey.NullInstance);
             var job = ProcessSingleEntry(ref entries, isNullTerm: true,
-                sortedTerms[termIndex], postingListId, termContainerId, termsOffsets[termIndex], out var totalLengthOfTermDelta);
+                sortedTerms[termIndex], (long)postingListId, termContainerId, termsOffsets[termIndex], out var totalLengthOfTermDelta);
             totalLengthOfTerm += totalLengthOfTermDelta;
             ProcessCompactTreeOperation(job, ref nullLookup, _fieldTree.CheckTreeStructureChanges(), pageOffset: -1, sortedTerms[termIndex]);
         }
@@ -214,7 +214,7 @@ public unsafe partial class IndexWriter
             }
         }
         
-        private LookupTreeOperationJob ProcessSingleEntry(ref EntriesModifications entries, bool isNullTerm, Slice term, long postListId, long termContainerId, int storageLocation, out int totalLengthOfTermDelta)
+        private LookupTreeOperationJob ProcessSingleEntry(ref EntriesModifications entries, bool isNullTerm, Slice term, long postListId, ContainerEntryId termContainerId, int storageLocation, out int totalLengthOfTermDelta)
         {
             UpdateEntriesForTerm(ref _entriesForTerm, in entries);
             if (_indexedField.Spatial == null) // For spatial, we handle this in InsertSpatialField, so we skip it here
@@ -277,7 +277,7 @@ public unsafe partial class IndexWriter
             {
                 Debug.Assert(_virtualTermIdToTermContainerId[storageLocation] == Constants.IndexedField.Invalid,
                     "virtualMapping[entries.StorageLocation] == Constants.IndexedField.Invalid, Term was already set! Persisted: {_virtualTermIdToTermContainerId[storageLocation]}, new: {termContainerId}");
-                _virtualTermIdToTermContainerId[storageLocation] = termContainerId;
+                _virtualTermIdToTermContainerId[storageLocation] = (long)termContainerId;
             }
 
             return lookupTreeOperationJob;
@@ -386,7 +386,7 @@ public unsafe partial class IndexWriter
                     out var listSpace);
 
                 processingBuffer.Slice(0, processingBufferPosition).CopyTo(listSpace);
-                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, (long)listContainerId);
+                var recordedTerm = RecordedTerm.CreateForStored(fieldTerms, storedFieldType, listContainerId);
 
                 fieldTerms.Dispose(_writer._entriesAllocator);
                 if (entryTerms.TryAdd(recordedTerm) == false)
@@ -413,7 +413,7 @@ public unsafe partial class IndexWriter
             }
         }
 
-        private void RecordTermsForEntries(in EntriesModifications entries, long termContainerId)
+        private void RecordTermsForEntries(in EntriesModifications entries, ContainerEntryId termContainerId)
         {
             foreach (var entry in _entriesForTerm)
             {
@@ -424,14 +424,14 @@ public unsafe partial class IndexWriter
 
                 ref var recordedTerm = ref recordedTermList.AddByRefUnsafe();
 
-                Debug.Assert((termContainerId & 0b111) == 0); // ensure that the three bottom bits are cleared
+                Debug.Assert(((long)termContainerId & 0b111) == 0); // ensure that the three bottom bits are cleared
 
                 long recordedTermContainerId = entry.Frequency switch
                 {
-                    > 1 => termContainerId << Constants.IndexWriter.TermFrequencyShift | // note, bottom 3 are cleared, so we have 11 bits to play with
+                    > 1 => (long)termContainerId << Constants.IndexWriter.TermFrequencyShift | // note, bottom 3 are cleared, so we have 11 bits to play with
                            EntryIdEncodings.FrequencyQuantization(entry.Frequency) << 3 |
                            0b100, // marker indicating that we have a term frequency here
-                    _ => termContainerId
+                    _ => (long)termContainerId
                 };
 
                 Debug.Assert(entry.InserterMode is not InserterMode.Ignore);
@@ -491,7 +491,7 @@ public unsafe partial class IndexWriter
             pageOffsets = new Span<int>(buffers.PageOffsets, 0, max);
         }
 
-        private (long NonExistingTermListId, long NonExistingTermId) GetOrCreateSpecialPostingList(Tree tree)
+        private (ContainerEntryId NonExistingTermListId, ContainerEntryId NonExistingTermId) GetOrCreateSpecialPostingList(Tree tree)
         {
             // In the case where the field does not have any null values, we will create a *large* posting list (an empty one)
             // then we'll insert data to it as if it was any other term
@@ -501,29 +501,30 @@ public unsafe partial class IndexWriter
             {
                 Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
                 Debug.Assert(entry.Reader.Length == sizeof((long, long)));
-                return *((long, long)*)entry.Reader.Base;
+                var tuple = *((long, long)*)entry.Reader.Base;
+                return (new ContainerEntryId(tuple.Item1), new ContainerEntryId(tuple.Item2));
             }
 
-            long setId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
+            var setId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
 
             _writer.InitializeFieldRootPage(_indexedField);
 
-            long nullMarkerId = (long)Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
+            var nullMarkerId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
                 1, _indexedField.FieldRootPage, out var nullBuffer);
             nullBuffer.Clear();
 
             // we need to account for the size of the posting lists, once a term has been switch to a posting list
             // it will always be in this model, so we don't need to do any cleanup
             _writer._largePostingListSet ??= _writer._transaction.OpenPostingList(Constants.IndexWriter.LargePostingListsSetSlice);
-            _writer._largePostingListSet.Add(setId);
+            _writer._largePostingListSet.Add((long)setId);
 
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
             PostingList.Create(_writer._transaction.LowLevelTransaction, ref postingListState);
-            var encodedPostingListId = EntryIdEncodings.Encode(setId, 0, TermIdMask.PostingList);
+            var encodedPostingListId = new ContainerEntryId(EntryIdEncodings.Encode((long)setId, 0, TermIdMask.PostingList));
 
             using (tree.DirectAdd(_indexedField.Name, sizeof((long, long)), out var p))
             {
-                *((long, long)*)p = (encodedPostingListId, nullMarkerId);
+                *((long, long)*)p = ((long)encodedPostingListId, (long)nullMarkerId);
             }
 
             return (encodedPostingListId, nullMarkerId);
@@ -548,6 +549,8 @@ public unsafe partial class IndexWriter
                 if ((cur & (long)TermIdMask.EnsureIsSingleMask) == 0)
                     continue;
 
+                // Decoding the posting list id yields the container root that stores the posting list. We keep it as
+                // ContainerId so later steps talk to the correct root instead of a payload slot.
                 long containerId = EntryIdEncodings.GetContainerId(cur);
                 postingListPagesProcessingBuffer.Add(containerId / Voron.Global.Constants.Storage.PageSize);
             }
@@ -558,6 +561,7 @@ public unsafe partial class IndexWriter
             postingListPagesProcessingBuffer.Clear();
 
             Debug.Assert(postListIds.Length <= 1024);
+
             //ContainerId has 10 lowest bits in use to encode the metadata. We can use them to store the offset of the item in the original order.
             for (int i = 0; i < postListIds.Length; i++)
             {

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -72,9 +72,9 @@ namespace Corax.Indexing
         private Dictionary<Slice, IndexedField> _dynamicFieldsTerms;
         private FieldsCache _fieldsCache;
 
-        private long _postingListContainerId;
-        private long _storedFieldsContainerId;
-        private long _entriesTermsContainerId;
+        private ContainerId _postingListContainerId;
+        private ContainerId _storedFieldsContainerId;
+        private ContainerId _entriesTermsContainerId;
         private Lookup<Int64LookupKey> _entryIdToLocation;
         private IndexFieldsMapping _dynamicFieldsMapping;
         private PostingList _largePostingListSet;
@@ -125,6 +125,9 @@ namespace Corax.Indexing
         /// we need to keep track of how many documents we actually deleted
         /// (e.g., when we perform a delete operation not by 'primary key,'
         /// we might end up in a situation where we try to remove the same document twice, and we need to detect it).
+        ///
+        /// Note: This stores document entry IDs (index-level identifiers), not ContainerEntryId (storage-level identifiers).
+        /// While both are represented as long, they are semantically different concepts and should not be confused.
         /// </summary>
         private readonly HashSet<long> _deletedEntries = new();
 
@@ -215,9 +218,9 @@ namespace Corax.Indexing
         {
             Debug.Assert(_transaction.LowLevelTransaction.Flags == TransactionFlags.ReadWrite);
             _compactKeyScope = new(_transaction.LowLevelTransaction);
-            _postingListContainerId = _transaction.OpenContainer(Constants.IndexWriter.PostingListsSlice);
-            _storedFieldsContainerId = _transaction.OpenContainer(Constants.IndexWriter.StoredFieldsSlice);
-            _entriesTermsContainerId = _transaction.OpenContainer(Constants.IndexWriter.EntriesTermsContainerSlice);
+            _postingListContainerId = (ContainerId)_transaction.OpenContainer(Constants.IndexWriter.PostingListsSlice);
+            _storedFieldsContainerId = (ContainerId)_transaction.OpenContainer(Constants.IndexWriter.StoredFieldsSlice);
+            _entriesTermsContainerId = (ContainerId)_transaction.OpenContainer(Constants.IndexWriter.EntriesTermsContainerSlice);
             _entryIdToLocation = _transaction.LookupFor<Int64LookupKey>(Constants.IndexWriter.EntryIdToLocationSlice);
             _jsonOperationContext = JsonOperationContext.ShortTermSingleUse();
             _fieldsTree = _transaction.CreateTree(Constants.IndexWriter.FieldsSlice);
@@ -554,17 +557,18 @@ namespace Corax.Indexing
             foreach (var entryToDelete in _entriesToDelete)
             {
                 _termsPerEntryId.EnsureCapacityFor(_entriesAllocator, 1);
-                if (_entryIdToLocation.TryRemove(entryToDelete, out var entryTermsId) == false)
+                if (_entryIdToLocation.TryRemove(entryToDelete, out var entryTermsIdLong) == false)
                     ThrowUnableToLocateEntry(entryToDelete);
 
+                ContainerEntryId entryTermsId = (ContainerEntryId)entryTermsIdLong;
                 RemoveDocumentBoost(entryToDelete);
-                var entryTerms = Container.Get(_transaction.LowLevelTransaction, entryTermsId);
+                Container.Get(_transaction.LowLevelTransaction, entryTermsId, out var entryTerms);
                 var termsPerEntryIndex = InsertTermsPerEntry(entryToDelete);
                 RecordTermDeletionsForEntry(entryTerms, _transaction.LowLevelTransaction, _fieldsByRootPage, _nullTermsMarkers, _nonExistingTermsMarkers,
                     _compactTreeDictionaryId, entryToDelete, termsPerEntryIndex);
 
 
-                Container.Delete(_transaction.LowLevelTransaction, _entriesTermsContainerId, entryTermsId);
+                Container.Delete(_transaction.LowLevelTransaction, _entriesTermsContainerId, (ContainerEntryId)entryTermsId);
             }
 
             _entriesToDelete.Clear();
@@ -581,7 +585,7 @@ namespace Corax.Indexing
                 if (reader.TermId == Constants.IndexSearcher.InvalidId)
                     continue;
 
-                Container.Delete(llt, _storedFieldsContainerId, reader.TermId);
+                Container.Delete(llt, _storedFieldsContainerId, new ContainerEntryId(reader.TermId));
             }
 
             reader.Reset();
@@ -879,13 +883,13 @@ namespace Corax.Indexing
 
             var countOfAlreadyDeletedEntries = _deletedEntries.Count;
             setsAreDisjoint = true;
-            var containerId = EntryIdEncodings.GetContainerId(postingListId);
+            var containerEntryId = (ContainerEntryId)EntryIdEncodings.GetContainerId(postingListId);
 
             if ((postingListId & (long)TermIdMask.EnsureIsSingleMask) == (long)TermIdMask.Single)
             {
-                singleDocumentEntryId = containerId;
+                singleDocumentEntryId = (long)containerEntryId;
                 Debug.Assert(singleDocumentEntryId > 0);
-                var isNewDocument = _deletedEntries.Add(containerId);
+                var isNewDocument = _deletedEntries.Add((long)containerEntryId);
                 if (isNewDocument)
                     _entriesToDelete.Add(singleDocumentEntryId);
                 setsAreDisjoint &= isNewDocument;
@@ -902,7 +906,7 @@ namespace Corax.Indexing
             singleDocumentEntryId = Constants.IndexSearcher.InvalidId;
             if ((postingListId & (long)TermIdMask.PostingList) != 0)
             {
-                var setSpace = Container.GetMutable(_transaction.LowLevelTransaction, containerId);
+                var setSpace = Container.GetMutable(_transaction.LowLevelTransaction, containerEntryId);
                 ref var setState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
                 using var set = new PostingList(_transaction.LowLevelTransaction, Slices.Empty, setState);
@@ -914,7 +918,7 @@ namespace Corax.Indexing
 
             if ((postingListId & (long)TermIdMask.SmallPostingList) != 0)
             {
-                var smallSet = Container.Get(_transaction.LowLevelTransaction, containerId);
+                Container.Get(_transaction.LowLevelTransaction, containerEntryId, out var smallSet);
                 // combine with existing value
                 _ = VariableSizeEncoding.Read<int>(smallSet.Address, out var pos);
                 _pforDecoder.Init(smallSet.Address + pos, smallSet.Length - pos);
@@ -1110,10 +1114,10 @@ namespace Corax.Indexing
 
                 int size = writer.Encode(termsRef);
 
-                long entryTermsId = Container.Allocate(_transaction.LowLevelTransaction, _entriesTermsContainerId, size, out var space);
+                ContainerEntryId entryTermsId = Container.Allocate(_transaction.LowLevelTransaction, _entriesTermsContainerId, size, out var space);
                 writer.Write(space);
 
-                _entryIdToLocation.Add(termsPerEntryIds[i], entryTermsId);
+                _entryIdToLocation.Add(termsPerEntryIds[i], (long)entryTermsId);
             }
         }
 
@@ -1200,7 +1204,7 @@ namespace Corax.Indexing
             var containerId = EntryIdEncodings.GetContainerId(idInTree);
 
             var llt = _transaction.LowLevelTransaction;
-            Container.GetMutable(llt, containerId, out var item);
+            Container.GetMutable(llt, new ContainerEntryId(containerId), out var item);
 
             Debug.Assert(entries.Removals.ToSpan().ToArray().Distinct().Count() == entries.Removals.Count, $"Removals list is not distinct.");
 
@@ -1237,7 +1241,7 @@ namespace Corax.Indexing
 
             if (_smallPostingListWorkingBuffer.Count == 0)
             {
-                Container.Delete(llt, _postingListContainerId, containerId);
+                Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
                 termIdInTree = Constants.IndexSearcher.InvalidId;
                 return AddEntriesToTermResult.RemoveTermId;
             }
@@ -1259,7 +1263,7 @@ namespace Corax.Indexing
                 return AddEntriesToTermResult.NothingToDo;
             }
 
-            Container.Delete(llt, _postingListContainerId, containerId);
+            Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
 
             termIdInTree = AllocatedSpaceForSmallSet(encoded, llt, out Span<byte> space);
 
@@ -1270,7 +1274,7 @@ namespace Corax.Indexing
 
         private long AllocatedSpaceForSmallSet(Span<byte> encoded, LowLevelTransaction llt, out Span<byte> space)
         {
-            long termIdInTree = Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
+            long termIdInTree = (long)Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
 
             return EntryIdEncodings.Encode(termIdInTree, 0, TermIdMask.SmallPostingList);
         }
@@ -1357,7 +1361,7 @@ namespace Corax.Indexing
         {
             var containerId = EntryIdEncodings.GetContainerId(id);
             var llt = _transaction.LowLevelTransaction;
-            var setSpace = Container.GetMutable(llt, containerId);
+            var setSpace = Container.GetMutable(llt, new ContainerEntryId(containerId));
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
             entries.GetEncodedAdditionsAndRemovals(_entriesAllocator, out var additions, out var removals);
@@ -1374,7 +1378,7 @@ namespace Corax.Indexing
 
                 llt.FreePage(postingListState.RootPage);
 
-                Container.Delete(llt, _postingListContainerId, containerId);
+                Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
                 RemovePostingListFromLargePostingListsSet(containerId);
 
                 return AddEntriesToTermResult.RemoveTermId;
@@ -1445,7 +1449,7 @@ namespace Corax.Indexing
         
         private void AddNewTermToSet(out long termId)
         {
-            long setId = Container.Allocate(_transaction.LowLevelTransaction, _postingListContainerId, sizeof(PostingListState), out var setSpace);
+            long setId = (long)Container.Allocate(_transaction.LowLevelTransaction, _postingListContainerId, sizeof(PostingListState), out var setSpace);
 
             // we need to account for the size of the posting lists, once a term has been switch to a posting list
             // it will always be in this model, so we don't need to do any cleanup

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -218,9 +218,9 @@ namespace Corax.Indexing
         {
             Debug.Assert(_transaction.LowLevelTransaction.Flags == TransactionFlags.ReadWrite);
             _compactKeyScope = new(_transaction.LowLevelTransaction);
-            _postingListContainerId = (ContainerId)_transaction.OpenContainer(Constants.IndexWriter.PostingListsSlice);
-            _storedFieldsContainerId = (ContainerId)_transaction.OpenContainer(Constants.IndexWriter.StoredFieldsSlice);
-            _entriesTermsContainerId = (ContainerId)_transaction.OpenContainer(Constants.IndexWriter.EntriesTermsContainerSlice);
+            _postingListContainerId = _transaction.OpenContainer(Constants.IndexWriter.PostingListsSlice);
+            _storedFieldsContainerId = _transaction.OpenContainer(Constants.IndexWriter.StoredFieldsSlice);
+            _entriesTermsContainerId = _transaction.OpenContainer(Constants.IndexWriter.EntriesTermsContainerSlice);
             _entryIdToLocation = _transaction.LookupFor<Int64LookupKey>(Constants.IndexWriter.EntryIdToLocationSlice);
             _jsonOperationContext = JsonOperationContext.ShortTermSingleUse();
             _fieldsTree = _transaction.CreateTree(Constants.IndexWriter.FieldsSlice);

--- a/src/Corax/Indexing/RecordedTerm.cs
+++ b/src/Corax/Indexing/RecordedTerm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Utils;
+using Voron.Data.Containers;
 using Voron.Util;
 
 namespace Corax.Indexing;
@@ -52,17 +53,17 @@ public struct RecordedTerm : IComparable<RecordedTerm>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static RecordedTerm CreateForStored<T>(in NativeList<T> fieldTerms, in StoredFieldType storedFieldType, in long listContainerId)
+    public static RecordedTerm CreateForStored<T>(in NativeList<T> fieldTerms, in StoredFieldType storedFieldType, in ContainerEntryId listContainerId)
         where T : unmanaged
     {
         return new RecordedTerm
         (
-            // why: entryTerms.Count << 8 
+            // why: entryTerms.Count << 8
             // we put entries count here because we are sorting the entries afterward
             // this ensure that stored values are then read using the same order we have for writing them
             // which is important for storing arrays
             termContainerId: fieldTerms.Count << Constants.IndexWriter.TermFrequencyShift | (int)storedFieldType | 0b110, // marker for stored field
-            @long: listContainerId
+            @long: (long)listContainerId
         );
     }
 }

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -171,7 +171,7 @@ public partial class IndexSearcher
         else if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
         {
             var smallSetId = EntryIdEncodings.GetContainerId(containerId);
-            Container.Get(_transaction.LowLevelTransaction, smallSetId, out var small);
+            Container.Get(_transaction.LowLevelTransaction, new ContainerEntryId(smallSetId), out var small);
             matches = TermMatch.YieldSmall(this, Allocator, small, termRatioToWholeCollection, field.HasBoost);
         }
         else
@@ -185,7 +185,7 @@ public partial class IndexSearcher
     public PostingList GetPostingList(long containerId)
     {
         var setId = EntryIdEncodings.GetContainerId(containerId);
-        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, setId);
+        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(setId));
 
         ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
         var set = new PostingList(_transaction.LowLevelTransaction, Slices.Empty, setState);
@@ -257,15 +257,15 @@ public partial class IndexSearcher
         if ((containerId & (long)TermIdMask.PostingList) != 0)
         {
             var setId = EntryIdEncodings.GetContainerId(containerId);
-            var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, setId);
+            var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(setId));
             ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             return setState.NumberOfEntries;
         }
-        
+
         if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
         {
             var smallSetId = EntryIdEncodings.GetContainerId(containerId);
-            var small = Container.GetReadOnly(_transaction.LowLevelTransaction, smallSetId);
+            var small = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(smallSetId));
             var itemsCount = VariableSizeEncoding.Read<int>(small, out _);
 
             return itemsCount;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -159,11 +159,12 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     
     public EntryTermsReader GetEntryTermsReader(long id, ref Page p)
     {
-        if (_entryIdToLocation.TryGetValue(id, out var loc) == false)
+        if (_entryIdToLocation.TryGetValue(id, out var locLong) == false)
             throw new InvalidOperationException("Unable to find entry id: " + id);
 
+        ContainerEntryId loc = (ContainerEntryId)locLong;
         InitializeSpecialTermsMarkers();
-        
+
         var item = Container.MaybeGetFromSamePage(_transaction.LowLevelTransaction, ref p, loc);
         return new EntryTermsReader(_transaction.LowLevelTransaction, _nullTermsMarkers, _nonExistingTermsMarkers, item.Address, item.Length, _dictionaryId);
     }

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -260,8 +260,8 @@ namespace Corax.Querying.Matches
                 _smallPostingListIndex = 0;
                 if (_smallPostListIds.Count == 0)
                     return;
-                
-                Container.GetAll(_searcher._transaction.LowLevelTransaction, _smallPostListIds.ToSpan(), _containerItems, long.MinValue, _pageLocator);
+
+                Container.GetAll(_searcher._transaction.LowLevelTransaction, _smallPostListIds.ToSpan(), new Span<UnmanagedSpan>(_containerItems, _smallPostListIds.Count), long.MinValue, _pageLocator);
             }
 
             private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -187,7 +187,7 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending);
             var indexes = SortByTerms(ref match, batchTermIds, batchTerms, descending, indirectComparer);
             for (int i = 0; i < indexes.Length; i++)
@@ -446,7 +446,7 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var heapCapacity = _take == -1 ? batchResults.Length : Math.Min(_take, batchResults.Length);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(heapCapacity)];
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -374,7 +374,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             if (_smallPostListIds.Count == 0)
                 return;
 
-            Container.GetAll(_llt, _smallPostListIds.ToSpan(), _containerItems, long.MinValue, _pageLocator);
+            Container.GetAll(_llt, _smallPostListIds.ToSpan(), new Span<UnmanagedSpan>(_containerItems, _smallPostListIds.Count), long.MinValue, _pageLocator);
         }
 
         private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -229,7 +229,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             match._token.ThrowIfCancellationRequested();
             bool isDescending = orderMetadata[0].Ascending == false;
 
@@ -560,7 +560,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, batchTerms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             for (int i = 0; i < batchTermIds.Length; i++)
                 documents[i] = i;

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
@@ -203,7 +203,7 @@ namespace Corax.Querying.Matches.TermProviders
             }
             
             
-            Voron.Data.Containers.Container.GetAll(_searcher._transaction.LowLevelTransaction, containersIds, containersPtr, -1, _searcher.Transaction.LowLevelTransaction.PageLocator);
+            Voron.Data.Containers.Container.GetAll(_searcher._transaction.LowLevelTransaction, containersIds, new Span<UnmanagedSpan>(containersPtr, NumberOfTerms), -1, _searcher.Transaction.LowLevelTransaction.PageLocator);
             
             for (int i = _nullExists ? 1 : 0; i < NumberOfTerms; ++i)
             {

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
@@ -266,9 +266,10 @@ namespace Corax.Querying.Matches.TermProviders
             }
             
             using var _ = allocator.Allocate((sizeof(UnmanagedSpan)) * postingLists.Count, out ByteString containers);
+            var containersSpan = containers.ToSpan<UnmanagedSpan>();
+
+            Container.GetAll(_searcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersSpan, singleMarker, _searcher._transaction.LowLevelTransaction.PageLocator);
             var containersPtr = (UnmanagedSpan*)containers.Ptr;
-      
-            Container.GetAll(_searcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersPtr, singleMarker, _searcher._transaction.LowLevelTransaction.PageLocator);
 
             long totalCount = 0;
             for (int i = 0; i < postingLists.Count; ++i)

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
@@ -267,10 +267,11 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, I
         }
 
         using var _ = allocator.Allocate((sizeof(UnmanagedSpan)) * postingLists.Count, out ByteString containers);
-        var containersPtr = (UnmanagedSpan*)containers.Ptr;
+        var containersSpan = containers.ToSpan<UnmanagedSpan>();
 
-        Container.GetAll(_indexSearcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersPtr, singleMarker,
+        Container.GetAll(_indexSearcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersSpan, singleMarker,
             _indexSearcher._transaction.LowLevelTransaction.PageLocator);
+        var containersPtr = (UnmanagedSpan*)containers.Ptr;
 
         long totalCount = 0;
         for (int i = 0; i < postingLists.Count; ++i)

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -102,34 +102,34 @@ public unsafe struct TermsReader : IDisposable
         
         _rawTermsContainer.ResetAndEnsureCapacity(ids.Length);
         _rawTermsContainer.Count = ids.Length;
-        Container.GetAll(_llt, _termsLocation.ToSpan(), _rawTermsContainer.RawItems, -1L, _llt.PageLocator);
+        Container.GetAll(_llt, _termsLocation.ToSpan(), _rawTermsContainer.ToSpan(), -1L, _llt.PageLocator);
         termsSet = _rawTermsContainer.ToSpan();
         return maxToProcess;
     }
     
     public bool TryGetRawTermFor(long id, out UnmanagedSpan term)
     {
-        if (_lookup.TryGetValue(id, out var termContainerId) == false)
+        if (_lookup.TryGetValue(id, out var termEntryId) == false)
         {
             term = default;
             return false;
         }
 
-        Container.Get(_llt, termContainerId, out var item);
+        Container.Get(_llt, new ContainerEntryId(termEntryId), out var item);
         term = item.ToUnmanagedSpan();
         return true;
     }
     
     public bool TryGetTermFor(long id, out string term)
     {
-        if (_lookup == null || 
-            _lookup.TryGetValue(id, out var termContainerId) == false)
+        if (_lookup == null ||
+            _lookup.TryGetValue(id, out var termEntryId) == false)
         {
             term = null;
             return false;
         }
 
-        Container.Get(_llt, termContainerId, out var item);
+        Container.Get(_llt, new ContainerEntryId(termEntryId), out var item);
         Set(_xKeyScope.Key, item, _dictionaryId);
         term = _xKeyScope.Key.ToString();
         return true;
@@ -186,7 +186,7 @@ public unsafe struct TermsReader : IDisposable
         UnmanagedSpan term = UnmanagedSpan.Empty;
         if (hasValue)
         {
-            var item = Container.MaybeGetFromSamePage(_llt, ref _lastPage, termId);
+            var item = Container.MaybeGetFromSamePage(_llt, ref _lastPage, new ContainerEntryId(termId));
             term = item.ToUnmanagedSpan();
         }
 

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -236,8 +236,8 @@ public unsafe struct EntryTermsReader
 
         IsNull = _nullTermsMarkers.Contains(TermId);
         IsNonExisting = _nonExistingTermsMarkers.Contains(TermId);
-        
-        Container.Get(_llt, TermId, out var termItem);
+
+        Container.Get(_llt, new ContainerEntryId(TermId), out var termItem);
         FieldRootPage = termItem.PageLevelMetadata;
         
         if (IsNull == false && IsNonExisting == false)
@@ -295,7 +295,7 @@ public unsafe struct EntryTermsReader
                         FieldRootPage = val;
                         break;
                     case StoredFieldType.Term:
-                        Container.Get(_llt, val, out var termItem);
+                        Container.Get(_llt, new ContainerEntryId(val), out var termItem);
                         TermId = val;
                         FieldRootPage = termItem.PageLevelMetadata;
                         StoredField = termItem.ToUnmanagedSpan();

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -55,7 +55,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentPages : AbstractSt
                     {
                         for (int i = 0; i < read; i++)
                         {
-                            Container.Get(tx.LowLevelTransaction, buffer[i], out var item);
+                            Container.Get(tx.LowLevelTransaction, new ContainerEntryId(buffer[i]), out var item);
                             var state = (PostingListState*)item.Address;
                             var pl = new PostingList(tx.LowLevelTransaction, Constants.IndexWriter.LargePostingListsSetSlice, *state);
                             list.AddRange(pl.AllPages());

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -5215,7 +5215,7 @@ namespace Raven.Server.Documents.Indexes
                     {
                         for (int i = 0; i < read; i++)
                         {
-                            Container.Get(llt, buffer[i], out var item);
+                            Container.Get(llt, new ContainerEntryId(buffer[i]), out var item);
                             var state = (PostingListState*)item.Address;
                             report.BranchPages += state->BranchPages;
                             report.LeafPages += state->LeafPages;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -50,6 +50,12 @@ public sealed partial class CompactTree : IPrepareForCommit
             ContainerId = ContainerEntryId.Invalid;
         }
 
+        public CompactKeyLookup(ContainerEntryId entryId)
+        {
+            ContainerId = entryId;
+            Key = null;
+        }
+
         public CompactKeyLookup(long keyData)
         {
             ContainerId = (ContainerEntryId)keyData;
@@ -195,7 +201,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (!IsValid)
+            if (IsValid == false)
             {
                 return -1;
             }
@@ -316,7 +322,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         Add(scope.Key, value);
     }
 
-    public long Add(ReadOnlySpan<byte> key, long value)
+    public ContainerEntryId Add(ReadOnlySpan<byte> key, long value)
     {
         using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
         return Add(scope.Key, value);
@@ -325,29 +331,29 @@ public sealed partial class CompactTree : IPrepareForCommit
     public void GetTermByContainerId(long containerId)
     {
     }
-    
+
     public void SetAfterTryGetNext(ref CompactKeyLookup lookup, long value)
     {
         _inner.SetAfterTryGetNext(ref lookup, value);
     }
 
 
-    public long Add(CompactKey key, long value)
+    public ContainerEntryId Add(CompactKey key, long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
         var lookup = new CompactKeyLookup(key);
         CompactTreeDumper.WriteAddition(this, ref lookup, value);
         _inner.Add(ref lookup, value);
 
-        return (long)lookup.ContainerId;
+        return lookup.ContainerId;
     }
 
-    public long Add(CompactKeyLookup key, long value)
+    public ContainerEntryId Add(CompactKeyLookup key, long value)
     {
         Debug.Assert(key.Key.Dictionary == _inner.State.DictionaryId);
         CompactTreeDumper.WriteAddition(this, ref key, value);
         _inner.Add(ref key, value);
-        return (long)key.ContainerId;
+        return key.ContainerId;
     }
 
     public void PrepareForCommit()
@@ -395,7 +401,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             }
 
             var containerId = Container.Create(llt);
-            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, (ContainerId)containerId);
+            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, containerId);
         }
         else
         {
@@ -449,12 +455,12 @@ public sealed partial class CompactTree : IPrepareForCommit
         return _inner.TryGetTermContainerId(new CompactKeyLookup(key), out value);
     }
 
-    public bool TryGetValue(ReadOnlySpan<byte> key, out long termContainerId, out long value)
+    public bool TryGetValue(ReadOnlySpan<byte> key, out ContainerEntryId termContainerId, out long value)
     {
         using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
         var ckl = new CompactKeyLookup(scope.Key);
         var found = _inner.TryGetValue(ref ckl, out value);
-        termContainerId = (long)ckl.ContainerId;
+        termContainerId = ckl.ContainerId;
         return found;
     }
 
@@ -465,7 +471,7 @@ public sealed partial class CompactTree : IPrepareForCommit
     /// <param name="value">The value stored under the CompactKey.</param>
     /// <param name="key">The underlying value of the CompactKey.</param>
     /// <returns>True if the value exists; otherwise, false.</returns>
-    public bool TryGetValue(long termContainerId, out long value, out ReadOnlySpan<byte> key)
+    public bool TryGetValue(ContainerEntryId termContainerId, out long value, out ReadOnlySpan<byte> key)
     {
         var containerId = new CompactKeyLookup(termContainerId);
         var found = _inner.TryGetValue(ref containerId, out value);
@@ -473,12 +479,12 @@ public sealed partial class CompactTree : IPrepareForCommit
         return found;
     }
 
-    public bool TryGetValue(CompactKey key, out long termContainerId, out long value)
+    public bool TryGetValue(CompactKey key, out ContainerEntryId termContainerId, out long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
         CompactKeyLookup compactKeyLookup = new(key);
         var result = _inner.TryGetValue(ref compactKeyLookup, out value);
-        termContainerId = (long)compactKeyLookup.ContainerId;
+        termContainerId = compactKeyLookup.ContainerId;
         return result;
     }
     
@@ -523,13 +529,13 @@ public sealed partial class CompactTree : IPrepareForCommit
         _inner.InitializeCursorState();
     }
 
-    public bool TryGetNextValue(CompactKey key, out long termContainerId, out long value,out CompactKeyLookup lookup)
+    public bool TryGetNextValue(CompactKey key, out ContainerEntryId termContainerId, out long value,out CompactKeyLookup lookup)
     {
         key.ChangeDictionary(DictionaryId);
         key.EncodedWithCurrent(out _);
         lookup = new CompactKeyLookup(key);
         var result = _inner.TryGetNextValue(ref lookup, out value);
-        termContainerId = (long)lookup.ContainerId;
+        termContainerId = lookup.ContainerId;
         return result;
     }
     

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -39,38 +39,41 @@ public sealed partial class CompactTree : IPrepareForCommit
     public unsafe struct CompactKeyLookup : ILookupKey
     {
         public CompactKey Key;
-        public long ContainerId;
+        public ContainerEntryId ContainerId;
+
+        public bool IsValid => ContainerId.IsValid;
+        public bool IsEmpty => ContainerId.IsEmpty;
 
         public CompactKeyLookup(CompactKey key)
         {
             Key = key;
-            ContainerId = -1;
+            ContainerId = ContainerEntryId.Invalid;
         }
 
-        public CompactKeyLookup(long containerId)
+        public CompactKeyLookup(long keyData)
         {
-            ContainerId = containerId;
+            ContainerId = (ContainerEntryId)keyData;
             Key = null;
         }
 
         public void Reset()
         {
-            ContainerId = -1;
+            ContainerId = ContainerEntryId.Invalid;
         }
 
         public long ToLong()
         {
-            return ContainerId;
+            return (long)ContainerId;
         }
 
-        public static T FromLong<T>(long l)
+        public static T FromLong<T>(long keyData)
         {
             if (typeof(T) != typeof(CompactKeyLookup))
             {
                 throw new NotSupportedException(typeof(T).FullName);
             }
 
-            return (T)(object)new CompactKeyLookup(l);
+            return (T)(object)new CompactKeyLookup(keyData);
         }
 
         public static long MinValue => 0;
@@ -83,7 +86,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
             byte* keyPtr;
             int keyLenInBits;
-            if (ContainerId == 0)
+            if (IsEmpty)
             {
                 keyPtr = null;
                 keyLenInBits = 0;
@@ -92,7 +95,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             {
                 GetEncodedKey(llt, ContainerId, out keyLenInBits, out keyPtr);
             }
-            
+
             Key = llt.AcquireCompactKey();
             Key.Initialize(llt);
             Key.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
@@ -105,7 +108,7 @@ public sealed partial class CompactTree : IPrepareForCommit
 
             byte* keyPtr;
             int keyLenInBits;
-            if (ContainerId == 0)
+            if (IsEmpty)
             {
                 keyPtr = null;
                 keyLenInBits = 0;
@@ -114,7 +117,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             {
                 GetEncodedKey(llt, ContainerId, out keyLenInBits, out keyPtr);
             }
-            
+
             key.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
         }
 
@@ -123,38 +126,39 @@ public sealed partial class CompactTree : IPrepareForCommit
             GetKey(parent);
         }
 
-        public int CompareTo<T>(Lookup<T> parent, long currentKeyId) where T : struct, ILookupKey
+        /// <summary>
+        /// Compares this CompactKeyLookup with key data from storage.
+        /// The keyData parameter contains a ContainerEntryId stored as a long for interface compatibility.
+        /// </summary>
+        public int CompareTo<T>(Lookup<T> parent, long keyData) where T : struct, ILookupKey
         {
             var llt = parent.Llt;
 
             byte* keyPtr;
             int keyLengthInBits;
-            if (currentKeyId == 0)
+            if (keyData == 0)
             {
                 keyPtr = null;
                 keyLengthInBits = 0;
             }
             else
             {
-                GetEncodedKey(llt, currentKeyId, out keyLengthInBits, out keyPtr);
+                GetEncodedKey(llt, (ContainerEntryId)keyData, out keyLengthInBits, out keyPtr);
             }
 
             var k = GetKey(parent);
-            if (ReferenceEquals(k, CompactKey.NullInstance))
-                return -1; // null is smallest
-            
             var match = k.CompareEncodedWithCurrent(keyPtr, keyLengthInBits);
             if (match == 0)
             {
-                ContainerId = currentKeyId;
+                ContainerId = (ContainerEntryId)keyData;
             }
 
             return match;
         }
 
-        private static void GetEncodedKey(LowLevelTransaction llt, long l, out int encodedKeyLengthInBits, out byte* encodedKeyPtr) 
+        private static void GetEncodedKey(LowLevelTransaction llt, ContainerEntryId entryId, out int encodedKeyLengthInBits, out byte* encodedKeyPtr)
         {
-            Container.Get(llt, l, out var keyItem);
+            Container.Get(llt, entryId, out var keyItem);
             int remainderInBits = *keyItem.Address >> 4;
             var encodedKeyLen = keyItem.Length - 1;
             encodedKeyLengthInBits = encodedKeyLen * 8 - remainderInBits;
@@ -170,16 +174,16 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public void CreateTermInContainer<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (ContainerId == -1) // need to save this in the external terms container
+            if (ContainerId == ContainerEntryId.Invalid) // need to save this in the external terms container
             {
                 var encodedKey = Key.EncodedWithCurrent(out int encodedKeyLengthInBits);
-                ContainerId = WriteTermToContainer(encodedKey, encodedKeyLengthInBits, ref parent.State, parent.Llt);
+                ContainerId = (ContainerEntryId)WriteTermToContainer(encodedKey, encodedKeyLengthInBits, ref parent.State, parent.Llt);
             }
         }
 
         public void OnKeyRemoval<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (ContainerId == 0)
+            if (IsEmpty)
                 return; // the empty key is not stored and cannot be referenced
             DecrementTermReferenceCount(parent.Llt, ContainerId, ref parent.State);
         }
@@ -191,23 +195,23 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         public int GetTermRefCount<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
-            if (ContainerId < 0)
+            if (!IsValid)
             {
                 return -1;
             }
 
-            var term = Container.Get(parent.Llt, ContainerId);
+            Container.Get(parent.Llt, ContainerId, out var term);
             return term.ToSpan()[0] & 0xF;
         }
 
         public T Clone<T>(Lookup<T> parent) where T : struct, ILookupKey
         {
             Debug.Assert(typeof(T) == typeof(CompactKeyLookup));
-            
+
             var llt = parent.Llt;
             byte* keyPtr;
             int keyLenInBits;
-            if (ContainerId == 0)
+            if (IsEmpty)
             {
                 keyPtr = null;
                 keyLenInBits = 0;
@@ -228,7 +232,7 @@ public sealed partial class CompactTree : IPrepareForCommit
             return Key?.ToString() ?? "ContainerId: " + ContainerId;
         }
 
-        private void DecrementTermReferenceCount(LowLevelTransaction llt, long keyContainerId, ref LookupState state)
+        private void DecrementTermReferenceCount(LowLevelTransaction llt, ContainerEntryId keyContainerId, ref LookupState state)
         {
             var term = Container.GetMutable(llt, keyContainerId);
             int termRefCount = term[0] & 0xF;
@@ -244,13 +248,13 @@ public sealed partial class CompactTree : IPrepareForCommit
         }
 
 
-        private void IncrementTermReferenceCount(LowLevelTransaction llt, long keyContainerId)
+        private void IncrementTermReferenceCount(LowLevelTransaction llt, ContainerEntryId keyContainerId)
         {
             var term = Container.GetMutable(llt, keyContainerId);
             int termRefCount = term[0] & 0xF;
             // A term usage count means that it is used by multiple pages at the same time. That can happen only if a leaf & branches are using
             // the same term as the separator. However, that has natural limits. As the term can only be in one path through the tree, the tree height
-            // is a natural limit. Compact tree at maximum storage will take ~17 bytes, which means at *least* 425 items, which means that that the 
+            // is a natural limit. Compact tree at maximum storage will take ~17 bytes, which means at *least* 425 items, which means that that the
             // height of the tree if we store 2^64 items it in would be 8. So even if we assume bad insert factor, which will increase the height of the
             // tree, having a limit of 15 is reasonable
             if (termRefCount == 15)
@@ -260,7 +264,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         }
 
 
-        private static long WriteTermToContainer(ReadOnlySpan<byte> encodedKey, int encodedKeyLengthInBits, ref LookupState state, LowLevelTransaction llt)
+        private static ContainerEntryId WriteTermToContainer(ReadOnlySpan<byte> encodedKey, int encodedKeyLengthInBits, ref LookupState state, LowLevelTransaction llt)
         {
             // the term in the container is:  [ metadata -1 byte ] [ term bytes ]
             // the metadata is composed of two nibbles - the first says the *remainder* of bits in the last byte in the term
@@ -312,18 +316,14 @@ public sealed partial class CompactTree : IPrepareForCommit
         Add(scope.Key, value);
     }
 
-    public void Add(ReadOnlySpan<byte> key, long value)
+    public long Add(ReadOnlySpan<byte> key, long value)
     {
         using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
-        Add(scope.Key, value);
+        return Add(scope.Key, value);
     }
 
-    public long AddAfterTryGetNext(ref CompactKeyLookup lookup, long value)
+    public void GetTermByContainerId(long containerId)
     {
-        CompactTreeDumper.WriteAddition(this, ref lookup, value);
-
-        _inner.AddAfterTryGetNext(ref lookup, value);
-        return lookup.ContainerId;
     }
     
     public void SetAfterTryGetNext(ref CompactKeyLookup lookup, long value)
@@ -339,15 +339,15 @@ public sealed partial class CompactTree : IPrepareForCommit
         CompactTreeDumper.WriteAddition(this, ref lookup, value);
         _inner.Add(ref lookup, value);
 
-        return lookup.ContainerId;
+        return (long)lookup.ContainerId;
     }
-    
+
     public long Add(CompactKeyLookup key, long value)
     {
         Debug.Assert(key.Key.Dictionary == _inner.State.DictionaryId);
         CompactTreeDumper.WriteAddition(this, ref key, value);
         _inner.Add(ref key, value);
-        return key.ContainerId;
+        return (long)key.ContainerId;
     }
 
     public void PrepareForCommit()
@@ -394,8 +394,8 @@ public sealed partial class CompactTree : IPrepareForCommit
                 dictionaryId = ((PersistentDictionaryRootHeader*)existingDictionary)->PageNumber;
             }
 
-            long containerId = Container.Create(llt);
-            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, containerId);
+            var containerId = Container.Create(llt);
+            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, (ContainerId)containerId);
         }
         else
         {
@@ -449,12 +449,36 @@ public sealed partial class CompactTree : IPrepareForCommit
         return _inner.TryGetTermContainerId(new CompactKeyLookup(key), out value);
     }
 
+    public bool TryGetValue(ReadOnlySpan<byte> key, out long termContainerId, out long value)
+    {
+        using var scope = new CompactKeyCacheScope(_inner.Llt, key, _inner.State.DictionaryId);
+        var ckl = new CompactKeyLookup(scope.Key);
+        var found = _inner.TryGetValue(ref ckl, out value);
+        termContainerId = (long)ckl.ContainerId;
+        return found;
+    }
+
+    /// <summary>
+    /// Retrieves the values associated with the specified CompactKey.
+    /// </summary>
+    /// <param name="termContainerId">The address of the CompactKey.</param>
+    /// <param name="value">The value stored under the CompactKey.</param>
+    /// <param name="key">The underlying value of the CompactKey.</param>
+    /// <returns>True if the value exists; otherwise, false.</returns>
+    public bool TryGetValue(long termContainerId, out long value, out ReadOnlySpan<byte> key)
+    {
+        var containerId = new CompactKeyLookup(termContainerId);
+        var found = _inner.TryGetValue(ref containerId, out value);
+        key = found ? containerId.Key.Decoded() : [];
+        return found;
+    }
+
     public bool TryGetValue(CompactKey key, out long termContainerId, out long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
         CompactKeyLookup compactKeyLookup = new(key);
         var result = _inner.TryGetValue(ref compactKeyLookup, out value);
-        termContainerId = compactKeyLookup.ContainerId;
+        termContainerId = (long)compactKeyLookup.ContainerId;
         return result;
     }
     
@@ -505,7 +529,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         key.EncodedWithCurrent(out _);
         lookup = new CompactKeyLookup(key);
         var result = _inner.TryGetNextValue(ref lookup, out value);
-        termContainerId = lookup.ContainerId;
+        termContainerId = (long)lookup.ContainerId;
         return result;
     }
     
@@ -533,13 +557,13 @@ public sealed partial class CompactTree : IPrepareForCommit
         #if DEBUG
         for (int i = 0; i < keys.Length; i++)
         {
-            Debug.Assert(keys[i].ContainerId == -1, "keys[i].ContainerId == -1");
+            Debug.Assert(keys[i].ContainerId == ContainerEntryId.Invalid, "keys[i].ContainerId == ContainerEntryId.Invalid");
         }
         #endif
         var read = _inner.BulkUpdateStart(keys, values, offsets, out pageNum);
         for (int i = 0; i < read; i++)
         {
-            if (keys[i].ContainerId == -1)
+            if (keys[i].ContainerId == ContainerEntryId.Invalid)
             {
                 keys[i].CreateTermInContainer(_inner);
             }

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -29,7 +29,53 @@ namespace Voron.Data.Containers
         [FieldOffset(1)]
         public long ContainerId;
     }
-    
+
+    [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
+    public readonly struct ContainerId(long id) : IEquatable<ContainerId>
+    {
+        [FieldOffset(0)]
+        private readonly long _id = id;
+
+        public static readonly ContainerId Invalid = new(-1);
+
+        public bool IsValid => _id > 0;
+        public bool IsEmpty => _id == 0;
+
+        public static explicit operator long(ContainerId containerId) => containerId._id;
+        public static explicit operator ContainerId(long id) => new(id);
+
+        public bool Equals(ContainerId other) => _id == other._id;
+        public override bool Equals(object obj) => obj is ContainerId other && Equals(other);
+        public override int GetHashCode() => _id.GetHashCode();
+        public override string ToString() => $"ContainerId({_id})";
+
+        public static bool operator ==(ContainerId left, ContainerId right) => left._id == right._id;
+        public static bool operator !=(ContainerId left, ContainerId right) => left._id != right._id;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
+    public readonly struct ContainerEntryId(long id) : IEquatable<ContainerEntryId>
+    {
+        [FieldOffset(0)]
+        private readonly long _id = id;
+
+        public static readonly ContainerEntryId Invalid = new(-1);
+
+        public bool IsValid => _id > 0;
+        public bool IsEmpty => _id == 0;
+
+        public static explicit operator long(ContainerEntryId entryId) => entryId._id;
+        public static explicit operator ContainerEntryId(long id) => new(id);
+
+        public bool Equals(ContainerEntryId other) => _id == other._id;
+        public override bool Equals(object obj) => obj is ContainerEntryId other && Equals(other);
+        public override int GetHashCode() => _id.GetHashCode();
+        public override string ToString() => $"ContainerEntryId({_id})";
+
+        public static bool operator ==(ContainerEntryId left, ContainerEntryId right) => left._id == right._id;
+        public static bool operator !=(ContainerEntryId left, ContainerEntryId right) => left._id != right._id;
+    }
+
     public readonly unsafe ref struct Container
     {
         public const int InvalidId = -1;
@@ -41,15 +87,15 @@ namespace Voron.Data.Containers
             // page -> page-level-metadata
             public Dictionary<long, long> FreeListAdditions = new();
             public HashSet<long> FreeListRemovals = new();
-            
+
             public HashSet<long> Removals = new();
             public HashSet<long> Additions = new();
 
             public Dictionary<long, long> LastFreePageByPageLevelMetadata = new();
 
-            public long ContainerId;
+            public ContainerId ContainerId;
 
-            public TransactionState(long containerId)
+            public TransactionState(ContainerId containerId)
             {
                 ContainerId = containerId;
             }
@@ -60,19 +106,19 @@ namespace Voron.Data.Containers
             {
                 if (_allPages != null)
                     return _allPages;
-                
-                var rootContainer = new Container(llt.GetPage(ContainerId));
+
+                var rootContainer = new Container(llt.GetPage((long)ContainerId));
                 ref var allPagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.AllPagesOffset));
                 _allPages = Lookup<Int64LookupKey>.Open(llt, allPagesState);
                 return _allPages;
             }
-            
+
             public Lookup<Int64LookupKey> GetFreePages(LowLevelTransaction llt)
             {
                 if (_freePages != null)
                     return _freePages;
-                
-                var rootContainer = new Container(llt.GetPage(ContainerId));
+
+                var rootContainer = new Container(llt.GetPage((long)ContainerId));
                 ref var allPagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.FreeListOffset));
                 _freePages = Lookup<Int64LookupKey>.Open(llt, allPagesState);
                 return _freePages;
@@ -131,11 +177,11 @@ namespace Voron.Data.Containers
                         freePages.TryRemoveExistingValue(ref key, out _);
                 }
                 
-                var rootContainer = new Container(tx.LowLevelTransaction.ModifyPage(ContainerId));
-                
+                var rootContainer = new Container(tx.LowLevelTransaction.ModifyPage((long)ContainerId));
+
                 ref var allPagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.AllPagesOffset));
                 allPagesState = allPages.State;
-                
+
                 ref var freePagesState = ref MemoryMarshal.AsRef<LookupState>(rootContainer.GetItem(ContainerPageHeader.FreeListOffset));
                 freePagesState = freePages.State;
             }
@@ -609,14 +655,14 @@ namespace Voron.Data.Containers
             Header = ref Unsafe.AsRef<ContainerPageHeader>(page.Pointer);
         }
 
-        public static long Create(LowLevelTransaction llt)
+        public static ContainerId Create(LowLevelTransaction llt)
         {
             var page = AllocateContainerPage(llt);
 
             var root = new Container(page);
             root.Header.NumberOfOverflowPages = 0;
             root.Header.PageLevelMetadata = -1;
-            
+
             root.Allocate(sizeof(LookupState), ContainerPageHeader.FreeListOffset, out var freeListStateBuf);
             root.Allocate(sizeof(LookupState), ContainerPageHeader.AllPagesOffset, out var allPagesStateBuf);
             root.Allocate(sizeof(long), ContainerPageHeader.NumberOfEntriesOffset, out var numberOfEntriesBuffer);
@@ -629,11 +675,11 @@ namespace Voron.Data.Containers
             Lookup<Int64LookupKey>.Create(llt, out freeListState);
             ref var allPagesListState = ref MemoryMarshal.AsRef<LookupState>(allPagesStateBuf);
             Lookup<Int64LookupKey>.Create(llt, out allPagesListState);
-            
+
             var list = Lookup<Int64LookupKey>.Open(llt, allPagesListState);
             list.Add(page.PageNumber, 0);
             allPagesListState = list.State;
-            return page.PageNumber;
+            return (ContainerId)page.PageNumber;
         }
 
         private static Page AllocateContainerPage( LowLevelTransaction llt )
@@ -690,7 +736,7 @@ namespace Voron.Data.Containers
             Memory.Copy(_page.Pointer, tmpPtr, Constants.Storage.PageSize);
         }
 
-        public static long Allocate(LowLevelTransaction llt, long containerId, int size, out Span<byte> allocatedSpace)
+        public static ContainerEntryId Allocate(LowLevelTransaction llt, ContainerId containerId, int size, out Span<byte> allocatedSpace)
         {
             return Allocate(llt, containerId, size, pageLevelMetadata: -1, out allocatedSpace);
         }
@@ -702,9 +748,9 @@ namespace Voron.Data.Containers
         ///
         /// If the current page isn't a match to the pageLevelMetadata value passed, we'll allocate a *new* page for that purpose.
         /// </summary>
-        public static long Allocate(LowLevelTransaction llt, long containerId, int size, long pageLevelMetadata, out Span<byte> allocatedSpace)
+        public static ContainerEntryId Allocate(LowLevelTransaction llt, ContainerId containerId, int size, long pageLevelMetadata, out Span<byte> allocatedSpace)
         {
-            long AllocateOverflowPageUnlikely(Container rootContainer, out Span<byte> allocatedSpace)
+            ContainerEntryId AllocateOverflowPageUnlikely(Container rootContainer, out Span<byte> allocatedSpace)
             {
                 // The space to allocate is big enough to be allocated in a dedicated overflow page.
                 // We will figure out how many pages we will need to store it.
@@ -718,7 +764,7 @@ namespace Voron.Data.Containers
                 AddToAllPagesList(llt, rootContainer, overflowPage.PageNumber);
 
                 allocatedSpace = overflowPage.AsSpan(PageHeader.SizeOf, size);
-                return overflowPage.PageNumber * Constants.Storage.PageSize;
+                return new ContainerEntryId(overflowPage.PageNumber * Constants.Storage.PageSize);
             }
 
             // This method will return the allocated space inside the container and also the entry internal id to 
@@ -726,24 +772,24 @@ namespace Voron.Data.Containers
             
             if(size <= 0)
                 throw new ArgumentOutOfRangeException(nameof(size));
-            
-            var rootContainer = new Container(llt.ModifyPage(containerId));
+
+            var rootContainer = new Container(llt.ModifyPage((long)containerId));
             rootContainer.UpdateNumberOfEntries(1);
-            
+
             if (size > MaxSizeInsideContainerPage)
                 return AllocateOverflowPageUnlikely(rootContainer, out allocatedSpace);
 
             var p = rootContainer.GetNextFreePage();
             var activePage = llt.ModifyPage(p);
             var container = new Container(activePage);
-            
+
             var (reqSize, pos) = container.GetRequiredSizeAndPosition(size);
             bool pageMatch = PageMetadataMatch(container, pageLevelMetadata) &&
                              // we limit the number of entries per page to ensure we always
                              // have the bottom 3 bits free, see also IndexToOffset
                              pos < 1024;
 
-            if (pageMatch == false || 
+            if (pageMatch == false ||
                 container.HasEnoughSpaceFor(reqSize) == false)
             {
                 var freedSpace = false;
@@ -776,7 +822,7 @@ namespace Voron.Data.Containers
             return container.Allocate(size, pos, out allocatedSpace);
         }
 
-        private long Allocate(int size, int pos, out Span<byte> allocatedSpace)
+        private ContainerEntryId Allocate(int size, int pos, out Span<byte> allocatedSpace)
         {
             Debug.Assert(pos < 1024, "pos < 1024");
             var reqSize = ComputeRequiredSize(size);
@@ -795,7 +841,7 @@ namespace Voron.Data.Containers
             allocatedSpace = _page.AsSpan(entryStartOffset, size);
 
             long id = Header.PageNumber * Constants.Storage.PageSize + IndexToOffset(pos);
-            return id;
+            return new ContainerEntryId(id);
         }
 
         private static long IndexToOffset(int pos)
@@ -815,11 +861,11 @@ namespace Voron.Data.Containers
             return (int)offset >> 3;
         }
 
-        private static Container MoveToNextPage(LowLevelTransaction llt, long containerId, long pageLevelMetadata, Container container, int size)
+        private static Container MoveToNextPage(LowLevelTransaction llt, ContainerId containerId, long pageLevelMetadata, Container container, int size)
         {
             Debug.Assert(size <= MaxSizeInsideContainerPage);
 
-            var rootPage = llt.ModifyPage(containerId);
+            var rootPage = llt.ModifyPage((long)containerId);
             var rootContainer = new Container(rootPage);
             // we'll only remove from the free list if the page level metadata matches, since it probably has space otherwise
             if (pageLevelMetadata == container.Header.PageLevelMetadata)
@@ -832,7 +878,8 @@ namespace Voron.Data.Containers
                 AddToFreeList(llt, rootContainer, container._page.PageNumber, container.Header.PageLevelMetadata);
             }
             
-        
+
+
             var txState = llt.Transaction.GetContainerState(containerId);
             if(txState.LastFreePageByPageLevelMetadata.TryGetValue(pageLevelMetadata, out var lastFreePage))
             {
@@ -976,11 +1023,11 @@ namespace Voron.Data.Containers
             return pageLevelMetadata == maybe.Header.PageLevelMetadata;
         }
 
-        public static List<long> GetAllIds(LowLevelTransaction llt, long containerId)
+        public static List<long> GetAllIds(LowLevelTransaction llt, ContainerId containerId)
         {
             var list = new List<long>();
             Span<long> items = stackalloc long[256];
-            Container rootContainer = new Container(llt.GetPage(containerId));
+            Container rootContainer = new Container(llt.GetPage((long)containerId));
             var txState = llt.Transaction.GetContainerState(containerId);
             var it = txState.GetAllPages(llt).Iterate();
             it.Reset();
@@ -995,7 +1042,7 @@ namespace Voron.Data.Containers
                 int itemsLeftOnCurrentPage = 0;
                 do
                 {
-                    int count = GetEntriesInto(containerId, ref offset, page, items, out itemsLeftOnCurrentPage);
+                    int count = GetEntriesInto((long)containerId, ref offset, page, items, out itemsLeftOnCurrentPage);
                     list.AddRange(items[..count]);
 
                     //need read to the end of page
@@ -1054,7 +1101,7 @@ namespace Voron.Data.Containers
 
         public static void AddToFreeList(LowLevelTransaction llt, in Container rootContainer, long pageNum, long pageLevelMetadata)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             ref long valRef = ref CollectionsMarshal.GetValueRefOrAddDefault(txState.FreeListAdditions, pageNum, out var exists);
             if (exists)
             {
@@ -1072,7 +1119,7 @@ namespace Voron.Data.Containers
         
         public static void RemoveFromFreeList(LowLevelTransaction llt, in Container rootContainer, long pageNum)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             txState.FreeListAdditions.Remove(pageNum);
             txState.FreeListRemovals.Add(pageNum);
             
@@ -1081,14 +1128,14 @@ namespace Voron.Data.Containers
         
         public static void AddToAllPagesList(LowLevelTransaction llt, in Container rootContainer, long pageNum)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             txState.Removals.Remove(pageNum);
             txState.Additions.Add(pageNum);
         }
         
         public static void RemoveFromAllPagesList(LowLevelTransaction llt, in Container rootContainer, long pageNum, long pageLevelMetadata)
         {
-            var txState = llt.Transaction.GetContainerState(rootContainer._page.PageNumber);
+            var txState = llt.Transaction.GetContainerState(new ContainerId(rootContainer._page.PageNumber));
             
             txState.FreeListAdditions.Remove(pageNum);
             txState.FreeListRemovals.Add(pageNum);
@@ -1174,11 +1221,11 @@ namespace Voron.Data.Containers
             return size + 1 + isLarge.ToInt32();
         }
 
-        public static void Delete(LowLevelTransaction llt, long containerId, long id)
+        public static void Delete(LowLevelTransaction llt, ContainerId containerId, ContainerEntryId id)
         {
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.ModifyPage(pageNum);
-            Container rootContainer = new Container(llt.ModifyPage(containerId));
+            Container rootContainer = new Container(llt.ModifyPage((long)containerId));
             rootContainer.UpdateNumberOfEntries(-1);
 
             if (page.IsOverflow)
@@ -1215,7 +1262,7 @@ namespace Voron.Data.Containers
 
             if (container.HasEntries() == false) // cannot delete root page
             {
-                Debug.Assert(pageNum != containerId);
+                Debug.Assert(pageNum != (long)containerId);
                 
                 // don't need to consider the root page, the free list & all pages
                 // entries will ensure that we never get here
@@ -1223,7 +1270,7 @@ namespace Voron.Data.Containers
                 {
                     // we delete the current free page, so we'll point to ourselves are resolve
                     // the next allocation via the free list
-                    rootContainer.UpdateNextFreePage(containerId);
+                    rootContainer.UpdateNextFreePage((long)containerId);
                 }
 
                 RemoveFromFreeList(llt, rootContainer, page.PageNumber);
@@ -1281,12 +1328,12 @@ namespace Voron.Data.Containers
             return *(long*)pagePointer;
         }
         
-        public static Span<byte> GetMutable(LowLevelTransaction llt, long id)
+        public static Span<byte> GetMutable(LowLevelTransaction llt, ContainerEntryId id)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.ModifyPage(pageNum);
 
             if (page.IsOverflow)
@@ -1304,12 +1351,12 @@ namespace Voron.Data.Containers
             return new Span<byte>(pagePointer, size);
         }
         
-        public static void GetMutable(LowLevelTransaction llt, long id, out Item item)
+        public static void GetMutable(LowLevelTransaction llt, ContainerEntryId id, out Item item)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.ModifyPage(pageNum);
 
             if (page.IsOverflow)
@@ -1326,12 +1373,12 @@ namespace Voron.Data.Containers
             item = new Item(page, pagePointer, size);
         }
 
-        public static void Get(LowLevelTransaction llt, long id, out Item item)
+        public static void Get(LowLevelTransaction llt, ContainerEntryId id, out Item item)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.GetPage(pageNum);
             if (page.IsOverflow)
             {
@@ -1348,12 +1395,12 @@ namespace Voron.Data.Containers
             item = new Item(page, pagePointer, size);
         }
 
-        public static Span<byte> GetReadOnly(LowLevelTransaction llt, long id)
+        public static Span<byte> GetReadOnly(LowLevelTransaction llt, ContainerEntryId id)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             var page = llt.GetPage(pageNum);
             if (page.IsOverflow)
             {
@@ -1368,19 +1415,13 @@ namespace Voron.Data.Containers
             var size = itemMetadata.Get(ref pagePointer);
             return new Span<byte>(pagePointer, size);
         }
-        
-        public static Item Get(LowLevelTransaction llt, long id)
-        {
-            Get(llt, id, out Item result);
-            return result;
-        }
 
-        public static Item MaybeGetFromSamePage(LowLevelTransaction llt, ref Page page, long id)
+        public static Item MaybeGetFromSamePage(LowLevelTransaction llt, ref Page page, ContainerEntryId id)
         {
-            if (id <= 0)
+            if ((long)id <= 0)
                 throw new InvalidOperationException("Got an invalid container id: " + id);
 
-            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var (pageNum, offset) = Math.DivRem((long)id, Constants.Storage.PageSize);
             if(!page.IsValid || pageNum != page.PageNumber)
                 page = llt.GetPage(pageNum);
 
@@ -1442,9 +1483,9 @@ namespace Voron.Data.Containers
         }
 
         /// <summary>
-        /// Assumes that ids is sorted 
+        /// Assumes that ids is sorted
         /// </summary>
-        public static void GetAll(LowLevelTransaction llt, Span<long> ids, UnmanagedSpan* spans, long missingValue, PageLocator pageCache)
+        public static void GetAll(LowLevelTransaction llt, Span<long> ids, Span<UnmanagedSpan> spans, long missingValue, PageLocator pageCache)
         {
             for (int i = 0; i < ids.Length; i++)
             {
@@ -1461,13 +1502,13 @@ namespace Voron.Data.Containers
                     pageCache.SetReadable(page);
                 }
 
-                var container = new Container(page);
-                
-                if (container._page.IsOverflow)
+                if (page.IsOverflow)
                 {
                     spans[i] = new(page.DataPointer, page.OverflowSize);
                     continue;
                 }
+
+                var container = new Container(page);
 
                 var metadata = container.MetadataFor(OffsetToIndex(offset));
                 Debug.Assert(metadata.IsFree == false);
@@ -1477,13 +1518,13 @@ namespace Voron.Data.Containers
             }
         }
 
-        public static (Lookup<Int64LookupKey> allPages, Lookup<Int64LookupKey> freePages) GetPagesFor(LowLevelTransaction tx, long containerId)
+        public static (Lookup<Int64LookupKey> allPages, Lookup<Int64LookupKey> freePages) GetPagesFor(LowLevelTransaction tx, ContainerId containerId)
         {
             var state = tx.Transaction.GetContainerState(containerId);
             return (state.GetAllPages(tx), state.GetFreePages(tx));
         }
-        
-        public static Lookup<Int64LookupKey>.ForwardIterator GetAllPagesIterator(LowLevelTransaction tx, long containerId)
+
+        public static Lookup<Int64LookupKey>.ForwardIterator GetAllPagesIterator(LowLevelTransaction tx, ContainerId containerId)
         {
             var state = tx.Transaction.GetContainerState(containerId);
             return state.GetAllPages(tx).Iterate();

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -6,12 +6,9 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 using System.Text;
 using Sparrow;
 using Sparrow.Server;
-using Sparrow.Server.Binary;
-using Sparrow.Server.Platform.Posix;
 using Voron.Data.Lookups;
 using Voron.Exceptions;
 using Voron.Global;
@@ -30,6 +27,10 @@ namespace Voron.Data.Containers
         public long ContainerId;
     }
 
+    // Represents the root container itself (the header page that owns freelists, lookup trees, etc.).
+    // Historically both container ids and entry ids were plain longs, so ContainerEntryId == 0 meant
+    // "empty entry" while ContainerId == 0 pointed at the storage header. Mixing them up would send
+    // callers to the wrong page or reuse a root as if it were an entry. This wrapper marks "root" level.
     [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
     public readonly struct ContainerId(long id) : IEquatable<ContainerId>
     {
@@ -53,6 +54,9 @@ namespace Voron.Data.Containers
         public static bool operator !=(ContainerId left, ContainerId right) => left._id != right._id;
     }
 
+    // Represents an entry allocated inside a container (the payload slot). Value 0 means "no entry" here,
+    // which collided with ContainerId == 0 (root header) when both were longs. Passing the wrong type would
+    // make us delete or read from the root instead of the payload. The dedicated type enforces the boundary.
     [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
     public readonly struct ContainerEntryId(long id) : IEquatable<ContainerEntryId>
     {

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -8,6 +8,7 @@ using Sparrow;
 using Sparrow.Server;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
 using Voron.Debugging;
 using Voron.Global;
 using Voron.Impl;
@@ -321,7 +322,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     public ref LookupState State => ref _state;
     public LowLevelTransaction Llt => _llt;
 
-    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId = -1, long termsContainerId = -1)
+    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId = -1, ContainerId termsContainerId = default)
     {
         var llt = parent.Llt;
 
@@ -358,7 +359,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         };
     }
     
-    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId = -1, long termsContainerId = -1)
+    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId = -1, ContainerId termsContainerId = default)
     {
         var newPage = llt.AllocatePage(1);
         var compactPageHeader = (LookupPageHeader*)newPage.Pointer;

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -322,7 +322,12 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     public ref LookupState State => ref _state;
     public LowLevelTransaction Llt => _llt;
 
-    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId = -1, ContainerId termsContainerId = default)
+    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId = -1)
+    {
+        return InternalCreate(parent, name, dictionaryId, ContainerId.Invalid);
+    }
+
+    public static Lookup<TLookupKey> InternalCreate(Tree parent, Slice name, long dictionaryId, ContainerId termsContainerId)
     {
         var llt = parent.Llt;
 
@@ -359,7 +364,12 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         };
     }
     
-    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId = -1, ContainerId termsContainerId = default)
+    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId = -1)
+    {
+        Create(llt, out state, dictionaryId, ContainerId.Invalid);
+    }
+
+    public static void Create(LowLevelTransaction llt, out LookupState state, long dictionaryId, ContainerId termsContainerId)
     {
         var newPage = llt.AllocatePage(1);
         var compactPageHeader = (LookupPageHeader*)newPage.Pointer;

--- a/src/Voron/Data/Lookups/LookupState.cs
+++ b/src/Voron/Data/Lookups/LookupState.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Voron.Data.Containers;
 
 namespace Voron.Data.Lookups
 {
@@ -24,7 +25,7 @@ namespace Voron.Data.Lookups
         [FieldOffset(40)]
         public long DictionaryId;
         [FieldOffset(48)]
-        public long TermsContainerId;
+        public ContainerId TermsContainerId;
         
 
         public override string ToString()

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -139,7 +139,7 @@ namespace Voron.Debugging
                                         string nestedReportName = treeReport.Name + "/" + nestedReport.Name;
                                         nestedReport.Name = nestedReportName +" (CompactTree)";
                                         trees.Add(nestedReport);
-                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", textLookup.State.TermsContainerId, input.IncludeDetails));
+                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", (long)textLookup.State.TermsContainerId, input.IncludeDetails));
                                     }
                                     break;
                                 case RootObjectType.EmbeddedFixedSizeTree:
@@ -474,7 +474,7 @@ namespace Voron.Debugging
             {
                 pageDensities = GetLookupPageDensities(lookup.Llt, lookup.AllPages());
             }
-            
+
             // CompactTree also has a ContainerId, but that is accounted for _separately_, using the EntriesTerms
             long pageCount = lookup.State.BranchPages + lookup.State.LeafPages;
 
@@ -504,7 +504,7 @@ namespace Voron.Debugging
             if (includeDetails)
             {
                 pageDensities = new();
-                var it = Container.GetAllPagesIterator(_tx, page);
+                var it = Container.GetAllPagesIterator(_tx, (ContainerId)page);
                 while (it.MoveNext(out var pageNum))
                 {
                     // cannot use GetPageHeader since we are reading not just from the header
@@ -522,7 +522,7 @@ namespace Voron.Debugging
                 }
             }
             
-            var (allPages, freePages) = Container.GetPagesFor(_tx, page);
+            var (allPages, freePages) = Container.GetPagesFor(_tx, (ContainerId)page);
             
             // cannot use GetPageHeader since we are reading not just from the header
             var root = new Container(_tx.GetPage(page));

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -52,7 +52,7 @@ namespace Voron.Debugging
         public List<JournalFile> Journals;
         public JournalFile[] FlushedJournals { get; set; }
         public List<Table> Tables;
-        public Dictionary<Slice, long> Containers;
+        public Dictionary<Slice, ContainerId> Containers;
         public List<PostingList> PostingLists;
         public List<PersistentDictionaryRootHeader> PersistentDictionaries;
         public List<Lookup<Int64LookupKey>> NumericLookups;
@@ -139,7 +139,7 @@ namespace Voron.Debugging
                                         string nestedReportName = treeReport.Name + "/" + nestedReport.Name;
                                         nestedReport.Name = nestedReportName +" (CompactTree)";
                                         trees.Add(nestedReport);
-                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", (long)textLookup.State.TermsContainerId, input.IncludeDetails));
+                                        trees.Add(GetContainerReport(nestedReportName +" (Entries)", textLookup.State.TermsContainerId, input.IncludeDetails));
                                     }
                                     break;
                                 case RootObjectType.EmbeddedFixedSizeTree:
@@ -497,14 +497,14 @@ namespace Voron.Debugging
             return treeReport;
         }
 
-        public TreeReport GetContainerReport(string name, long page, bool includeDetails)
+        public TreeReport GetContainerReport(string name, ContainerId page, bool includeDetails)
         {
             List<double> pageDensities = null;
 
             if (includeDetails)
             {
                 pageDensities = new();
-                var it = Container.GetAllPagesIterator(_tx, (ContainerId)page);
+                var it = Container.GetAllPagesIterator(_tx, page);
                 while (it.MoveNext(out var pageNum))
                 {
                     // cannot use GetPageHeader since we are reading not just from the header
@@ -522,10 +522,10 @@ namespace Voron.Debugging
                 }
             }
             
-            var (allPages, freePages) = Container.GetPagesFor(_tx, (ContainerId)page);
+            var (allPages, freePages) = Container.GetPagesFor(_tx, page);
             
             // cannot use GetPageHeader since we are reading not just from the header
-            var root = new Container(_tx.GetPage(page));
+            var root = new Container(_tx.GetPage((long)page));
             double density = pageDensities?.Average() ?? -1;
             long totalPages = allPages.State.NumberOfEntries + root.Header.NumberOfOverflowPages + freePages.State.PageCount + allPages.State.PageCount;
             var treeReport = new TreeReport

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -200,11 +200,11 @@ namespace Voron.Impl
                 *((ContainerRootHeader*)ptr) = new ContainerRootHeader
                 {
                     RootObjectType = RootObjectType.Container,
-                    ContainerId = id
+                    ContainerId = (long)id
                 };
-            
-            
-            return id;
+
+
+            return (long)id;
         }
 
         public PostingList OpenPostingList(string name)
@@ -736,13 +736,13 @@ namespace Voron.Impl
             LowLevelTransaction.RootObjects.Forget(name);
         }
 
-        public Container.TransactionState GetContainerState(long containerId)
+        public Container.TransactionState GetContainerState(ContainerId containerId)
         {
             _containers ??= new Dictionary<long, Container.TransactionState>();
-            if (_containers.TryGetValue(containerId, out var state))
+            if (_containers.TryGetValue((long)containerId, out var state))
                 return state;
             state = new Container.TransactionState(containerId);
-            _containers[containerId] = state;
+            _containers[(long)containerId] = state;
             return state;
         }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -167,7 +167,7 @@ namespace Voron.Impl
             _lowLevelTransaction.EndAsyncCommit();
         }
 
-        public long OpenContainer(string name)
+        public ContainerId OpenContainer(string name)
         {
             using (Slice.From(Allocator, name, ByteStringType.Immutable, out Slice nameSlice))
             {
@@ -187,12 +187,12 @@ namespace Voron.Impl
             return LowLevelTransaction.RootObjects.LookupFor<TKey>(name);
         }
 
-        public long OpenContainer(Slice name)
+        public ContainerId OpenContainer(Slice name)
         {
             var exists = LowLevelTransaction.RootObjects.DirectRead(name);
             if (exists != null)
             {
-                return ((ContainerRootHeader*)exists)->ContainerId;
+                return new ContainerId(((ContainerRootHeader*)exists)->ContainerId);
             }
             var id = Container.Create(LowLevelTransaction);
 
@@ -204,7 +204,7 @@ namespace Voron.Impl
                 };
 
 
-            return (long)id;
+            return id;
         }
 
         public PostingList OpenPostingList(string name)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -18,6 +18,7 @@ using Sparrow.Server.Utils;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron.Data;
+using Voron.Data.Containers;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Compression;
@@ -1300,10 +1301,10 @@ namespace Voron
             {
                 r.Add(container, name);
                 var overflowName = $"{name}/OverflowPage";
-                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, container);
+                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, (ContainerId)container);
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");
                 RegisterPages(freePages.AllPages(), name + "/FreePagesSet");
-                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, container);
+                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, (ContainerId)container);
                 while (iterator.MoveNext(out var page))
                 {
                     var pageObject = tx.LowLevelTransaction.GetPage(page);
@@ -1321,9 +1322,9 @@ namespace Voron
             void RegisterLookup(Lookup<Int64LookupKey> numeric, string name)
             {
                 RegisterPages(numeric.AllPages(), name);
-                if (numeric.State.TermsContainerId > 0)
+                if ((long)numeric.State.TermsContainerId > 0)
                 {
-                    RegisterContainer(numeric.State.TermsContainerId, name + "/TermsContainer");
+                    RegisterContainer((long)numeric.State.TermsContainerId, name + "/TermsContainer");
                 }
             }
         }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1228,7 +1228,7 @@ namespace Voron
                                 }
                                 break;
                             case RootObjectType.Container:
-                                long container = tx.OpenContainer(currentKey);
+                                var container = tx.OpenContainer(currentKey);
                                 RegisterContainer(container, name);
                                 break;
                             case RootObjectType.Set:
@@ -1297,14 +1297,14 @@ namespace Voron
                 }
             }
 
-            void RegisterContainer(long container, string name)
+            void RegisterContainer(ContainerId container, string name)
             {
-                r.Add(container, name);
+                r.Add((long)container, name);
                 var overflowName = $"{name}/OverflowPage";
-                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, (ContainerId)container);
+                var (allPages, freePages) = Voron.Data.Containers.Container.GetPagesFor(tx.LowLevelTransaction, container);
                 RegisterPages(allPages.AllPages(), name + "/AllPagesSet");
                 RegisterPages(freePages.AllPages(), name + "/FreePagesSet");
-                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, (ContainerId)container);
+                var iterator = Voron.Data.Containers.Container.GetAllPagesIterator(tx.LowLevelTransaction, container);
                 while (iterator.MoveNext(out var page))
                 {
                     var pageObject = tx.LowLevelTransaction.GetPage(page);
@@ -1324,7 +1324,7 @@ namespace Voron
                 RegisterPages(numeric.AllPages(), name);
                 if ((long)numeric.State.TermsContainerId > 0)
                 {
-                    RegisterContainer((long)numeric.State.TermsContainerId, name + "/TermsContainer");
+                    RegisterContainer(numeric.State.TermsContainerId, name + "/TermsContainer");
                 }
             }
         }
@@ -1393,7 +1393,7 @@ namespace Voron
                                 detailedReportInput.Tables.Add(table);
                                 break;
                             case RootObjectType.Container:
-                                long container = tx.OpenContainer(currentKey);
+                                var container = tx.OpenContainer(currentKey);
                                 detailedReportInput.Containers[currentKey] = container;
                                 break;
                             case RootObjectType.Set:

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -70,7 +70,7 @@ public class FacetIndexingRepro : StorageTest
     {
         using (var wtx = Env.WriteTransaction())
         {
-            var c = wtx.OpenContainer("test");
+            var c = (ContainerId)wtx.OpenContainer("test");
 
             var items = Items;
             for (int i = 0; i < items.Length; i++)
@@ -81,7 +81,7 @@ public class FacetIndexingRepro : StorageTest
                         Container.Allocate(wtx.LowLevelTransaction, c, items[i].Item2, out _);
                         break;
                     case '-':
-                        Container.Delete(wtx.LowLevelTransaction, c, items[i].Item2);
+                        Container.Delete(wtx.LowLevelTransaction, c, (ContainerEntryId)items[i].Item2);
                         break;
                 }
             }

--- a/test/FastTests/Corax/Bugs/RavenDB-21223.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21223.cs
@@ -20,11 +20,11 @@ namespace FastTests.Corax.Bugs
         [RavenFact(RavenTestCategory.Voron)]
         public void ContainerAllocateDeleteAndAllocate()
         {
-            List<long> toDelete = new();
+            List<ContainerEntryId> toDelete = new();
 
             {
                 using var wtx = Env.WriteTransaction();
-                var rootContainer = wtx.OpenContainer("TestContainer");
+                var rootContainer = (ContainerId)wtx.OpenContainer("TestContainer");
                 for (int i = 0; i < 1000; i++)
                 {
                     var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);
@@ -37,7 +37,7 @@ namespace FastTests.Corax.Bugs
 
             {
                 using var wtx = Env.WriteTransaction();
-                var rootContainer = wtx.OpenContainer("TestContainer");
+                var rootContainer = (ContainerId)wtx.OpenContainer("TestContainer");
                 for (int i = 0; i < 1000; i++)
                 {
                     var allocatedPage = Container.Allocate(wtx.LowLevelTransaction, rootContainer, 50, out var space);

--- a/test/FastTests/Corax/Bugs/RavenDB-21272.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-21272.cs
@@ -3,6 +3,7 @@ using System.Text;
 using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,7 +37,7 @@ public class RavenDB_21272 : StorageTest
                 keys[i].Key.Set(Encoding.UTF8.GetBytes(i.ToString("00000")));
                 keys[i].Key.ChangeDictionary(tree.DictionaryId);
                 keys[i].Key.EncodedWithCurrent(out _);
-                keys[i].ContainerId = -1;
+                keys[i].ContainerId = ContainerEntryId.Invalid;
                 vals[i] = 100000 + i;
             }
 
@@ -61,7 +62,7 @@ public class RavenDB_21272 : StorageTest
                     {
                         for (int j = i; j < num; j++)
                         {
-                            k[j].ContainerId = -1;
+                            k[j].ContainerId = ContainerEntryId.Invalid;
                         }
                         i++;
                         if (separatorIndex == -1)
@@ -91,7 +92,7 @@ public class RavenDB_21272 : StorageTest
             k = keys.Skip(10).Take(separatorIndex-10).Concat(new[]{keys[separatorIndex]}).ToArray();
             for (int i = 0; i < k.Length; i++)
             {
-                k[i].ContainerId = -1;
+                k[i].ContainerId = ContainerEntryId.Invalid;
             }
             v = vals;
             o = offsets;
@@ -117,7 +118,7 @@ public class RavenDB_21272 : StorageTest
                     {
                         for (int j = i; j < num; j++)
                         {
-                            k[j].ContainerId = -1;
+                            k[j].ContainerId = ContainerEntryId.Invalid;
                         }
                         break;
                     }

--- a/test/FastTests/Voron/Containers/ContainerTests.cs
+++ b/test/FastTests/Voron/Containers/ContainerTests.cs
@@ -35,7 +35,7 @@ namespace FastTests.Voron.Containers
         public void CanScanValues()
         {
             var expected = new List<long>();
-            long containerId;
+            ContainerId containerId;
 
             using (var wtx = Env.WriteTransaction())
             {
@@ -44,13 +44,13 @@ namespace FastTests.Voron.Containers
                 for (int i = 0; i < 1024; i++)
                 {
                     var id = Container.Allocate(wtx.LowLevelTransaction, containerId, 8, out _);
-                    expected.Add(id);
+                    expected.Add((long)id);
                 }
 
                 for (int i = 0; i < 16; i++)
                 {
                     var id = Container.Allocate(wtx.LowLevelTransaction, containerId, 10_000, out _);
-                    expected.Add(id);
+                    expected.Add((long)id);
                 }
 
                 wtx.Commit();
@@ -76,7 +76,7 @@ namespace FastTests.Voron.Containers
             var containerId = Container.Create(wtx.LowLevelTransaction);
 
             Span<byte> expected = Encoding.UTF8.GetBytes("Stav");
-            var ids = new List<long>();
+            var ids = new List<ContainerEntryId>();
 
             for (int i = 0; i < 16; i++)
             {
@@ -117,7 +117,7 @@ namespace FastTests.Voron.Containers
             var containerId = Container.Create(wtx.LowLevelTransaction);
 
             Span<byte> expected = Encoding.UTF8.GetBytes("Stav");
-            var ids = new List<long>();
+            var ids = new List<ContainerEntryId>();
 
             for (int i = 0; i < 16; i++)
             {
@@ -139,8 +139,8 @@ namespace FastTests.Voron.Containers
         [RavenFact(RavenTestCategory.Voron)]
         public void CanStoreDeleteAndRecoverSpaceForOverflowPage()
         {
-            long containerItemId;
-            long containerId;
+            ContainerEntryId containerItemId;
+            ContainerId containerId;
             long pageId;
             int overflowPageCount;
             const string name = "maciej";
@@ -158,7 +158,7 @@ namespace FastTests.Voron.Containers
             {
                 using var wtx = Env.WriteTransaction();
                 var container = Container.GetMutable(wtx.LowLevelTransaction, containerItemId);
-                (pageId, _) = Math.DivRem(containerItemId, Constants.Storage.PageSize);
+                (pageId, _) = Math.DivRem((long)containerItemId, Constants.Storage.PageSize);
                 var page = wtx.LowLevelTransaction.ModifyPage(pageId);
                 Assert.True(page.IsOverflow);
                 overflowPageCount = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(page.OverflowSize);

--- a/test/SlowTests/Corax/DeleteTest.cs
+++ b/test/SlowTests/Corax/DeleteTest.cs
@@ -93,7 +93,7 @@ public class DeleteTest : StorageTest
             Assert.True(terms!.TryGetValue("9", out var containerId));
             Assert.NotEqual(0, containerId & (long)TermIdMask.PostingList);
             var setId = EntryIdEncodings.DecodeAndDiscardFrequency(containerId);
-            var setStateSpan = Container.GetMutable(llt, setId);
+            var setStateSpan = Container.GetMutable(llt, (ContainerEntryId)setId);
             ref var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             using var _ = Slice.From(llt.Allocator, "Content", ByteStringType.Immutable, out var fieldName);
             var set = new PostingList(llt, fieldName, in setState);

--- a/test/SlowTests/Voron/ContainerSpaceUsageCalculationTests.cs
+++ b/test/SlowTests/Voron/ContainerSpaceUsageCalculationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using FastTests.Voron;
 using FastTests.Voron.FixedSize;
@@ -37,7 +37,7 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
 
             for (int i = 0; i < elementsUsed; i++)
             {
-                Container.Allocate(llt: wTx.LowLevelTransaction, containerId: currentContainer, size: random.Next(17, 512), out var memory);
+                Container.Allocate(llt: wTx.LowLevelTransaction, containerId: (ContainerId)currentContainer, size: random.Next(17, 512), out var memory);
                 
                 memory.Fill((byte)random.Next(0, byte.MaxValue +1));
             }
@@ -74,11 +74,11 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
         if (iterations > elementsUsed)
             elementsUsed = iterations;
         
-        long[] containersToRemove = new long[elementsUsed];
-        long rootContainerPage;
+        ContainerEntryId[] containersToRemove = new ContainerEntryId[elementsUsed];
+        ContainerId rootContainerPage;
         using (var wTx = Env.WriteTransaction())
         {
-            rootContainerPage = wTx.OpenContainer(nameof(ContainerSpaceUsageCalculationTests));
+            rootContainerPage = (ContainerId)wTx.OpenContainer(nameof(ContainerSpaceUsageCalculationTests));
             for (int i = 0; i < elementsUsed; i++)
             {
                 containersToRemove[i] = Container.Allocate(llt: wTx.LowLevelTransaction, containerId: rootContainerPage, size: random.Next(1, 512), out var memory);
@@ -88,7 +88,7 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
             wTx.Commit();
         }
 
-        AssertSpaceUsedInItems(rootContainerPage, -1);
+        AssertSpaceUsedInItems((long)rootContainerPage, -1);
         
         var perIteration = Enumerable.Repeat(elementsUsed / iterations, iterations).ToArray();
         perIteration[^1] += elementsUsed - perIteration.Sum(); // Make sure we remove all elements now
@@ -111,14 +111,14 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
                     wTx.Commit();
                 }
 
-                AssertSpaceUsedInItems(rootContainerPage, itCount);
+                AssertSpaceUsedInItems((long)rootContainerPage, itCount);
             }
         }
 
-        AssertSpaceUsedInItems(rootContainerPage, iterations);
+        AssertSpaceUsedInItems((long)rootContainerPage, iterations);
         using (var rTx = Env.ReadTransaction())
         {
-            var rootPage = rTx.LowLevelTransaction.GetPage(rootContainerPage);
+            var rootPage = rTx.LowLevelTransaction.GetPage((long)rootContainerPage);
             var rootContainer = new Container(rootPage);
 
             var hasEntries = false;

--- a/test/SlowTests/Voron/ContainerSpaceUsageCalculationTests.cs
+++ b/test/SlowTests/Voron/ContainerSpaceUsageCalculationTests.cs
@@ -48,7 +48,7 @@ public class ContainerSpaceUsageCalculationTests(ITestOutputHelper output) : Sto
         using (var rTx = Env.ReadTransaction())
         {
             var currentContainer = rTx.OpenContainer(nameof(ContainerSpaceUsageCalculationTests));
-            var rootPage = rTx.LowLevelTransaction.GetPage(currentContainer);
+            var rootPage = rTx.LowLevelTransaction.GetPage((long)currentContainer);
             var rootContainer = new Container(rootPage);
 
             var spaceUsedFromMethod = rootContainer.SpaceUsedInItems(rootPage.Pointer, out var usedItemsFromMethod);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24624

### Additional description

Backport to v6.2, we still need both because there are some changes. We should apply on v6.2 and then when that change is available, we should apply the v7.0 after changes become available. (v7.0 won't compile with this PR applied)
See: https://github.com/ravendb/ravendb/pull/21085

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
