### PR TITLE
RavenDB-24102 Reducing await overhead - load document

### DIFF
--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Net.Http;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Server.Documents.Handlers.Processors.Documents;
@@ -29,32 +30,24 @@ namespace Raven.Server.Documents.Handlers
                 await processor.ExecuteAsync();
             }
         }
-
+        
         [RavenAction("/databases/*/docs/size", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetDocSize()
         {
             using (var processor = new DocumentHandlerProcessorForGetDocSize(this))
-            {
                 await processor.ExecuteAsync();
-            }
         }
 
         [RavenAction("/databases/*/docs", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
-        public async Task Get()
+        public Task Get()
         {
-            using (var processor = new DocumentHandlerProcessorForGet(HttpMethod.Get, this))
-            {
-                await processor.ExecuteAsync();
-            }
+            return new DocumentHandlerProcessorForGet(HttpMethod.Get, this).ExecuteAsTaskAsync();
         }
 
         [RavenAction("/databases/*/docs", "POST", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
-        public async Task PostGet()
+        public Task PostGet()
         {
-            using (var processor = new DocumentHandlerProcessorForGet(HttpMethod.Post, this))
-            {
-                await processor.ExecuteAsync();
-            }
+            return new DocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync();
         }
 
         [RavenAction("/databases/*/docs", "DELETE", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -41,12 +41,14 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/docs", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public Task Get()
         {
+            // Disposal of the processor is handled in the `ExecuteAsTaskAsync` method.
             return new DocumentHandlerProcessorForGet(HttpMethod.Get, this).ExecuteAsTaskAsync();
         }
 
         [RavenAction("/databases/*/docs", "POST", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
         public Task PostGet()
         {
+            // Disposal of the processor is handled in the `ExecuteAsTaskAsync` method.
             return new DocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync();
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForDelete.cs
@@ -15,11 +15,12 @@ internal abstract class AbstractDocumentHandlerProcessorForDelete<TRequestHandle
 
     protected abstract ValueTask HandleDeleteDocumentAsync(string docId, string changeVector);
 
-    public override async ValueTask ExecuteAsync()
+    public override ValueTask ExecuteAsync()
     {
+        
         var id = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("id");
         var changeVector = RequestHandler.GetStringFromHeaders(Constants.Headers.IfMatch);
 
-        await HandleDeleteDocumentAsync(id, changeVector);
+        return HandleDeleteDocumentAsync(id, changeVector);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -32,7 +32,8 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Processors.Documents;
 
-internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, TOperationContext, TDocumentType> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+internal abstract class
+    AbstractDocumentHandlerProcessorForGet<TRequestHandler, TOperationContext, TDocumentType> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
     where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
     where TOperationContext : JsonOperationContext
 {
@@ -55,139 +56,145 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
     protected abstract CancellationToken CancellationToken { get; }
 
-    public override async ValueTask ExecuteAsync()
+    public override ValueTask ExecuteAsync() => throw new NotImplementedException();
+    
+    public async Task ExecuteAsTaskAsync()
     {
+        using (this)
         using (ContextPool.AllocateOperationContext(out TOperationContext context))
         {
-            await ExecuteInternalAsync(context);
-        }
-    }
+            var sw = Stopwatch.StartNew();
 
-    protected virtual async ValueTask ExecuteInternalAsync(TOperationContext context)
-    {
-        var sw = Stopwatch.StartNew();
+            var parameters = QueryStringParameters.Create(RequestHandler.HttpContext.Request);
 
-        var parameters = QueryStringParameters.Create(RequestHandler.HttpContext.Request);
-
-        if (_method == HttpMethod.Get)
-        {
-            // no-op - this was parses via QueryStringParameters few lines up
-        }
-        else if (_method == HttpMethod.Post)
-            parameters.Ids = await GetIdsFromRequestBodyAsync(context, RequestHandler);
-        else
-            throw new NotSupportedException($"Unhandled method type: {_method}");
-
-        if (SupportsShowingRequestInTrafficWatch && TrafficWatchManager.HasRegisteredClients)
-            RequestHandler.AddStringToHttpContext(IdsToString(parameters.Ids), TrafficWatchChangeType.Documents);
-
-        (long NumberOfResults, long TotalDocumentsSizeInBytes) responseWriteStats;
-        int pageSize;
-        string actionName;
-
-        if (parameters.Ids is { Count: > 0 })
-        {
-            pageSize = parameters.Ids.Count;
-            actionName = nameof(GetDocumentsByIdAsync);
-
-            var etag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
-
-            // includes
-            var revisions = GetRevisionsToInclude(parameters);
-            var timeSeries = GetTimeSeriesToInclude(parameters);
-
-            responseWriteStats = await GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag);
-        }
-        else
-        {
-            pageSize = RequestHandler.GetPageSize();
-            actionName = nameof(GetDocumentsAsync);
-
-            var changeVector = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
-            var etag = RequestHandler.GetLongQueryString("etag", false);
-
-            var isStartsWith = HttpContext.Request.Query.ContainsKey("startsWith");
-
-            StartsWithParams startsWithParams = null;
-
-            if (isStartsWith)
+            if (_method == HttpMethod.Get)
             {
-                startsWithParams = new StartsWithParams
+                // no-op - this was parses via QueryStringParameters few lines up
+            }
+            else if (_method == HttpMethod.Post)
+                parameters.Ids = await GetIdsFromRequestBodyAsync(context, RequestHandler);
+            else
+                throw new NotSupportedException($"Unhandled method type: {_method}");
+
+            if (SupportsShowingRequestInTrafficWatch && TrafficWatchManager.HasRegisteredClients)
+                RequestHandler.AddStringToHttpContext(IdsToString(parameters.Ids), TrafficWatchChangeType.Documents);
+
+            (long NumberOfResults, long TotalDocumentsSizeInBytes) responseWriteStats;
+            int pageSize;
+            string actionName;
+
+            if (parameters.Ids is { Count: > 0 })
+            {
+                pageSize = parameters.Ids.Count;
+                actionName = nameof(GetDocumentsByIdAsync);
+
+                var etag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+
+                // includes
+                var revisions = GetRevisionsToInclude(parameters);
+                var timeSeries = GetTimeSeriesToInclude(parameters);
+
+                var getDocumentsByIds = GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag);
+                responseWriteStats = getDocumentsByIds.IsCompletedSuccessfully 
+                    ? getDocumentsByIds.Result 
+                    : await getDocumentsByIds.ConfigureAwait(false);
+            }
+            else
+            {
+                pageSize = RequestHandler.GetPageSize();
+                actionName = nameof(GetDocumentsAsync);
+
+                var changeVector = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+                var etag = RequestHandler.GetLongQueryString("etag", false);
+
+                var isStartsWith = HttpContext.Request.Query.ContainsKey("startsWith");
+
+                StartsWithParams startsWithParams = null;
+
+                if (isStartsWith)
                 {
-                    IdPrefix = HttpContext.Request.Query["startsWith"],
-                    Matches = HttpContext.Request.Query["matches"],
-                    Exclude = HttpContext.Request.Query["exclude"],
-                    StartAfterId = HttpContext.Request.Query["startAfter"],
-                };
+                    startsWithParams = new StartsWithParams
+                    {
+                        IdPrefix = HttpContext.Request.Query["startsWith"],
+                        Matches = HttpContext.Request.Query["matches"],
+                        Exclude = HttpContext.Request.Query["exclude"],
+                        StartAfterId = HttpContext.Request.Query["startAfter"],
+                    };
+                }
+
+                var getDocumentsAsync = GetDocumentsAsync(context, etag, startsWithParams, parameters.MetadataOnly, changeVector);
+                
+                
+                responseWriteStats = getDocumentsAsync.IsCompletedSuccessfully 
+                    ? getDocumentsAsync.Result 
+                    : await getDocumentsAsync;
             }
 
-            responseWriteStats = await GetDocumentsAsync(context, etag, startsWithParams, parameters.MetadataOnly, changeVector);
-        }
-
-        if (responseWriteStats != NoResults)
-        {
-            if (RequestHandler.ShouldAddPagingPerformanceHint(responseWriteStats.NumberOfResults))
+            if (responseWriteStats != NoResults)
             {
-                string details;
+                if (RequestHandler.ShouldAddPagingPerformanceHint(responseWriteStats.NumberOfResults))
+                {
+                    string details;
 
-                if (parameters.Ids is { Count: > 0 })
-                    details = CreatePerformanceHintDetails();
-                else
-                    details = HttpContext.Request.QueryString.Value;
+                    if (parameters.Ids is { Count: > 0 })
+                        details = CreatePerformanceHintDetails();
+                    else
+                        details = HttpContext.Request.QueryString.Value;
 
-                RequestHandler.AddPagingPerformanceHint(
-                    PagingOperationType.Documents,
-                    actionName,
-                    details,
-                    responseWriteStats.NumberOfResults,
-                    pageSize,
-                    sw.ElapsedMilliseconds,
-                    responseWriteStats.TotalDocumentsSizeInBytes);
+                    RequestHandler.AddPagingPerformanceHint(
+                        PagingOperationType.Documents,
+                        actionName,
+                        details,
+                        responseWriteStats.NumberOfResults,
+                        pageSize,
+                        sw.ElapsedMilliseconds,
+                        responseWriteStats.TotalDocumentsSizeInBytes);
+                }
             }
-        }
 
-        string CreatePerformanceHintDetails()
-        {
-            var sb = new StringBuilder();
-            var addedIdsCount = 0;
-            var first = true;
-
-            while (sb.Length < 1024 && addedIdsCount < parameters.Ids.Count)
+            string CreatePerformanceHintDetails()
             {
-                if (first == false)
-                    sb.Append(", ");
-                else
-                    first = false;
+                var sb = new StringBuilder();
+                var addedIdsCount = 0;
+                var first = true;
 
-                sb.Append($"{parameters.Ids[addedIdsCount++]}");
+                while (sb.Length < 1024 && addedIdsCount < parameters.Ids.Count)
+                {
+                    if (first == false)
+                        sb.Append(", ");
+                    else
+                        first = false;
+
+                    sb.Append($"{parameters.Ids[addedIdsCount++]}");
+                }
+
+                var idsLeftCount = parameters.Ids.Count - addedIdsCount;
+
+                if (idsLeftCount > 0)
+                {
+                    sb.Append($" ... (and {idsLeftCount} more)");
+                }
+
+                return sb.ToString();
             }
 
-            var idsLeftCount = parameters.Ids.Count - addedIdsCount;
-
-            if (idsLeftCount > 0)
+            static string IdsToString(List<ReadOnlyMemory<char>> ids)
             {
-                sb.Append($" ... (and {idsLeftCount} more)");
+                if (ids == null || ids.Count == 0)
+                    return string.Empty;
+
+                var sb = new StringBuilder();
+                for (int i = 0; i < ids.Count; i++)
+                {
+                    if (i != 0)
+                        sb.Append(",");
+
+                    ReadOnlyMemory<char> id = ids[i];
+                    sb.Append(id.ToString());
+                }
+
+                return sb.ToString();
             }
-
-            return sb.ToString();
-        }
-
-        static string IdsToString(List<ReadOnlyMemory<char>> ids)
-        {
-            if (ids == null || ids.Count == 0)
-                return string.Empty;
-
-            var sb = new StringBuilder();
-            for (int i = 0; i < ids.Count; i++)
-            {
-                if (i != 0)
-                    sb.Append(",");
-
-                ReadOnlyMemory<char> id = ids[i];
-                sb.Append(id.ToString());
-            }
-
-            return sb.ToString();
         }
     }
 
@@ -195,7 +202,13 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         QueryStringParameters parameters, RevisionIncludeField revisions, HashSet<AbstractTimeSeriesRange> timeSeries, string etag)
     {
         var clusterWideTx = parameters.TxMode == TransactionMode.ClusterWide;
-        var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag);
+        var getDocumentsByIdImplAsyncTask = GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries,
+            parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag);
+
+        var result = getDocumentsByIdImplAsyncTask.IsCompletedSuccessfully 
+            ? getDocumentsByIdImplAsyncTask.Result 
+            : await getDocumentsByIdImplAsyncTask;
+
 
         if (result.StatusCode == HttpStatusCode.NotFound)
         {
@@ -216,7 +229,11 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
         HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + result.Etag + "\"";
 
-        return await WriteDocumentsByIdResultAsync(context, parameters.MetadataOnly, clusterWideTx, result);
+        var writeDocumentsByIdResult = WriteDocumentsByIdResultAsync(context, parameters.MetadataOnly, clusterWideTx, result);
+
+        return writeDocumentsByIdResult.IsCompletedSuccessfully
+            ? writeDocumentsByIdResult.Result
+            : await writeDocumentsByIdResult.ConfigureAwait(false);
     }
 
     private async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsByIdResultAsync(
@@ -230,24 +247,35 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
             writer.WritePropertyName(nameof(GetDocumentsResult.Results));
 
-            (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
+            var writeDocumentsValueTaskAsync = WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
+            
+            (numberOfResults, totalDocumentsSizeInBytes) = writeDocumentsValueTaskAsync.IsCompletedSuccessfully 
+                ? writeDocumentsValueTaskAsync.Result 
+                : await writeDocumentsValueTaskAsync;
+
 
             writer.WriteComma();
 
-            await WriteIncludesAsync(writer, context, nameof(GetDocumentsResult.Includes), result.Includes, CancellationToken);
+            var includeAsync = WriteIncludesAsync(writer, context, nameof(GetDocumentsResult.Includes), result.Includes, CancellationToken);
+            if (includeAsync.IsCompletedSuccessfully == false)
+                await includeAsync;
 
             if (result.CounterIncludes?.Count > 0)
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.CounterIncludes));
-                await result.CounterIncludes.WriteIncludesAsync(writer, context, CancellationToken);
+                var writeCounterIncludes = result.CounterIncludes.WriteIncludesAsync(writer, context, CancellationToken);
+                if (writeCounterIncludes.IsCompletedSuccessfully == false)    
+                    await writeCounterIncludes;
             }
 
             if (result.TimeSeriesIncludes?.Count > 0)
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.TimeSeriesIncludes));
-                await result.TimeSeriesIncludes.WriteIncludesAsync(writer, context, CancellationToken);
+                var writeTimeSeries = result.TimeSeriesIncludes.WriteIncludesAsync(writer, context, CancellationToken);
+                if (writeTimeSeries.IsCompletedSuccessfully == false)
+                    await writeTimeSeries;
             }
 
             if (result.RevisionIncludes?.Count > 0)
@@ -255,7 +283,9 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.RevisionIncludes));
                 writer.WriteStartArray();
-                await result.RevisionIncludes.WriteIncludesAsync(writer, context, CancellationToken);
+                var writeRevisionIncludes = result.RevisionIncludes.WriteIncludesAsync(writer, context, CancellationToken);
+                if (writeRevisionIncludes.IsCompletedSuccessfully == false)
+                    await writeRevisionIncludes;
                 writer.WriteEndArray();
             }
 
@@ -263,11 +293,14 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(GetDocumentsResult.CompareExchangeValueIncludes));
-                await writer.WriteCompareExchangeValuesAsync(result.CompareExchangeIncludes, CancellationToken);
+                var writeCompareExchange = writer.WriteCompareExchangeValuesAsync(result.CompareExchangeIncludes, CancellationToken);
+                if (writeCompareExchange.IsCompletedSuccessfully == false)
+                    await writeCompareExchange;
             }
 
             writer.WriteEndObject();
         }
+
         return (numberOfResults, totalDocumentsSizeInBytes);
     }
 
@@ -279,7 +312,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         TOperationContext context,
         IAsyncEnumerable<TDocumentType> documentsToWrite, bool metadataOnly, CancellationToken token);
 
-    protected abstract ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, TOperationContext context, string propertyName,
+    protected abstract ValueTask<(long Count, long SizeInBytes)> WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, TOperationContext context, string propertyName,
         List<TDocumentType> includes, CancellationToken token);
 
     protected abstract ValueTask<DocumentsByIdResult<TDocumentType>> GetDocumentsByIdImplAsync(
@@ -294,10 +327,13 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         bool clusterWideTx,
         string etag);
 
-    protected async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> GetDocumentsAsync(TOperationContext context, long? etag, StartsWithParams startsWith, bool metadataOnly, string changeVector)
+    protected async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> GetDocumentsAsync(TOperationContext context, long? etag,
+        StartsWithParams startsWith, bool metadataOnly, string changeVector)
     {
-        var result = await GetDocumentsImplAsync(context, etag, startsWith, changeVector);
-
+        var getDocuments = GetDocumentsImplAsync(context, etag, startsWith, changeVector);
+        var result = getDocuments.IsCompletedSuccessfully ? getDocuments.Result : await getDocuments;
+        
+        
         if (changeVector == result.Etag)
         {
             HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
@@ -321,7 +357,12 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             }
             else
             {
-                (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
+                var writeDocuments = WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
+
+                (numberOfResults, totalDocumentsSizeInBytes) = writeDocuments.IsCompletedSuccessfully
+                    ? writeDocuments.Result
+                    : await writeDocuments;
+
             }
 
             if (result.ContinuationToken != null)
@@ -345,7 +386,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
         var rif = new RevisionIncludeField();
 
-        if (parameters.RevisionsBefore.HasValue && DateTime.TryParseExact(parameters.RevisionsBefore.Value.Span, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dateTime))
+        if (parameters.RevisionsBefore.HasValue && DateTime.TryParseExact(parameters.RevisionsBefore.Value.Span, DefaultFormat.DateTimeFormatsToRead,
+                CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dateTime))
             rif.RevisionsBeforeDateTime = dateTime.ToUniversalTime();
 
         if (parameters.Revisions != null)
@@ -375,7 +417,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                                                 $"Got : timeseriesNames.Count = {timeSeriesCount}, fromList.Count = {parameters.From.Count}, toList.Count = {parameters.To.Count}.");
 
         var timeSeriesTimesCount = parameters.TimeSeriesTimes?.Count ?? 0;
-        if (timeSeriesTimesCount != parameters.TimeTypes.Count || parameters.TimeTypes.Count != parameters.TimeValues.Count || parameters.TimeValues.Count != parameters.TimeUnits.Count)
+        if (timeSeriesTimesCount != parameters.TimeTypes.Count || parameters.TimeTypes.Count != parameters.TimeValues.Count ||
+            parameters.TimeValues.Count != parameters.TimeUnits.Count)
             throw new InvalidOperationException($"Parameters 'timeseriesTime', 'timeType', 'timeValue' and 'timeUnit' must be of equal length. " +
                                                 $"Got : timeseriesTime.Count = {timeSeriesTimesCount}, timeType.Count = {parameters.TimeTypes.Count}, timeValue.Count = {parameters.TimeValues.Count}, timeUnit.Count = {parameters.TimeUnits.Count}.");
 
@@ -393,12 +436,12 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                 hs.Add(new TimeSeriesRange
                 {
                     Name = parameters.TimeSeries[i].ToString(),
-                    From = string.IsNullOrEmpty(parameters.From[i])
+                    From = parameters.From[i].IsEmpty
                         ? DateTime.MinValue
-                        : TimeSeriesHandlerProcessorForGetTimeSeries.ParseDate(parameters.From[i], "from"),
-                    To = string.IsNullOrEmpty(parameters.To[i])
+                        : TimeSeriesHandlerProcessorForGetTimeSeries.ParseDate(parameters.From[i].Span, "from"),
+                    To = parameters.To[i].IsEmpty
                         ? DateTime.MaxValue
-                        : TimeSeriesHandlerProcessorForGetTimeSeries.ParseDate(parameters.To[i], "to")
+                        : TimeSeriesHandlerProcessorForGetTimeSeries.ParseDate(parameters.To[i].Span, "to")
                 });
             }
         }
@@ -407,18 +450,18 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         {
             for (int i = 0; i < parameters.TimeSeriesTimes.Count; i++)
             {
-                var timeValueUnit = (TimeValueUnit)Enum.Parse(typeof(TimeValueUnit), parameters.TimeUnits[i]);
+                var timeValueUnit = (TimeValueUnit)Enum.Parse(typeof(TimeValueUnit), parameters.TimeUnits[i].Span);
                 if (timeValueUnit == TimeValueUnit.None)
                     throw new InvalidOperationException(
                         $"Got unexpected {nameof(TimeValueUnit)} '{nameof(TimeValueUnit.None)}'. Only the following are supported: '{nameof(TimeValueUnit.Second)}' or '{nameof(TimeValueUnit.Month)}'.");
 
-                if (int.TryParse(parameters.TimeValues[i], out int res) == false)
+                if (int.TryParse(parameters.TimeValues[i].Span, out int res) == false)
                     throw new InvalidOperationException($"Could not parse timeseries time range value.");
 
                 hs.Add(new TimeSeriesTimeRange
                 {
                     Name = parameters.TimeSeriesTimes[i].ToString(),
-                    Type = (TimeSeriesRangeType)Enum.Parse(typeof(TimeSeriesRangeType), parameters.TimeTypes[i]),
+                    Type = (TimeSeriesRangeType)Enum.Parse(typeof(TimeSeriesRangeType), parameters.TimeTypes[i].Span),
                     Time = timeValueUnit == TimeValueUnit.Second ? TimeValue.FromSeconds(res) : TimeValue.FromMonths(res)
                 });
             }
@@ -428,13 +471,13 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         {
             for (int i = 0; i < parameters.TimeSeriesCounts.Count; i++)
             {
-                if (int.TryParse(parameters.CountValues[i], out int res) == false)
+                if (int.TryParse(parameters.CountValues[i].Span, out int res) == false)
                     throw new InvalidOperationException($"Could not parse timeseries count value.");
 
                 hs.Add(new TimeSeriesCountRange
                 {
                     Name = parameters.TimeSeriesCounts[i].ToString(),
-                    Type = (TimeSeriesRangeType)Enum.Parse(typeof(TimeSeriesRangeType), parameters.CountTypes[i]),
+                    Type = (TimeSeriesRangeType)Enum.Parse(typeof(TimeSeriesRangeType), parameters.CountTypes[i].Span),
                     Count = res
                 });
             }
@@ -539,19 +582,19 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
         public bool TimeSeriesCountsHasAllTimeSeries;
 
-        public StringValues From;
+        public List<ReadOnlyMemory<char>> From;
 
-        public StringValues To;
+        public List<ReadOnlyMemory<char>> To;
 
-        public StringValues TimeTypes;
+        public List<ReadOnlyMemory<char>> TimeTypes;
 
-        public StringValues TimeValues;
+        public List<ReadOnlyMemory<char>> TimeValues;
 
-        public StringValues TimeUnits;
+        public List<ReadOnlyMemory<char>> TimeUnits;
 
-        public StringValues CountTypes;
+        public List<ReadOnlyMemory<char>> CountTypes;
 
-        public StringValues CountValues;
+        public List<ReadOnlyMemory<char>> CountValues;
 
         public StringValues CompareExchange;
 
@@ -573,13 +616,13 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             IncludePaths = ConvertToStringValues("include");
             Counters = ConvertToStringValues("counter");
             CompareExchange = ConvertToStringValues("cmpxchg");
-            From = ConvertToStringValues("from");
-            To = ConvertToStringValues("to");
-            TimeTypes = ConvertToStringValues("timeType");
-            TimeValues = ConvertToStringValues("timeValue");
-            TimeUnits = ConvertToStringValues("timeUnit");
-            CountTypes = ConvertToStringValues("countType");
-            CountValues = ConvertToStringValues("countValue");
+            From = RetrieveValues("from");
+            To = RetrieveValues("to");
+            TimeTypes = RetrieveValues("timeType");
+            TimeValues = RetrieveValues("timeValue");
+            TimeUnits = RetrieveValues("timeUnit");
+            CountTypes = RetrieveValues("countType");
+            CountValues = RetrieveValues("countValue");
         }
 
         protected override void OnValue(QueryStringEnumerable.EncodedNameValuePair pair)
@@ -598,7 +641,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                     }
 
                     if (IsMatch(name, ToQueryStringName))
-                        AddForStringValues("to", pair.DecodeValue());  // optimize this
+                        AddForStringValues("to", pair.DecodeValue()); // optimize this
                     return;
                 }
                 case 4:
@@ -614,6 +657,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                         if (TryGetEnumValue<TransactionMode>(pair.EncodedValue, out var value))
                             TxMode = value;
                     }
+
                     return;
                 }
                 case 7:
@@ -634,7 +678,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
                     if (IsMatch(name, CounterQueryStringName))
                         AddForStringValues("counter", pair.DecodeValue()); // optimize this
-                    
+
                     return;
                 }
                 case 8:
@@ -675,7 +719,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                     if (IsMatch(name, CountValueQueryStringName))
                     {
                         AddForStringValues("countValue", pair.DecodeValue()); // optimize this
-                            return;
+                        return;
                     }
 
                     if (IsMatch(name, TimeSeriesQueryStringName))
@@ -709,6 +753,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
                         TimeSeriesTimes.Add(value);
                     }
+
                     return;
                 }
                 case 15:
@@ -718,6 +763,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
                         RevisionsBefore = pair.DecodeValue();
                         return;
                     }
+
                     if (IsMatch(name, TimeSeriesCountsQueryStringName))
                     {
                         TimeSeriesCounts ??= new List<ReadOnlyMemory<char>>(1);
@@ -728,6 +774,7 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
                         TimeSeriesCounts.Add(value);
                     }
+
                     return;
                 }
             }
@@ -741,5 +788,4 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
             return parameters;
         }
     }
-
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -412,20 +412,22 @@ internal abstract class
             throw new InvalidOperationException($"Cannot have more than one include on '{Constants.TimeSeries.All}'.");
 
         var timeSeriesCount = parameters.TimeSeries?.Count ?? 0;
-        if (timeSeriesCount != parameters.From.Count || parameters.From.Count != parameters.To.Count)
+        if (timeSeriesCount != (parameters.From?.Count ?? 0) || (parameters.From?.Count ?? 0) != (parameters.To?.Count ?? 0))
             throw new InvalidOperationException("Parameters 'timeseriesNames', 'fromList' and 'toList' must be of equal length. " +
-                                                $"Got : timeseriesNames.Count = {timeSeriesCount}, fromList.Count = {parameters.From.Count}, toList.Count = {parameters.To.Count}.");
-
+                                                $"Got : timeseriesNames.Count = {timeSeriesCount}, fromList.Count = {parameters.From?.Count ?? 0}, toList.Count = {parameters.To?.Count ?? 0}.");
+        
         var timeSeriesTimesCount = parameters.TimeSeriesTimes?.Count ?? 0;
-        if (timeSeriesTimesCount != parameters.TimeTypes.Count || parameters.TimeTypes.Count != parameters.TimeValues.Count ||
-            parameters.TimeValues.Count != parameters.TimeUnits.Count)
+        if (timeSeriesTimesCount != (parameters.TimeTypes?.Count ?? 0)
+            || (parameters.TimeTypes?.Count ?? 0) != (parameters.TimeValues?.Count ?? 0)
+            || (parameters.TimeValues?.Count ?? 0) != (parameters.TimeUnits?.Count ?? 0))
             throw new InvalidOperationException($"Parameters 'timeseriesTime', 'timeType', 'timeValue' and 'timeUnit' must be of equal length. " +
-                                                $"Got : timeseriesTime.Count = {timeSeriesTimesCount}, timeType.Count = {parameters.TimeTypes.Count}, timeValue.Count = {parameters.TimeValues.Count}, timeUnit.Count = {parameters.TimeUnits.Count}.");
+                                                $"Got : timeseriesTime.Count = {timeSeriesTimesCount}, timeType.Count = {parameters.TimeTypes?.Count ?? 0}, timeValue.Count = {parameters.TimeValues?.Count ?? 0}, timeUnit.Count = {parameters.TimeUnits?.Count ?? 0}.");
 
         var timeSeriesCountsCount = parameters.TimeSeriesCounts?.Count ?? 0;
-        if (timeSeriesCountsCount != parameters.CountTypes.Count || parameters.CountTypes.Count != parameters.CountValues.Count)
+        if (timeSeriesCountsCount != (parameters.CountTypes?.Count ?? 0) 
+            || (parameters.CountTypes?.Count ?? 0) != (parameters.CountValues?.Count ?? 0))
             throw new InvalidOperationException($"Parameters 'timeseriesCount', 'countType', 'countValue' must be of equal length. " +
-                                                $"Got : timeseriesCount.Count = {timeSeriesCountsCount}, countType.Count = {parameters.CountTypes}, countValue.Count = {parameters.CountValues.Count}.");
+                                                $"Got : timeseriesCount.Count = {timeSeriesCountsCount}, countType.Count = {parameters.CountTypes?.Count ?? 0}, countValue.Count = {parameters.CountValues?.Count ?? 0}.");
 
         var hs = new HashSet<AbstractTimeSeriesRange>(AbstractTimeSeriesRangeComparer.Instance);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -60,6 +60,9 @@ internal abstract class
     
     public async Task ExecuteAsTaskAsync()
     {
+        // This processor is being disposed here. It means you can execute a command only once per processor instance. 
+        // The reason behind this is to avoid awaiting execution in the handler and do it directly in the router code.
+        // This reduces AsyncStateMachine size by avoiding creating state in the handler code.
         using (this)
         using (ContextPool.AllocateOperationContext(out TOperationContext context))
         {
@@ -95,9 +98,9 @@ internal abstract class
                 var timeSeries = GetTimeSeriesToInclude(parameters);
 
                 var getDocumentsByIds = GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag);
-                responseWriteStats = getDocumentsByIds.IsCompletedSuccessfully 
-                    ? getDocumentsByIds.Result 
-                    : await getDocumentsByIds.ConfigureAwait(false);
+                responseWriteStats = getDocumentsByIds.IsCompletedSuccessfully
+                    ? getDocumentsByIds.Result
+                    : await getDocumentsByIds;
             }
             else
             {
@@ -233,7 +236,7 @@ internal abstract class
 
         return writeDocumentsByIdResult.IsCompletedSuccessfully
             ? writeDocumentsByIdResult.Result
-            : await writeDocumentsByIdResult.ConfigureAwait(false);
+            : await writeDocumentsByIdResult;
     }
 
     private async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsByIdResultAsync(

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -138,7 +138,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         {
             Debug.Assert(includeCompareExchangeValues != null, "includeCompareExchangeValues != null");
 
-            if (includeCompareExchangeValues.Results is { Count: > 0 })
+            if (includeCompareExchangeValues?.Results is { Count: > 0 })
             {
                 foreach (var (k, v) in includeCompareExchangeValues.Results)
                 {
@@ -160,23 +160,22 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         });
     }
 
-    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
+    protected override ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        return writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
     }
 
-    protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
+    protected override ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IAsyncEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        return writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
     }
 
-    protected override async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName, List<Document> includes, CancellationToken token)
+    protected override ValueTask<(long Count, long SizeInBytes)> WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName, List<Document> includes, CancellationToken token)
     {
         writer.WritePropertyName(propertyName);
-
-        await writer.WriteIncludesAsync(context, includes, token);
+        return writer.WriteIncludesAsync(context, includes, token);
     }
 
     protected override ValueTask<DocumentsResult> GetDocumentsImplAsync(DocumentsOperationContext context, long? etag, StartsWithParams startsWith, string changeVector)

--- a/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessor.cs
@@ -60,6 +60,18 @@ namespace Raven.Server.Documents.Handlers.Processors.TimeSeries
                 return dt;
             }
         }
+        
+        public static unsafe DateTime ParseDate(ReadOnlySpan<char> dateStr, string name)
+        {
+            fixed (char* c = dateStr)
+            {
+                var result = LazyStringParser.TryParseDateTime(c, dateStr.Length, out var dt, out _, properlyParseThreeDigitsMilliseconds: true);
+                if (result != LazyStringParser.Result.DateTime)
+                    Web.RequestHandler.ThrowInvalidDateTime(name, dateStr.ToString());
+
+                return dt;
+            }
+        }
 
         public static bool CheckIfIncrementalTs(string tsName)
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessorForGetTimeSeriesRanges.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/TimeSeries/AbstractTimeSeriesHandlerProcessorForGetTimeSeriesRanges.cs
@@ -108,7 +108,9 @@ namespace Raven.Server.Documents.Handlers.Processors.TimeSeries
 
                     size += TimeSeriesHandlerProcessorForGetTimeSeries.WriteRange(writer, ranges[i], totalCount);
 
-                    await writer.MaybeFlushAsync(token);
+                    var maybeFlushAsync = writer.MaybeFlushAsync(token);
+                    if (maybeFlushAsync.IsCompletedSuccessfully == false)
+                        await maybeFlushAsync;
                 }
                 writer.WriteEndArray();
             }

--- a/src/Raven.Server/Documents/Includes/IncludeCountersCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeCountersCommand.cs
@@ -85,7 +85,9 @@ namespace Raven.Server.Documents.Includes
 
                 writer.WritePropertyName(kvp.Key);
 
-                await writer.WriteCountersForDocumentAsync(kvp.Value, token);
+                var writeCounters = writer.WriteCountersForDocumentAsync(kvp.Value, token);
+                if (writeCounters.IsCompletedSuccessfully == false)
+                    await writeCounters;
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -122,6 +122,7 @@ namespace Raven.Server.Documents.Includes
         public async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, CancellationToken token)
         {
             var first = true;
+            ValueTask<int> maybeFlush;
             if (IdByRevisionsByDateTimeResults != null)
             {
                 foreach ((string id, var dateTimeToDictionary) in IdByRevisionsByDateTimeResults)
@@ -150,7 +151,9 @@ namespace Raven.Server.Documents.Includes
                         writer.WriteDocument(context, metadataOnly: false, document: doc);
                         writer.WriteEndObject();
 
-                        await writer.MaybeFlushAsync(token);
+                        maybeFlush = writer.MaybeFlushAsync(token);
+                        if (maybeFlush.IsCompletedSuccessfully == false)
+                            await maybeFlush;
                     }
                 }
             }
@@ -174,12 +177,16 @@ namespace Raven.Server.Documents.Includes
 
                     writer.WritePropertyName(nameof(RevisionIncludeResult.Revision));
                     writer.WriteDocument(context, metadataOnly: false, document: document);
-                    await writer.MaybeFlushAsync(token);
-
+                    maybeFlush = writer.MaybeFlushAsync(token);
+                    if (maybeFlush.IsCompletedSuccessfully == false)
+                        await maybeFlush;
                     writer.WriteEndObject();
                 }
             }
-            await writer.MaybeFlushAsync(token);
+            
+            maybeFlush = writer.MaybeFlushAsync(token);
+            if (maybeFlush.IsCompletedSuccessfully == false)
+                await maybeFlush;
         }
 
         public int Count => RevisionsChangeVectorResults?.Count ?? 0 + IdByRevisionsByDateTimeResults?.Count ?? 0;

--- a/src/Raven.Server/Documents/Includes/IncludeTimeSeriesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeTimeSeriesCommand.cs
@@ -189,7 +189,9 @@ namespace Raven.Server.Documents.Includes
 
                 writer.WritePropertyName(kvp.Key);
                 size += kvp.Key.Length;
-                size += await TimeSeriesHandlerProcessorForGetTimeSeriesRanges.WriteTimeSeriesRangeResultsAsync(context: null, writer, documentId: null, kvp.Value, calcTotalCount: true, token);
+                var writeResults = TimeSeriesHandlerProcessorForGetTimeSeriesRanges.WriteTimeSeriesRangeResultsAsync(context: null, writer, documentId: null, kvp.Value, calcTotalCount: true, token);
+                size += writeResults.IsCompletedSuccessfully ? writeResults.Result : await writeResults;
+
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Documents/ShardedDocumentHandlerProcessorForGet.cs
@@ -120,11 +120,11 @@ internal sealed class ShardedDocumentHandlerProcessorForGet : AbstractDocumentHa
         return await writer.WriteObjectsAsync(context, documentsToWrite, token);
     }
 
-    protected override async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, TransactionOperationContext context, string propertyName, List<BlittableJsonReaderObject> includes, CancellationToken token)
+    protected override ValueTask<(long Count, long SizeInBytes)> WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, TransactionOperationContext context, string propertyName, List<BlittableJsonReaderObject> includes, CancellationToken token)
     {
         writer.WritePropertyName(propertyName);
 
-        await writer.WriteIncludesAsync(includes, token);
+        return writer.WriteIncludesAsync(includes, token);
     }
 
     protected override async ValueTask<DocumentsResult> GetDocumentsImplAsync(TransactionOperationContext context, long? etag, StartsWithParams startsWith, string changeVector)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentHandler.cs
@@ -26,21 +26,15 @@ namespace Raven.Server.Documents.Sharding.Handlers
         }
 
         [RavenShardedAction("/databases/*/docs", "GET")]
-        public async Task Get()
+        public Task Get()
         {
-            using (var processor = new ShardedDocumentHandlerProcessorForGet(HttpMethod.Get, this))
-            {
-                await processor.ExecuteAsync();
-            }
+            return new ShardedDocumentHandlerProcessorForGet(HttpMethod.Get, this).ExecuteAsTaskAsync();
         }
 
         [RavenShardedAction("/databases/*/docs", "POST")]
-        public async Task PostGet()
+        public Task PostGet()
         {
-            using (var processor = new ShardedDocumentHandlerProcessorForGet(HttpMethod.Post, this))
-            {
-                await processor.ExecuteAsync();
-            }
+            return new ShardedDocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync();
         }
 
         [RavenShardedAction("/databases/*/docs", "DELETE")]

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedQueriesHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedQueriesHandler.cs
@@ -8,15 +8,17 @@ namespace Raven.Server.Documents.Sharding.Handlers
     public sealed class ShardedQueriesHandler : ShardedDatabaseRequestHandler
     {
         [RavenShardedAction("/databases/*/queries", "POST")]
-        public Task Post()
+        public async Task Post()
         {
-            return new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Post).ExecuteTaskAsync();
+            using (var processor = new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Post))
+                await processor.ExecuteAsync();
         }
 
         [RavenShardedAction("/databases/*/queries", "GET")]
-        public Task Get()
+        public async Task Get()
         {
-            return new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Get).ExecuteTaskAsync();
+            using (var processor = new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Get))
+                await processor.ExecuteAsync();
         }
 
         [RavenShardedAction("/databases/*/queries", "PATCH")]

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedQueriesHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedQueriesHandler.cs
@@ -8,17 +8,15 @@ namespace Raven.Server.Documents.Sharding.Handlers
     public sealed class ShardedQueriesHandler : ShardedDatabaseRequestHandler
     {
         [RavenShardedAction("/databases/*/queries", "POST")]
-        public async Task Post()
+        public Task Post()
         {
-            using (var processor = new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Post))
-                await processor.ExecuteAsync();
+            return new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Post).ExecuteTaskAsync();
         }
 
         [RavenShardedAction("/databases/*/queries", "GET")]
-        public async Task Get()
+        public Task Get()
         {
-            using (var processor = new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Get))
-                await processor.ExecuteAsync();
+            return new ShardedQueriesHandlerProcessorForGet(this, HttpMethod.Get).ExecuteTaskAsync();
         }
 
         [RavenShardedAction("/databases/*/queries", "PATCH")]

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -709,7 +709,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static async Task WriteIndexEntriesQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IndexEntriesQueryResult result, CancellationToken token)
+        public static async ValueTask WriteIndexEntriesQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IndexEntriesQueryResult result, CancellationToken token)
         {
             writer.WriteStartObject();
 
@@ -732,12 +732,14 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            var writeQueryResult = writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            if (writeQueryResult.IsCompletedSuccessfully == false)
+                await writeQueryResult;
 
             writer.WriteEndObject();
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentQueryResultAsync<T>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultServerSide<T> result, bool metadataOnly, Action<AsyncBlittableJsonTextWriter> writeAdditionalData = null, CancellationToken token = default)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentQueryResultAsync<T>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultServerSide<T> result, bool metadataOnly, Action<AsyncBlittableJsonTextWriter> writeAdditionalData = null, CancellationToken token = default)
         {
             writer.WriteStartObject();
 
@@ -770,7 +772,10 @@ namespace Raven.Server.Json
             writer.WriteArray(nameof(result.IncludedPaths), result.IncludedPaths);
             writer.WriteComma();
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token);
+            var writeQueryResults = writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token);
+            var numberOfResults = writeQueryResults.IsCompletedSuccessfully 
+                ? writeQueryResults.Result 
+                : await writeQueryResults;
 
             if (result.Highlightings != null)
             {
@@ -828,7 +833,9 @@ namespace Raven.Server.Json
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.RevisionIncludes));
                 writer.WriteStartArray();
-                await revisionIncludes.WriteIncludesAsync(writer, context, token);
+                var writeRevisionIncludes = revisionIncludes.WriteIncludesAsync(writer, context, token);
+                if (writeRevisionIncludes.IsCompletedSuccessfully == false)
+                    await writeRevisionIncludes;
                 writer.WriteEndArray();
             }
 
@@ -837,7 +844,9 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CounterIncludes));
-                await counters.WriteIncludesAsync(writer, context, token);
+                var writeCountersIncludes = counters.WriteIncludesAsync(writer, context, token);
+                if (writeCountersIncludes.IsCompletedSuccessfully == false)
+                    await writeCountersIncludes;
 
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.IncludedCounterNames));
@@ -849,7 +858,9 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.TimeSeriesIncludes));
-                await timeSeries.WriteIncludesAsync(writer, context, token);
+                var writeTimeSeriesIncludes = timeSeries.WriteIncludesAsync(writer, context, token);
+                if (writeTimeSeriesIncludes.IsCompletedSuccessfully == false)    
+                    await writeTimeSeriesIncludes;
             }
 
             if (result.TimeSeriesFields != null)
@@ -863,7 +874,9 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CompareExchangeValueIncludes));
-                await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, token);
+                var writeCompareExchangeValues = writer.WriteCompareExchangeValuesAsync(compareExchangeValues, token);
+                if (writeCompareExchangeValues.IsCompletedSuccessfully == false)
+                    await writeCompareExchangeValues;
             }
 
             var spatialProperties = result.SpatialProperties;
@@ -939,7 +952,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        private static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteQueryResultAsync<TResult, TInclude>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultBase<TResult, TInclude> result, bool metadataOnly, bool partial = false, CancellationToken token = default)
+        private static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteQueryResultAsync<TResult, TInclude>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultBase<TResult, TInclude> result, bool metadataOnly, bool partial = false, CancellationToken token = default)
         {
             long numberOfResults;
             long totalDocumentsSizeInBytes = -1; // Size of facet is constant - no need to count that - similar situation happens on suggestions
@@ -954,13 +967,21 @@ namespace Raven.Server.Json
             if (results is List<Document> documents)
             {
                 writer.WritePropertyName(nameof(result.Results));
-                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, documents, metadataOnly, token);
+                var writeDocuments = writer.WriteDocumentsAsync(context, documents, metadataOnly, token);
+                (numberOfResults, totalDocumentsSizeInBytes) = writeDocuments.IsCompletedSuccessfully 
+                    ? writeDocuments.Result 
+                    : await writeDocuments;
                 writer.WriteComma();
             }
             else if (results is List<BlittableJsonReaderObject> objects)
             {
                 writer.WritePropertyName(nameof(result.Results));
-                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteObjectsAsync(context, objects, token);
+                var writeObjects = writer.WriteObjectsAsync(context, objects, token);
+                
+                (numberOfResults, totalDocumentsSizeInBytes) = writeObjects.IsCompletedSuccessfully 
+                    ? writeObjects.Result 
+                    : await writeObjects;
+                
                 writer.WriteComma();
             }
             else if (results is List<FacetResult> facets)
@@ -968,14 +989,18 @@ namespace Raven.Server.Json
                 numberOfResults = facets.Count;
                 writer.WriteArray(context, nameof(result.Results), facets, (w, c, facet) => w.WriteFacetResult(c, facet));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token);
+                var maybeFlush = writer.MaybeFlushAsync(token);
+                if (maybeFlush.IsCompletedSuccessfully == false)    
+                    await maybeFlush;
             }
             else if (results is List<SuggestionResult> suggestions)
             {
                 numberOfResults = suggestions.Count;
                 writer.WriteArray(context, nameof(result.Results), suggestions, (w, c, suggestion) => w.WriteSuggestionResult(c, suggestion));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token);
+                var maybeFlush = writer.MaybeFlushAsync(token);
+                if (maybeFlush.IsCompletedSuccessfully == false)    
+                    await maybeFlush;
             }
             else
                 throw new NotSupportedException($"Cannot write query result of '{typeof(TResult)}' type in '{result.GetType()}'.");
@@ -984,13 +1009,17 @@ namespace Raven.Server.Json
             if (includes is List<Document> includeDocuments)
             {
                 writer.WritePropertyName(nameof(result.Includes));
-                await writer.WriteIncludesAsync(context, includeDocuments, token);
+                var writeIncludes = writer.WriteIncludesAsync(context, includeDocuments, token);
+                if (writeIncludes.IsCompletedSuccessfully == false)    
+                    await writeIncludes;
                 writer.WriteComma();
             }
             else if (includes is List<BlittableJsonReaderObject> includeObjects)
             {
                 writer.WritePropertyName(nameof(result.Includes));
-                await writer.WriteIncludesAsync(includeObjects, token);
+                var writeIncludes = writer.WriteIncludesAsync(includeObjects, token);
+                if (writeIncludes.IsCompletedSuccessfully == false)    
+                    await writeIncludes;
                 writer.WriteComma();
             }
             else
@@ -1875,12 +1904,12 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
+        public static ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
         {
             return WriteDocumentsAsync(writer, context, documents.GetEnumerator(), metadataOnly, token);
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerator<Document> documents, bool metadataOnly, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerator<Document> documents, bool metadataOnly, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -1900,7 +1929,9 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, documents.Current, metadataOnly);
-                await writer.MaybeFlushAsync(token);
+                var maybeFlushValueTask = writer.MaybeFlushAsync(token);
+                if (maybeFlushValueTask.IsCompletedSuccessfully == false)
+                    await maybeFlushValueTask;
             }
 
             writer.WriteEndArray();
@@ -1913,7 +1944,7 @@ namespace Raven.Server.Json
             writer.WriteString(continuation.ToBase64(context));
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IAsyncEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IAsyncEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -1998,7 +2029,10 @@ namespace Raven.Server.Json
 
                 writer.WritePropertyName(document.Id);
                 WriteDocument(writer, context, metadataOnly: false, document: document);
-                await writer.MaybeFlushAsync(token);
+                var maybeFlushValueTask = writer.MaybeFlushAsync(token);
+                if (maybeFlushValueTask.IsCompletedSuccessfully == false)
+                    await maybeFlushValueTask;
+
             }
 
             writer.WriteEndObject();
@@ -2061,7 +2095,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteObjectsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<BlittableJsonReaderObject> objects, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteObjectsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<BlittableJsonReaderObject> objects, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -2087,7 +2121,10 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token);
+                    var maybeFlush = writer.MaybeFlushAsync(token);
+                    var writtenBytes = maybeFlush.IsCompletedSuccessfully 
+                        ? maybeFlush.Result 
+                        : await maybeFlush;
 
                     if (o.HasParent)
                     {
@@ -2203,7 +2240,7 @@ namespace Raven.Server.Json
             writer.WriteEndArray();
         }
 
-        public static async Task WriteCountersForDocumentAsync(this AsyncBlittableJsonTextWriter writer, List<CounterDetail> counters, CancellationToken token)
+        public static async ValueTask WriteCountersForDocumentAsync(this AsyncBlittableJsonTextWriter writer, List<CounterDetail> counters, CancellationToken token)
         {
             writer.WriteStartArray();
 
@@ -2236,13 +2273,15 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token);
+                var maybeFlush = writer.MaybeFlushAsync(token);
+                if (maybeFlush.IsCompletedSuccessfully == false)
+                    await maybeFlush;
             }
 
             writer.WriteEndArray();
         }
 
-        public static async Task WriteCompareExchangeValuesAsync(this AsyncBlittableJsonTextWriter writer, Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>> compareExchangeValues, CancellationToken token)
+        public static async ValueTask WriteCompareExchangeValuesAsync(this AsyncBlittableJsonTextWriter writer, Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>> compareExchangeValues, CancellationToken token)
         {
             writer.WriteStartObject();
 
@@ -2278,7 +2317,9 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token);
+                var maybeFlush = writer.MaybeFlushAsync(token);
+                if (maybeFlush.IsCompletedSuccessfully == false)
+                    await maybeFlush;
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Web/AbstractQueryStringParameters.cs
+++ b/src/Raven.Server/Web/AbstractQueryStringParameters.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
@@ -78,8 +80,8 @@ internal abstract class AbstractQueryStringParameters(HttpRequest httpRequest)
     protected static readonly ReadOnlyMemory<char> NumberOfReplicasToWaitForQueryStringName = "numberOfReplicasToWaitFor".AsMemory();
 
     protected static readonly ReadOnlyMemory<char> ThrowOnTimeoutInWaitForReplicasQueryStringName = "throwOnTimeoutInWaitForReplicas".AsMemory();
-
-    private Dictionary<string, List<string>> _tempStringValues;
+    
+    private Dictionary<string, List<ReadOnlyMemory<char>>> _tempStringValues;
 
     protected void Parse()
     {
@@ -93,13 +95,13 @@ internal abstract class AbstractQueryStringParameters(HttpRequest httpRequest)
 
     protected void AddForStringValues(string name, ReadOnlyMemory<char> value)
     {
-        _tempStringValues ??= new Dictionary<string, List<string>>();
+        _tempStringValues ??= new Dictionary<string, List<ReadOnlyMemory<char>>>();
 
         ref var item = ref CollectionsMarshal.GetValueRefOrAddDefault(_tempStringValues, name, out bool exists);
         if (exists == false)
-            item = new List<string>(1);
+            item = new (1);
 
-        item.Add(value.ToString());
+        item.Add(value);
     }
 
     protected bool AnyStringValues() => _tempStringValues is { Count: > 0 };
@@ -109,7 +111,15 @@ internal abstract class AbstractQueryStringParameters(HttpRequest httpRequest)
         if (_tempStringValues == null || _tempStringValues.TryGetValue(name, out var list) == false)
             return default;
 
-        return new StringValues(list.ToArray());
+        return new StringValues(list.Select(x => x.ToString()).ToArray());
+    }
+
+    protected List<ReadOnlyMemory<char>> RetrieveValues(string name)
+    {
+        if (_tempStringValues == null || _tempStringValues.TryGetValue(name, out var list) == false)
+            return null;
+        
+        return list;
     }
 
     protected abstract void OnFinalize();

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -12,13 +12,16 @@ namespace Sparrow.Json
         private readonly CancellationToken _cancellationToken;
         
         // PERF: Cache the MemoryStream reference to avoid repeated casting
-        private readonly MemoryStream _memoryStream;
+        private readonly MemoryStream _innerStream;
 
         public AsyncBlittableJsonTextWriter(JsonOperationContext context, Stream stream, CancellationToken cancellationToken = default) : base(context, RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
             _outputStream = stream ?? throw new ArgumentNullException(nameof(stream));
             _cancellationToken = cancellationToken;
-            _memoryStream = (MemoryStream)_stream; // Cache the cast since we know it's always MemoryStream
+            _innerStream = _stream as MemoryStream; // Cache the cast since we know it's always MemoryStream
+            
+            if (_innerStream == null)
+                throw new ArgumentException($"Expected stream to be MemoryStream, but got {(_stream?.GetType() == null ? "null" : _stream.ToString())}.");
         }
 
         public async ValueTask WriteStreamAsync(Stream stream, CancellationToken token = default)
@@ -39,7 +42,7 @@ namespace Sparrow.Json
         public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
         {
             // PERF: Use cached MemoryStream reference
-            if (_memoryStream.Length * 2 <= _memoryStream.Capacity)
+            if (_innerStream.Length * 2 <= _innerStream.Capacity)
                 return new ValueTask<int>(0);
 
             FlushInternal(); // this is OK, because inner stream is a MemoryStream
@@ -50,7 +53,7 @@ namespace Sparrow.Json
         {
             // PERF: Use cached MemoryStream reference
             FlushInternal();
-            _memoryStream.TryGetBuffer(out var bytes);
+            _innerStream.TryGetBuffer(out var bytes);
             var bytesCount = bytes.Count;
             if (bytesCount == 0)
                 return new ValueTask<int>(0);
@@ -61,12 +64,12 @@ namespace Sparrow.Json
                 // PERF: Fast synchronous path - avoid async state machine overhead
                 // This happens when _outputStream is MemoryStream, FileStream with sync completion, etc.
                 writeTask.GetAwaiter().GetResult();
-                _memoryStream.SetLength(0);
+                _innerStream.SetLength(0);
                 return new ValueTask<int>(bytesCount);
             }
             
             // Slow asynchronous path for network streams, slow disk I/O, etc.
-            return FlushAsyncSlow(writeTask, _memoryStream, bytesCount);
+            return FlushAsyncSlow(writeTask, _innerStream, bytesCount);
         }
         
         private static async ValueTask<int> FlushAsyncSlow(Task writeTask, MemoryStream innerStream, int bytesCount)
@@ -82,10 +85,10 @@ namespace Sparrow.Json
 
             // PERF: Check if flush completed synchronously to avoid async state machine
             var flushTask = FlushAsync();
-            if (flushTask.IsCompleted)
+            if (flushTask.IsCompletedSuccessfully)
             {
                 // Fast synchronous path
-                var bytesWritten = flushTask.GetAwaiter().GetResult();
+                var bytesWritten = flushTask.Result;
                 if (bytesWritten > 0)
                 {
                     var outputFlushTask = _outputStream.FlushAsync();

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -10,11 +10,15 @@ namespace Sparrow.Json
     {
         private readonly Stream _outputStream;
         private readonly CancellationToken _cancellationToken;
+        
+        // PERF: Cache the MemoryStream reference to avoid repeated casting
+        private readonly MemoryStream _memoryStream;
 
         public AsyncBlittableJsonTextWriter(JsonOperationContext context, Stream stream, CancellationToken cancellationToken = default) : base(context, RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
             _outputStream = stream ?? throw new ArgumentNullException(nameof(stream));
             _cancellationToken = cancellationToken;
+            _memoryStream = (MemoryStream)_stream; // Cache the cast since we know it's always MemoryStream
         }
 
         public async ValueTask WriteStreamAsync(Stream stream, CancellationToken token = default)
@@ -34,48 +38,100 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
         {
-            var innerStream = _stream as MemoryStream;
-            if (innerStream == null)
-                ThrowInvalidTypeException(_stream?.GetType());
-            if (innerStream.Length * 2 <= innerStream.Capacity)
+            // PERF: Use cached MemoryStream reference
+            if (_memoryStream.Length * 2 <= _memoryStream.Capacity)
                 return new ValueTask<int>(0);
 
             FlushInternal(); // this is OK, because inner stream is a MemoryStream
             return FlushAsync(token);
         }
 
-        public async ValueTask<int> FlushAsync(CancellationToken token = default)
+        public ValueTask<int> FlushAsync(CancellationToken token = default)
         {
-            var innerStream = _stream as MemoryStream;
-            if (innerStream == null)
-                ThrowInvalidTypeException(_stream?.GetType());
+            // PERF: Use cached MemoryStream reference
             FlushInternal();
-            innerStream.TryGetBuffer(out var bytes);
+            _memoryStream.TryGetBuffer(out var bytes);
             var bytesCount = bytes.Count;
             if (bytesCount == 0)
-                return 0;
-            await _outputStream.WriteAsync(bytes.Array, bytes.Offset, bytesCount, token).ConfigureAwait(false);
+                return new ValueTask<int>(0);
+            
+            var writeTask = _outputStream.WriteAsync(bytes.Array, bytes.Offset, bytesCount, token);
+            if (writeTask.IsCompleted)
+            {
+                // PERF: Fast synchronous path - avoid async state machine overhead
+                // This happens when _outputStream is MemoryStream, FileStream with sync completion, etc.
+                writeTask.GetAwaiter().GetResult();
+                _memoryStream.SetLength(0);
+                return new ValueTask<int>(bytesCount);
+            }
+            
+            // Slow asynchronous path for network streams, slow disk I/O, etc.
+            return FlushAsyncSlow(writeTask, _memoryStream, bytesCount);
+        }
+        
+        private static async ValueTask<int> FlushAsyncSlow(Task writeTask, MemoryStream innerStream, int bytesCount)
+        {
+            await writeTask.ConfigureAwait(false);
             innerStream.SetLength(0);
             return bytesCount;
         }
 
-        public async ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             DisposeInternal();
 
-            if (await FlushAsync().ConfigureAwait(false) > 0)
+            // PERF: Check if flush completed synchronously to avoid async state machine
+            var flushTask = FlushAsync();
+            if (flushTask.IsCompleted)
+            {
+                // Fast synchronous path
+                var bytesWritten = flushTask.GetAwaiter().GetResult();
+                if (bytesWritten > 0)
+                {
+                    var outputFlushTask = _outputStream.FlushAsync();
+                    if (outputFlushTask.IsCompleted)
+                    {
+                        outputFlushTask.GetAwaiter().GetResult();
+                        return DisposeStreamAsync();
+                    }
+                    else
+                    {
+                        return DisposeAsyncSlow(outputFlushTask);
+                    }
+                }
+                else
+                {
+                    return DisposeStreamAsync();
+                }
+            }
+            
+            return DisposeAsyncSlow(flushTask);
+        }
+
+        private async ValueTask DisposeAsyncSlow(ValueTask<int> flushTask)
+        {
+            var bytesWritten = await flushTask.ConfigureAwait(false);
+            if (bytesWritten > 0)
                 await _outputStream.FlushAsync().ConfigureAwait(false);
 
+            await DisposeStreamAsync().ConfigureAwait(false);
+        }
+
+        private async ValueTask DisposeAsyncSlow(Task outputFlushTask)
+        {
+            await outputFlushTask.ConfigureAwait(false);
+            await DisposeStreamAsync().ConfigureAwait(false);
+        }
+
+        private ValueTask DisposeStreamAsync()
+        {
 #if !NETSTANDARD2_0
-            await _stream.DisposeAsync().ConfigureAwait(false);
+            return _stream.DisposeAsync();
 #else
             _stream.Dispose();
+            return default;
 #endif
         }
 
-        private void ThrowInvalidTypeException(Type typeOfStream)
-        {
-            throw new ArgumentException($"Expected stream to be MemoryStream, but got {(typeOfStream == null ? "null" : typeOfStream.ToString())}.");
-        }
     }
 }

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -83,7 +83,7 @@ namespace Sparrow.Json
                 
                 // PERF: Check if WriteStreamAsync completed synchronously to avoid async state machine
                 var writeTask = writer.WriteStreamAsync(item);
-                if (!writeTask.IsCompleted)
+                if (writeTask.IsCompletedSuccessfully == false)
                     await writeTask.ConfigureAwait(false);
             }
 
@@ -189,7 +189,7 @@ namespace Sparrow.Json
                 
                 // PERF: Check if flush completed synchronously to avoid async state machine
                 var flushTask = writer.MaybeFlushAsync();
-                if (!flushTask.IsCompleted)
+                if (flushTask.IsCompletedSuccessfully == false)
                     await flushTask.ConfigureAwait(false);
             }
             writer.WriteEndArray();
@@ -212,7 +212,7 @@ namespace Sparrow.Json
                 
                 // PERF: Check if flush completed synchronously to avoid async state machine
                 var flushTask = writer.MaybeFlushAsync();
-                if (!flushTask.IsCompleted)
+                if (flushTask.IsCompletedSuccessfully == false)
                     await flushTask.ConfigureAwait(false);
             }
             writer.WriteEndArray();

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -67,7 +67,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<Stream> items)
+        public static async ValueTask WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<Stream> items)
         {
             writer.WritePropertyName(name);
 
@@ -80,7 +80,11 @@ namespace Sparrow.Json
                 first = false;
 
                 item.Position = 0;
-                await writer.WriteStreamAsync(item).ConfigureAwait(false);
+                
+                // PERF: Check if WriteStreamAsync completed synchronously to avoid async state machine
+                var writeTask = writer.WriteStreamAsync(item);
+                if (!writeTask.IsCompleted)
+                    await writeTask.ConfigureAwait(false);
             }
 
             writer.WriteEndArray();
@@ -169,7 +173,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<BlittableJsonReaderObject> items)
+        public static async ValueTask WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<BlittableJsonReaderObject> items)
         {
             writer.WritePropertyName(name);
 
@@ -182,13 +186,17 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeFlushAsync().ConfigureAwait(false);
+                
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IAsyncEnumerable<BlittableJsonReaderObject> items)
+        public static async ValueTask WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IAsyncEnumerable<BlittableJsonReaderObject> items)
         {
             writer.WritePropertyName(name);
 
@@ -201,7 +209,11 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeFlushAsync().ConfigureAwait(false);
+                
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -974,7 +974,11 @@ namespace Sparrow.Json
             await using (var writer = new AsyncBlittableJsonTextWriter(this, stream))
             {
                 writer.WriteObject(json);
-                await writer.FlushAsync(token).ConfigureAwait(false);
+                
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.FlushAsync(token);
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
         }
 

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -977,7 +977,7 @@ namespace Sparrow.Json
                 
                 // PERF: Check if flush completed synchronously to avoid async state machine
                 var flushTask = writer.FlushAsync(token);
-                if (!flushTask.IsCompleted)
+                if (flushTask.IsCompletedSuccessfully == false)
                     await flushTask.ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24102

### Additional description

Using too many awaits can increase latency in the most critical paths. In this PR, we're trying to reduce overhead generated by Async State Machine. Additionally, we're trying to reduce allocations made by parameter parsing by using ReadOnlyMemory<char> instead of materializing it to strings.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
