### PR TITLE
RavenDB-24791 - ai-agent parameters of primitive types

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
@@ -1,0 +1,289 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_24791 : RavenTestBase
+    {
+        public RavenDB_24791(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class QuestionOutputSchema
+        {
+            public string Answer = "Combined answer of the answers for the questions ";
+
+            public List<string> RelevantQuestionsIds = ["The questions ids relevant to the query or response"];
+        }
+
+        private class Question
+        {
+            public string Id { get; set; }
+            public string Author { get; set; }
+            public int Priority { get; set; }
+            public bool ShouldAnswer { get; set; }
+            public string ActualQuestion { get; set; }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ArrayParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Question { Id = "Questions/16", Author = "Aviv", ActualQuestion = "Is Russia still at war?" });
+                await session.StoreAsync(new Question { Id = "Questions/17", Author = "Karmel", ActualQuestion = "What time is it in Israel?" });
+                await session.StoreAsync(new Question { Id = "Questions/18", Author = "Shahar", ActualQuestion = "What time is it in Italy?" });
+
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("knowledge-agent",
+                config.ConnectionStringName,
+                "You are an ai agent that answer knowledge questions"
+            )
+            {
+                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats"},
+                Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "QuestionsSearch",
+                        Description = "search questions",
+                        Query = "from 'Questions' where Author in ($authors)",
+                        ParametersSampleObject = "{}"
+                    }
+                ]
+            };
+
+            agent.Parameters.Add(new AiAgentParameter("authors"));
+
+            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
+            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+                createResult.Identifier,
+                parameters: new Dictionary<string, object>() { { "authors", new string[] { "Aviv" } } });
+
+            chat.SetUserPrompt("Can you answer the questions?");
+            var more = await chat.RunAsync(CancellationToken.None);
+            Assert.True(more == AiConversationResult.Done);
+
+            var aviv = chat.Answer;
+            Assert.NotNull(aviv.Answer);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                Assert.Equal(1, toolCallAnswer.Count);
+                Assert.Equal("Aviv", toolCallAnswer.FirstOrDefault()?.Author);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task IntParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Question { Id = "Questions/16", Author = "Aviv", Priority = 10, ActualQuestion = "Is Russia still at war?" });
+                await session.StoreAsync(new Question { Id = "Questions/17", Author = "Karmel", Priority = 20, ActualQuestion = "What time is it in Israel?" });
+                await session.StoreAsync(new Question { Id = "Questions/18", Author = "Shahar", Priority = 30, ActualQuestion = "What time is it in Italy?" });
+
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("knowledge-agent",
+                config.ConnectionStringName,
+                "You are an ai agent that answer knowledge questions"
+            )
+            {
+                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats" },
+                Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "QuestionsSearch",
+                        Description = "search questions",
+                        Query = "from 'Questions' where Priority>=$priority",
+                        ParametersSampleObject = "{}"
+                    }
+                ]
+            };
+
+            agent.Parameters.Add(new AiAgentParameter("priority"));
+            int priority = 25;
+
+            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
+            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+                createResult.Identifier,
+                parameters: new Dictionary<string, object>() { { "priority", priority } });
+
+            chat.SetUserPrompt("Can you answer the questions?");
+            var more = await chat.RunAsync(CancellationToken.None);
+            Assert.True(more == AiConversationResult.Done);
+
+            var shahar = chat.Answer;
+            Assert.NotNull(shahar.Answer);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                Assert.Equal(1, toolCallAnswer.Count);
+                Assert.Equal("Shahar", toolCallAnswer.FirstOrDefault()?.Author);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task DoubleParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Question { Id = "Questions/16", Author = "Aviv", Priority = 10, ActualQuestion = "Is Russia still at war?" });
+                await session.StoreAsync(new Question { Id = "Questions/17", Author = "Karmel", Priority = 20, ActualQuestion = "What time is it in Israel?" });
+                await session.StoreAsync(new Question { Id = "Questions/18", Author = "Shahar", Priority = 30, ActualQuestion = "What time is it in Italy?" });
+
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("knowledge-agent",
+                config.ConnectionStringName,
+                "You are an ai agent that answer knowledge questions"
+            )
+            {
+                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats" },
+                Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "QuestionsSearch",
+                        Description = "search questions",
+                        Query = "from 'Questions' where Priority>=$priority",
+                        ParametersSampleObject = "{}"
+                    }
+                ]
+            };
+
+            agent.Parameters.Add(new AiAgentParameter("priority"));
+            double priority = 25.7;
+
+            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
+            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+                createResult.Identifier,
+                parameters: new Dictionary<string, object>() { { "priority", priority } });
+
+            chat.SetUserPrompt("Can you answer the questions?");
+            var more = await chat.RunAsync(CancellationToken.None);
+            Assert.True(more == AiConversationResult.Done);
+
+            var shahar = chat.Answer;
+            Assert.NotNull(shahar.Answer);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                Assert.Equal(1, toolCallAnswer.Count);
+                Assert.Equal("Shahar", toolCallAnswer.FirstOrDefault()?.Author);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task BoolParameter(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Question { Id = "Questions/16", ShouldAnswer = false, Author = "Aviv", Priority = 10, ActualQuestion = "Is Russia still at war?" });
+                await session.StoreAsync(new Question { Id = "Questions/17", ShouldAnswer = true, Author = "Karmel", Priority = 20, ActualQuestion = "What time is it in Israel?" });
+                await session.StoreAsync(new Question { Id = "Questions/18", ShouldAnswer = false, Author = "Shahar", Priority = 30, ActualQuestion = "What time is it in Italy?" });
+
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("knowledge-agent",
+                config.ConnectionStringName,
+                "You are an ai agent that answer knowledge questions"
+            )
+            {
+                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats" },
+                Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "QuestionsSearch",
+                        Description = "search questions",
+                        Query = "from 'Questions' where ShouldAnswer==$shouldAnswer",
+                        ParametersSampleObject = "{}"
+                    }
+                ]
+            };
+            agent.Parameters.Add(new AiAgentParameter("shouldAnswer"));
+            agent.Persistence = new AiAgentPersistenceConfiguration("Chats/");
+
+            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
+            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+                createResult.Identifier,
+                parameters: new Dictionary<string, object>() { { "shouldAnswer", true } });
+
+            chat.SetUserPrompt("Can you answer the questions?");
+            var more = await chat.RunAsync(CancellationToken.None);
+            Assert.True(more == AiConversationResult.Done);
+
+            var shahar = chat.Answer;
+            Assert.NotNull(shahar.Answer);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                Assert.Equal(1, toolCallAnswer.Count);
+                Assert.Equal("Karmel", toolCallAnswer.FirstOrDefault()?.Author);
+            }
+        }
+
+        private class Chat
+        {
+            public List<ChatMessage> Messages { get; set; }
+        }
+
+        public class ChatMessage
+        {
+            [JsonPropertyName("role")]
+            public string Role { get; set; }
+
+            [JsonPropertyName("content")]
+            public string Content { get; set; }
+
+            [JsonPropertyName("date")]
+            public DateTime Date { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
@@ -25,6 +25,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
         private class QuestionOutputSchema
         {
+            public static QuestionOutputSchema Instance = new();
+
             public string Answer = "Combined answer of the answers for the questions ";
 
             public List<string> RelevantQuestionsIds = ["The questions ids relevant to the query or response"];
@@ -60,7 +62,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "You are an ai agent that answer knowledge questions"
             )
             {
-                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats"},
                 Queries =
                 [
                     new AiAgentToolQuery
@@ -75,16 +76,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             agent.Parameters.Add(new AiAgentParameter("authors"));
 
-            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
-            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+            var createResult = await store.AI.CreateAgentAsync(agent, QuestionOutputSchema.Instance);
+            var chat = store.AI.Conversation(
                 createResult.Identifier,
-                parameters: new Dictionary<string, object>() { { "authors", new string[] { "Aviv" } } });
+                "Chats/",
+                new AiConversationCreationOptions().AddParameter("authors", new string[] { "Aviv" }));
 
             chat.SetUserPrompt("Can you answer the questions?");
-            var more = await chat.RunAsync(CancellationToken.None);
-            Assert.True(more == AiConversationResult.Done);
+            var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
+            Assert.True(more.Status == AiConversationResult.Done);
 
-            var aviv = chat.Answer;
+            var aviv = more.Answer;
             Assert.NotNull(aviv.Answer);
 
             using (var session = store.OpenAsyncSession())
@@ -117,7 +119,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "You are an ai agent that answer knowledge questions"
             )
             {
-                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats" },
                 Queries =
                 [
                     new AiAgentToolQuery
@@ -133,16 +134,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             agent.Parameters.Add(new AiAgentParameter("priority"));
             int priority = 25;
 
-            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
-            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+            var createResult = await store.AI.CreateAgentAsync(agent, QuestionOutputSchema.Instance);
+            var chat = store.AI.Conversation(
                 createResult.Identifier,
-                parameters: new Dictionary<string, object>() { { "priority", priority } });
+                "Chats/",
+                new AiConversationCreationOptions().AddParameter("priority", priority));
 
             chat.SetUserPrompt("Can you answer the questions?");
-            var more = await chat.RunAsync(CancellationToken.None);
-            Assert.True(more == AiConversationResult.Done);
+            var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
+            Assert.True(more.Status == AiConversationResult.Done);
 
-            var shahar = chat.Answer;
+            var shahar = more.Answer;
             Assert.NotNull(shahar.Answer);
 
             using (var session = store.OpenAsyncSession())
@@ -175,7 +177,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "You are an ai agent that answer knowledge questions"
             )
             {
-                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats" },
                 Queries =
                 [
                     new AiAgentToolQuery
@@ -191,16 +192,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             agent.Parameters.Add(new AiAgentParameter("priority"));
             double priority = 25.7;
 
-            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
-            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+            var createResult = await store.AI.CreateAgentAsync(agent, QuestionOutputSchema.Instance);
+            var chat = store.AI.Conversation(
                 createResult.Identifier,
-                parameters: new Dictionary<string, object>() { { "priority", priority } });
+                "Chats/",
+                new AiConversationCreationOptions().AddParameter("priority", priority));
 
             chat.SetUserPrompt("Can you answer the questions?");
-            var more = await chat.RunAsync(CancellationToken.None);
-            Assert.True(more == AiConversationResult.Done);
+            var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
+            Assert.True(more.Status == AiConversationResult.Done);
 
-            var shahar = chat.Answer;
+            var shahar = more.Answer;
             Assert.NotNull(shahar.Answer);
 
             using (var session = store.OpenAsyncSession())
@@ -233,7 +235,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "You are an ai agent that answer knowledge questions"
             )
             {
-                Persistence = new AiAgentPersistenceConfiguration { ConversationIdPrefix = "Chats" },
                 Queries =
                 [
                     new AiAgentToolQuery
@@ -246,18 +247,19 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 ]
             };
             agent.Parameters.Add(new AiAgentParameter("shouldAnswer"));
-            agent.Persistence = new AiAgentPersistenceConfiguration("Chats/");
 
-            var createResult = await store.AI.CreateAgentAsync<QuestionOutputSchema>(agent);
-            var chat = store.AI.StartConversation<QuestionOutputSchema>(
+            var createResult = await store.AI.CreateAgentAsync(agent, QuestionOutputSchema.Instance);
+
+            var chat = store.AI.Conversation(
                 createResult.Identifier,
-                parameters: new Dictionary<string, object>() { { "shouldAnswer", true } });
+                "Chats/",
+                new AiConversationCreationOptions().AddParameter("shouldAnswer", true));
 
             chat.SetUserPrompt("Can you answer the questions?");
-            var more = await chat.RunAsync(CancellationToken.None);
-            Assert.True(more == AiConversationResult.Done);
+            var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
+            Assert.True(more.Status == AiConversationResult.Done);
 
-            var shahar = chat.Answer;
+            var shahar = more.Answer;
             Assert.NotNull(shahar.Answer);
 
             using (var session = store.OpenAsyncSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24791/AI-Agent-Passing-a-nested-object-to-AddParameter-throws-Unknown-type-instead-of-serializing-it

### Additional description

Add tests for scenarios where AI Agent tool calls receive primitive data types (e.g., int, bool) as parameters.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
