### PR TITLE
RavenDB-24767 - Increase the MaxStatements in TryCompileScript for ValidateSmugglerOptions

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -175,7 +175,7 @@ namespace Raven.Server.Documents.Patch
             {
                 var engine = new Engine(options =>
                 {
-                    options.MaxStatements(1).LimitRecursion(1);
+                    options.MaxStatements(128).LimitRecursion(1);
                 });
                 engine.Execute(script);
             }

--- a/test/FastTests/Issues/RavenDB_24767.cs
+++ b/test/FastTests/Issues/RavenDB_24767.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Server.Routing;
+using Raven.Server.Smuggler.Documents.Data;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_24767 : RavenTestBase
+    {
+        public RavenDB_24767(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Studio | RavenTestCategory.BackupExportImport)]
+        public async Task Can_Validate_Smuggler_options()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var options = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.ValidUser)
+                {
+                    TransformScript = @"
+                        this.Name = this.Name + '_transformed';
+                    "
+                };
+
+                await store.Maintenance.SendAsync(new ValidateSmugglerOptionsOperation(options));
+            }
+        }
+
+        private sealed class ValidateSmugglerOptionsOperation : IMaintenanceOperation
+        {
+            private readonly DatabaseSmugglerOptionsServerSide _options;
+
+            public ValidateSmugglerOptionsOperation(DatabaseSmugglerOptionsServerSide options)
+            {
+                _options = options ?? throw new ArgumentNullException(nameof(options));
+            }
+            public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new ValidateSmugglerOptionsCommand(_options);
+            }
+
+            private sealed class ValidateSmugglerOptionsCommand : RavenCommand
+            {
+                private readonly DatabaseSmugglerOptionsServerSide _options;
+
+                public ValidateSmugglerOptionsCommand(DatabaseSmugglerOptionsServerSide options)
+                {
+                    _options = options ?? throw new ArgumentNullException(nameof(options));
+                }
+
+                public override bool IsReadRequest => false;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/smuggler/validate-options";
+
+                    var request = new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Post,
+                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false), DocumentConventions.Default)
+                    };
+
+                    return request;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24767

### Additional description

This pull request introduces an important update to the script compilation limits and adds a new test to validate smuggler options in the backup/export/import workflow. The most significant changes are grouped below:

**Script Engine Configuration:**

* Increased the maximum allowed statements in the JavaScript engine from 1 to 128 in `TryCompileScript` within `ScriptRunner.cs`, allowing more complex scripts to be validated during smuggler operations.

**Testing and Validation:**

* Added a new test class `RavenDB_24767` in `RavenDB_24767.cs` to verify that smuggler options, including transformation scripts, can be validated via a dedicated maintenance operation.
* Implemented `ValidateSmugglerOptionsOperation` and its command to send smuggler options to the server for validation, ensuring that transformation scripts are properly checked before running export/import operations.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
