### PR TITLE
RavenDB-24798 fix change vector logic

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -8,7 +8,6 @@ using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Documents;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.AI.AiGen;
@@ -105,7 +104,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
             var conversationId = RequestHandler.GetStringQueryString("conversationId");
             var agentId = RequestHandler.GetStringQueryString("agentId");
-            var changeVector = RequestHandler.GetStringQueryString("changeVector", required: false);
+            var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
 
             using var _ = ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
             var body = await ReadRequestBodyAsync(context, token.Token);
@@ -118,7 +117,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 var conversation = RequestHandler.Database.DocumentsStorage.Get(context, conversationId);
                 if (conversation == null)
                 {
-                    if (changeVector == string.Empty)
+                    if (string.IsNullOrEmpty(changeVector) == false)
                     {
                         throw new ConcurrencyException(
                             $"The conversation '{conversationId}' doesn't exists.")

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -369,6 +369,20 @@ namespace Raven.Server.Web
             return val[0];
         }
 
+        internal string GetChangeVectorStringQueryString(string name, bool required = true)
+        {
+            var val = HttpContext.Request.Query[name];
+            if (val.Count == 0)
+            {
+                if (required)
+                    ThrowRequiredMember(name);
+
+                return null;
+            }
+
+            return val[0];
+        }
+
         internal char? GetCharQueryString(string name, bool required = true)
         {
             var val = HttpContext.Request.Query[name];

--- a/src/Raven.Studio/typescript/commands/database/aiAgents/runAiAgentCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/aiAgents/runAiAgentCommand.ts
@@ -7,7 +7,8 @@ class runAiAgentCommand extends commandBase {
         private db: string,
         private dto: Raven.Client.Documents.Operations.AI.Agents.ConversionRequestBody,
         private agentId: string,
-        private conversationId?: string,
+        private conversationId: string,
+        private changeVector: string
     ) {
         super();
     }
@@ -16,7 +17,7 @@ class runAiAgentCommand extends commandBase {
         const args = {
             agentId: this.agentId,
             conversationId: this.conversationId,
-            changeVector: "''", // if initial conversationId already exists it will throw an error
+            changeVector: this.changeVector
         };
 
         const url = endpoints.databases.aiAgent.aiAgent + this.urlEncodeArgs(args);

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -123,7 +123,7 @@ const getDocument = createAsyncThunk(
         const result = await services.databasesService.getDocumentWithMetadata(payload.id, payload.databaseName);
 
         if (result instanceof document) {
-            return result.toDto();
+            return result.toDto(true);
         }
         return result;
     }
@@ -145,7 +145,7 @@ const runChat = createAsyncThunk(
         const state = getState() as RootState;
         const conversationId = state.chatAiAgent.conversationId;
         const config = state.chatAiAgent.config;
-
+        const changeVector = state.chatAiAgent.document.data?.["@metadata"]?.["@change-vector"] ?? "";
         const result = await services.aiAgentService.runAiAgent(
             databaseName,
             {
@@ -167,7 +167,8 @@ const runChat = createAsyncThunk(
                 },
             },
             config.data?.Identifier,
-            conversationId != null ? conversationId : formValues.persistenceConversationIdPrefix
+            conversationId != null ? conversationId : formValues.persistenceConversationIdPrefix,
+            changeVector
         );
         dispatch(chatAiAgentActions.conversationIdSet(result.ConversationId));
         await dispatch(chatAiAgentActions.getDocument({ databaseName, id: result.ConversationId })).unwrap();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24798

### Additional description

- revert to previous logic
- passing the change vector over the query string resulted in `null` when we passed an empty string
- adjust the studio

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
