### PR TITLE
RavenDB-24809 Fixing logging for CertificateExecTimeout if an executable won't exit in a given timeout

### DIFF
--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -464,6 +464,7 @@ namespace Raven.Server.ServerWide
             var ms = new MemoryStream();
             var readErrors = process.StandardError.ReadToEndAsync();
             var readStdOut = process.StandardOutput.BaseStream.CopyToAsync(ms);
+            var timeoutInMs = (int)_config.CertificateExecTimeout.AsTimeSpan.TotalMilliseconds;
 
             string GetStdError()
             {
@@ -477,20 +478,20 @@ namespace Raven.Server.ServerWide
                 }
             }
 
-            if (process.WaitForExit((int)_config.CertificateExecTimeout.AsTimeSpan.TotalMilliseconds) == false)
+            if (process.WaitForExit(timeoutInMs) == false)
             {
                 process.Kill();
-                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {_config.CertificateExecTimeout} ms but the process didn't exit. Stderr: {GetStdError()}");
+                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {timeoutInMs} ms but the process didn't exit. Stderr: {GetStdError()}");
             }
 
             try
             {
-                readStdOut.Wait(_config.CertificateExecTimeout.AsTimeSpan);
-                readErrors.Wait(_config.CertificateExecTimeout.AsTimeSpan);
+                readStdOut.Wait(timeoutInMs);
+                readErrors.Wait(timeoutInMs);
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {_config.CertificateExecTimeout} ms but the process didn't exit. Stderr: {GetStdError()}", e);
+                throw new InvalidOperationException($"Unable to get certificate by executing {executable} {args}, waited for {timeoutInMs} ms but the process didn't exit. Stderr: {GetStdError()}", e);
             }
 
             if (Logger.IsOperationsEnabled)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24809/Faulty-logging-for-CertificateExecTimeout

### Additional description

It fixes the logging issue

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
