### PR TITLE
RavenDB-24629 Optimize compression buffers zeroing to reduce disk writes in encrypted databases

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -64,6 +64,7 @@ namespace Voron.Impl.Journal
 
         private readonly object _writeLock = new object();
         private int _maxNumberOfPagesRequiredForCompressionBuffer;
+        private int _numberOfUsedCompressionBufferPagesSinceZeroing;
 
         internal NativeMemory.ThreadStats CurrentFlushingInProgressHolder;
 
@@ -1735,7 +1736,7 @@ namespace Voron.Impl.Journal
 
                 using (tempEncCompressionPagerTxState)
                 {
-                    var journalEntry = PrepareToWriteToJournal(tx, tempEncCompressionPagerTxState);
+                    var journalEntry = PrepareToWriteToJournal(tx, tempEncCompressionPagerTxState, out var numberOfUsedCompressionBufferPages);
                     if (_logger.IsInfoEnabled)
                     {
                         _logger.Info(
@@ -1762,6 +1763,7 @@ namespace Voron.Impl.Journal
                     sp.Stop();
                     _lastCompressionAccelerationInfo.WriteDuration = sp.Elapsed;
                     _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
+                    _numberOfUsedCompressionBufferPagesSinceZeroing = Math.Max(_numberOfUsedCompressionBufferPagesSinceZeroing, numberOfUsedCompressionBufferPages);
 
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Writing {new Size(journalEntry.NumberOf4Kbs * 4, SizeUnit.Kilobytes)} to journal {CurrentFile.Number:D19} took {sp.Elapsed}");
@@ -1784,7 +1786,8 @@ namespace Voron.Impl.Journal
             }
         }
 
-        private CompressedPagesResult PrepareToWriteToJournal(LowLevelTransaction tx, IPagerLevelTransactionState tempEncCompressionPagerTxState)
+        private CompressedPagesResult PrepareToWriteToJournal(LowLevelTransaction tx, IPagerLevelTransactionState tempEncCompressionPagerTxState,
+            out int totalNumberOfUsedCompressionBufferPages)
         {
             var txPages = tx.GetTransactionPages();
             var numberOfPages = txPages.Count;
@@ -1906,6 +1909,7 @@ namespace Voron.Impl.Journal
                                                         ((outputBufferSize + sizeof(TransactionHeader)) % Constants.Storage.PageSize == 0 ? 0 : 1)));
 
                 _maxNumberOfPagesRequiredForCompressionBuffer = Math.Max(pagesRequired + outputBufferInPages, _maxNumberOfPagesRequiredForCompressionBuffer);
+                totalNumberOfUsedCompressionBufferPages = pagesRequired + outputBufferInPages;
 
                 var totalSizeWrittenPlusTxHeader = totalSizeWritten + sizeof(TransactionHeader);
                 var pagesWritten = (totalSizeWrittenPlusTxHeader / Constants.Storage.PageSize) +
@@ -1953,6 +1957,7 @@ namespace Voron.Impl.Journal
             else
             {
                 _maxNumberOfPagesRequiredForCompressionBuffer = Math.Max(pagesRequired, _maxNumberOfPagesRequiredForCompressionBuffer);
+                totalNumberOfUsedCompressionBufferPages = pagesRequired;
             }
 
             // We need to account for the transaction header as part of the total length.
@@ -2188,11 +2193,12 @@ namespace Voron.Impl.Journal
 
             try
             {
-                var compressionBufferSize = _compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize;
-                _compressionPager.EnsureMapped(tx, 0, checked((int)_compressionPager.NumberOfAllocatedPages));
+                var compressionBufferSize = _numberOfUsedCompressionBufferPagesSinceZeroing * Constants.Storage.PageSize;
+                _compressionPager.EnsureMapped(tx, 0, _numberOfUsedCompressionBufferPagesSinceZeroing);
                 var pagePointer = _compressionPager.AcquirePagePointer(tx, 0);
 
                 Sodium.sodium_memzero(pagePointer, (UIntPtr)compressionBufferSize);
+                _numberOfUsedCompressionBufferPagesSinceZeroing = 0;
             }
             finally
             {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24629

### Additional description

Avoid calling `sodium_memzero` on the entire compression.buffers file as it causes excessive disk I/O. Instead, track the number of used pages and only zero the actually touched memory regions to minimize write operations.

**Context & Impact:**

This change is especially important for Lucene indexes, where internal merge operations can result in large transactions and enlarge the `compression.buffers` file far beyond typical commit sizes. In encrypted databases with multiple indexes, the previous approach led to heavy and growing write amplification, as every index operation zeroed the entire (potentially very large) buffer file. Those changes were synced to disk causing high writes.

As a result, even a single document update and its related index update would previously trigger disk writes equivalent to the full size of the `compression.buffers` file.


**Example: Index writes caused by a single document update**

_Before:_

- `compression.0000000000.buffers` size: **256MB**

```
-rw------- 1 ravendb ravendb 256M Aug  6 09:07 compression.0000000000.buffers
```

- Accumulated writes grow by 256MB per batch:

```
sudo iotop -a -p 7527 -b -t -q -d 10
    TIME    TID  PRIO  USER     DISK READ  DISK WRITE  SWAPIN      IO    COMMAND
09:12:26    7527 be/4 ravendb     352.00 K    256.32 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
09:12:36    7527 be/4 ravendb     352.00 K    512.24 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
09:12:46    7527 be/4 ravendb     356.00 K    713.30 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
09:12:56    7527 be/4 ravendb     356.00 K    768.56 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
09:13:06    7527 be/4 ravendb     420.00 K   1024.76 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
09:13:16    7527 be/4 ravendb     420.00 K   1280.76 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
09:13:36    7527 be/4 ravendb     420.00 K   1536.80 M ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
```

_After:_

- `compression.0000000000.buffers` size still **256MB**
```
-rw------- 1 ravendb ravendb 256M Aug  6 13:06 compression.0000000000.buffers
```

- Accumulated writes greatly reduced, reflecting only actual sizes of transactions:

```
sudo iotop -a -p 10408 -b -t -q -d 10
    TIME    TID  PRIO  USER     DISK READ  DISK WRITE  SWAPIN      IO    COMMAND
13:05:57   10408 be/4 ravendb     100.00 K    296.00 K ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
13:06:07   10408 be/4 ravendb     100.00 K    544.00 K ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
13:06:17   10408 be/4 ravendb     100.00 K    752.00 K ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
13:06:28   10408 be/4 ravendb     100.00 K   1048.00 K ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
13:06:38   10408 be/4 ravendb     100.00 K   1256.00 K ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
13:06:48   10408 be/4 ravendb     100.00 K   1504.00 K ?unavailable?  Raven.Server -c /ravendb/config/settings.json [Idx test test-L]
```

---

Also more details in https://issues.hibernatingrhinos.com/issue/RavenDB-24629/Writes-grow-over-time-until-restart#focus=Comments-67-1066692.0-0

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
