### PR TITLE
RavenDB-24641 Skip Coraxs' indexes during compact database

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -19,6 +19,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Exceptions.Corax;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations;
@@ -4924,7 +4925,7 @@ namespace Raven.Server.Documents.Indexes
         public void Compact(Action<IOperationProgress> onProgress, CompactionResult result, bool shouldSkipOptimization, CancellationToken token)
         {
             if (IndexPersistence is CoraxIndexPersistence)
-                throw new NotSupportedException($"{nameof(Compact)} is not supported for Corax indexes.");
+                throw new NotSupportedInCoraxException($"{nameof(Compact)} is not supported for Corax indexes.");
 
             AssertCompactionOrOptimizationIsNotInProgress(Name, nameof(Compact));
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -21,6 +21,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Corax;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Extensions;
@@ -1197,7 +1198,18 @@ namespace Raven.Server.Web.System
                                             }
 
                                             // we want to send progress of entire operation (indexes and documents), but we should update stats only for index compaction
-                                            index.Compact(progress => onProgress(overallResult.Progress), indexCompactionResult, compactSettings.SkipOptimizeIndexes, indexCts.Token);
+                                            try
+                                            {
+                                                index.Compact(progress => onProgress(overallResult.Progress), indexCompactionResult, compactSettings.SkipOptimizeIndexes,
+                                                    indexCts.Token);
+                                            }
+                                            catch (NotSupportedInCoraxException)
+                                            {
+                                                indexCompactionResult.Skipped = true;
+                                                indexCompactionResult.AddInfo(
+                                                    $"Skipping data compaction of '{indexName}' index because data compaction of Corax indexes isn't supported.");
+                                            }
+                                            
                                             indexCompactionResult.Processed = true;
                                         }
                                     }

--- a/test/SlowTests/Issues/RavenDB-24641.cs
+++ b/test/SlowTests/Issues/RavenDB-24641.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Sparrow;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24641 : RavenTestBase
+{
+    public RavenDB_24641(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Core | RavenTestCategory.Indexes)]
+    public void DatabaseCompactOperationWillSkipCoraxIndexes()
+    {
+        using var store = GetDocumentStore(new Options() { RunInMemory = false });
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Orders.Order { Company = "Company1" });
+            session.SaveChanges();
+        }
+
+        var coraxIndex = new IndexToCompact(SearchEngineType.Corax, "CoraxIndex");
+        var luceneIndex = new IndexToCompact(SearchEngineType.Lucene, "LuceneIndex");
+        coraxIndex.Execute(store);
+        luceneIndex.Execute(store);
+
+        Indexes.WaitForIndexing(store);
+
+
+        var compactDatabaseOperation = new CompactDatabaseOperation(new CompactSettings()
+        {
+            DatabaseName = store.Database, Documents = true, Indexes = [coraxIndex.IndexName, luceneIndex.IndexName], SkipOptimizeIndexes = false
+        });
+
+        var operation = store.Maintenance.Server.Send(compactDatabaseOperation);
+        var result = operation.WaitForCompletion(TimeSpan.FromSeconds(30));
+        var compactionResult = Assert.IsType<CompactionResult>(result);
+        Assert.Equal(2, compactionResult.IndexesResults.Count);
+        var coraxResult = compactionResult.IndexesResults[coraxIndex.IndexName];
+        Assert.True(coraxResult.Processed);
+        Assert.True(coraxResult.Skipped);
+        Assert.Contains("Skipping data compaction of 'CoraxIndex' index because data compaction of Corax indexes isn't supported.", coraxResult.Message);
+        
+        var luceneResult = compactionResult.IndexesResults[luceneIndex.IndexName];
+        Assert.True(luceneResult.Processed);
+        Assert.False(luceneResult.Skipped);
+
+        Assert.True(compactionResult.Processed);
+        Assert.False(compactionResult.Skipped);
+    }
+
+    private class IndexToCompact : AbstractIndexCreationTask<Orders.Order>
+    {
+        private string _indexName;
+        public override string IndexName => _indexName;
+
+        public IndexToCompact(SearchEngineType searchEngineType, string indexName)
+        {
+            Map = orders => from order in orders
+                select new { order.Company };
+
+            SearchEngineType = searchEngineType;
+            _indexName = indexName;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24641

### Additional description

Skipping Coraxs' indexes during database compact operation.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
