### PR TITLE
RavenDB-24801 Wait for workers of EmbeddingsGenerationTask in tests.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-23720.cs
+++ b/test/SlowTests/Issues/RavenDB-23720.cs
@@ -30,8 +30,10 @@ public class RavenDB_23720 : EmbeddingsGenerationTestBase
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
 
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-                
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 
                 var autoResults1 = session.Query<Dto>().VectorSearch(x => x.WithText(x => x.Name).UsingTask(configuration.Identifier),
                     factory => factory.ByText("some text")).ToList();

--- a/test/SlowTests/Issues/RavenDB-23909.cs
+++ b/test/SlowTests/Issues/RavenDB-23909.cs
@@ -22,6 +22,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         {
             var (configuration, _) = AddEmbeddingsGenerationTask(store);
 
+
             using (var session = store.OpenSession())
             {
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
@@ -30,6 +31,9 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
                 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 
                 var result = session.Query<Dto>()
                     .VectorSearch(x => 
@@ -52,6 +56,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         {
             var (configuration, _) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Int8);
 
+
             using (var session = store.OpenSession())
             {
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
@@ -60,7 +65,10 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
                 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
+                
                 try
                 {
                     _ = session.Query<Dto>()
@@ -93,8 +101,9 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
     {
         using (var store = GetDocumentStore(options))
         {
-            _ = AddEmbeddingsGenerationTask(store);
+            var (configuration, _) = AddEmbeddingsGenerationTask(store);
 
+            
             using (var session = store.OpenSession())
             {
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
@@ -103,6 +112,9 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
                 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
 
                 var index = new DummyIndex();
                 index.Execute(store);
@@ -126,8 +138,9 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
     {
         using (var store = GetDocumentStore(options))
         {
-            _ = AddEmbeddingsGenerationTask(store);
+            var (configuration, _) = AddEmbeddingsGenerationTask(store);
 
+            
             using (var session = store.OpenSession())
             {
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
@@ -136,7 +149,10 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
+
                 var index = new DummyJsIndex();
                 index.Execute(store);
                 Indexes.WaitForIndexing(store);

--- a/test/SlowTests/Issues/RavenDB-23960.cs
+++ b/test/SlowTests/Issues/RavenDB-23960.cs
@@ -15,6 +15,9 @@ public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestB
         using (var store = GetDocumentStore(options))
         {
             var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "Task1");
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             
             var op = new GetOngoingTaskInfoOperation(configuration.Name, OngoingTaskType.EmbeddingsGeneration);
             var taskInfo = (EmbeddingsGeneration)store.Maintenance.Send(op);
@@ -22,7 +25,10 @@ public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestB
             store.Maintenance.Send(new ToggleOngoingTaskStateOperation(taskInfo.TaskId, OngoingTaskType.EmbeddingsGeneration, true));
                 
             var (configuration2, _) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "Task2");
-
+            (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration2);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             op = new GetOngoingTaskInfoOperation(configuration.Name, OngoingTaskType.EmbeddingsGeneration);
             taskInfo = (EmbeddingsGeneration)store.Maintenance.Send(op);
 

--- a/test/SlowTests/Issues/RavenDB-23962.cs
+++ b/test/SlowTests/Issues/RavenDB-23962.cs
@@ -31,7 +31,10 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
+
                 var result = session.Query<Dto>()
                     .Customize(c => c.WaitForNonStaleResults())
                     .Statistics(out var stats)
@@ -137,8 +140,10 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
             
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-            
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 
                 _ = session.Query<Dto>()
                     .Customize(c => c.WaitForNonStaleResults())
@@ -184,8 +189,11 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
             
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-            
+                
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 
                 var result = session.Query<Dto>()
                     .Statistics(out var stats)

--- a/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/EmbeddingsGenerationTestBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents;
@@ -11,7 +12,9 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Extensions.Streams;
+using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.AI.Embeddings;
 using Raven.Server.Documents.ETL.Providers.AI;
@@ -29,7 +32,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
     protected const string DefaultConnectionStringName = "Local AI connection";
     protected const string DefaultEmbeddingGenerationTaskName = "localAiTask";
     protected ByteStringContext _allocator;
-    protected readonly TimeSpan DefaultEtlTimeout = Debugger.IsAttached == false ? TimeSpan.FromSeconds(30) : TimeSpan.FromMinutes(15);
+    protected static readonly TimeSpan DefaultEtlTimeout = Debugger.IsAttached == false ? TimeSpan.FromSeconds(30) : TimeSpan.FromMinutes(15);
 
     protected static readonly ChunkingOptions DefaultChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 };
     
@@ -80,8 +83,25 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         Assert.NotNull(putResult.RaftCommandIndex);
 
         store.Maintenance.Send(new AddEmbeddingsGenerationOperation(configuration));
-
+        
         return (configuration, connectionString);
+    }
+
+    protected (bool QueriesWorkerRegistered, bool IndexingWorkerRegistered) WaitForEmbeddingsGenerationWorkerToRegister(IDocumentStore store, EmbeddingsGenerationConfiguration embeddingsGenerationConfigurationTask,
+        string database = null)
+    {
+        return AsyncHelpers.RunSync(() => WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, embeddingsGenerationConfigurationTask, database));
+    }
+    
+    protected async Task<(bool QueriesWorkerRegistered, bool IndexingWorkerRegistered)> WaitForEmbeddingsGenerationWorkerToRegisterAsync(IDocumentStore store, EmbeddingsGenerationConfiguration embeddingsGenerationConfigurationTask, string databaseName = null)
+    {
+        databaseName ??= store.Database;
+        var database = await GetDatabase(databaseName);
+
+        var queriesGenerator = await WaitForValueAsync(() => database.EmbeddingsGeneratorQueries.EmbeddingTaskExists(new EmbeddingsGenerationTaskIdentifier(embeddingsGenerationConfigurationTask.Identifier)), true, timeout: (int)DefaultEtlTimeout.TotalMilliseconds);
+        var indexingGenerator = await WaitForValueAsync(() => database.EmbeddingsGeneratorEtl.EmbeddingTaskExists(new EmbeddingsGenerationTaskIdentifier(embeddingsGenerationConfigurationTask.Identifier)), true, timeout: (int)DefaultEtlTimeout.TotalMilliseconds);
+        
+        return (queriesGenerator, indexingGenerator);
     }
     
     protected void AssertEmbeddingsForPath(IDocumentStore store,

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -45,8 +45,12 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions },
             new EmbeddingPathConfiguration() { Path = "SubDto.Name", ChunkingOptions = DefaultChunkingOptions }
         ]);
+        
         Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        
         var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
         var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);
 
@@ -88,6 +92,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["Name1"], dto.Id);
         }
     }
@@ -108,6 +116,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }]);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Names", ["Name1", "Name2", "Name3"], dto.Id);
         }
     }
@@ -130,6 +142,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "SubDto.Name" , ChunkingOptions = DefaultChunkingOptions }]);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "SubDto.Name", ["Subname1"], dto.Id);
         }
     }
@@ -152,6 +168,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "SubDtos.Name" , ChunkingOptions = DefaultChunkingOptions}]);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, config, connectionString, "SubDtos.Name", ["Subname1", "Subname2"], dto.Id);
         }
     }
@@ -177,6 +197,9 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var embeddingDocName = EmbeddingsHelper.GetEmbeddingCacheDocumentId(aiConnectionStringIdentifier, EmbeddingsHelper.CalculateInputValueHash("Name1"), VectorEmbeddingType.Single);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
 
             //Assert document exists
             var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
@@ -223,6 +246,9 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
 
             var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
             var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
@@ -259,6 +285,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Age", ChunkingOptions = DefaultChunkingOptions }]);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Age", ["21"], dto.Id);
         }
     }
@@ -279,6 +309,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["SomeName"], dto.Id);
 
             using (var session = store.OpenSession())
@@ -296,7 +330,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         {
             var dto = new Dto { Name = "SomeName", Age = 21 };
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            AddEmbeddingsGenerationTask(store);
+            var (configuration, _) = AddEmbeddingsGenerationTask(store);
 
             using (var session = store.OpenSession())
             {
@@ -304,7 +338,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 session.Store(dto);
                 session.SaveChanges();
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
+                
                 var db = await GetDatabase(store.Database);
 
                 var etlProcess = (EmbeddingsGenerationTask)db.EtlLoader.Processes.First();
@@ -366,6 +403,9 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (configuration, _) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
 
             var db = await GetDatabase(store.Database);
 
@@ -399,9 +439,12 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             }
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
-            AddEmbeddingsGenerationTask(store);
+            var (configuration, _) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             var db = await GetDatabase(store.Database);
 
             var etlProcess = (EmbeddingsGenerationTask)db.EtlLoader.Processes.First();
@@ -427,9 +470,12 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 session.SaveChanges();
 
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
-                AddEmbeddingsGenerationTask(store);
+                var (configuration, _) = AddEmbeddingsGenerationTask(store);
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
+                
                 aiTaskDone.Reset();
 
                 session.Delete(dto1);
@@ -468,6 +514,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["Name1"], dto.Id);
             
             using (var session = store.OpenSession())
@@ -499,6 +549,10 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Name1"], dto.Id);
 
             Test embeddingCache;
@@ -570,7 +624,10 @@ embeddings.generate(
 });");
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Foo", ["Name1"], dto.Id);
 
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Bar", ["ConstValue"], dto.Id);
@@ -600,6 +657,9 @@ embeddings.generate(
 });");
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
 
             // testing case-insensitive hashing of strings as well here
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Foo", ["Name1", "HELLO"], dto.Id);
@@ -624,7 +684,10 @@ embeddings.generate(
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["uppercasevalue"], dto.Id);
         }
     }
@@ -654,6 +717,9 @@ embeddings.generate(
                 script: "embeddings.generate({ ChunkedName: text.splitLines(this.Name, 5) });");
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
 
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
         }
@@ -729,7 +795,9 @@ Console.WriteLine(""Hello, World!"");";
                 script: "embeddings.generate({ ChunkedName: markdown.splitLines(this.Name, 20) });");
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
         }
     }
@@ -775,7 +843,9 @@ Console.WriteLine(""Hello, World!"");";
                 script: "embeddings.generate({ ChunkedName: html.strip(this.Name, 5) });");
             
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
         }
     }
@@ -827,7 +897,9 @@ Console.WriteLine(""Hello, World!"");";
             });
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", expectedChunks, dto.Id);
         }
     }
@@ -851,7 +923,9 @@ Console.WriteLine(""Hello, World!"");";
                 script: "embeddings.generate({ ArrayField: [this.Name, 'ConstValue'] });");
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ArrayField", ["CoolName", "ConstValue"], dto.Id);
         }
     }
@@ -873,14 +947,18 @@ Console.WriteLine(""Hello, World!"");";
         var (configuration1, connectionString1) = AddEmbeddingsGenerationTask(store,
             embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], targetQuantization: VectorEmbeddingType.Int8);
         Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration1);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configuration1, connectionString1, "Name", ["CoolName"], id, VectorEmbeddingType.Int8);
         
         aiTaskDone.Reset();
         var (configuration2, connectionString2) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "secondtask",
             embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }], targetQuantization: VectorEmbeddingType.Single);
         Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        
+        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration2);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configuration1, connectionString1, "Name", ["CoolName"], id, VectorEmbeddingType.Int8);
         AssertEmbeddingsForPath(store, configuration2, connectionString2, "Names", ["CoolName"], id);
     }
@@ -904,7 +982,9 @@ Console.WriteLine(""Hello, World!"");";
                     embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], targetQuantization: targetQuantization);
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 var connectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
                 var integrationIdentifier = new EmbeddingsGenerationTaskIdentifier(configuration.Identifier);
 
@@ -964,6 +1044,9 @@ Console.WriteLine(""Hello, World!"");";
                     embeddingsPaths: [nameConfig, subdtoNameConfig]);
                 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 AssertEmbeddingsForPath(store, configuration, connectionString, nameConfig.Path, Raven.Server.Documents.AI.TextChunker.Chunk(dto.Name, nameConfig.ChunkingOptions).ToArray(), dto.Id, quantization);
                 AssertEmbeddingsForPath(store, configuration, connectionString, subdtoNameConfig.Path, Raven.Server.Documents.AI.TextChunker.Chunk(dto.SubDto.Name, subdtoNameConfig.ChunkingOptions).ToArray(), dto.Id, quantization);
 
@@ -1046,7 +1129,9 @@ Console.WriteLine(""Hello, World!"");";
         ]);
         
         Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-       
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connection, "Name", ["Name1"], id);
         AssertEmbeddingsForPath(store, config, connection, "Names", ["Name1"], id);
 
@@ -1086,7 +1171,13 @@ Console.WriteLine(""Hello, World!"");";
         ]);
         
         Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-       
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config2);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        
         AssertEmbeddingsForPath(store, config, connection, "Name", ["Name1"], id);
         AssertEmbeddingsForPath(store, config2, connection2, "Names", ["Name1"], id);
 
@@ -1124,7 +1215,9 @@ Console.WriteLine(""Hello, World!"");";
                     script: "embeddings.generate({ ChunkedName: text.split(this.Name, 2048) });");
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier),
                     new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
@@ -38,6 +38,9 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         }, targetQuantization: VectorEmbeddingType.Int8);
         
         etl.Wait(DefaultEtlTimeout);
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Int8);
         
         
@@ -76,6 +79,10 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
             new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }}
         }, targetQuantization: VectorEmbeddingType.Single);
         Assert.True(etl.Wait(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id);
         
         new QuantizationInIndex().Execute(store);
@@ -110,6 +117,10 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         var etl = Etl.WaitForEtlToComplete(store);
         var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Binary);
         Assert.True(etl.Wait(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Binary);
 
         new Index().Execute(store);
@@ -144,11 +155,17 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         var etl = Etl.WaitForEtlToComplete(store);
         var (configurationSingle, connectionStringSingle) = AddEmbeddingsGenerationTask(embeddingsGenerationTaskName: "secondEtl", store: store, targetQuantization: VectorEmbeddingType.Single);
         Assert.True(etl.Wait(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configurationSingle);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configurationSingle, connectionStringSingle, "Name", ["car"], id, VectorEmbeddingType.Single);
         etl.Reset();
         
         var (configurationInt8, connectionStringInt8) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Int8);
         Assert.True(etl.Wait(DefaultEtlTimeout));
+        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configurationInt8);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configurationInt8, connectionStringInt8, "Name", ["car"], id, VectorEmbeddingType.Int8);
 
         

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
@@ -54,6 +54,9 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store);
         Assert.True(etlStatus.Wait(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Joe"], id);
 
         store.Maintenance.Send(new StartIndexOperation(index.IndexName));
@@ -135,7 +138,9 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }]);
         Assert.True(etlStatus.Wait(DefaultEtlTimeout));
-
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         store.Maintenance.Send(new StartIndexOperation(index.IndexName));
         Indexes.WaitForIndexing(store);
 
@@ -223,6 +228,9 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName);
         
         Assert.True(etlStatus.Wait(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["Joe"], id);
         
         store.Maintenance.Send(new StartIndexOperation(index.IndexName));
@@ -247,7 +255,9 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         etlStatus.Reset();
         var (config2, connectionString2) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName2);
         Assert.True(etlStatus.Wait(DefaultEtlTimeout));
-
+        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config2);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         Indexes.WaitForIndexing(store);
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -61,6 +61,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["apple"], dto1.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
             
@@ -112,6 +115,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
 
@@ -159,6 +165,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 });
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["computer"], dto2.Id);
             
@@ -199,6 +208,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
             
@@ -252,6 +264,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             ], chunkingOptionsForQuerying: new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 5 });
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
             
             var index = new SomeIndex();
@@ -290,6 +305,10 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.SaveChanges();
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto3.TextualValue], dto3.Id);
@@ -350,6 +369,10 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 await session1.SaveChangesAsync();
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
+                
                 AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
                 AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
                 AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto3.TextualValue], dto3.Id);
@@ -389,6 +412,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.SaveChanges();
 
             Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, config, connection, "TextualValue", ["asdsdfsdf"], "dto/1");
             
             var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
@@ -432,6 +458,9 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.SaveChanges();
 
                 Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(queriesWorkerRegistered);
+                Assert.True(indexingWorkerRegistered);
                 AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
                 AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto2.TextualValue], dto2.Id);
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
@@ -29,6 +29,9 @@ public class RemovalTests(ITestOutputHelper output) : EmbeddingsGenerationTestBa
         var etlWait = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: "eg");
         Assert.True(etlWait.Wait(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Maciej"], id0);
         AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Car"], id1);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24801

### Additional description

EmbeddingsGenerationTask workers are created in an async manner. In tests, we waited for the ETL to register; however, we must also wait for workers to be registered as well.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
