### PR TITLE
[DO-NOT-MERGE] RavenDB-21218: Avoid async transition when possible

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AbstractAttachmentHandlerProcessorForGetMissingAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AbstractAttachmentHandlerProcessorForGetMissingAttachment.cs
@@ -83,15 +83,18 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
                 }
 
                 writer.WriteEndObject();
-                await writer.FlushAsync(token.Token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.FlushAsync(token.Token);
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
         }
 
-        protected abstract Task WriteMissingAttachmentsForCollection(TOperationContext context, AsyncBlittableJsonTextWriter writer, string collection, long start, int pageSize, AttachmentType document, OperationCancelToken token);
-        protected abstract Task WriteMissingAttachmentsForRevisions(TOperationContext context, AsyncBlittableJsonTextWriter writer, long start, int pageSize, AttachmentType revision, OperationCancelToken token);
+        protected abstract ValueTask WriteMissingAttachmentsForCollection(TOperationContext context, AsyncBlittableJsonTextWriter writer, string collection, long start, int pageSize, AttachmentType document, OperationCancelToken token);
+        protected abstract ValueTask WriteMissingAttachmentsForRevisions(TOperationContext context, AsyncBlittableJsonTextWriter writer, long start, int pageSize, AttachmentType revision, OperationCancelToken token);
         protected abstract void CheckCollectionAndThrowIfNeeded(string collection);
 
-        protected static async Task WriteMissingAttachmentsInternal(DocumentDatabase database, IEnumerable<Document> results, DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, AttachmentType attachmentType, OperationCancelToken token)
+        protected static async ValueTask WriteMissingAttachmentsInternal(DocumentDatabase database, IEnumerable<Document> results, DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, AttachmentType attachmentType, OperationCancelToken token)
         {
             bool firstResult = true;
             foreach (var result in results)

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForGetMissingAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForGetMissingAttachment.cs
@@ -16,7 +16,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
         {
         }
 
-        protected override async Task WriteMissingAttachmentsForCollection(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, string collection, long start, int pageSize, AttachmentType document, OperationCancelToken token)
+        protected override async ValueTask WriteMissingAttachmentsForCollection(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, string collection, long start, int pageSize, AttachmentType document, OperationCancelToken token)
         {
             using var tx = context.OpenReadTransaction();
             if (collection != Constants.Documents.Collections.AllDocumentsCollection)
@@ -40,7 +40,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
             }
         }
 
-        protected override async Task WriteMissingAttachmentsForRevisions(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, long start, int pageSize, AttachmentType revision, OperationCancelToken token)
+        protected override async ValueTask WriteMissingAttachmentsForRevisions(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, long start, int pageSize, AttachmentType revision, OperationCancelToken token)
         {
             using var tx = context.OpenReadTransaction();
             await WriteMissingAttachmentsInternal(RequestHandler.Database, RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, start, pageSize),

--- a/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionDocuments.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionDocuments.cs
@@ -27,7 +27,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Collections
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("Results");
-                    (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, documents, metadataOnly: false, token);
+                    // PERF: Check if WriteDocumentsAsync completed synchronously to avoid async state machine
+                    var writeTask = writer.WriteDocumentsAsync(context, documents, metadataOnly: false, token);
+                    (numberOfResults, totalDocumentsSizeInBytes) = writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
                     writer.WriteEndObject();
                 }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -230,7 +230,9 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
 
             writer.WritePropertyName(nameof(GetDocumentsResult.Results));
 
-            (numberOfResults, totalDocumentsSizeInBytes) = await WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
+            // PERF: Check if WriteDocumentsAsync completed synchronously to avoid async state machine
+            var writeTask = WriteDocumentsAsync(writer, context, result.Documents, metadataOnly, CancellationToken);
+            (numberOfResults, totalDocumentsSizeInBytes) = writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
 
             writer.WriteComma();
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -163,13 +163,17 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
     protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        // PERF: Check if WriteDocumentsAsync completed synchronously to avoid async state machine
+        var writeTask = writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        return writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
     }
 
     protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IAsyncEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        // PERF: Check if WriteDocumentsAsync completed synchronously to avoid async state machine
+        var writeTask = writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        return writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
     }
 
     protected override async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName, List<Document> includes, CancellationToken token)

--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -150,7 +150,10 @@ namespace Raven.Server.Documents.Includes
                         writer.WriteDocument(context, metadataOnly: false, document: doc);
                         writer.WriteEndObject();
 
-                        await writer.MaybeFlushAsync(token);
+                        // PERF: Check if flush completed synchronously to avoid async state machine
+                        var flushTask = writer.MaybeFlushAsync(token);
+                        if (!flushTask.IsCompleted)
+                            await flushTask;
                     }
                 }
             }
@@ -174,7 +177,10 @@ namespace Raven.Server.Documents.Includes
 
                     writer.WritePropertyName(nameof(RevisionIncludeResult.Revision));
                     writer.WriteDocument(context, metadataOnly: false, document: document);
-                    await writer.MaybeFlushAsync(token);
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                    var flushTask = writer.MaybeFlushAsync(token);
+                    if (!flushTask.IsCompleted)
+                        await flushTask;
 
                     writer.WriteEndObject();
                 }

--- a/src/Raven.Server/Documents/Includes/Sharding/ShardedCounterIncludes.cs
+++ b/src/Raven.Server/Documents/Includes/Sharding/ShardedCounterIncludes.cs
@@ -122,7 +122,10 @@ public sealed class ShardedCounterIncludes : AbstractIncludeCountersCommand
                     writer.WriteNull();
             }
 
-            await writer.MaybeFlushAsync(token);
+            // PERF: Check if flush completed synchronously to avoid async state machine
+            var flushTask = writer.MaybeFlushAsync(token);
+            if (!flushTask.IsCompleted)
+                await flushTask;
 
             writer.WriteEndArray();
         }

--- a/src/Raven.Server/Documents/Includes/Sharding/ShardedRevisionIncludes.cs
+++ b/src/Raven.Server/Documents/Includes/Sharding/ShardedRevisionIncludes.cs
@@ -51,7 +51,10 @@ public sealed class ShardedRevisionIncludes : IRevisionIncludes
 
                 writer.WriteObject(revision);
 
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.MaybeFlushAsync(token);
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
         }
     }

--- a/src/Raven.Server/Documents/Includes/Sharding/ShardedTimeSeriesIncludes.cs
+++ b/src/Raven.Server/Documents/Includes/Sharding/ShardedTimeSeriesIncludes.cs
@@ -127,7 +127,10 @@ public sealed class ShardedTimeSeriesIncludes : AbstractIncludeTimeSeriesCommand
             size += kvp.Key.Length;
             size += kvp.Value.Size;
 
-            await writer.MaybeFlushAsync(token);
+            // PERF: Check if flush completed synchronously to avoid async state machine
+            var flushTask = writer.MaybeFlushAsync(token);
+            if (!flushTask.IsCompleted)
+                await flushTask;
         }
 
         writer.WriteEndObject();

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -417,7 +417,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteSuggestionQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, SuggestionQueryResult result, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteSuggestionQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, SuggestionQueryResult result, CancellationToken token)
         {
             writer.WriteStartObject();
 
@@ -450,14 +450,16 @@ namespace Raven.Server.Json
                 writer.WriteComma();
             }
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            // PERF: Check if WriteQueryResultAsync completed synchronously to avoid async state machine
+            var writeTask = writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            var numberOfResults = writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
 
             writer.WriteEndObject();
 
             return numberOfResults;
         }
 
-        public static async Task<long> WriteFacetedQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, FacetedQueryResult result, CancellationToken token)
+        public static async ValueTask<long> WriteFacetedQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, FacetedQueryResult result, CancellationToken token)
         {
             writer.WriteStartObject();
 
@@ -476,7 +478,9 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            var (numberOfResults, _) = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            // PERF: Check if WriteQueryResultAsync completed synchronously to avoid async state machine
+            var writeTask = writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            var (numberOfResults, _) = writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
 
             writer.WriteEndObject();
 
@@ -709,7 +713,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static async Task WriteIndexEntriesQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IndexEntriesQueryResult result, CancellationToken token)
+        public static async ValueTask WriteIndexEntriesQueryResultAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IndexEntriesQueryResult result, CancellationToken token)
         {
             writer.WriteStartObject();
 
@@ -732,12 +736,15 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            // PERF: Check if WriteQueryResultAsync completed synchronously to avoid async state machine
+            var writeTask = writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            if (!writeTask.IsCompleted)
+                await writeTask.ConfigureAwait(false);
 
             writer.WriteEndObject();
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentQueryResultAsync<T>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultServerSide<T> result, bool metadataOnly, Action<AsyncBlittableJsonTextWriter> writeAdditionalData = null, CancellationToken token = default)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentQueryResultAsync<T>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultServerSide<T> result, bool metadataOnly, Action<AsyncBlittableJsonTextWriter> writeAdditionalData = null, CancellationToken token = default)
         {
             writer.WriteStartObject();
 
@@ -770,7 +777,9 @@ namespace Raven.Server.Json
             writer.WriteArray(nameof(result.IncludedPaths), result.IncludedPaths);
             writer.WriteComma();
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token);
+            // PERF: Check if WriteQueryResultAsync completed synchronously to avoid async state machine
+            var writeTask = writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token);
+            var numberOfResults = writeTask.IsCompleted ? writeTask.GetAwaiter().GetResult() : await writeTask.ConfigureAwait(false);
 
             if (result.Highlightings != null)
             {
@@ -828,7 +837,10 @@ namespace Raven.Server.Json
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.RevisionIncludes));
                 writer.WriteStartArray();
-                await revisionIncludes.WriteIncludesAsync(writer, context, token);
+                // PERF: Check if WriteIncludesAsync completed synchronously to avoid async state machine
+                var revisionWriteTask = revisionIncludes.WriteIncludesAsync(writer, context, token);
+                if (!revisionWriteTask.IsCompleted)
+                    await revisionWriteTask.ConfigureAwait(false);
                 writer.WriteEndArray();
             }
 
@@ -837,7 +849,10 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CounterIncludes));
-                await counters.WriteIncludesAsync(writer, context, token);
+                // PERF: Check if WriteIncludesAsync completed synchronously to avoid async state machine
+                var counterWriteTask = counters.WriteIncludesAsync(writer, context, token);
+                if (!counterWriteTask.IsCompleted)
+                    await counterWriteTask.ConfigureAwait(false);
 
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.IncludedCounterNames));
@@ -849,7 +864,10 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.TimeSeriesIncludes));
-                await timeSeries.WriteIncludesAsync(writer, context, token);
+                // PERF: Check if WriteIncludesAsync completed synchronously to avoid async state machine
+                var timeSeriesWriteTask = timeSeries.WriteIncludesAsync(writer, context, token);
+                if (!timeSeriesWriteTask.IsCompleted)
+                    await timeSeriesWriteTask.ConfigureAwait(false);
             }
 
             if (result.TimeSeriesFields != null)
@@ -939,7 +957,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        private static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteQueryResultAsync<TResult, TInclude>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultBase<TResult, TInclude> result, bool metadataOnly, bool partial = false, CancellationToken token = default)
+        private static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteQueryResultAsync<TResult, TInclude>(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, QueryResultBase<TResult, TInclude> result, bool metadataOnly, bool partial = false, CancellationToken token = default)
         {
             long numberOfResults;
             long totalDocumentsSizeInBytes = -1; // Size of facet is constant - no need to count that - similar situation happens on suggestions
@@ -968,14 +986,20 @@ namespace Raven.Server.Json
                 numberOfResults = facets.Count;
                 writer.WriteArray(context, nameof(result.Results), facets, (w, c, facet) => w.WriteFacetResult(c, facet));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var facetFlushTask = writer.MaybeFlushAsync(token);
+                if (!facetFlushTask.IsCompleted)
+                    await facetFlushTask.ConfigureAwait(false);
             }
             else if (results is List<SuggestionResult> suggestions)
             {
                 numberOfResults = suggestions.Count;
                 writer.WriteArray(context, nameof(result.Results), suggestions, (w, c, suggestion) => w.WriteSuggestionResult(c, suggestion));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var suggestionFlushTask = writer.MaybeFlushAsync(token);
+                if (!suggestionFlushTask.IsCompleted)
+                    await suggestionFlushTask.ConfigureAwait(false);
             }
             else
                 throw new NotSupportedException($"Cannot write query result of '{typeof(TResult)}' type in '{result.GetType()}'.");
@@ -1915,12 +1939,12 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
+        public static ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
         {
             return WriteDocumentsAsync(writer, context, documents.GetEnumerator(), metadataOnly, token);
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerator<Document> documents, bool metadataOnly, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerator<Document> documents, bool metadataOnly, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -1940,7 +1964,10 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, documents.Current, metadataOnly);
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var docFlushTask = writer.MaybeFlushAsync(token);
+                if (!docFlushTask.IsCompleted)
+                    await docFlushTask.ConfigureAwait(false);
             }
 
             writer.WriteEndArray();
@@ -1953,7 +1980,7 @@ namespace Raven.Server.Json
             writer.WriteString(continuation.ToBase64(context));
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IAsyncEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IAsyncEnumerable<Document> documents, bool metadataOnly, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -1973,7 +2000,10 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, document, metadataOnly);
-                await writer.FlushAsync(token); // we must flush here because we dispose the document
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.FlushAsync(token);
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false); // we must flush here because we dispose the document
             }
 
             writer.WriteEndArray();
@@ -2032,13 +2062,19 @@ namespace Raven.Server.Json
                 {
                     writer.WritePropertyName(conflict.Id);
                     WriteConflict(writer, conflict);
-                    await writer.MaybeFlushAsync(token);
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                    var conflictFlushTask = writer.MaybeFlushAsync(token);
+                    if (!conflictFlushTask.IsCompleted)
+                        await conflictFlushTask.ConfigureAwait(false);
                     continue;
                 }
 
                 writer.WritePropertyName(document.Id);
                 WriteDocument(writer, context, metadataOnly: false, document: document);
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var documentFlushTask = writer.MaybeFlushAsync(token);
+                if (!documentFlushTask.IsCompleted)
+                    await documentFlushTask.ConfigureAwait(false);
             }
 
             writer.WriteEndObject();
@@ -2070,7 +2106,10 @@ namespace Raven.Server.Json
                 else
                     writer.WriteObject(includeDoc);
 
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var includeFlushTask = writer.MaybeFlushAsync(token);
+                if (!includeFlushTask.IsCompleted)
+                    await includeFlushTask.ConfigureAwait(false);
             }
 
             writer.WriteEndObject();
@@ -2101,7 +2140,7 @@ namespace Raven.Server.Json
             writer.WriteEndObject();
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteObjectsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<BlittableJsonReaderObject> objects, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteObjectsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IEnumerable<BlittableJsonReaderObject> objects, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -2127,7 +2166,17 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token);
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                    var objectFlushTask = writer.MaybeFlushAsync(token);
+                    int writtenBytes;
+                    if (objectFlushTask.IsCompleted)
+                    {
+                        writtenBytes = objectFlushTask.GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        writtenBytes = await objectFlushTask.ConfigureAwait(false);
+                    }
 
                     if (o.HasParent)
                     {
@@ -2144,7 +2193,7 @@ namespace Raven.Server.Json
             return (numberOfResults, totalDocumentsSizeInBytes);
         }
 
-        public static async Task<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteObjectsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IAsyncEnumerable<BlittableJsonReaderObject> objects, CancellationToken token)
+        public static async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteObjectsAsync(this AsyncBlittableJsonTextWriter writer, JsonOperationContext context, IAsyncEnumerable<BlittableJsonReaderObject> objects, CancellationToken token)
         {
             long numberOfResults = 0;
             long totalDocumentsSizeInBytes = 0;
@@ -2170,7 +2219,17 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token);
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                    var asyncObjectFlushTask = writer.MaybeFlushAsync(token);
+                    int writtenBytes;
+                    if (asyncObjectFlushTask.IsCompleted)
+                    {
+                        writtenBytes = asyncObjectFlushTask.GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        writtenBytes = await asyncObjectFlushTask.ConfigureAwait(false);
+                    }
 
                     if (o.HasParent)
                     {
@@ -2243,7 +2302,7 @@ namespace Raven.Server.Json
             writer.WriteEndArray();
         }
 
-        public static async Task WriteCountersForDocumentAsync(this AsyncBlittableJsonTextWriter writer, List<CounterDetail> counters, CancellationToken token)
+        public static async ValueTask WriteCountersForDocumentAsync(this AsyncBlittableJsonTextWriter writer, List<CounterDetail> counters, CancellationToken token)
         {
             writer.WriteStartArray();
 
@@ -2257,7 +2316,10 @@ namespace Raven.Server.Json
                 if (counter == null)
                 {
                     writer.WriteNull();
-                    await writer.MaybeFlushAsync(token);
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                    var nullCounterFlushTask = writer.MaybeFlushAsync(token);
+                    if (!nullCounterFlushTask.IsCompleted)
+                        await nullCounterFlushTask.ConfigureAwait(false);
                     continue;
                 }
 
@@ -2276,13 +2338,16 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var counterFlushTask = writer.MaybeFlushAsync(token);
+                if (!counterFlushTask.IsCompleted)
+                    await counterFlushTask.ConfigureAwait(false);
             }
 
             writer.WriteEndArray();
         }
 
-        public static async Task WriteCompareExchangeValuesAsync(this AsyncBlittableJsonTextWriter writer, Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>> compareExchangeValues, CancellationToken token)
+        public static async ValueTask WriteCompareExchangeValuesAsync(this AsyncBlittableJsonTextWriter writer, Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>> compareExchangeValues, CancellationToken token)
         {
             writer.WriteStartObject();
 
@@ -2318,7 +2383,10 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token);
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var compareExchangeFlushTask = writer.MaybeFlushAsync(token);
+                if (!compareExchangeFlushTask.IsCompleted)
+                    await compareExchangeFlushTask.ConfigureAwait(false);
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -542,7 +542,10 @@ namespace Raven.Server.Smuggler.Documents
                         break;
                 }
 
-                await _writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = _writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
 
             private void WriteRevisionsForConflictsConfiguration(RevisionsCollectionConfiguration revisionsForConflictsConfiguration)
@@ -1256,7 +1259,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 Writer.WriteEndObject();
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
 
             public async ValueTask WriteIndexAsync(IndexDefinition indexDefinition, AuthorizationStatus authorizationStatus)
@@ -1276,7 +1282,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 Writer.WriteEndObject();
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
         }
 
@@ -1309,7 +1318,10 @@ namespace Raven.Server.Smuggler.Documents
 
                     Writer.WriteEndObject();
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
             }
 
@@ -1337,7 +1349,10 @@ namespace Raven.Server.Smuggler.Documents
                 Writer.WriteString(counterDetail.ChangeVector);
 
                 Writer.WriteEndObject();
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
 
             public void RegisterForDisposal(IDisposable data)
@@ -1429,7 +1444,10 @@ namespace Raven.Server.Smuggler.Documents
                         Writer.WriteMemoryChunk(item.Segment.Ptr, item.Segment.NumberOfBytes);
                     }
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
             }
 
@@ -1469,7 +1487,10 @@ namespace Raven.Server.Smuggler.Documents
 
                     Writer.WriteEndObject();
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
             }
 
@@ -1520,7 +1541,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 _context.Write(_writer, subscriptionState.ToJson());
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
         }
 
@@ -1545,7 +1569,10 @@ namespace Raven.Server.Smuggler.Documents
                 djv[nameof(RegisterReplicationHubAccessCommand.HubName)] = hub;
                 _context.Write(_writer, djv);
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
         }
 
@@ -1594,7 +1621,10 @@ namespace Raven.Server.Smuggler.Documents
 
                     Writer.WriteDocument(_context, document, metadataOnly: false, _filterMetadataProperty);
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
             }
 
@@ -1626,7 +1656,10 @@ namespace Raven.Server.Smuggler.Documents
                         }
                     }
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
             }
 
@@ -1649,7 +1682,10 @@ namespace Raven.Server.Smuggler.Documents
                         [nameof(DocumentConflict.Doc)] = conflict.Doc,
                     });
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
             }
 
@@ -1760,7 +1796,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 await Writer.WriteStreamAsync(stream);
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
 
             public override async ValueTask DisposeAsync()
@@ -1794,7 +1833,10 @@ namespace Raven.Server.Smuggler.Documents
                 Writer.WriteString(value.ToString());
                 Writer.WriteEndObject();
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
         }
 
@@ -1823,7 +1865,10 @@ namespace Raven.Server.Smuggler.Documents
                     Writer.WriteString(value.ToString());
                     Writer.WriteEndObject();
 
-                    await Writer.MaybeFlushAsync();
+                    // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
                 }
 
                 return false;
@@ -1840,7 +1885,10 @@ namespace Raven.Server.Smuggler.Documents
                 Writer.WriteString(key);
                 Writer.WriteEndObject();
 
-                await Writer.MaybeFlushAsync();
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = Writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask;
             }
 
             public ValueTask FlushAsync()

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -88,7 +88,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
 
     protected abstract bool NotModified(TOperationContext context, out string etag);
 
-    protected abstract Task WriteItemsAsync(TOperationContext context, AsyncBlittableJsonTextWriter writer);
+    protected abstract ValueTask WriteItemsAsync(TOperationContext context, AsyncBlittableJsonTextWriter writer);
 
     protected abstract Task InitializeAsync(TOperationContext context, CancellationToken token);
 

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForRevisionsIds.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForRevisionsIds.cs
@@ -38,6 +38,6 @@ namespace Raven.Server.Web.Studio.Processors
             }
         }
 
-        protected abstract Task WriteItemsAsync(TOperationContext context, AsyncBlittableJsonTextWriter writer, CancellationToken token);
+        protected abstract ValueTask WriteItemsAsync(TOperationContext context, AsyncBlittableJsonTextWriter writer, CancellationToken token);
     }
 }

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -35,7 +35,7 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
     {
     }
 
-    protected override async Task WriteItemsAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
+    protected override async ValueTask WriteItemsAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
         var shardItems = RequestHandler.DatabaseContext.Streaming.PagedShardedStream(
             _combinedReadState,

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForRevisionsIds.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForRevisionsIds.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Web.Studio.Sharding.Processors
         {
         }
 
-        protected override async Task WriteItemsAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer, CancellationToken token)
+        protected override async ValueTask WriteItemsAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer, CancellationToken token)
         {
             var op = new ShardedRevisionsIdsOperation(RequestHandler, Prefix, PageSize);
             var result = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(op, token);

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -59,7 +59,7 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
         return context.OpenReadTransaction();
     }
 
-    protected override Task WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
+    protected override ValueTask WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
         writer.WriteStartArray();
 
@@ -78,7 +78,7 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
         }
 
         writer.WriteEndArray();
-        return Task.CompletedTask;
+        return default;
     }
 
     private void WriteItemsInternal(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, IEnumerable<Document> revisions)

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForRevisionsIds.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForRevisionsIds.cs
@@ -14,7 +14,7 @@ internal sealed class StudioCollectionsHandlerProcessorForRevisionsIds : Abstrac
     {
     }
 
-    protected override Task WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, CancellationToken token)
+    protected override ValueTask WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer, CancellationToken token)
     {
         using var _ = context.OpenReadTransaction();
     
@@ -35,7 +35,7 @@ internal sealed class StudioCollectionsHandlerProcessorForRevisionsIds : Abstrac
             writer.WriteEndObject();
         }
         writer.WriteEndArray();
-        return Task.CompletedTask;
+        return default;
     }
 }
 

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -10,11 +10,15 @@ namespace Sparrow.Json
     {
         private readonly Stream _outputStream;
         private readonly CancellationToken _cancellationToken;
+        
+        // PERF: Cache the MemoryStream reference to avoid repeated casting
+        private readonly MemoryStream _memoryStream;
 
         public AsyncBlittableJsonTextWriter(JsonOperationContext context, Stream stream, CancellationToken cancellationToken = default) : base(context, RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
             _outputStream = stream ?? throw new ArgumentNullException(nameof(stream));
             _cancellationToken = cancellationToken;
+            _memoryStream = (MemoryStream)_stream; // Cache the cast since we know it's always MemoryStream
         }
 
         public async ValueTask WriteStreamAsync(Stream stream, CancellationToken token = default)
@@ -34,48 +38,100 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<int> MaybeFlushAsync(CancellationToken token = default)
         {
-            var innerStream = _stream as MemoryStream;
-            if (innerStream == null)
-                ThrowInvalidTypeException(_stream?.GetType());
-            if (innerStream.Length * 2 <= innerStream.Capacity)
+            // PERF: Use cached MemoryStream reference
+            if (_memoryStream.Length * 2 <= _memoryStream.Capacity)
                 return new ValueTask<int>(0);
 
             FlushInternal(); // this is OK, because inner stream is a MemoryStream
             return FlushAsync(token);
         }
 
-        public async ValueTask<int> FlushAsync(CancellationToken token = default)
+        public ValueTask<int> FlushAsync(CancellationToken token = default)
         {
-            var innerStream = _stream as MemoryStream;
-            if (innerStream == null)
-                ThrowInvalidTypeException(_stream?.GetType());
+            // PERF: Use cached MemoryStream reference
             FlushInternal();
-            innerStream.TryGetBuffer(out var bytes);
+            _memoryStream.TryGetBuffer(out var bytes);
             var bytesCount = bytes.Count;
             if (bytesCount == 0)
-                return 0;
-            await _outputStream.WriteAsync(bytes.Array, bytes.Offset, bytesCount, token).ConfigureAwait(false);
+                return new ValueTask<int>(0);
+            
+            var writeTask = _outputStream.WriteAsync(bytes.Array, bytes.Offset, bytesCount, token);
+            if (writeTask.IsCompleted)
+            {
+                // PERF: Fast synchronous path - avoid async state machine overhead
+                // This happens when _outputStream is MemoryStream, FileStream with sync completion, etc.
+                writeTask.GetAwaiter().GetResult();
+                _memoryStream.SetLength(0);
+                return new ValueTask<int>(bytesCount);
+            }
+            
+            // Slow asynchronous path for network streams, slow disk I/O, etc.
+            return FlushAsyncSlow(writeTask, _memoryStream, bytesCount);
+        }
+        
+        private static async ValueTask<int> FlushAsyncSlow(Task writeTask, MemoryStream innerStream, int bytesCount)
+        {
+            await writeTask.ConfigureAwait(false);
             innerStream.SetLength(0);
             return bytesCount;
         }
 
-        public async ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             DisposeInternal();
 
-            if (await FlushAsync().ConfigureAwait(false) > 0)
+            // PERF: Check if flush completed synchronously to avoid async state machine
+            var flushTask = FlushAsync();
+            if (flushTask.IsCompleted)
+            {
+                // Fast synchronous path
+                var bytesWritten = flushTask.GetAwaiter().GetResult();
+                if (bytesWritten > 0)
+                {
+                    var outputFlushTask = _outputStream.FlushAsync();
+                    if (outputFlushTask.IsCompleted)
+                    {
+                        outputFlushTask.GetAwaiter().GetResult();
+                        return DisposeStreamAsync();
+                    }
+                    else
+                    {
+                        return DisposeAsyncSlow(outputFlushTask);
+                    }
+                }
+                else
+                {
+                    return DisposeStreamAsync();
+                }
+            }
+            
+            return DisposeAsyncSlow(flushTask);
+        }
+
+        private async ValueTask DisposeAsyncSlow(ValueTask<int> flushTask)
+        {
+            var bytesWritten = await flushTask.ConfigureAwait(false);
+            if (bytesWritten > 0)
                 await _outputStream.FlushAsync().ConfigureAwait(false);
 
+            await DisposeStreamAsync().ConfigureAwait(false);
+        }
+
+        private async ValueTask DisposeAsyncSlow(Task outputFlushTask)
+        {
+            await outputFlushTask.ConfigureAwait(false);
+            await DisposeStreamAsync().ConfigureAwait(false);
+        }
+
+        private ValueTask DisposeStreamAsync()
+        {
 #if !NETSTANDARD2_0
-            await _stream.DisposeAsync().ConfigureAwait(false);
+            return _stream.DisposeAsync();
 #else
             _stream.Dispose();
+            return default;
 #endif
         }
 
-        private void ThrowInvalidTypeException(Type typeOfStream)
-        {
-            throw new ArgumentException($"Expected stream to be MemoryStream, but got {(typeOfStream == null ? "null" : typeOfStream.ToString())}.");
-        }
     }
 }

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -67,7 +67,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<Stream> items)
+        public static async ValueTask WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<Stream> items)
         {
             writer.WritePropertyName(name);
 
@@ -80,7 +80,11 @@ namespace Sparrow.Json
                 first = false;
 
                 item.Position = 0;
-                await writer.WriteStreamAsync(item).ConfigureAwait(false);
+                
+                // PERF: Check if WriteStreamAsync completed synchronously to avoid async state machine
+                var writeTask = writer.WriteStreamAsync(item);
+                if (!writeTask.IsCompleted)
+                    await writeTask.ConfigureAwait(false);
             }
 
             writer.WriteEndArray();
@@ -169,7 +173,7 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<BlittableJsonReaderObject> items)
+        public static async ValueTask WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IEnumerable<BlittableJsonReaderObject> items)
         {
             writer.WritePropertyName(name);
 
@@ -182,13 +186,17 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeFlushAsync().ConfigureAwait(false);
+                
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static async Task WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IAsyncEnumerable<BlittableJsonReaderObject> items)
+        public static async ValueTask WriteArrayAsync(this AsyncBlittableJsonTextWriter writer, string name, IAsyncEnumerable<BlittableJsonReaderObject> items)
         {
             writer.WritePropertyName(name);
 
@@ -201,7 +209,11 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeFlushAsync().ConfigureAwait(false);
+                
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.MaybeFlushAsync();
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -974,7 +974,11 @@ namespace Sparrow.Json
             await using (var writer = new AsyncBlittableJsonTextWriter(this, stream))
             {
                 writer.WriteObject(json);
-                await writer.FlushAsync(token).ConfigureAwait(false);
+                
+                // PERF: Check if flush completed synchronously to avoid async state machine
+                var flushTask = writer.FlushAsync(token);
+                if (!flushTask.IsCompleted)
+                    await flushTask.ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21218

### Additional description

There are many places where judicious use of ValueTask can allow us to avoid async transitions. Experimenting with avoiding the usage of await.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
