### PR TITLE
RavenDB-24629 Applied to v8.0: Optimize compression buffers zeroing to reduce disk writes in encrypted databases

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -87,6 +87,7 @@ namespace Voron.Impl.Journal
 
         private readonly object _writeLock = new object();
         private int _maxNumberOfPagesRequiredForCompressionBuffer;
+        private int _numberOfUsedCompressionBufferPagesSinceZeroing;
 
         private readonly DisposeOnce<SingleAttempt> _disposeRunner;
 
@@ -1802,7 +1803,7 @@ namespace Voron.Impl.Journal
                     if (tx.ShouldWriteTransactionChangesToJournal)
                     {
                         var start = Stopwatch.GetTimestamp();
-                        var entry = PrepareToWriteToJournal(tx, ref tempTxState, out numberOfUncompressedPages);
+                        var entry = PrepareToWriteToJournal(tx, ref tempTxState, out numberOfUncompressedPages, out var numberOfUsedCompressionBufferPages);
                         branchCommit = new TaskCompletionSource();
                         numberOf4Kbs = entry.NumberOf4Kbs;
                         var pendingJournalStateRecord = new PendingJournalStateRecord(tx, branchCommit, entry);
@@ -1811,6 +1812,8 @@ namespace Voron.Impl.Journal
                         {
                             rootJournal.SharedJournalState.Enqueue(pendingJournalStateRecord);
                         }
+                        
+                        _numberOfUsedCompressionBufferPagesSinceZeroing = Math.Max(_numberOfUsedCompressionBufferPagesSinceZeroing, numberOfUsedCompressionBufferPages);
 
                         if (_logger.IsDebugEnabled)
                         {
@@ -2071,7 +2074,8 @@ namespace Voron.Impl.Journal
         }
 
 
-        private Pal.journal_entry PrepareToWriteToJournal(LowLevelTransaction tx, ref Pager.PagerTransactionState txState, out long numberOfUncompressedPages)
+        private Pal.journal_entry PrepareToWriteToJournal(LowLevelTransaction tx, ref Pager.PagerTransactionState txState, out long numberOfUncompressedPages, 
+            out int totalNumberOfUsedCompressionBufferPages)
         {
             var txPages = tx.GetTransactionPages();
             var numberOfPages = txPages.Count;
@@ -2195,6 +2199,7 @@ namespace Voron.Impl.Journal
                                                         ((outputBufferSize + sizeof(TransactionHeader)) % Constants.Storage.PageSize == 0 ? 0 : 1)));
 
                 _maxNumberOfPagesRequiredForCompressionBuffer = Math.Max(pagesRequired + outputBufferInPages, _maxNumberOfPagesRequiredForCompressionBuffer);
+                totalNumberOfUsedCompressionBufferPages = pagesRequired + outputBufferInPages;
 
                 var totalSizeWrittenPlusTxHeader = totalSizeWritten + sizeof(TransactionHeader);
                 var pagesWritten = (totalSizeWrittenPlusTxHeader / Constants.Storage.PageSize) +
@@ -2245,6 +2250,7 @@ namespace Voron.Impl.Journal
             else
             {
                 _maxNumberOfPagesRequiredForCompressionBuffer = Math.Max(pagesRequired, _maxNumberOfPagesRequiredForCompressionBuffer);
+                totalNumberOfUsedCompressionBufferPages = pagesRequired;
             }
 
             // We need to account for the transaction header as part of the total length.
@@ -2415,12 +2421,15 @@ namespace Voron.Impl.Journal
 
             try
             {
-                var compressionBufferSize = _compressionPagerState.NumberOfAllocatedPages * Constants.Storage.PageSize;
-                _compressionPager.EnsureMapped(_compressionPagerState, ref txState, 0, checked((int)_compressionPagerState.NumberOfAllocatedPages));
+                var numberOfPagesToZero = Math.Min(_numberOfUsedCompressionBufferPagesSinceZeroing, _compressionPagerState.NumberOfAllocatedPages);
+                var numberOfBytesToZero = numberOfPagesToZero * Constants.Storage.PageSize;
+                
+                _compressionPager.EnsureMapped(_compressionPagerState, ref txState, 0, checked((int)numberOfPagesToZero));
                 var pagePointer = _compressionPager.MakeWritable(_compressionPagerState,
                  _compressionPager.AcquirePagePointer(_compressionPagerState, ref txState, 0)
              );
-                Sodium.sodium_memzero(pagePointer, (UIntPtr)compressionBufferSize);
+                Sodium.sodium_memzero(pagePointer, (UIntPtr)numberOfBytesToZero);
+                _numberOfUsedCompressionBufferPagesSinceZeroing = 0;
             }
             finally
             {

--- a/test/SlowTests/Voron/Issues/RavenDB_24629.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_24629.cs
@@ -1,0 +1,46 @@
+﻿using FastTests.Voron;
+using Sparrow.Platform;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.BTrees;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_24629 : StorageTest
+{
+    public RavenDB_24629(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        options.ManualFlushing = true;
+        options.Encryption.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+        options.MaxScratchBufferSize = 65536 - 1; // to make ShouldReduceSizeOfCompressionPager() return true
+        options.Encryption.RegisterForJournalCompressionHandler();
+    }
+    
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MustNotZeroMoreBytesThanCompressionBufferSize()
+    {
+        using (var tx = Env.WriteTransaction())
+        {
+            Tree tree = tx.CreateTree("foo");
+            
+            for (int i = 0; i < 100; i++)
+            {
+                tree.Add("items/" + i, new byte[1024 * 1024]);
+            }
+            
+            tx.Commit();
+        }
+        
+        Env.Journal.TryReduceSizeOfCompressionBufferIfNeeded();
+        
+        using (var tx = Env.WriteTransaction())
+        {
+            Env.Journal.ZeroCompressionBuffer(ref tx.LowLevelTransaction.PagerTransactionState); // AVE before the fix
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24629 

### Additional description

https://github.com/ravendb/ravendb/pull/21128 and https://github.com/ravendb/ravendb/pull/21145 applied to v8.0

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
