### PR TITLE
RavenDB-24837 add duplicate tool name validation

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/AI/AddOrUpdateAiAgentCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AI/AddOrUpdateAiAgentCommand.cs
@@ -151,9 +151,13 @@ namespace Raven.Server.ServerWide.Commands.AI
             if (duplicateNames.Count > 0)
                 throw new InvalidOperationException($"Duplicate parameter names found in agent configuration: {string.Join(", ", duplicateNames)}");
 
+            var uniqueToolNames = new HashSet<string>(); // tool names are case-sensitive
             var scopeParams = configuration.Parameters.Select(x => x.Name).ToHashSet();
             foreach (var tool in configuration.Queries)
             {
+                if (uniqueToolNames.Add(tool.Name) == false)
+                    throw new InvalidOperationException($"Tool query name '{tool.Name}' is not unique. It is already defined in the agent configuration.");
+
                 if (ToolNameChecker.IsMatch(tool.Name) == false)
                     throw new InvalidOperationException($"Query name '{tool.Name}' is invalid. It must match the pattern: {ToolNameChecker}");
 
@@ -182,6 +186,9 @@ namespace Raven.Server.ServerWide.Commands.AI
 
             foreach (var action in configuration.Actions)
             {
+                if (uniqueToolNames.Add(action.Name) == false)
+                    throw new InvalidOperationException($"Tool action name '{action.Name}' is not unique. It is already defined in the agent configuration.");
+
                 if (ToolNameChecker.IsMatch(action.Name) == false)
                     throw new InvalidOperationException($"Action name '{action.Name}' is invalid. It must match the pattern: {ToolNameChecker}");
             }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentConfigurationValidation.cs
@@ -150,5 +150,38 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None));
             Assert.Contains($"Parameter 'company' is missing", e.Message);
         }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+        public async Task ThrowDuplicateToolName(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Parameters.Add(new AiAgentParameter("company"));
+            agent.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "ProductSearch", 
+                    Description =  "semantic search the store product catalog",
+                    Query = "from Products where vector.search(embedding.text(Name), $query)",
+                    ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                }
+            ];
+            agent.Actions =
+            [
+                new AiAgentToolAction("ProductSearch", "semantic search the store product catalog")
+            ];
+
+            var e = await Assert.ThrowsAsync<RavenException>(() => store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance));
+            Assert.Contains("Tool action name 'ProductSearch' is not unique", e.Message);
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24837

### Additional description

Avoid having duplicate tool names

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
