### PR TITLE
RavenDB-24629 Custom build on top of 6.2.8 + PR #21103

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -63,6 +63,7 @@ namespace Voron.Impl.Journal
 
         private readonly object _writeLock = new object();
         private int _maxNumberOfPagesRequiredForCompressionBuffer;
+        private int _numberOfUsedCompressionBufferPagesSinceZeroing;
 
         internal NativeMemory.ThreadStats CurrentFlushingInProgressHolder;
 
@@ -1715,7 +1716,7 @@ namespace Voron.Impl.Journal
 
                 using (tempEncCompressionPagerTxState)
                 {
-                    var journalEntry = PrepareToWriteToJournal(tx, tempEncCompressionPagerTxState);
+                    var journalEntry = PrepareToWriteToJournal(tx, tempEncCompressionPagerTxState, out var numberOfUsedCompressionBufferPages);
                     if (_logger.IsInfoEnabled)
                     {
                         _logger.Info(
@@ -1737,6 +1738,7 @@ namespace Voron.Impl.Journal
                     sp.Stop();
                     _lastCompressionAccelerationInfo.WriteDuration = sp.Elapsed;
                     _lastCompressionAccelerationInfo.CalculateOptimalAcceleration();
+                    _numberOfUsedCompressionBufferPagesSinceZeroing = Math.Max(_numberOfUsedCompressionBufferPagesSinceZeroing, numberOfUsedCompressionBufferPages);
 
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"Writing {new Size(journalEntry.NumberOf4Kbs * 4, SizeUnit.Kilobytes)} to journal {CurrentFile.Number:D19} took {sp.Elapsed}");
@@ -1758,7 +1760,8 @@ namespace Voron.Impl.Journal
             }
         }
 
-        private CompressedPagesResult PrepareToWriteToJournal(LowLevelTransaction tx, IPagerLevelTransactionState tempEncCompressionPagerTxState)
+        private CompressedPagesResult PrepareToWriteToJournal(LowLevelTransaction tx, IPagerLevelTransactionState tempEncCompressionPagerTxState,
+            out int totalNumberOfUsedCompressionBufferPages)
         {
             var txPages = tx.GetTransactionPages();
             var numberOfPages = txPages.Count;
@@ -1880,6 +1883,7 @@ namespace Voron.Impl.Journal
                                                         ((outputBufferSize + sizeof(TransactionHeader)) % Constants.Storage.PageSize == 0 ? 0 : 1)));
 
                 _maxNumberOfPagesRequiredForCompressionBuffer = Math.Max(pagesRequired + outputBufferInPages, _maxNumberOfPagesRequiredForCompressionBuffer);
+                totalNumberOfUsedCompressionBufferPages = pagesRequired + outputBufferInPages;
 
                 var totalSizeWrittenPlusTxHeader = totalSizeWritten + sizeof(TransactionHeader);
                 var pagesWritten = (totalSizeWrittenPlusTxHeader / Constants.Storage.PageSize) +
@@ -1927,6 +1931,7 @@ namespace Voron.Impl.Journal
             else
             {
                 _maxNumberOfPagesRequiredForCompressionBuffer = Math.Max(pagesRequired, _maxNumberOfPagesRequiredForCompressionBuffer);
+                totalNumberOfUsedCompressionBufferPages = pagesRequired;
             }
 
             // We need to account for the transaction header as part of the total length.
@@ -2159,11 +2164,12 @@ namespace Voron.Impl.Journal
 
             try
             {
-                var compressionBufferSize = _compressionPager.NumberOfAllocatedPages * Constants.Storage.PageSize;
-                _compressionPager.EnsureMapped(tx, 0, checked((int)_compressionPager.NumberOfAllocatedPages));
+                var compressionBufferSize = _numberOfUsedCompressionBufferPagesSinceZeroing * Constants.Storage.PageSize;
+                _compressionPager.EnsureMapped(tx, 0, _numberOfUsedCompressionBufferPagesSinceZeroing);
                 var pagePointer = _compressionPager.AcquirePagePointer(tx, 0);
 
                 Sodium.sodium_memzero(pagePointer, (UIntPtr)compressionBufferSize);
+                _numberOfUsedCompressionBufferPagesSinceZeroing = 0;
             }
             finally
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24629

### Additional description

Custom build which applies https://github.com/ravendb/ravendb/pull/21128 on top of 6.2.8 and https://github.com/ravendb/ravendb/pull/21103 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
