### PR TITLE
RavenDB-24831 AI Agent: UX improvements [release/v7.1]

### DIFF
--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -814,6 +814,21 @@ class genUtils {
 
         return genUtils.formatNumberToStringFixed(tokens, 0);
     }
+
+    static getNestedField(object: any, path: string) {
+        const keys = path.split(".");
+        let current = object;
+    
+        for (const key of keys) {
+            if (current && typeof current === "object") {
+                current = current[key];
+            } else {
+                return null;
+            }
+        }
+    
+        return current;
+    }
 } 
 
 export = genUtils;

--- a/src/Raven.Studio/typescript/components/common/ace/AceEditor.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/ace/AceEditor.stories.tsx
@@ -2,6 +2,8 @@ import { Meta, StoryObj } from "@storybook/react";
 import { withStorybookContexts, withBootstrap5 } from "test/storybookTestUtils";
 import AceEditor from "./AceEditor";
 import AceUnifiedDiff from "./AceUnifiedDiff";
+import ReactAce from "react-ace/lib/ace";
+import { useRef, useState } from "react";
 
 export default {
     title: "Bits/AceEditor",
@@ -15,10 +17,30 @@ export default {
     },
 } satisfies Meta;
 
-export const JavascriptEditor: StoryObj = {
+export const Default: StoryObj = {
     name: "Ace Editor",
-    render: () => <AceEditor mode="javascript" />,
+    render: () => <JsonEditorComponent />,
 };
+
+function JsonEditorComponent() {
+    const aceRef = useRef<ReactAce>(null);
+    const [aceValue, setAceValue] = useState("");
+
+    return (
+        <AceEditor
+            aceRef={aceRef}
+            mode="json"
+            actions={[
+                { component: <AceEditor.FullScreenAction /> },
+                { component: <AceEditor.FormatAction /> },
+                { component: <AceEditor.ToggleNewLinesAction /> },
+            ]}
+            value={aceValue}
+            onChange={(value) => setAceValue(value)}
+            height="300px"
+        />
+    );
+}
 
 export const UnifiedDiff: StoryObj = {
     render: () => {

--- a/src/Raven.Studio/typescript/components/common/ace/AceEditor.tsx
+++ b/src/Raven.Studio/typescript/components/common/ace/AceEditor.tsx
@@ -11,6 +11,7 @@ import AceEditorFormatAction from "./actions/AceEditorFormatAction";
 import AceEditorLoadFileAction from "./actions/AceEditorLoadFileAction";
 import AceEditorDeleteAction from "./actions/AceEditorDeleteAction";
 import AceEditorHelpAction from "./actions/AceEditorHelpAction";
+import AceEditorToggleNewLinesAction from "./actions/AceEditorToggleNewLinesAction";
 
 interface ActionItem {
     component: ReactNode;
@@ -195,5 +196,6 @@ AceEditor.FormatAction = AceEditorFormatAction;
 AceEditor.LoadFileAction = AceEditorLoadFileAction;
 AceEditor.DeleteAction = AceEditorDeleteAction;
 AceEditor.HelpAction = AceEditorHelpAction;
+AceEditor.ToggleNewLinesAction = AceEditorToggleNewLinesAction;
 
 export default AceEditor;

--- a/src/Raven.Studio/typescript/components/common/ace/AceEditor.tsx
+++ b/src/Raven.Studio/typescript/components/common/ace/AceEditor.tsx
@@ -38,6 +38,7 @@ function AceEditor(props: AceEditorProps) {
         setIsValid,
         actions = [],
         onLoad,
+        height = "200px",
         ...rest
     } = props;
 
@@ -118,7 +119,7 @@ function AceEditor(props: AceEditorProps) {
     return (
         <AceEditorContext.Provider value={aceRef}>
             <div className={classNames("ace-editor", { "has-error": errorMessage })}>
-                <div className="react-ace-wrapper">
+                <div className="react-ace-wrapper" style={{ height }}>
                     <ReactAce
                         ref={aceRef}
                         mode="csharp"
@@ -130,7 +131,7 @@ function AceEditor(props: AceEditorProps) {
                         showGutter={true}
                         highlightActiveLine={true}
                         width="100%"
-                        height="200px"
+                        height="100%"
                         setOptions={overriddenSetOptions}
                         onValidate={onValidate}
                         commands={commands}

--- a/src/Raven.Studio/typescript/components/common/ace/actions/AceEditorFormatAction.tsx
+++ b/src/Raven.Studio/typescript/components/common/ace/actions/AceEditorFormatAction.tsx
@@ -2,26 +2,41 @@ import { Icon } from "components/common/Icon";
 import Button from "react-bootstrap/Button";
 import { useAceEditorContext } from "../AceEditorContext";
 import "ace-builds/src-noconflict/ext-beautify";
+import { RefObject } from "react";
+import ReactAce from "react-ace";
 
 const beautify = ace.require("ace/ext/beautify").beautify;
 
 export default function AceEditorFormatAction() {
     const reactAce = useAceEditorContext();
 
-    const handleFormat = () => {
-        try {
-            const value = reactAce?.current.editor.session.getValue();
-            const parsed = JSON.parse(value);
-            const formatted = JSON.stringify(parsed, null, 2);
-            reactAce?.current.editor.session.setValue(formatted);
-        } catch {
-            beautify(reactAce?.current.editor.session);
-        }
-    };
-
     return (
-        <Button variant="link" onClick={handleFormat} className="p-0 text-reset" size="sm" title="Format">
+        <Button
+            variant="link"
+            onClick={() => handleFormat(reactAce)}
+            className="p-0 text-reset"
+            size="sm"
+            title="Format"
+        >
             <Icon icon="indent" margin="m-0" />
         </Button>
     );
+}
+
+export function handleFormat(reactAce: RefObject<ReactAce>) {
+    const session = reactAce?.current.editor.session;
+
+    if (!session) {
+        console.error("No Ace Editor session found");
+        return;
+    }
+
+    try {
+        const value = session.getValue();
+        const parsed = JSON.parse(value);
+        const formatted = JSON.stringify(parsed, null, 2);
+        session.setValue(formatted);
+    } catch {
+        beautify(session);
+    }
 }

--- a/src/Raven.Studio/typescript/components/common/ace/actions/AceEditorToggleNewLinesAction.tsx
+++ b/src/Raven.Studio/typescript/components/common/ace/actions/AceEditorToggleNewLinesAction.tsx
@@ -1,0 +1,54 @@
+import { Icon } from "components/common/Icon";
+import Button from "react-bootstrap/Button";
+import { useAceEditorContext } from "../AceEditorContext";
+import useBoolean from "components/hooks/useBoolean";
+import messagePublisher from "common/messagePublisher";
+import documentHelpers from "common/helpers/database/documentHelpers";
+import { handleFormat } from "./AceEditorFormatAction";
+import classNames from "classnames";
+
+(ace as any).config.loadModule("ace/mode/raven_document_newline_friendly");
+
+export default function AceEditorToggleNewLinesAction() {
+    const reactAce = useAceEditorContext();
+    const { value: isNewLinesEnabled, toggle: toggleNewLinesEnabled } = useBoolean(false);
+
+    const handleToggleNewLines = () => {
+        try {
+            const session = reactAce?.current.editor.session;
+
+            if (!session) {
+                console.error("No Ace Editor session found");
+                return;
+            }
+
+            if (isNewLinesEnabled) {
+                const value = documentHelpers.escapeNewlinesAndTabsInTextFields(session.getValue());
+                session.setValue(value);
+                session.setMode("ace/mode/raven_document");
+                handleFormat(reactAce);
+            } else {
+                const value = documentHelpers.unescapeNewlinesAndTabsInTextFields(session.getValue());
+                session.setValue(value);
+                session.setMode("ace/mode/raven_document_newline_friendly");
+            }
+
+            toggleNewLinesEnabled();
+        } catch (e) {
+            console.error(e);
+            messagePublisher.reportError("The document data isn't a legal JSON expression!");
+        }
+    };
+
+    return (
+        <Button
+            variant="link"
+            onClick={handleToggleNewLines}
+            className={classNames("p-0 text-reset", { border: isNewLinesEnabled })}
+            size="sm"
+            title="Toggle new lines"
+        >
+            <Icon icon="newline" margin="m-0" />
+        </Button>
+    );
+}

--- a/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
+++ b/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
@@ -14,6 +14,7 @@ import Tab from "react-bootstrap/Tab";
 import useUniqueId from "components/hooks/useUniqueId";
 import classNames from "classnames";
 import genUtils from "common/generalUtils";
+import messagePublisher from "common/messagePublisher";
 
 interface SampleObjectAndSchemaFieldsProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> {
     control: Control<TFieldValues>;
@@ -65,9 +66,14 @@ export default function SampleObjectAndSchemaFields<
     const [lastSampleObjectForGenerate, setLastSampleObjectForGenerate] = useState<string>(sampleObjectValue);
 
     const asyncGenerateSchema = useAsyncCallback(async () => {
-        const result = await tasksService.getJsonSchemaFromSampleObject(JSON.parse(sampleObject), schemaType);
-        setValue(jsonSchemaName, result.Result as TFieldValues[TName], { shouldValidate: true });
-        setLastSampleObjectForGenerate(sampleObject);
+        try {
+            const result = await tasksService.getJsonSchemaFromSampleObject(JSON.parse(sampleObject), schemaType);
+            setValue(jsonSchemaName, result.Result as TFieldValues[TName], { shouldValidate: true });
+            setLastSampleObjectForGenerate(sampleObject);
+        } catch (e) {
+            console.error(e);
+            messagePublisher.reportError("Failed to generate schema, please check the sample object");
+        }
     });
 
     const canRegenerateSchema = !!sampleObject && !!jsonSchema && lastSampleObjectForGenerate !== sampleObject;

--- a/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
+++ b/src/Raven.Studio/typescript/components/common/sampleObjectAndSchemaFields/SampleObjectAndSchemaFields.tsx
@@ -13,6 +13,7 @@ import Tabs from "react-bootstrap/Tabs";
 import Tab from "react-bootstrap/Tab";
 import useUniqueId from "components/hooks/useUniqueId";
 import classNames from "classnames";
+import genUtils from "common/generalUtils";
 
 interface SampleObjectAndSchemaFieldsProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> {
     control: Control<TFieldValues>;
@@ -72,7 +73,7 @@ export default function SampleObjectAndSchemaFields<
     const canRegenerateSchema = !!sampleObject && !!jsonSchema && lastSampleObjectForGenerate !== sampleObject;
 
     useEffect(() => {
-        if (formState.dirtyFields[sampleObjectName]) {
+        if (genUtils.getNestedField(formState.dirtyFields, sampleObjectName)) {
             setValue(canRegenerateSchemaName, canRegenerateSchema as TFieldValues[TName], {
                 shouldValidate: true,
             });
@@ -84,8 +85,8 @@ export default function SampleObjectAndSchemaFields<
 
     const defaultActiveTab = jsonSchema ? "json-schema" : "sample-object";
 
-    const hasSampleObjectError = formState.errors[sampleObjectName];
-    const hasJsonSchemaError = formState.errors[jsonSchemaName];
+    const hasSampleObjectError = genUtils.getNestedField(formState.errors, sampleObjectName);
+    const hasJsonSchemaError = genUtils.getNestedField(formState.errors, jsonSchemaName);
 
     return (
         <div className="sample-object-and-schema-tabs">

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -22,7 +22,7 @@ import { useServices } from "components/hooks/useServices";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { defaultItemsToProcess } from "components/pages/database/settings/documentExpiration/DocumentExpiration";
 import ChatAiAgentFormBody from "./partials/ChatAiAgentFormBody";
-import ChatAiAgentParametersDropdown from "./partials/ChatAiAgentParametersDropdown";
+import AiAgentParametersDropdown from "../partials/AiAgentParametersDropdown";
 
 interface QueryParams {
     agentId: string;
@@ -179,9 +179,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
                     >
                         Raw data
                     </Switch>
-                    {document.data?.Parameters && (
-                        <ChatAiAgentParametersDropdown parameters={document.data.Parameters} />
-                    )}
+                    {document.data?.Parameters && <AiAgentParametersDropdown parameters={document.data.Parameters} />}
                 </div>
             </div>
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
@@ -91,6 +91,7 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
                             setIsWaitingForActionToolSubmit={(value: boolean) =>
                                 dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(value))
                             }
+                            parametersFromUser={document.data?.Parameters}
                         />
                     )}
                     {isRawData && document.data && (

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentActionToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentActionToolItem.tsx
@@ -145,6 +145,8 @@ function ActionFieldSampleObjectSyntaxHelp() {
     "problemDescription": "Provide a description of the issue."
 }`;
 
+    const exampleCodeNoParameters = `{}`;
+
     return (
         <div>
             <div>
@@ -156,6 +158,8 @@ function ActionFieldSampleObjectSyntaxHelp() {
                 tools.
             </div>
             <Code code={exampleCode} elementToCopy={exampleCode} language="json" />
+            <div className="mt-2">Example 2 (no parameters will be used):</div>
+            <Code code={exampleCodeNoParameters} elementToCopy={exampleCodeNoParameters} language="json" />
         </div>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
@@ -72,7 +72,6 @@ export default function EditAiAgentQueryToolItem({ index, remove, save, edit }: 
 
         query.queryText(queryText);
         query.queryParameters(parameters);
-        query.name(queryText);
         query.recentQuery(true);
         query.skipRunOnInit(true);
         const queryDto = query.toStorageDto();

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
@@ -64,14 +64,19 @@ export default function EditAiAgentQueryToolItem({ index, remove, save, edit }: 
 
     const linkToQuery = () => {
         const query = queryCriteria.empty();
-        const queryText = queryItem.query;
+        let queryText = "";
 
         const regexToFind$: RegExp = /\$\w+/g;
-        const matches = queryText.match(regexToFind$) || [];
-        const parameters: Record<string, null> = Object.fromEntries(matches.map((match) => [match, null]));
+        const matches = queryItem.query.match(regexToFind$) || [];
+
+        if (matches.length > 0) {
+            queryText += matches.map((x) => `${x} = null`).join("\n");
+            queryText += "\n\n";
+        }
+
+        queryText += queryItem.query;
 
         query.queryText(queryText);
-        query.queryParameters(parameters);
         query.recentQuery(true);
         query.skipRunOnInit(true);
         const queryDto = query.toStorageDto();

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
@@ -204,12 +204,16 @@ const QueryFieldQuerySyntaxHelp = () => {
     "similarityLevel": "Provide the similarity level to apply in the search."
 }`;
 
+    const exampleCode3 = `{}`;
+
     return (
         <div>
             <div>Example 1:</div>
             <Code code={exampleCode1} elementToCopy={exampleCode1} language="json" />
             <div className="mt-2">Example 2:</div>
             <Code code={exampleCode2} elementToCopy={exampleCode2} language="json" />
+            <div className="mt-2">Example 3:</div>
+            <Code code={exampleCode3} elementToCopy={exampleCode3} language="json" />
         </div>
     );
 };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
@@ -213,7 +213,7 @@ const QueryFieldQuerySyntaxHelp = () => {
             <Code code={exampleCode1} elementToCopy={exampleCode1} language="json" />
             <div className="mt-2">Example 2:</div>
             <Code code={exampleCode2} elementToCopy={exampleCode2} language="json" />
-            <div className="mt-2">Example 3:</div>
+            <div className="mt-2">Example 3 (no parameters will be used):</div>
             <Code code={exampleCode3} elementToCopy={exampleCode3} language="json" />
         </div>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
@@ -74,6 +74,7 @@ export default function EditAiAgentQueryToolItem({ index, remove, save, edit }: 
         query.queryParameters(parameters);
         query.name(queryText);
         query.recentQuery(true);
+        query.skipRunOnInit(true);
         const queryDto = query.toStorageDto();
         savedQueriesStorage.saveAndNavigate(dbName, queryDto, {
             newWindow: true,

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
@@ -183,6 +183,7 @@ export default function EditAiAgentTestPanel({ testForm, editForm, allQueriesNam
                             setIsWaitingForActionToolSubmit={(value: boolean) =>
                                 dispatch(editAiAgentActions.isWaitingForActionToolSubmitSet(value))
                             }
+                            parametersFromUser={testDocument?.Parameters}
                         />
                     )}
                     {isRawData && testDocument && (

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
@@ -21,6 +21,7 @@ import messagePublisher from "common/messagePublisher";
 import { AiAgentToolCall } from "../../utils/aiAgentsTypes";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { compareSets } from "common/typeUtils";
+import AiAgentParametersDropdown from "../../partials/AiAgentParametersDropdown";
 
 interface EditAiAgentTestPanelProps {
     testForm: UseFormReturn<TestAiAgentFormData>;
@@ -137,6 +138,9 @@ export default function EditAiAgentTestPanel({ testForm, editForm, allQueriesNam
                     >
                         New chat
                     </Button>
+                    {testDocument?.Parameters && (
+                        <AiAgentParametersDropdown parameters={testDocument.Parameters} isCompact />
+                    )}
                     {testDocument && messages.length > 0 && (
                         <Button
                             variant="secondary"

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTrimmingSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTrimmingSection.tsx
@@ -2,7 +2,6 @@ import { FormDurationPicker, FormGroup, FormInput, FormLabel, FormSwitch } from 
 import { useFormContext, useWatch } from "react-hook-form";
 import { AiAgentTrimmingMethod, EditAiAgentFormData } from "../utils/editAiAgentValidation";
 import ClickableCard from "components/common/ClickableCard";
-import OptionalLabel from "components/common/OptionalLabel";
 import Button from "react-bootstrap/Button";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { Icon } from "components/common/Icon";
@@ -25,7 +24,7 @@ export default function EditAiAgentTrimmingSection() {
     return (
         <>
             <h3 className="m-0 mt-3">
-                Configure chat trimming <OptionalLabel />
+                Configure chat trimming
                 <PopoverWithHoverWrapper
                     message={
                         <>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -19,6 +19,10 @@ import Badge from "react-bootstrap/Badge";
 import { aiAgentsUtils } from "../utils/aiAgentsUtils";
 import useRqlLanguageService from "components/hooks/useRqlLanguageService";
 import genUtils from "common/generalUtils";
+import queryCriteria from "models/database/query/queryCriteria";
+import savedQueriesStorage from "common/storage/savedQueriesStorage";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
 type ToolQuery = Raven.Client.Documents.Operations.AI.Agents.AiAgentToolQuery;
 type ToolAction = Raven.Client.Documents.Operations.AI.Agents.AiAgentToolAction;
@@ -29,6 +33,7 @@ interface AiAgentMessagesProps {
     toolActions: ToolAction[];
     handleSaveParameters: (toolCallParameters: AiAgentToolCall[]) => void;
     setIsWaitingForActionToolSubmit: (isWaiting: boolean) => void;
+    parametersFromUser?: Record<string, string>;
 }
 
 export default function AiAgentMessages({
@@ -37,6 +42,7 @@ export default function AiAgentMessages({
     toolActions,
     handleSaveParameters,
     setIsWaitingForActionToolSubmit,
+    parametersFromUser,
 }: AiAgentMessagesProps) {
     return (
         <div className="w-100 vstack gap-2 ai-agent-messages pb-1">
@@ -49,6 +55,7 @@ export default function AiAgentMessages({
                     toolActions={toolActions}
                     handleSaveParameters={handleSaveParameters}
                     setIsWaitingForActionToolSubmit={setIsWaitingForActionToolSubmit}
+                    parametersFromUser={parametersFromUser}
                 />
             ))}
         </div>
@@ -62,6 +69,7 @@ interface AiAgentMessageProps {
     toolActions: ToolAction[];
     handleSaveParameters: (toolCallParameters: AiAgentToolCall[]) => void;
     setIsWaitingForActionToolSubmit: (isWaiting: boolean) => void;
+    parametersFromUser?: Record<string, string>;
 }
 
 function AiAgentMessage({
@@ -71,6 +79,7 @@ function AiAgentMessage({
     toolActions,
     handleSaveParameters,
     setIsWaitingForActionToolSubmit,
+    parametersFromUser,
 }: AiAgentMessageProps) {
     const toolName = allMessages
         .find((x) => x.toolCalls?.some((y) => y.id === message.toolCallId))
@@ -93,6 +102,7 @@ function AiAgentMessage({
                     toolActions={toolActions}
                     handleSaveParameters={handleSaveParameters}
                     setIsWaitingForActionToolSubmit={setIsWaitingForActionToolSubmit}
+                    parametersFromUser={parametersFromUser}
                 />
             )}
         </div>
@@ -232,6 +242,7 @@ interface AgentMessageProps {
     toolActions: ToolAction[];
     handleSaveParameters?: (parameters: AiAgentToolCall[]) => void;
     setIsWaitingForActionToolSubmit: (isWaiting: boolean) => void;
+    parametersFromUser?: Record<string, string>;
 }
 
 function AgentMessage({
@@ -241,6 +252,7 @@ function AgentMessage({
     toolActions,
     handleSaveParameters,
     setIsWaitingForActionToolSubmit,
+    parametersFromUser,
 }: AgentMessageProps) {
     const aceRef = useRef<ReactAce>(null);
 
@@ -348,6 +360,7 @@ function AgentMessage({
                                     toolCall={toolCall}
                                     toolQueries={toolQueries}
                                     toolActions={toolActions}
+                                    parametersFromUser={parametersFromUser}
                                 />
                             ))}
                         </div>
@@ -405,9 +418,10 @@ interface ToolCallProps {
     toolCall: AiAgentToolCall;
     toolQueries: ToolQuery[];
     toolActions: ToolAction[];
+    parametersFromUser?: Record<string, string>;
 }
 
-function ToolCall({ toolCall, toolQueries, toolActions }: ToolCallProps) {
+function ToolCall({ toolCall, toolQueries, toolActions, parametersFromUser }: ToolCallProps) {
     const id = useUniqueId("tool-call");
 
     const toolQuery = toolQueries?.find((x) => x.Name === toolCall.name);
@@ -431,7 +445,11 @@ function ToolCall({ toolCall, toolQueries, toolActions }: ToolCallProps) {
                 </Accordion.Header>
                 <Accordion.Collapse eventKey={id} mountOnEnter unmountOnExit>
                     <Accordion.Body className="panel-bg-1 rounded-2">
-                        <ToolCallBody tool={toolQuery ?? toolAction} toolCall={toolCall} />
+                        <ToolCallBody
+                            tool={toolQuery ?? toolAction}
+                            toolCall={toolCall}
+                            parametersFromUser={parametersFromUser}
+                        />
                     </Accordion.Body>
                 </Accordion.Collapse>
             </Accordion.Item>
@@ -442,13 +460,12 @@ function ToolCall({ toolCall, toolQueries, toolActions }: ToolCallProps) {
 interface ToolCallBodyProps {
     tool: ToolQuery | ToolAction;
     toolCall: AiAgentToolCall;
+    parametersFromUser?: Record<string, string>;
 }
 
-function ToolCallBody({ tool, toolCall }: ToolCallBodyProps) {
+function ToolCallBody({ tool, toolCall, parametersFromUser }: ToolCallBodyProps) {
     const prettifiedArguments = aiAgentsUtils.getPrettifiedContent(toolCall?.arguments);
     const argumentsMode = getAceEditorMode(prettifiedArguments);
-
-    const rqlLanguageService = useRqlLanguageService();
 
     const id = useUniqueId("tool-call-details");
 
@@ -477,16 +494,11 @@ function ToolCallBody({ tool, toolCall }: ToolCallBodyProps) {
                                     </div>
                                 )}
                                 {"Query" in tool && tool.Query && (
-                                    <div>
-                                        <small className="text-muted">Query</small>
-                                        <AceEditor
-                                            value={tool.Query}
-                                            readOnly
-                                            mode="rql"
-                                            height="100px"
-                                            languageService={rqlLanguageService}
-                                        />
-                                    </div>
+                                    <ToolDetailsQuery
+                                        queryText={tool.Query}
+                                        parametersFromUser={parametersFromUser}
+                                        parametersFromModel={toolCall.arguments}
+                                    />
                                 )}
                             </Accordion.Body>
                         </Accordion.Collapse>
@@ -507,7 +519,115 @@ function ToolCallBody({ tool, toolCall }: ToolCallBodyProps) {
     );
 }
 
-function getAgentAceEditorHeight(content: string): `${number}px` {
+interface Argument {
+    key: string;
+    value: any;
+}
+
+function ToolDetailsQuery({
+    queryText,
+    parametersFromUser,
+    parametersFromModel,
+}: {
+    queryText: string;
+    parametersFromUser?: Record<string, string>;
+    parametersFromModel?: string;
+}) {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const rqlLanguageService = useRqlLanguageService();
+
+    const getLlmParametersForQuery = (matches: string[]): Argument[] => {
+        try {
+            const parametersObject = JSON.parse(parametersFromModel);
+            return matches
+                .map((x) => ({ key: x, value: parametersObject[x] }))
+                .filter((x) => x.value && !Object.keys(parametersFromUser).includes(x.key));
+        } catch {
+            return [];
+        }
+    };
+
+    const getAgentParametersForQuery = (matches: string[]): Argument[] => {
+        return matches.map((x) => ({ key: x, value: parametersFromUser?.[x] })).filter((x) => x.value);
+    };
+
+    const getArgumentFormattedValue = (value: string): string => {
+        if (typeof value === "number") {
+            return value;
+        }
+        return JSON.stringify(value);
+    };
+
+    const getQueryWithParameters = (): string => {
+        const regexToFind$: RegExp = /\$\w+/g;
+        const matches = queryText.match(regexToFind$).map((x) => x.replace("$", "")) || [];
+
+        const llmParametersForQuery = getLlmParametersForQuery(matches);
+        const agentParametersForQuery = getAgentParametersForQuery(matches);
+
+        let resultQuery = "";
+
+        if (llmParametersForQuery.length > 0) {
+            resultQuery += `// LLM parameters\n`;
+            resultQuery += llmParametersForQuery
+                .map((x) => `$${x.key} = ${getArgumentFormattedValue(x.value)}`)
+                .join("\n");
+            resultQuery += "\n\n";
+        }
+
+        if (agentParametersForQuery.length > 0) {
+            resultQuery += `// Agent parameters\n`;
+            resultQuery += agentParametersForQuery
+                .map((x) => `$${x.key} = ${getArgumentFormattedValue(x.value)}`)
+                .join("\n");
+            resultQuery += "\n\n";
+        }
+
+        resultQuery += queryText;
+
+        return resultQuery;
+    };
+
+    const queryWithParameters = getQueryWithParameters();
+
+    const linkToQuery = () => {
+        const query = queryCriteria.empty();
+
+        query.queryText(queryWithParameters);
+        query.recentQuery(true);
+        const queryDto = query.toStorageDto();
+        savedQueriesStorage.saveAndNavigate(databaseName, queryDto, {
+            newWindow: true,
+        });
+    };
+
+    return (
+        <div>
+            <div className="d-flex justify-content-between mb-1 align-items-end">
+                <small className="text-muted">Query</small>
+                <Button
+                    variant="info"
+                    className="rounded-pill"
+                    onClick={linkToQuery}
+                    title="Click to test this query in the Studio's Query View"
+                    size="sm"
+                >
+                    <Icon icon="rocket" />
+                    Test query
+                </Button>
+            </div>
+            <AceEditor
+                value={queryWithParameters}
+                readOnly
+                mode="rql"
+                height={getAgentAceEditorHeight(queryWithParameters, 200)}
+                languageService={rqlLanguageService}
+            />
+        </div>
+    );
+}
+
+function getAgentAceEditorHeight(content: string, maxHeightInPx = 320): `${number}px` {
     if (!content) {
         return "100px";
     }
@@ -522,7 +642,7 @@ function getAgentAceEditorHeight(content: string): `${number}px` {
         return `${effectiveLineCount * lineHeight + halfLineHeight}px`;
     }
 
-    return "320px";
+    return `${maxHeightInPx}px`;
 }
 
 function getAceEditorMode(content: string): "json" | "text" {

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -161,7 +161,7 @@ function ToolMessage({ message, type }: ToolMessageProps) {
             ) : (
                 <AceEditor
                     aceRef={aceRef}
-                    value={message.content}
+                    defaultValue={message.content}
                     readOnly
                     mode={contentMode}
                     height="150px"
@@ -336,7 +336,7 @@ function AgentMessage({
                         <div className="mt-2">
                             <AceEditor
                                 aceRef={aceRef}
-                                value={agentMessage.content}
+                                defaultValue={agentMessage.content}
                                 readOnly
                                 mode={contentMode}
                                 actions={[
@@ -490,7 +490,12 @@ function ToolCallBody({ tool, toolCall, parametersFromUser }: ToolCallBodyProps)
                                 {tool.ParametersSchema && (
                                     <div>
                                         <small className="text-muted">Parameters schema</small>
-                                        <AceEditor value={tool.ParametersSchema} readOnly mode="json" height="100px" />
+                                        <AceEditor
+                                            defaultValue={tool.ParametersSchema}
+                                            readOnly
+                                            mode="json"
+                                            height="100px"
+                                        />
                                     </div>
                                 )}
                                 {"Query" in tool && tool.Query && (
@@ -508,7 +513,7 @@ function ToolCallBody({ tool, toolCall, parametersFromUser }: ToolCallBodyProps)
             <div>
                 <small className="text-muted">Parameters filled by LLM</small>
                 <AceEditor
-                    value={prettifiedArguments}
+                    defaultValue={prettifiedArguments}
                     readOnly
                     mode={argumentsMode}
                     height={getAgentAceEditorHeight(prettifiedArguments)}
@@ -617,7 +622,7 @@ function ToolDetailsQuery({
                 </Button>
             </div>
             <AceEditor
-                value={queryWithParameters}
+                defaultValue={queryWithParameters}
                 readOnly
                 mode="rql"
                 height={getAgentAceEditorHeight(queryWithParameters, 200)}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -560,7 +560,7 @@ function ToolDetailsQuery({
 
     const getQueryWithParameters = (): string => {
         const regexToFind$: RegExp = /\$\w+/g;
-        const matches = queryText.match(regexToFind$).map((x) => x.replace("$", "")) || [];
+        const matches = queryText.match(regexToFind$)?.map((x) => x.replace("$", "")) || [];
 
         const llmParametersForQuery = getLlmParametersForQuery(matches);
         const agentParametersForQuery = getAgentParametersForQuery(matches);

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -469,17 +469,6 @@ function ToolCallBody({ tool, toolCall }: ToolCallBodyProps) {
                                         <hr className="my-1" />
                                     </div>
                                 )}
-                                {tool.ParametersSampleObject && (
-                                    <div>
-                                        <small className="text-muted">Sample parameters object</small>
-                                        <AceEditor
-                                            value={tool.ParametersSampleObject}
-                                            readOnly
-                                            mode="json"
-                                            height="100px"
-                                        />
-                                    </div>
-                                )}
                                 {tool.ParametersSchema && (
                                     <div>
                                         <small className="text-muted">Parameters schema</small>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -330,6 +330,7 @@ function AgentMessage({
                                 actions={[
                                     { component: <AceEditor.FullScreenAction /> },
                                     { component: <AceEditor.FormatAction /> },
+                                    { component: <AceEditor.ToggleNewLinesAction /> },
                                 ]}
                                 height={getAgentAceEditorHeight(agentMessage.content)}
                                 wrapEnabled={contentMode === "text" ? true : false}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
@@ -1,13 +1,15 @@
+import { CustomDropdownToggle } from "components/common/Dropdown";
 import { Icon } from "components/common/Icon";
 import Badge from "react-bootstrap/Badge";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 
-interface ChatAiAgentParametersDropdownProps {
+interface AiAgentParametersDropdownProps {
     parameters: Record<string, string>;
+    isCompact?: boolean;
 }
 
-export default function ChatAiAgentParametersDropdown({ parameters }: ChatAiAgentParametersDropdownProps) {
+export default function AiAgentParametersDropdown({ parameters, isCompact = false }: AiAgentParametersDropdownProps) {
     const parametersArray = Object.entries(parameters).map(([name, value]) => ({ name, value }));
 
     if (parametersArray.length === 0) {
@@ -16,8 +18,15 @@ export default function ChatAiAgentParametersDropdown({ parameters }: ChatAiAgen
 
     return (
         <Dropdown>
-            <Dropdown.Toggle title="Parameters" variant="outline-secondary" className="rounded-pill text-reset">
-                <Icon icon="metrics" /> Parameters
+            <Dropdown.Toggle
+                title="Parameters"
+                variant="outline-secondary"
+                className="rounded-pill text-reset"
+                as={CustomDropdownToggle}
+                isCaretHidden={isCompact}
+            >
+                <Icon icon="metrics" margin={isCompact ? "m-0" : "me-1"} />
+                {isCompact ? null : "Parameters"}
             </Dropdown.Toggle>
             <Dropdown.Menu
                 style={{ width: "500px", maxHeight: "316px" }}

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -1,7 +1,6 @@
 /// <reference path="../../../../typings/tsd.d.ts"/>
 import genUtils = require("common/generalUtils");
 import queryUtil = require("common/queryUtil");
-import typeUtils = require("common/typeUtils");
 import moment = require("moment");
 
 class queryCriteria {
@@ -12,7 +11,6 @@ class queryCriteria {
     ignoreIndexQueryLimit = ko.observable<boolean>(false);
     
     queryText = ko.observable<string>("");
-    queryParameters = ko.observable<Record<string, string>>({});
     metadataOnly = ko.observable<boolean>(false);
     recentQuery = ko.observable<boolean>(false);
     graphOutput = ko.observable<boolean>(false);
@@ -57,12 +55,6 @@ class queryCriteria {
                 this.ignoreIndexQueryLimit(false);
             }
         });
-
-        this.queryParameters.subscribe(queryParameters => {
-            if (queryParameters && !typeUtils.isEmpty(queryParameters)) {
-                this.queryText(this.formatQueryParameters(queryParameters) + "\r\n\r\n" + this.queryText());
-            }
-        })
 
         this.queryText.subscribe(queryText => {
             if (queryUtil.isDynamicQuery(queryText)) {

--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -17,6 +17,7 @@ class queryCriteria {
     recentQuery = ko.observable<boolean>(false);
     graphOutput = ko.observable<boolean>(false);
     diagnostics = ko.observable<boolean>(false);
+    skipRunOnInit = ko.observable<boolean>(false);
     
     validationGroup: KnockoutValidationGroup;
 
@@ -90,6 +91,7 @@ class queryCriteria {
             name: name,
             queryText: queryText,
             recentQuery: this.recentQuery(),
+            skipRunOnInit: this.skipRunOnInit(),
             modificationDate: moment().format("YYYY-MM-DD HH:mm"),
             hash: genUtils.hashCode(name + (queryText || "")) 
         };

--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -925,7 +925,11 @@ class query extends shardViewModelBase {
             const hash = parseInt(indexNameOrRecentQueryHash.substr("recentquery-".length), 10);
             const matchingQuery = this.savedQueries().find(q => q.hash === hash);
             if (matchingQuery) {
-                this.runRecentQuery(matchingQuery);
+                if (matchingQuery?.skipRunOnInit) {
+                    this.previewQueryInAceEditor(matchingQuery);
+                } else {
+                    this.runRecentQuery(matchingQuery);
+                }
             } else {
                 this.navigate(appUrl.forQuery(this.db));
             }
@@ -1326,6 +1330,10 @@ class query extends shardViewModelBase {
 
     previewQuery(item: storedQueryDto): void {
         this.previewItem(item);
+    }
+
+    previewQueryInAceEditor(item: storedQueryDto): void {
+        this.criteria().updateUsing(item);
     }
 
     useQueryItem(item: storedQueryDto): void {

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -340,6 +340,7 @@ interface queryDto {
 
 interface storedQueryDto extends queryDto {
     hash: number;
+    skipRunOnInit?: boolean;
 }
 
 interface replicationConflictListItemDto {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24831/AI-Agent-UX-improvements

### Additional description

- don't run test query on load
- fix validation for nested objects
- add examples with {} for tools
- add parameters dropdown in test
- format new lines in ace editor
- remove "(optional)" from trimming
- remove sample parameters from tool call details
- add parameters at top of the query in tool call query
- fix ace editor full-screen height

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
