### PR TITLE
RavenDB-24620 Allow generating embeddings via embeddings generation task for vectors indexed via CreateVector.

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -599,8 +599,9 @@ namespace Raven.Client
 
         internal static class VectorSearch
         {
+            internal const string AiTaskMethodName = "ai.task";
             private const string EmbeddingPrefix = "embedding.";
-
+            
             internal const string EmbeddingForDocument = EmbeddingPrefix + "forDoc";
             internal const string EmbeddingForRaw = EmbeddingPrefix + "Raw";
             internal const string EmbeddingText = EmbeddingPrefix + "text";

--- a/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
@@ -210,6 +210,14 @@ public interface IVectorEmbeddingTextFieldValueFactory
     /// </summary>
     /// <param name="text">Queried text.</param>
     public void ByText(string text);
+    
+    /// <summary>
+    /// Defines queried text.
+    /// This method should be used only to query static index when vectors where prepared via a specific model outside EmbeddingsGenerationTask and indexed via the `CreateVector` method. 
+    /// </summary>
+    /// <param name="text">Queried text.</param>
+    /// <param name="embeddingsGenerationTaskIdentifier">Embeddings generation task identifier.</param>
+    public void ByText(string text, string embeddingsGenerationTaskIdentifier);
 
     /// <summary>
     /// Query by the embedding(s) indexed from the specified document for the queried field. 
@@ -221,6 +229,14 @@ public interface IVectorEmbeddingTextFieldValueFactory
     /// </summary>
     /// <param name="texts">Queried texts.</param>
     public void ByTexts(IEnumerable<string> texts);
+    
+    /// <summary>
+    /// Defines queried texts.
+    /// This method should be used only to query static index when vectors where prepared via a specific model outside EmbeddingsGenerationTask and indexed via the `CreateVector` method.
+    /// </summary>
+    /// <param name="texts">Queried texts.</param>
+    /// <param name="embeddingsGenerationTaskIdentifier">Embeddings generation task identifier.</param>
+    public void ByTexts(IEnumerable<string> texts, string embeddingsGenerationTaskIdentifier);
 }
 
 public interface IVectorEmbeddingFieldValueFactory
@@ -295,6 +311,8 @@ public interface IVectorFieldValueFactoryAccessor
     internal string Text { get; set; }
     internal string ById { get; set; }
     internal IEnumerable<string> Texts { get; set; }
+    internal string EmbeddingsGenerationTaskIdentifier { get; set; }
+
 }
 
 internal class VectorFieldValueFactory : IVectorFieldValueFactory, IVectorFieldValueFactoryAccessor
@@ -303,6 +321,7 @@ internal class VectorFieldValueFactory : IVectorFieldValueFactory, IVectorFieldV
     public string Text { get; set; }
     public string ById { get; set; }
     public IEnumerable<string> Texts { get; set; }
+    public string EmbeddingsGenerationTaskIdentifier { get; set; }
     
     void IVectorEmbeddingFieldValueFactory.ByEmbedding<T>(IEnumerable<T> embedding)
     {
@@ -353,10 +372,22 @@ internal class VectorFieldValueFactory : IVectorFieldValueFactory, IVectorFieldV
     {
         Text = text;
     }
-    
+
+    void IVectorEmbeddingTextFieldValueFactory.ByText(string text, string embeddingsGenerationTaskIdentifier)
+    {
+        Text = text;
+        EmbeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
+    }
+
     void IVectorEmbeddingTextFieldValueFactory.ByTexts(IEnumerable<string> texts)
     {
         Texts = texts;
+    }
+    
+    void IVectorEmbeddingTextFieldValueFactory.ByTexts(IEnumerable<string> texts, string embeddingsGenerationTaskIdentifier)
+    {
+        Texts = texts;
+        EmbeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
     }
     
     void IVectorEmbeddingFieldValueFactory.ByEmbedding<T>(RavenVector<T> embedding)

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1533,8 +1533,9 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var texts = fieldValueFactoryAccessor.Texts;
             var embeddings = fieldValueFactoryAccessor.Embeddings;
             var byId = fieldValueFactoryAccessor.ById;
+            var embeddingsGenerationTaskIdentifierFromValue = fieldValueFactoryAccessor.EmbeddingsGenerationTaskIdentifier;
 
-            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts,  embeddings, byId, embeddingsGenerationTaskIdentifier);
+            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts,  embeddings, byId, embeddingsGenerationTaskIdentifier, embeddingsGenerationTaskIdentifierFromValue);
         }
         
         internal void VectorSearch(VectorEmbeddingFieldFactory<T> embeddingFieldFactory, VectorFieldValueFactory embeddingValueFactory,
@@ -1549,12 +1550,13 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var texts = embeddingValueFactory.Texts;
             var embeddings = embeddingValueFactory.Embeddings;
             var byId = embeddingValueFactory.ById;
-            
-            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts, embeddings, byId, embeddingsGenerationTaskIdentifier);
+            var embeddingsGenerationTaskIdentifierFromValue = embeddingValueFactory.EmbeddingsGenerationTaskIdentifier;
+
+            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, texts, embeddings, byId, embeddingsGenerationTaskIdentifier, embeddingsGenerationTaskIdentifierFromValue);
         }
         
         private void VectorSearch(string fieldName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? minimumSimilarity,
-            int? numberOfCandidates, bool isExact, string text, IEnumerable<string> texts, object embeddings, string byId, string embeddingsGenerationTaskIdentifier = null)
+            int? numberOfCandidates, bool isExact, string text, IEnumerable<string> texts, object embeddings, string byId, string embeddingsGenerationTaskIdentifier = null, string embeddingsGenerationTaskIdentifierValue = null)
         {
             string queryParameterName;
 
@@ -1593,7 +1595,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 throw new InvalidOperationException("Cannot use VectorSearch without text(s), document id or embedding(s).");
             }
             
-            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, isDocumentId, embeddingsGenerationTaskIdentifier);
+            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, isDocumentId, embeddingsGenerationTaskIdentifier, embeddingsGenerationTaskIdentifierValue);
 
             WhereTokens.AddLast(vectorSearchToken);
         }

--- a/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Extensions;
+using Sparrow;
 using Sparrow.Extensions;
 
 namespace Raven.Client.Documents.Session.Tokens;
@@ -16,10 +17,9 @@ public sealed class VectorSearchToken : WhereToken
     private readonly int? _numberOfCandidatesForQuerying;
     private readonly bool _isDocumentId;
     private readonly string _embeddingsGenerationTaskIdentifier;
-
-    private static string AiTaskMethodName = "ai.task";
+    private readonly string _embeddingsGenerationTaskIdentifierByValue;
     
-    public VectorSearchToken(string fieldName, string parameterName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? similarityThreshold, int? numberOfCandidatesForQuerying, bool isExact, bool isDocumentId, string embeddingsGenerationTaskIdentifier)
+    public VectorSearchToken(string fieldName, string parameterName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? similarityThreshold, int? numberOfCandidatesForQuerying, bool isExact, bool isDocumentId, string embeddingsGenerationTaskIdentifier, string embeddingsGenerationTaskIdentifierByValue = null)
     {
         FieldName = fieldName;
         ParameterName = parameterName;
@@ -34,6 +34,9 @@ public sealed class VectorSearchToken : WhereToken
         Options = new(isExact);
 
         _embeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
+        _embeddingsGenerationTaskIdentifierByValue = embeddingsGenerationTaskIdentifierByValue;
+        
+        PortableExceptions.ThrowIf<InvalidOperationException>(embeddingsGenerationTaskIdentifier != null && embeddingsGenerationTaskIdentifierByValue != null, $"Embeddings generation task identifier set in value factory cannot be used with field factory. It solely purpose to use already generated embeddings.");
     }
     
     public override void WriteTo(StringBuilder writer)
@@ -55,7 +58,7 @@ public sealed class VectorSearchToken : WhereToken
             var methodName = Constants.VectorSearch.ConfigurationToMethodName(_sourceQuantizationType, _targetQuantizationType);
             
             if (_sourceQuantizationType is VectorEmbeddingType.Text && _embeddingsGenerationTaskIdentifier != null)
-                writer.Append($"{methodName}({FieldName},{AiTaskMethodName}('{_embeddingsGenerationTaskIdentifier}'))");
+                writer.Append($"{methodName}({FieldName},{Constants.VectorSearch.AiTaskMethodName}('{_embeddingsGenerationTaskIdentifier}'))");
             else
                 writer.Append($"{methodName}({FieldName})");
         }
@@ -64,6 +67,11 @@ public sealed class VectorSearchToken : WhereToken
         if (_isDocumentId)
         {
             writer.Append($"{Constants.VectorSearch.EmbeddingForDocument}(${ParameterName})");
+        }
+        else if (_embeddingsGenerationTaskIdentifierByValue != null)
+        {
+            //embedding.text('textual input', ai.task('task-name'))
+            writer.Append($"{Constants.VectorSearch.EmbeddingText}(${ParameterName}, {Constants.VectorSearch.AiTaskMethodName}('{_embeddingsGenerationTaskIdentifierByValue}'))");
         }
         else
         {

--- a/src/Raven.Server/Documents/Indexes/IndexField.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexField.cs
@@ -341,8 +341,6 @@ namespace Raven.Server.Documents.Indexes
 
         public static string GetVectorAutoIndexFieldName(string name, AutoVectorOptions autoVectorOptions)
         {
-            const string aiTask = "ai.task";
-            
             var methodName = Constants.VectorSearch.ConfigurationToMethodName(autoVectorOptions.SourceEmbeddingType, autoVectorOptions.DestinationEmbeddingType);
 
             string inner;
@@ -351,7 +349,7 @@ namespace Raven.Server.Documents.Indexes
             
             if (autoVectorOptions.SourceEmbeddingType == VectorEmbeddingType.Text && embeddingsGenerationTaskIdentifier != null)
             {
-                inner = methodName == string.Empty ? name : $"{methodName}({name},{aiTask}('{embeddingsGenerationTaskIdentifier}'))";
+                inner = methodName == string.Empty ? name : $"{methodName}({name},{Constants.VectorSearch.AiTaskMethodName}('{embeddingsGenerationTaskIdentifier}'))";
             }
             else
                 inner = methodName == string.Empty ? name : $"{methodName}({name})";

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -22,7 +23,8 @@ public static partial class CoraxQueryBuilder
     private static IQueryMatch HandleVector(Parameters builderParameters, MethodExpression me, bool exact)
     {
         var metadata = builderParameters.Metadata;
-        
+        IndexField indexField;
+        string embeddingsGenerationTaskIdentifier;
         var minimumMatch = builderParameters.Index.Configuration.CoraxVectorSearchDefaultMinimumSimilarity;
         if (me.Arguments.Count > 2)
         {
@@ -60,38 +62,84 @@ public static partial class CoraxQueryBuilder
 
         if (srcVector is MethodExpression methodValue) // embedding.forDoc(docId) ...
         {
-            PortableExceptions.ThrowIf<InvalidDataException>(methodValue.Name != Constants.VectorSearch.EmbeddingForDocument && methodValue.Name != Constants.VectorSearch.EmbeddingForRaw,
+            var supportedMethods = methodValue.Name != Constants.VectorSearch.EmbeddingForDocument
+                                   && methodValue.Name != Constants.VectorSearch.EmbeddingForRaw
+                                   && methodValue.Name != Constants.VectorSearch.EmbeddingText;
+                
+            PortableExceptions.ThrowIf<InvalidDataException>(supportedMethods,
                 $"Expected {Constants.VectorSearch.EmbeddingForDocument}() method call, but got: {methodValue.Name}");
 
-            var (methodParameter, _) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)methodValue.Arguments[0],
-                allowObjectsInParameters: false, allowArraysInParameters: true);
+            var (methodParameter, valueTokenType) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)methodValue.Arguments[0], allowObjectsInParameters: false, allowArraysInParameters: true);
             
-            var isForDoc = methodValue.Name == Constants.VectorSearch.EmbeddingForDocument;
-
-            return (isForDoc, methodParameter) switch
+            var method = methodValue.Name.ToString() switch
             {
-                (isForDoc: true, string docId) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docId, minimumMatch, numberOfCandidates, exact,
-                    builderParameters.IsVectorSingleClause),
-                (isForDoc: true, StringSegment docIdSegment) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docIdSegment.Value, minimumMatch,
-                    numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
-                (isForDoc: false, string vectorAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
-                    GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, vectorAsBase64, false), minimumMatch, numberOfCandidates,
-                    exact, builderParameters.IsVectorSingleClause),
-                (isForDoc: false, StringSegment stringSegmentAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
-                    GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString(), false), minimumMatch,
-                    numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
-                (_, BlittableJsonReaderArray { Length: > 0 }) => throw new InvalidDataException("Cannot perform search on empty value."),
-                _ => throw new InvalidQueryException($"Unknown method in value ({methodValue.Name}. Parameter type: {methodParameter.GetType().FullName}, Value: {methodParameter}")
+                Constants.VectorSearch.EmbeddingForDocument => VectorHelpers.MethodVectorValue.ForDocument,
+                Constants.VectorSearch.EmbeddingForRaw => VectorHelpers.MethodVectorValue.ForRaw,
+                Constants.VectorSearch.EmbeddingText => VectorHelpers.MethodVectorValue.EmbeddingText,
+                _ => throw new InvalidDataException(
+                    $"Unknown method in value ({methodValue.Name}. Parameter type: {methodParameter.GetType().FullName}, Value: {methodParameter}")
             };
+
+            if (method is not VectorHelpers.MethodVectorValue.EmbeddingText)
+            {
+                return (method, methodParameter) switch
+                {
+                    (method: VectorHelpers.MethodVectorValue.ForDocument, string docId) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata, docId,
+                        minimumMatch, numberOfCandidates, exact,
+                        builderParameters.IsVectorSingleClause),
+                    (method: VectorHelpers.MethodVectorValue.ForDocument, StringSegment docIdSegment) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
+                        docIdSegment.Value, minimumMatch,
+                        numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
+                    (method: VectorHelpers.MethodVectorValue.ForRaw, string vectorAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
+                        GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, vectorAsBase64, false), minimumMatch, numberOfCandidates,
+                        exact, builderParameters.IsVectorSingleClause),
+                    (method: VectorHelpers.MethodVectorValue.ForRaw, StringSegment stringSegmentAsBase64) => builderParameters.IndexSearcher.VectorSearch(fieldMetadata,
+                        GenerateEmbeddings.FromBase64Array(VectorOptions.Default, builderParameters.Allocator, stringSegmentAsBase64.ToString(), false), minimumMatch,
+                        numberOfCandidates, exact, builderParameters.IsVectorSingleClause),
+                    (_, BlittableJsonReaderArray { Length: > 0 }) => throw new InvalidDataException("Cannot perform search on empty value."),
+                    _ => throw new InvalidQueryException(
+                        $"Unknown method in value ({methodValue.Name}. Parameter type: {methodParameter.GetType().FullName}, Value: {methodParameter}")
+                };
+            }
+
+            var aiTaskMethod = (MethodExpression)methodValue.Arguments[1];
+            PortableExceptions.ThrowIfNot<InvalidOperationException>(aiTaskMethod.Name == Constants.VectorSearch.AiTaskMethodName, "Expected to find an AI task method call, but got: " + aiTaskMethod.Name);
+            embeddingsGenerationTaskIdentifier = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)aiTaskMethod.Arguments[0],
+                allowObjectsInParameters: false, allowArraysInParameters: false).Value.ToString();
+            var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
+            if (vectorOptions != null)
+            {
+                vectorOptions = new VectorOptions()
+                {
+                    DestinationEmbeddingType = vectorOptions.DestinationEmbeddingType,
+                    Dimensions = vectorOptions.Dimensions,
+                    SourceEmbeddingType = VectorEmbeddingType.Text,
+                    NumberOfCandidatesForIndexing = vectorOptions.NumberOfCandidatesForIndexing,
+                    NumberOfEdges = vectorOptions.NumberOfEdges
+                };
+            }
+            
+            var vector = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueTokenType, methodParameter, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
+
+            if (vector.SingleVector != null)
+            {
+                return builderParameters.IndexSearcher.VectorSearch(fieldMetadata, vector.SingleVector.Value, minimumMatch, numberOfCandidates, exact,
+                    builderParameters.IsVectorSingleClause);
+            }
+
+            return builderParameters.IndexSearcher.MultiVectorSearch(fieldMetadata, vector.MultiVector, minimumMatch, numberOfCandidates, exact,
+                builderParameters.IsVectorSingleClause);
+
+
+            // We need to handle embedding generation from embedding.text()
         }
         
         var (value, valueType) = QueryBuilderHelper.GetValue(metadata.Query, metadata, builderParameters.QueryParameters, (ValueExpression)srcVector,
             allowObjectsInParameters: false, allowArraysInParameters: true);
 
         (VectorValue? SingleVector, VectorValue[] MultiVector) transformedEmbeddings = (null, null);
-        IndexField indexField;
 
-        if (VectorHelpers.TryRetrieveEtlTaskName(builderParameters, fieldName, out var embeddingsGenerationTaskIdentifier))
+        if (VectorHelpers.TryRetrieveEtlTaskName(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
         {
             var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
             transformedEmbeddings = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueType, value, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
@@ -194,6 +242,13 @@ public static partial class CoraxQueryBuilder
 
     private static class VectorHelpers
     {
+        public enum MethodVectorValue
+        {
+            ForDocument,
+            ForRaw,
+            EmbeddingText
+        }
+        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryRetrieveEtlTaskName(Parameters builderParameters, in string fieldName, out string embeddingsGenerationTaskIdentifier)
         {

--- a/test/SlowTests/Issues/RavenDB-22076.cs
+++ b/test/SlowTests/Issues/RavenDB-22076.cs
@@ -50,6 +50,9 @@ public class RavenDB_22076 : RavenTestBase
                 var q5 = session.Advanced.DocumentQuery<Dto>().VectorSearch(x => x.WithText("TextField").TargetQuantization(VectorEmbeddingType.Int8),
                     factory => factory.ByText("aaaa")).ToString();
                 
+
+                
+                
                 Assert.Equal("from 'Dtos' where vector.search(embedding.text_i8(TextField), $p0)", q5);
                 
                 var q6 = session.Advanced.DocumentQuery<Dto>()

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.Embeddings;
+
+public class RavenDB_24620(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [InlineData(null, null)]
+    [InlineData(null, VectorEmbeddingType.Single)]
+    [InlineData(null, VectorEmbeddingType.Int8)]
+    [InlineData(null, VectorEmbeddingType.Binary)]
+    [InlineData(VectorEmbeddingType.Single, VectorEmbeddingType.Single)]
+    [InlineData(VectorEmbeddingType.Single, VectorEmbeddingType.Int8)]
+    [InlineData(VectorEmbeddingType.Single, VectorEmbeddingType.Binary)]
+    [InlineData(VectorEmbeddingType.Int8, VectorEmbeddingType.Int8)]
+    [InlineData(VectorEmbeddingType.Binary, VectorEmbeddingType.Binary)]
+    public void CanUseTaskToQueryPregeneratedEmbedding(VectorEmbeddingType? source, VectorEmbeddingType? destination)
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        PrepareDocumentsWithAttachments(store, source);
+        var aiTaskDone = Etl.WaitForEtlToComplete(store);
+        var (aiIntegrationConfiguration, aiConnectionString) = AddEmbeddingsGenerationTask(store, targetQuantization: source ?? VectorEmbeddingType.Single);
+        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+
+        var index = new VectorIndex(source, destination);
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var rqlResult = session.Query<Dto, VectorIndex>().VectorSearch(
+                f => f.WithField(s => s.Vector),
+                v => v.ByText("car", aiIntegrationConfiguration.Identifier)).ToString();
+            Assert.Equal("from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('localaitask')))", rqlResult);
+
+            var results = session.Query<Dto, VectorIndex>().VectorSearch(
+                    f => f.WithField(s => s.Vector),
+                    v => v.ByText("animal", aiIntegrationConfiguration.Identifier))
+                .ToList();
+
+            Assert.Equal(results[0].HelpName, "dog");
+
+
+            results = session.Advanced.DocumentQuery<Dto, VectorIndex>()
+                .VectorSearch(
+                    f => f.WithField(s => s.Vector),
+                    v => v.ByText("animal", aiIntegrationConfiguration.Identifier))
+                .ToList();
+            Assert.Equal(results[0].HelpName, "dog");
+        }
+        
+        using (var session = store.OpenSession())
+        {
+            var rqlResult = session.Query<Dto, VectorIndex>().VectorSearch(
+                f => f.WithField(s => s.Vector),
+                v => v.ByTexts(["car", "planet"], aiIntegrationConfiguration.Identifier)).ToString();
+            Assert.Equal("from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('localaitask')))", rqlResult);
+
+            var results = session.Query<Dto, VectorIndex>().VectorSearch(
+                    f => f.WithField(s => s.Vector),
+                    v => v.ByTexts(["car", "cosmos"], aiIntegrationConfiguration.Identifier))
+                .ToList();
+
+            Assert.True(new[]{"car", "sun"}.Contains(results[0].HelpName));
+            Assert.True(new[]{"car", "sun"}.Contains(results[1].HelpName));
+
+
+            results = session.Advanced.DocumentQuery<Dto, VectorIndex>()
+                .VectorSearch(
+                    f => f.WithField(s => s.Vector),
+                    v => v.ByTexts(["car", "cosmos"], aiIntegrationConfiguration.Identifier))
+                .ToList();
+            Assert.True(new[]{"car", "sun"}.Contains(results[0].HelpName));
+            Assert.True(new[]{"car", "sun"}.Contains(results[1].HelpName));
+        }
+    }
+
+    private static void PrepareDocumentsWithAttachments(IDocumentStore store, VectorEmbeddingType? embeddingType)
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var session = store.OpenSession();
+        Dto[] dtos = [new() { HelpName = "car" }, new() { HelpName = "dog" }, new() { HelpName = "sun" }];
+        session.Store(dtos[0]);
+        session.Store(dtos[1]);
+        session.Store(dtos[2]);
+        session.SaveChanges();
+
+        var config = new VectorOptions() { SourceEmbeddingType = VectorEmbeddingType.Text, DestinationEmbeddingType = embeddingType ?? VectorEmbeddingType.Single };
+
+        using var car = Raven.Server.Documents.Indexes.VectorSearch.GenerateEmbeddings.FromText(bsc, config, "car");
+        using var dog = Raven.Server.Documents.Indexes.VectorSearch.GenerateEmbeddings.FromText(bsc, config, "dog");
+        using var sun = Raven.Server.Documents.Indexes.VectorSearch.GenerateEmbeddings.FromText(bsc, config, "sun");
+
+        session.Advanced.Attachments.Store(dtos[0].Id, "vector", new MemoryStream(car.GetEmbedding().ToArray()));
+        session.Advanced.Attachments.Store(dtos[1].Id, "vector", new MemoryStream(dog.GetEmbedding().ToArray()));
+        session.Advanced.Attachments.Store(dtos[2].Id, "vector", new MemoryStream(sun.GetEmbedding().ToArray()));
+        session.SaveChanges();
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string HelpName { get; set; }
+        public object Vector { get; set; }
+    }
+
+    private class VectorIndex : AbstractIndexCreationTask
+    {
+        private readonly VectorEmbeddingType? _source;
+        private readonly VectorEmbeddingType? _destination;
+
+        public VectorIndex()
+        {
+            // for querying
+        }
+        
+        public VectorIndex(VectorEmbeddingType? source, VectorEmbeddingType? destination)
+        {
+            _source = source;
+            _destination = destination;
+        }
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            var indexDefinition = new IndexDefinition()
+            {
+                Maps =
+                [
+                    @"from dto in docs.Dtos
+                let attachment = LoadAttachment(dto, ""vector"")
+                select new { Vector =  CreateVector(attachment.GetContentAsStream())}"
+                ]
+            };
+
+            if (_source != null || _destination != null)
+            {
+                var vecOptions = new VectorOptions()
+                {
+                    DestinationEmbeddingType = _destination ?? VectorEmbeddingType.Single, SourceEmbeddingType = _source ?? VectorEmbeddingType.Single,
+                };
+
+                indexDefinition.Fields = new Dictionary<string, IndexFieldOptions>();
+                indexDefinition.Fields.Add("Vector", new IndexFieldOptions() { Vector = vecOptions });
+            }
+
+            return indexDefinition;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24620/Allow-to-use-ai.task-for-static-indexes
### Additional description

Allow to use ai task to generate embeddings in vector search for fields that are not generated via task.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
