### PR TITLE
RavenDB-24858 - Take into account `PropertyNameConverter` when building Static Index Definition

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -388,7 +388,6 @@ namespace Raven.Client.Documents.Conventions
         private bool? _useHttpCompression;
         private HttpCompressionAlgorithm _httpCompressionAlgorithm;
         private Func<MemberInfo, string> _propertyNameConverter;
-        private Func<MemberInfo, string> _findPropertyNameForIndexDefinition;
         private Func<Type, bool> _typeIsKnownServerSide = _ => false;
         private Func<MemberInfo, bool> _shouldApplyPropertyNameConverter;
         private OperationStatusFetchMode _operationStatusFetchMode;
@@ -555,22 +554,6 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _propertyNameConverter = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a function to find the property name for a member when building an index definition from a LINQ expression.
-        /// </summary>
-        [Obsolete("This convention is a workaround for an issue where `PropertyNameConverter` is not respected during index definition creation. " +
-                  "A direct fix is a breaking change scheduled for RavenDB v8.0. " +
-                  "This temporary convention was added in v7.1 to address the problem and will be removed in v8.0.", error: false)]
-        public Func<MemberInfo, string> FindPropertyNameForIndexDefinition
-        {
-            get => _findPropertyNameForIndexDefinition;
-            set
-            {
-                AssertNotFrozen();
-                _findPropertyNameForIndexDefinition = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -272,14 +272,19 @@ namespace Raven.Client.Documents.Indexes
 
         private string GetPropertyName(MemberInfo memberInfo)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            var propName = _conventions.FindPropertyNameForIndexDefinition?.Invoke(memberInfo);
-#pragma warning restore CS0618 // Type or member is obsolete
-            if (propName != null)
-                return propName;
+            if (memberInfo == null)
+                return null;
+
+            if (_conventions.PropertyNameConverter != null)
+            {
+                var convertedName = _conventions.GetConvertedPropertyNameFor(memberInfo);
+                if (convertedName != null)
+                    return convertedName;
+            }
 
             foreach (var customAttribute in memberInfo.GetCustomAttributes(inherit: true))
             {
+                string propName;
                 var customAttributeType = customAttribute.GetType();
                 if (typeof(JsonPropertyAttribute).Namespace != customAttributeType.Namespace)
                     continue;
@@ -302,7 +307,7 @@ namespace Raven.Client.Documents.Indexes
                     return propName;
             }
 
-            return _conventions.GetConvertedPropertyNameFor(memberInfo);
+            return memberInfo.Name;
         }
 
         private static Type GetMemberType(MemberInfo member)

--- a/test/SlowTests/Client/Indexing/Issues/RavenDB-24858.cs
+++ b/test/SlowTests/Client/Indexing/Issues/RavenDB-24858.cs
@@ -20,7 +20,7 @@ public class RavenDB_24858 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-    public async Task FindPropertyNameForIndexDefinitionAsWorkaroundInsteadOfPropertyNameConverter_ShouldWork()
+    public async Task ShouldTakeIntoAccount_PropertyNameConverter_WhenBuildingIndexDefinition()
     {
         using var store = GetDocumentStore(new Options
         {
@@ -28,9 +28,7 @@ public class RavenDB_24858 : RavenTestBase
             {
                 documentStore.Conventions.FindPropertyNameForIndex = ConvertStripePropertyNamesForIndex;
                 documentStore.Conventions.FindPropertyNameForDynamicIndex = ConvertStripePropertyNamesForIndex;
-#pragma warning disable CS0618 // Type or member is obsolete
-                documentStore.Conventions.FindPropertyNameForIndexDefinition = info => info.Name;
-#pragma warning restore CS0618 // Type or member is obsolete
+                documentStore.Conventions.PropertyNameConverter = info => info.Name;
                 documentStore.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
                 {
                     JsonContractResolver = new IgnoreJsonPropertyNamesForSomeNamespaceContractResolver()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24858

### Additional description

We should take into account `PropertyNameConverter` when building Static Index Definition

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed