### PR TITLE
RavenDB-24586 Added timeout to MRE in RavenDB_23473.CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocument test

### DIFF
--- a/test/SlowTests/Issues/RavenDB-23473.cs
+++ b/test/SlowTests/Issues/RavenDB-23473.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -110,7 +111,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
                 }
             }
 
-            await mre.WaitAsync();
+            Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
 
             await Indexes.WaitForIndexingAsync(store);
             var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24586

### Additional description

Missing timeout could cause the test suite to hang

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
