### PR TITLE
RavenDB-24629 Prevent zeroing more bytes than allocated in compression.buffers causing AVE

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -2164,11 +2164,13 @@ namespace Voron.Impl.Journal
 
             try
             {
-                var compressionBufferSize = _numberOfUsedCompressionBufferPagesSinceZeroing * Constants.Storage.PageSize;
-                _compressionPager.EnsureMapped(tx, 0, _numberOfUsedCompressionBufferPagesSinceZeroing);
+                var numberOfPagesToZero = Math.Min(_numberOfUsedCompressionBufferPagesSinceZeroing, _compressionPager.NumberOfAllocatedPages);
+                
+                var numberOfBytesToZero = numberOfPagesToZero * Constants.Storage.PageSize;
+                _compressionPager.EnsureMapped(tx, 0, checked((int)numberOfPagesToZero));
                 var pagePointer = _compressionPager.AcquirePagePointer(tx, 0);
 
-                Sodium.sodium_memzero(pagePointer, (UIntPtr)compressionBufferSize);
+                Sodium.sodium_memzero(pagePointer, (UIntPtr)numberOfBytesToZero);
                 _numberOfUsedCompressionBufferPagesSinceZeroing = 0;
             }
             finally

--- a/test/SlowTests/Voron/Issues/RavenDB_24629.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_24629.cs
@@ -1,0 +1,46 @@
+﻿using FastTests.Voron;
+using Sparrow.Platform;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_24629 : StorageTest
+{
+    public RavenDB_24629(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.ManualFlushing = true;
+        options.Encryption.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+        options.MaxScratchBufferSize = 65536 - 1; // to make ShouldReduceSizeOfCompressionPager() return true
+        options.Encryption.RegisterForJournalCompressionHandler();
+    }
+    
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MustNotZeroMoreBytesThanCompressionBufferSize()
+    {
+        using (var tx = Env.WriteTransaction())
+        {
+            Tree tree = tx.CreateTree("foo");
+            
+            for (int i = 0; i < 100; i++)
+            {
+                tree.Add("items/" + i, new byte[1024 * 1024]);
+            }
+            
+            tx.Commit();
+        }
+        
+        Env.Journal.TryReduceSizeOfCompressionBufferIfNeeded();
+        
+        using (var tx = Env.WriteTransaction())
+        {
+            Env.Journal.ZeroCompressionBuffer(tx.LowLevelTransaction); // AVE before the fix
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24629

### Additional description

It applies https://github.com/ravendb/ravendb/pull/21145 fix to https://github.com/ravendb/ravendb/pull/21131

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
