### PR TITLE
RavenDB-20555 & RavenDB-24104 - Enhancements for an encrypted database

### DIFF
--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -541,7 +541,7 @@ namespace Voron.Data.Fixed
                     if (MoveNext(count) == false)
                         return false;
                 }
-                else
+                else if (count < 0)
                 {
                     if (MovePrev(-count) == false)
                         return false;

--- a/src/Voron/Data/Fixed/FixedSizeIterators.cs
+++ b/src/Voron/Data/Fixed/FixedSizeIterators.cs
@@ -363,13 +363,26 @@ namespace Voron.Data.Fixed
                 if (_currentPage == null || _currentPage.IsLeaf == false)
                     throw new InvalidOperationException("No current page was set or is wasn't a leaf!");
 
+                var currentPageHeader = _currentPage.PageHeader;
+                var lastSearchPosition = _currentPage.LastSearchPosition;
+
                 while (skip >= 0)
                 {
-                    var skipInPage = (int)Math.Min(_currentPage.LastSearchPosition, skip);
+                    var skipInPage = (int)Math.Min(lastSearchPosition, skip);
                     skip -= skipInPage;
-                    _currentPage.LastSearchPosition -= skipInPage;
+                    lastSearchPosition -= skipInPage;
+
                     if (skip == 0)
                     {
+                        // We've completed skipping the requested number of entries. Now we need to:
+                        // 1. Set the _currentPage to the appropriate page based on the current page info
+                        // 2. Update its LastSearchPosition to point to the correct entry
+
+                        if (_currentPage.PageNumber != currentPageHeader.PageNumber)
+                            _currentPage = _parent.GetReadOnlyPage(currentPageHeader.PageNumber);
+
+                        _currentPage.LastSearchPosition = lastSearchPosition;
+
                         return true;
                     }
                     
@@ -385,20 +398,23 @@ namespace Voron.Data.Fixed
                             _parent._cursor.Pop();
                             continue;
                         }
-                        
+
                         var nextChildPageNumber = parent.GetEntry(parent.LastSearchPosition)->PageNumber;
-                        var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
-                        
-                        // we move one beyond the end of elements because in both cases
-                        // (branch and leaf) we first decrement and then run it
-                        childPage.LastSearchPosition = childPage.NumberOfEntries;
-                        if (childPage.IsBranch)
+                        var childPageHeader = _parent.GetPageHeader(nextChildPageNumber);
+                        if ((childPageHeader.TreeFlags & FixedSizeTreePageFlags.Branch) == FixedSizeTreePageFlags.Branch)
                         {
+                            var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
+
+                            // we move one beyond the end of elements because in both cases
+                            // (branch and leaf) we first decrement and then run it
+                            childPage.LastSearchPosition = childPage.NumberOfEntries;
+
                             _parent._cursor.Push(childPage);
                             continue;
                         }
 
-                        _currentPage = childPage;
+                        currentPageHeader = childPageHeader;
+                        lastSearchPosition = childPageHeader.NumberOfEntries;
                         break;
                     }
                 }
@@ -414,13 +430,27 @@ namespace Voron.Data.Fixed
                 if (_currentPage == null || _currentPage.IsLeaf == false)
                     throw new InvalidOperationException("No current page was set or is wasn't a leaf!");
 
+                var currentPageHeader = _currentPage.PageHeader;
+                var lastSearchPosition = _currentPage.LastSearchPosition;
+
                 while (skip >= 0)
                 {
-                    var skipInPage = (int)Math.Min(_currentPage.NumberOfEntries - _currentPage.LastSearchPosition, skip);
+                    var skipInPage = (int)Math.Min(currentPageHeader.NumberOfEntries - lastSearchPosition, skip);
                     skip -= skipInPage;
-                    _currentPage.LastSearchPosition += skipInPage;
+                    lastSearchPosition += skipInPage;
+
                     if (skip == 0)
                     {
+                        // We've completed skipping the requested number of entries. Now we need to:
+                        // 1. Set the _currentPage to the appropriate page based on the current page info
+                        // 2. Update its LastSearchPosition to point to the correct entry
+                        // 3. Check if we've reached the end of the current page, and if so, move to the next page
+
+                        if (_currentPage.PageNumber != currentPageHeader.PageNumber)
+                            _currentPage = _parent.GetReadOnlyPage(currentPageHeader.PageNumber);
+
+                        _currentPage.LastSearchPosition = lastSearchPosition;
+
                         if (_currentPage.LastSearchPosition >= _currentPage.NumberOfEntries)
                             return MoveNext();
                         return true;
@@ -440,22 +470,20 @@ namespace Voron.Data.Fixed
                         }
                         
                         var nextChildPageNumber = parent.GetEntry(parent.LastSearchPosition)->PageNumber;
-                        var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
-
-                        if (childPage.IsBranch)
+                        var childPageHeader = _parent.GetPageHeader(nextChildPageNumber);
+                        if ((childPageHeader.TreeFlags & FixedSizeTreePageFlags.Branch) == FixedSizeTreePageFlags.Branch)
                         {
+                            var childPage = _parent.GetReadOnlyPage(nextChildPageNumber);
+
                             // we set it to negative one so the first
                             // call will increment that to zero
                             childPage.LastSearchPosition = -1;
                             _parent._cursor.Push(childPage);
                             continue;
                         }
-                        else
-                        {
-                            childPage.LastSearchPosition = 0;
-                        }
-                        
-                        _currentPage = childPage;
+
+                        currentPageHeader = childPageHeader;
+                        lastSearchPosition = 0;
                         break;
                     }
                 }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -406,6 +406,11 @@ namespace Voron.Data.Fixed
             return new FixedSizeTreePage<TVal>(readOnlyPage.Pointer, _entrySize, Constants.Storage.PageSize);
         }
 
+        internal FixedSizeTreePageHeader GetPageHeader(long pageNumber)
+        {
+            return _tx.GetPageHeader<FixedSizeTreePageHeader>(pageNumber);
+        }
+
         private FixedSizeTreePage<TVal> FindPageFor(TVal key)
         {
             var header = (FixedSizeTreeHeader.Large*)_parent.DirectRead(_treeName);

--- a/src/Voron/Data/Fixed/FixedSizeTreePage.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTreePage.cs
@@ -34,6 +34,12 @@ namespace Voron.Data.Fixed
             get { return (FixedSizeTreePageHeader*)_ptr; }
         }
 
+        public FixedSizeTreePageHeader PageHeader
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return *(FixedSizeTreePageHeader*)_ptr; }
+        }
+
         public long PageNumber
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -198,7 +198,7 @@ namespace Voron.Debugging
 
             foreach (PersistentDictionaryRootHeader dic in input.PersistentDictionaries)
             {
-                // cannot use GetPageHeaderForDebug since the header is at the data pointer
+                // cannot use GetPageHeader since the header is at the data pointer
                 Page page = _tx.GetPage(dic.PageNumber);
                 var header = (PersistentDictionaryHeader*)page.DataPointer;
 
@@ -498,7 +498,7 @@ namespace Voron.Debugging
                 var it = Container.GetAllPagesIterator(_tx, page);
                 while (it.MoveNext(out var pageNum))
                 {
-                    // cannot use GetPageHeaderForDebug since we are reading not just from the header
+                    // cannot use GetPageHeader since we are reading not just from the header
                     Page cur = _tx.GetPage(pageNum);
                     if (cur.IsOverflow)
                     {
@@ -515,7 +515,7 @@ namespace Voron.Debugging
             
             var (allPages, freePages) = Container.GetPagesFor(_tx, page);
             
-            // cannot use GetPageHeaderForDebug since we are reading not just from the header
+            // cannot use GetPageHeader since we are reading not just from the header
             var root = new Container(_tx.GetPage(page));
             double density = pageDensities?.Average() ?? -1;
             long totalPages = allPages.State.NumberOfEntries + root.Header.NumberOfOverflowPages + freePages.State.PageCount + allPages.State.PageCount;
@@ -770,7 +770,7 @@ namespace Voron.Debugging
             for (var i = 0; i < allPages.Count; i++)
             {
                 // we don't need the entire page contents in order to calculate the page density, just the header
-                var pageHeaderUnion = tree.Llt.GetPageHeaderForDebug<PageHeaderUnion>(allPages[i]);
+                var pageHeaderUnion = tree.Llt.GetPageHeader<PageHeaderUnion>(allPages[i]);
 
                 if ((pageHeaderUnion.PageHeader.Flags & PageFlags.Overflow) == PageFlags.Overflow)
                 {
@@ -810,7 +810,7 @@ namespace Voron.Debugging
 
             foreach (var p in allPages)
             {
-                // cannot use GetPageHeaderForDebug since we are reading not just from the header
+                // cannot use GetPageHeader since we are reading not just from the header
                 var page = postingList.Llt.GetPage(p);
                 var state = new PostingListCursorState { Page = page };
                 if (state.IsLeaf)
@@ -834,7 +834,7 @@ namespace Voron.Debugging
             var densities = new List<double>();
             foreach (var p in allPages)
             {
-                var lookupPageHeader = llt.GetPageHeaderForDebug<LookupPageHeader>(p);
+                var lookupPageHeader = llt.GetPageHeader<LookupPageHeader>(p);
                 densities.Add((double)lookupPageHeader.FreeSpace / Constants.Storage.PageSize);
             }
             return densities;
@@ -850,7 +850,7 @@ namespace Voron.Debugging
 
             foreach (var pageNumber in allPages)
             {
-                var fstph = tree.Llt.GetPageHeaderForDebug<FixedSizeTreePageHeader>(pageNumber);
+                var fstph = tree.Llt.GetPageHeader<FixedSizeTreePageHeader>(pageNumber);
                 var isLeaf = (fstph.TreeFlags & FixedSizeTreePageFlags.Leaf) == FixedSizeTreePageFlags.Leaf;
                 var sizeUsed = Constants.FixedSizeTree.PageHeaderSize +
                                fstph.NumberOfEntries * (isLeaf ? fstph.ValueSize + sizeof(long) : FixedSizeTree.BranchEntrySize);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -516,6 +516,18 @@ namespace Voron.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T GetPageHeader<T>(long pageNumber) where T : unmanaged
+        {
+            if (IsValid == false)
+                ThrowObjectDisposed();
+
+            if (_pageLocator.TryGetReadOnlyPage(pageNumber, out Page result))
+                return *(T*)result.Pointer;
+
+            return GetPageHeaderInternal<T>(pageNumber);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Page GetPageWithoutCache(long pageNumber)
         {
             if (IsValid == false)
@@ -546,6 +558,31 @@ namespace Voron.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private T GetPageHeaderInternal<T>(long pageNumber) where T : unmanaged
+        {
+            switch (_getPageMethod)
+            {
+                case GetPageMethod.WriteScratchFirst:
+                    if (_scratchPagesInUse.TryGetValue(pageNumber, out var pageInUse))
+                        return *(T*)pageInUse.ReadWritableRawPagePointer(ref PagerTransactionState);
+
+                    return GetPageHeaderFromDataFile<T>(pageNumber);
+
+                case GetPageMethod.ReadScratchFirst:
+                    if (_scratchPagesForReads.TryGetValue(pageNumber, out var readPage))
+                        return *(T*)readPage.ReadRawPagePointer(ref PagerTransactionState);
+
+                    return GetPageHeaderFromDataFile<T>(pageNumber);
+
+                case GetPageMethod.DataFile:
+                    return GetPageHeaderFromDataFile<T>(pageNumber);
+
+                default:
+                    throw new ArgumentOutOfRangeException(_getPageMethod.ToString());
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Page PageInternalFromWriteScratchTable(long pageNumber)
         {
             if (_scratchPagesInUse.TryGetValue(pageNumber, out var value))
@@ -570,9 +607,10 @@ namespace Voron.Impl
             return page;
         }
 
-        public T GetPageHeaderForDebug<T>(long pageNumber) where T : unmanaged
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private T GetPageHeaderFromDataFile<T>(long pageNumber) where T : unmanaged
         {
-            return *(T*)GetPage(pageNumber).Pointer;
+            return *(T*)DataPager.AcquireRawPagePointer(DataPagerState, ref PagerTransactionState, pageNumber);
         }
 
         public void TryReleasePage(long pageNumber)

--- a/src/Voron/Impl/Scratch/PageFromScratchBuffer.cs
+++ b/src/Voron/Impl/Scratch/PageFromScratchBuffer.cs
@@ -51,6 +51,12 @@ namespace Voron.Impl.Scratch
             return File.Pager.AcquirePagePointerWithOverflowHandling(State, ref txState, PositionInScratchBuffer);
         }
 
+        public unsafe byte* ReadRawPagePointer(ref Pager.PagerTransactionState txState)
+        {
+            File.VerifyMatch(PageNumberInDataFile, PositionInScratchBuffer, NumberOfPages);
+            return File.Pager.AcquireRawPagePointer(State, ref txState, PositionInScratchBuffer);
+        }
+
         public unsafe Page ReadNewPage(LowLevelTransaction tx)
         {
             var p = File.Pager.AcquirePagePointerForNewPage(State, ref tx.PagerTransactionState, PositionInScratchBuffer, NumberOfPages);
@@ -77,6 +83,12 @@ namespace Voron.Impl.Scratch
         public unsafe byte* ReadWritable(ref Pager.PagerTransactionState txPagerTransactionState)
         {
             var ptr = Read(ref txPagerTransactionState);
+            return File.Pager.MakeWritable(State, ptr);
+        }
+
+        public unsafe byte* ReadWritableRawPagePointer(ref Pager.PagerTransactionState txPagerTransactionState)
+        {
+            var ptr = ReadRawPagePointer(ref txPagerTransactionState);
             return File.Pager.MakeWritable(State, ptr);
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20555/High-unmanaged-memory-during-querying-of-an-encrypted-database
https://issues.hibernatingrhinos.com/issue/RavenDB-24104/Deep-paging-is-using-high-unmanaged-memory

### Additional description

`RavenDB-20555` - Storage report fix for reading only the page header.
`RavenDB-24104` - Reduce allocations when skipping documents for an encrypted database.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
