### PR TITLE
RavenDB-24604 - Remove unwrap in external replication & etl

### DIFF
--- a/src/Raven.Client/Documents/Attachments/RetiredAttachmentsConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RetiredAttachmentsConfiguration.cs
@@ -100,7 +100,7 @@ namespace Raven.Client.Documents.Attachments
                 if (kvp.Value == null)
                     throw new InvalidOperationException($"Destination configuration for key {kvp.Key} is null{databaseNameStr}.");
 
-                kvp.Value.AssertConfiguration(databaseName);
+                kvp.Value.AssertConfiguration(kvp.Key, databaseName);
             }
 
             if (RetireFrequencyInSec == null)

--- a/src/Raven.Client/Documents/Attachments/RetiredAttachmentsDestinationConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RetiredAttachmentsDestinationConfiguration.cs
@@ -83,11 +83,14 @@ public sealed class RetiredAttachmentsDestinationConfiguration : IDynamicJson
         return BackupConfiguration.CanBackupUsing(S3Settings) || BackupConfiguration.CanBackupUsing(AzureSettings);
     }
 
-    internal void AssertConfiguration(string databaseName = null)
+    internal void AssertConfiguration(string key, string databaseName = null)
     {
         var databaseNameStr = string.IsNullOrEmpty(databaseName) ? string.Empty : $" for database '{databaseName}'";
 
         if (string.IsNullOrEmpty(Identifier))
             throw new InvalidOperationException($"Identifier{databaseNameStr} must have a value.");
+
+        if (key != Identifier)
+            throw new InvalidOperationException($"Identifier '{Identifier}' does not match the key '{key}'{databaseNameStr}.");
     }
 }

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -13,7 +13,6 @@ using Sparrow.Binary;
 using Sparrow.Json;
 using Voron;
 using Voron.Impl;
-using Voron.Util;
 
 namespace Raven.Server.Documents;
 
@@ -31,6 +30,10 @@ public abstract unsafe class AbstractBackgroundWorkStorage
         _treeName = treeName;
         MetadataPropertyName = metadataPropertyName;
     }
+
+    protected abstract void ProcessDocument(DocumentsOperationContext context, Slice lowerId, string id, DateTime currentTime);
+    protected abstract void HandleDocumentConflict(BackgroundWorkParameters options, Slice ticksAsSlice, Slice clonedId, Queue<DocumentExpirationInfo> expiredDocs, ref int totalCount);
+    protected abstract void HandleSkippedItem(DocumentExpirationInfo item);
 
     public void Put(DocumentsOperationContext context, Slice lowerId, string processDateString)
     {
@@ -113,21 +116,26 @@ public abstract unsafe class AbstractBackgroundWorkStorage
         try
         {
             var item = GetDocumentAndId(options, clonedId, ticksAsSlice);
-            if (item.Document == null)
+            if (item.Status == DocumentExpirationInfoStatus.Delete)
             {
                 toProcess.Enqueue(item);
                 totalCount++;
                 return true;
             }
 
-            using (item.GetDocumentDisposable())
-            {
-                if (ShouldHandleWorkOnCurrentNode(options.DatabaseRecord.Topology, options.NodeTag) == false)
-                    return false;
+            if (ShouldHandleWorkOnCurrentNode(options.DatabaseRecord.Topology, options.NodeTag) == false)
+                return false;
 
-                toProcess.Enqueue(item);
+            if (item.Status == DocumentExpirationInfoStatus.Skip)
+            {
+                // TODO: RavenDB-24862 - if we skip number of items that is equals to totalCount then we might end up with skips only in the batch, need to handle such scenario
                 totalCount++;
+                HandleSkippedItem(item);
+                return true;
             }
+
+            toProcess.Enqueue(item);
+            totalCount++;
             return true;
         }
         catch (DocumentConflictException)
@@ -138,51 +146,18 @@ public abstract unsafe class AbstractBackgroundWorkStorage
         return false;
     }
 
-    public class DocumentExpirationInfo
-    {
-        public Document Document { get; set; }
-        public Slice Ticks { get; }
-        public Slice LowerId { get; }
-        public string Id { get; }
-
-        private DocumentExpirationInfo()
-        {
-        }
-
-        public DocumentExpirationInfo(Slice ticks, Slice lowerId, string id)
-        {
-            Ticks = ticks;
-            LowerId = lowerId;
-            Id = id;
-        }
-
-        public IDisposable GetDocumentDisposable()
-        {
-            return new DisposableAction(() =>
-            {
-                Document?.Dispose();
-                Document = null;
-            });
-        }
-    }
-
     protected virtual DocumentExpirationInfo GetDocumentAndId(BackgroundWorkParameters options, Slice clonedId, Slice ticksSlice)
     {
-        var document = Database.DocumentsStorage.Get(options.Context, clonedId, DocumentFields.Id | DocumentFields.Data | DocumentFields.ChangeVector);
+        using var document = Database.DocumentsStorage.Get(options.Context, clonedId, DocumentFields.Id | DocumentFields.Data | DocumentFields.ChangeVector);
         if (document == null ||
             document.TryGetMetadata(out var metadata) == false ||
             HasPassed(metadata, options.CurrentTime, MetadataPropertyName) == false)
         {
-            return new DocumentExpirationInfo(ticksSlice, clonedId, id: null);
+            return new DocumentExpirationInfo(ticksSlice, clonedId, id: null, DocumentExpirationInfoStatus.Delete);
         }
 
-        return new DocumentExpirationInfo(ticksSlice, clonedId, id: document.Id)
-        {
-            Document = document
-        };
+        return new DocumentExpirationInfo(ticksSlice, clonedId, id: document.Id, DocumentExpirationInfoStatus.Process);
     }
-
-    protected abstract void HandleDocumentConflict(BackgroundWorkParameters options, Slice ticksAsSlice, Slice clonedId, Queue<DocumentExpirationInfo> expiredDocs, ref int totalCount);
 
     public static bool ShouldHandleWorkOnCurrentNode(DatabaseTopology topology, string nodeTag)
     {
@@ -218,8 +193,6 @@ public abstract unsafe class AbstractBackgroundWorkStorage
         return currentTime >= date;
     }
     
-    protected abstract void ProcessDocument(DocumentsOperationContext context, Slice lowerId, string id, DateTime currentTime);
-
     public int ProcessDocuments(DocumentsOperationContext context, Queue<DocumentExpirationInfo> toProcess, DateTime currentTime)
     {
         var processedCount = 0;
@@ -255,6 +228,32 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
         return processedCount;
     }
-    
-}
 
+    public enum DocumentExpirationInfoStatus
+    {
+        Process,
+        Skip,
+        Delete
+    }
+
+    public class DocumentExpirationInfo
+    {
+        public Slice Ticks { get; }
+        public Slice LowerId { get; }
+        public string Id { get; }
+        public DocumentExpirationInfoStatus Status { get; }
+
+
+        private DocumentExpirationInfo()
+        {
+        }
+
+        public DocumentExpirationInfo(Slice ticks, Slice lowerId, string id, DocumentExpirationInfoStatus status)
+        {
+            Status = status;
+            Ticks = ticks;
+            LowerId = lowerId;
+            Id = id;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -499,7 +499,14 @@ namespace Raven.Server.Documents
                 {
                     // this works similar to expiration, we populate the tree even if we don't have a configuration for attachments retirement
                     if (flags == RetiredAttachmentFlags.None && retireAt.HasValue)
+                    {
                         RetiredAttachmentsStorage.Put(context, key, retireAt.Value.GetDefaultRavenFormat(), identifier);
+                    }
+                    else if (flags == RetiredAttachmentFlags.Retired)
+                    {
+                        // we got retired attachment, so we can remove the stream from data file
+                        context.Transaction.CheckIfShouldDeleteAttachmentStream(base64Hash);
+                    }
                 }
             }
 

--- a/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
@@ -34,7 +34,7 @@ internal class ArchiveDocumentsCommand : MergedTransactionCommand<DocumentsOpera
     {
         return new ArchiveDocumentsCommandDto 
         {
-            ToArchive = _toArchive.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id)).ToArray(),
+            ToArchive = _toArchive.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id, Status: x.Status)).ToArray(),
             CurrentTime = _currentTime
         };
     }
@@ -48,13 +48,13 @@ internal class ArchiveDocumentsCommandDto: IReplayableCommandDto<DocumentsOperat
         var toArchive = new Queue<DocumentExpirationInfo>();
         foreach (var item in ToArchive)
         {
-            toArchive.Enqueue(new DocumentExpirationInfo(item.Ticks.Clone(context.Allocator), item.LowerId.Clone(context.Allocator), item.Id));
+            toArchive.Enqueue(new DocumentExpirationInfo(item.Ticks.Clone(context.Allocator), item.LowerId.Clone(context.Allocator), item.Id, item.Status));
         }
         var command = new ArchiveDocumentsCommand(toArchive, database, CurrentTime);
         return command;
     }
 
-    public (Slice Ticks, Slice LowerId, string Id)[] ToArchive { get; set; }
+    public (Slice Ticks, Slice LowerId, string Id, DocumentExpirationInfoStatus Status)[] ToArchive { get; set; }
 
     public DateTime CurrentTime { get; set; }
 }

--- a/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
+++ b/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
@@ -49,4 +49,9 @@ public sealed class DataArchivalStorage : AbstractBackgroundWorkStorage
     {
         // data archival ignores conflicts
     }
+
+    protected override void HandleSkippedItem(DocumentExpirationInfo item)
+    {
+        // no-op, data archival doesn't skip items
+    }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -790,21 +790,6 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 if (attachmentInfo.TryGet(nameof(AttachmentName.Name), out string name))
                 {
                     var attachmentData = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(Context, item.DocumentId, name, AttachmentType.Document, null);
-                    if (attachmentData.RetireParameters.IsRetiredAttachment())
-                    {
-                        using Stream stream = AsyncHelpers.RunSync(() =>
-                            Database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.StreamForDownloadDestinationInternal(_downloader.Value,
-                                attachmentData.Base64Hash.ToString()));
-                        var memStream = new MemoryStream();
-                        stream.CopyTo(memStream);
-                        memStream.Position = 0;
-                        attachmentData.Stream = memStream;
-                        attachmentData.RetireParameters = new RetireAttachmentParameters(attachmentData.RetireParameters.Identifier, attachmentData.RetireParameters.At)
-                        {
-                            Flags = RetiredAttachmentFlags.None // we are loading retired attachment, so we need to reset the flag
-                        };
-
-                    }
                     results.Add(attachmentData);
                 }
             }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -72,18 +72,12 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 return;
 
             var commands = _fullDocuments[id] = new List<ICommandData>();
-            bool hasAttachments = attachments is { Count: > 0 };
-            if (hasAttachments)
-            {
-                DropRetiredAttachmentFlagFromAttachmentMetadataIfNeeded(context, id, doc, out doc);
-            }
-
             string remoteDocumentId = GetRemoteDocumentId(id);
             commands.Add(new PutCommandDataWithBlittableJson(remoteDocumentId, null, null, doc));
 
             _stats.IncrementBatchSize(doc.Size);
 
-            if (hasAttachments)
+            if (attachments != null && attachments.Count > 0)
             {
                 foreach (var attachment in attachments)
                 {
@@ -116,81 +110,6 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                     });    
                 }
             }
-        }
-
-        internal static bool DropRetiredAttachmentFlagFromAttachmentMetadataIfNeeded(DocumentsOperationContext context, string id,
-            BlittableJsonReaderObject src, out BlittableJsonReaderObject dest)
-        {
-            dest = src;
-
-            if (src.TryGet(Client.Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) != false &&
-                metadata.TryGet(Client.Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray att) != false)
-            {
-                var attachmentsToSave = new DynamicJsonArray();
-
-                var hasRetired = false;
-                foreach (BlittableJsonReaderObject attachment in att)
-                {
-                    if (attachment.TryGet(nameof(AttachmentName.RetireParameters), out BlittableJsonReaderObject retireParameters) == false)
-                    {
-                        throw new ArgumentException($"The attachment info in missing a mandatory value: {attachment}");
-                    }
-
-                    if (retireParameters == null)
-                    {
-                        attachmentsToSave.Add(attachment);
-                    }
-                    else
-                    {
-                        if (retireParameters.TryGet(nameof(RetireAttachmentParameters.Flags), out RetiredAttachmentFlags flags) == false)
-                            throw new ArgumentException($"The attachment info in missing a mandatory value: {attachment}");
-
-                        if (flags == RetiredAttachmentFlags.Retired)
-                        {
-                            hasRetired = true;
-                            retireParameters.Modifications = new DynamicJsonValue(retireParameters)
-                            {
-                                [nameof(RetireAttachmentParameters.Flags)] = RetiredAttachmentFlags.None
-                            };
-                            attachment.Modifications = new DynamicJsonValue(attachment)
-                            {
-                                [nameof(AttachmentName.RetireParameters)] = retireParameters
-                            };
-
-                            attachmentsToSave.Add(context.ReadObject(attachment, $"{id}_attachment", BlittableJsonDocumentBuilder.UsageMode.ToDisk));
-                        }
-                        else
-                        {
-                            attachmentsToSave.Add(attachment);
-                        }
-                    }
-
-                }
-
-                if (hasRetired)
-                {
-                    metadata.Modifications = new DynamicJsonValue(metadata)
-                    {
-                        [Client.Constants.Documents.Metadata.Attachments] = attachmentsToSave
-                    };
-
-                    metadata = context.ReadObject(metadata, $"{id}_metadata", BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-
-                    src.Modifications = new DynamicJsonValue(src)
-                    {
-                        [Client.Constants.Documents.Metadata.Key] = metadata
-                    };
-
-                    using (var old = src)
-                    {
-                        dest = context.ReadObject(src, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                    }
-
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         public void Put(string id, JsValue instance, BlittableJsonReaderObject doc)

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -49,9 +49,14 @@ namespace Raven.Server.Documents.Expiration
 
             if (allExpired)
             {
-                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id));
+                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, DocumentExpirationInfoStatus.Process));
                 totalCount++;
             }
+        }
+
+        protected override void HandleSkippedItem(DocumentExpirationInfo item)
+        {
+            // no-op, we don't handle skipped items in expiration storage
         }
 
         private (bool AllExpired, string Id) GetConflictedExpiration(DocumentsOperationContext context, DateTime currentTime, Slice clonedId)

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -234,7 +234,7 @@ namespace Raven.Server.Documents.Expiration
             {
                 return new DeleteExpiredDocumentsCommandDto
                 {
-                    Expired = _expired.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id)).ToArray(),
+                    Expired = _expired.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id, Status: x.Status)).ToArray(),
                     ForExpiration = _forExpiration,
                     CurrentTime = _currentTime
                 };
@@ -249,13 +249,13 @@ namespace Raven.Server.Documents.Expiration
             var expired = new Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo>();
             foreach (var item in Expired)
             {
-                expired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3));
+                expired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3, item.Item4));
             }
             var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(expired, database, ForExpiration, CurrentTime);
             return command;
         }
 
-        public (Slice, Slice, string)[] Expired { get; set; }
+        public (Slice, Slice, string, AbstractBackgroundWorkStorage.DocumentExpirationInfoStatus)[] Expired { get; set; }
 
         public bool ForExpiration { get; set; }
 

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -168,11 +168,17 @@ public sealed class MergedBatchCommand : TransactionMergedCommand
                 case CommandType.AttachmentPUT:
                     var docId = EtlGetDocIdFromPrefixIfNeeded(cmd.Id, cmd, lastPutResult);
 
-                    AttachmentStream attachmentStream = GetAttachmentStream(attachmentIterator, out Stream stream);
-                    AttachmentDetailsServer attachmentPutResult = Database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, docId, cmd.Name, cmd.ContentType, attachmentStream.Hash, stream.Length, cmd.RetireParameters, cmd.ChangeVector, stream, updateDocument: false, extractCollectionName: ModifiedCollections is not null, fromEtl: cmd.FromEtl);
+                    Stream stream = null;
 
-                    Debug.Assert(cmd.RetireParameters.IsLocalAttachment(), "cmd.RetireParameters.IsLocalAttachment()");
+                    if (cmd.RetireParameters.IsLocalAttachment())
+                    {
+                        var attachmentStream = GetAttachmentStream(attachmentIterator, out stream);
+                        cmd.Hash = attachmentStream.Hash;
 
+                        Debug.Assert(cmd.SizeInBytes == stream.Length, "cmd.SizeInBytes == stream.Length");
+                    }
+
+                    var attachmentPutResult = Database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, docId, cmd.Name, cmd.ContentType, cmd.Hash, cmd.SizeInBytes, cmd.RetireParameters, cmd.ChangeVector, stream, updateDocument: false, extractCollectionName: ModifiedCollections is not null, fromEtl: cmd.FromEtl);
                     LastChangeVector = attachmentPutResult.ChangeVector;
 
                     var apReply = new DynamicJsonValue

--- a/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
+++ b/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
@@ -64,9 +64,14 @@ namespace Raven.Server.Documents.Refresh
 
             if (allExpired)
             {
-                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id));
+                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, DocumentExpirationInfoStatus.Process));
                 totalCount++;
             }
+        }
+
+        protected override void HandleSkippedItem(DocumentExpirationInfo item)
+        {
+            // no-op, we don't handle skipped items in refresh storage
         }
 
         private (bool AllExpired, string Id) GetConflictedExpiration(DocumentsOperationContext context, DateTime currentTime, Slice clonedId)

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -318,31 +318,6 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             protected virtual ChangeVector PreProcessItem(DocumentsOperationContext context, ReplicationBatchItem item, List<IDisposable> disposables)
             {
-                if (_isInternal == false)
-                {
-                    switch (item)
-                    {
-                        case AttachmentReplicationItem attachmentReplicationItem:
-                            if (attachmentReplicationItem.Flags == RetiredAttachmentFlags.Retired)
-                            {
-                                attachmentReplicationItem.Flags = RetiredAttachmentFlags.None;
-                            }
-                            break;
-
-                        case DocumentReplicationItem document:
-
-                            if (document.Type != ReplicationBatchItem.ReplicationItemType.DocumentTombstone)
-                            {
-                                if (RavenEtlScriptRun.DropRetiredAttachmentFlagFromAttachmentMetadataIfNeeded(context, document.Id, document.Data, out document.Data))
-                                {
-                                    disposables.Add(document.Data);
-                                }
-                            }
-
-                            break;
-                    }
-                }
-
                 return context.GetChangeVector(item.ChangeVector).Order;
             }
 
@@ -821,7 +796,9 @@ namespace Raven.Server.Documents.Replication.Incoming
                 {
                     if (attachment.TryGet(nameof(AttachmentName.Hash), out LazyStringValue hash) == false)
                         continue;
-
+                    if (attachment.TryGet(nameof(AttachmentName.RetireParameters), out BlittableJsonReaderObject retireParameters) && retireParameters != null
+                        && retireParameters.TryGet(nameof(RetireAttachmentParameters.Flags), out RetiredAttachmentFlags flags) && flags == RetiredAttachmentFlags.Retired)
+                        continue;
                     if (context.DocumentDatabase.DocumentsStorage.AttachmentsStorage.AttachmentExists(context, hash))
                         continue;
 

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -47,7 +47,6 @@ namespace Raven.Server.Documents.Replication.Senders
         private Queue<Slice> _deduplicatedAttachmentHashesLru = new();
         private readonly int _numberOfAttachmentsTrackedForDeduplication;
         private readonly ByteStringContext _allocator; // required to clone the hashes 
-        private readonly Lazy<DirectFileDownloader> _downloader;
 
         protected ReplicationDocumentSenderBase(Stream stream, DatabaseOutgoingReplicationHandler parent, RavenLogger log)
         {
@@ -57,7 +56,6 @@ namespace Raven.Server.Documents.Replication.Senders
 
             _numberOfAttachmentsTrackedForDeduplication = parent._database.Configuration.Replication.MaxNumberOfAttachmentsTrackedForDeduplication;
             _allocator = new ByteStringContext(SharedMultipleUseFlag.None);
-            _downloader = new Lazy<DirectFileDownloader>(() => _parent._database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.GetDownloader(null, new(_parent.CancellationToken))); // TODO: EGOR RavenDB-24604
         }
 
         protected virtual IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentsOperationContext ctx, long etag, ReplicationStats stats,
@@ -499,26 +497,6 @@ namespace Raven.Server.Documents.Replication.Senders
 
                     if (MissingAttachmentsInLastBatch)
                         state.MissingAttachmentBase64Hashes?.Remove(attachment.Base64Hash);
-                }
-                else if (_parent.Destination.Type != ReplicationNode.ReplicationType.Internal)
-                {
-                    if (ShouldSendAttachmentStream(attachment))
-                    {
-                        stats.RecordRetiredAttachmentStreamOutput(attachment.Size);
-                        var hash = attachment.Base64Hash.ToString();
-                        using Stream stream = Client.Util.AsyncHelpers.RunSync(() => _parent._database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.StreamForDownloadDestinationInternal(_downloader.Value, hash));
-                        var memStream = new MemoryStream();
-                        stream.CopyTo(memStream);
-                        memStream.Position = 0;
-                        attachment.Stream = memStream;
-
-                        _replicaAttachmentStreams[attachment.Base64Hash] = attachment;
-
-                        if (Log.IsInfoEnabled)
-                        {
-                            Log.Info($"Successfully downloaded retired attachment '{attachment.Name}' with hash '{hash}' from cloud, attachment key '{attachment.Key}'.");
-                        }
-                    }
                 }
             }
 

--- a/src/Raven.Server/Documents/RetireAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RetireAttachmentsSender.cs
@@ -295,7 +295,7 @@ namespace Raven.Server.Documents
             {
                 return new UpdateRetiredAttachmentsCommandDto
                 {
-                    Retired = _retired.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id)).ToArray(),
+                    Retired = _retired.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id, Status: x.Status)).ToArray(),
                     CurrentTime = _currentTime
                 };
             }
@@ -326,13 +326,13 @@ namespace Raven.Server.Documents
             var retired = new Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo>();
             foreach (var item in Retired)
             {
-                retired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3));
+                retired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3, item.Item4));
             }
             var command = new RetireAttachmentsSender.UpdateRetiredAttachmentsCommand(retired, database, CurrentTime);
             return command;
         }
 
-        public (Slice, Slice, string)[] Retired { get; set; }
+        public (Slice, Slice, string, AbstractBackgroundWorkStorage.DocumentExpirationInfoStatus)[] Retired { get; set; }
 
         public DateTime CurrentTime { get; set; }
     }

--- a/src/Raven.Server/Documents/RetireAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RetireAttachmentsSender.cs
@@ -123,8 +123,8 @@ namespace Raven.Server.Documents
 
                                 if (string.IsNullOrEmpty(doc.Id))
                                 {
-                                    if (Logger.IsInfoEnabled)
-                                        Logger.Info($"Skipping PutRetire of retired attachment with key: '{doc.LowerId}' because it's identifier '{doc.Id}' IsNullOrEmpty.");
+                                    if (Logger.IsDebugEnabled)
+                                        Logger.Debug($"Skipping PutRetire of retired attachment with key: '{doc.LowerId}' because it's identifier '{doc.Id}' IsNullOrEmpty.");
 
                                     // document was deleted, need to remove it from retired tree
                                     retired.Enqueue(doc);
@@ -193,22 +193,22 @@ namespace Raven.Server.Documents
                                 }
                                 else
                                 {
-                                    if (Logger.IsInfoEnabled)
-                                        Logger.Info($"Timed out waiting for free thread to PutRetire retired attachments with '{doc.LowerId}', ReadTransactionMaxOpenTimeInMs: {duration.ElapsedMilliseconds > ReadTransactionMaxOpenTimeInMs}, IsCancellationRequested: {_token.Token.IsCancellationRequested}, the PutRetire will happen on next iteration.");
+                                    if (Logger.IsDebugEnabled)
+                                        Logger.Debug($"Timed out waiting for free thread to PutRetire retired attachments with '{doc.LowerId}', ReadTransactionMaxOpenTimeInMs: {duration.ElapsedMilliseconds > ReadTransactionMaxOpenTimeInMs}, IsCancellationRequested: {_token.Token.IsCancellationRequested}, the PutRetire will happen on next iteration.");
                                 }
                             }
 
                             if (toRetire.Count != retired.Count)
                             {
                                 // we had skipped items
-                                if (Logger.IsInfoEnabled)
-                                    Logger.Info($"Skipping retiring of '{toRetire.Count - retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
+                                if (Logger.IsDebugEnabled)
+                                    Logger.Debug($"Skipping retiring of '{toRetire.Count - retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
                             }
 
                             if (retired.Count == 0)
                             {
-                                if (Logger.IsInfoEnabled)
-                                    Logger.Info($"Skipping retiring whole batch of '{retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
+                                if (Logger.IsDebugEnabled)
+                                    Logger.Debug($"Skipping retiring whole batch of '{retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
 
                                 continue;
                             }
@@ -226,8 +226,8 @@ namespace Raven.Server.Documents
                     var command = new UpdateRetiredAttachmentsCommand(retired, _database, currentTime);
                     await _database.TxMerger.Enqueue(command);
 
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Successfully retired '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms.");
+                    if (Logger.IsDebugEnabled)
+                        Logger.Debug($"Successfully retired '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms.");
                 }
             }
             catch (OperationCanceledException)
@@ -237,8 +237,8 @@ namespace Raven.Server.Documents
             }
             catch (Exception e)
             {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info($"Failed to retire attachments on '{_database.Name}' which are older than '{currentTime}'.", e);
+                if (Logger.IsErrorEnabled)
+                    Logger.Error($"Failed to retire attachments on '{_database.Name}' which are older than '{currentTime}'.", e);
             }
             return totalCount;
         }

--- a/src/Raven.Server/Documents/RetiredAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RetiredAttachmentsStorage.cs
@@ -200,35 +200,40 @@ public class RetiredAttachmentsStorage : AbstractBackgroundWorkStorage
     {
         using (ExtractIdentifierStringAndDocumentIdSliceFromRetiredAttachmentKey(options.Context, clonedId, out string identifier, out Slice documentIdSlice))
         {
-            // document is disposed in caller method
-            var document = Database.DocumentsStorage.Get(options.Context, documentIdSlice, DocumentFields.Id);
-            // doc was deleted
-            if (document == null)
+            if (Database.DocumentsStorage.GetTableValueReaderForDocument(options.Context, documentIdSlice, throwOnConflict: false, out _) == false)
             {
-                return new DocumentExpirationInfo(ticksSlice, clonedId, id: null);
+                // doc was deleted
+                return new DocumentExpirationInfo(ticksSlice, clonedId, id: null, DocumentExpirationInfoStatus.Delete);
             }
 
-            if (options.DatabaseRecord.RetiredAttachments == null)
+            if (ShouldSkipItem(options.DatabaseRecord.RetiredAttachments, identifier))
             {
-                // no configuration, we don't care about this collection
-                return new DocumentExpirationInfo(ticksSlice, clonedId, id: null);
+                return new DocumentExpirationInfo(ticksSlice, clonedId, id: identifier, DocumentExpirationInfoStatus.Skip);
             }
 
-            if (options.DatabaseRecord.RetiredAttachments.Destinations == null)
-            {
-                return new DocumentExpirationInfo(ticksSlice, clonedId, id: null);
-            }
+            return new DocumentExpirationInfo(ticksSlice, clonedId, id: identifier, DocumentExpirationInfoStatus.Process);
+        }
+    }
 
-
-            if (options.DatabaseRecord.RetiredAttachments.Destinations.ContainsKey(identifier) == false)
-            {
-                // no destinations, we don't care about this collection
-                return new DocumentExpirationInfo(ticksSlice, clonedId, id: null);
-            }
-
-            return new DocumentExpirationInfo(ticksSlice, clonedId, id: identifier);
+    private bool ShouldSkipItem(RetiredAttachmentsConfiguration config, string identifier)
+    {
+        if (config?.Destinations == null)
+        {
+            return true;
         }
 
+        if (config.Destinations.Count == 0)
+        {
+            return true;
+        }
+
+        if (config.Destinations.ContainsKey(identifier) == false)
+        {
+            // no destinations, we don't care about this attachment
+            return true;
+        }
+
+        return false;
     }
 
     [StorageIndexEntryKeyGenerator]
@@ -273,8 +278,27 @@ public class RetiredAttachmentsStorage : AbstractBackgroundWorkStorage
 
         if (allExpired)
         {
-            expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id));
+            expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, DocumentExpirationInfoStatus.Process));
             totalCount++;
+        }
+    }
+
+    private const string AlertTitle = "Remote Attachments";
+    private const string WarnMessage = "A retired attachment was skipped.";
+    private long _counter = 0;
+
+    protected override void HandleSkippedItem(DocumentExpirationInfo item)
+    {
+        if (_logger.IsDebugEnabled)
+        {
+            _logger.Debug($"Skipping retired attachment '{item.LowerId}' with identifier '{item.Id}'");
+        }
+
+        //TODO: RavenDB-24862 - rise an alert similar to BlockingTombstonesDetails or HugeDocumentsDetails
+        if (_counter++ % 1024 == 0)
+        {
+            var alert = AlertRaised.Create(Database.Name, AlertTitle, WarnMessage, AlertType.Attachments_RemoteAttachmentWithoutIdentifier, NotificationSeverity.Warning, key: nameof(AlertType.Attachments_RemoteAttachmentWithoutIdentifier)/*, details: "TODO"*/);
+            Database.NotificationCenter.Add(alert);
         }
     }
 

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -98,5 +98,7 @@ namespace Raven.Server.NotificationCenter.Notifications
         ConflictRevisionsExceeded,
         
         SqlConnectionString_DeprecatedFactoryReplaced,
+
+        Attachments_RemoteAttachmentWithoutIdentifier
     }
 }

--- a/test/FastTests/Server/Documents/Attachments/RetiredAttachmentsBasicTests.cs
+++ b/test/FastTests/Server/Documents/Attachments/RetiredAttachmentsBasicTests.cs
@@ -350,6 +350,26 @@ namespace FastTests.Server.Documents.Attachments
                     RetireFrequencyInSec = 1,
                 })));
                 Assert.Contains("Only one uploader for RetiredAttachmentsConfiguration can be configured.", e.Message);
+
+                e = await Assert.ThrowsAsync<InvalidOperationException>(async () => await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRetiredAttachmentsOperation(new RetiredAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RetiredAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            "test", new RetiredAttachmentsDestinationConfiguration()
+                            {
+                                Disabled = false,
+                                S3Settings = new S3Settings()
+                                {
+                                    BucketName = "testS3Bucket"
+                                },
+                                Identifier = "conf-identifier",
+                            }
+                        }
+                    },
+                    RetireFrequencyInSec = 1
+                })));
+                Assert.Contains("Identifier 'conf-identifier' does not match the key 'test'", e.Message);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_24162.cs
+++ b/test/SlowTests/Issues/RavenDB_24162.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Attachments;
@@ -7,7 +6,6 @@ using Raven.Client.Documents.Operations.Attachments.Retired;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.ServerWide.Operations.Certificates;
-using Sparrow.Logging;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -25,7 +23,7 @@ namespace SlowTests.Issues
             Destinations = new Dictionary<string, RetiredAttachmentsDestinationConfiguration>()
             {
                 {
-                    "test", new RetiredAttachmentsDestinationConfiguration()
+                    "conf-identifier", new RetiredAttachmentsDestinationConfiguration()
                     {
                         Disabled = true,
                         S3Settings = new S3Settings

--- a/test/SlowTests/Issues/RavenDB_24488.cs
+++ b/test/SlowTests/Issues/RavenDB_24488.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                     Destinations = new Dictionary<string, RetiredAttachmentsDestinationConfiguration>()
                     {
                         {
-                            "test", new RetiredAttachmentsDestinationConfiguration()
+                            "conf-identifier", new RetiredAttachmentsDestinationConfiguration()
                             {
                                 Disabled = false, 
                                 S3Settings = s3Settings, 

--- a/test/SlowTests/Server/Documents/Attachments/AzureRetiredAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/AzureRetiredAttachmentsSlowTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -142,7 +141,7 @@ namespace SlowTests.Server.Documents.Attachments
             await CanUploadRetiredAttachmentToCloudFromBackupAndGet(attachmentsCount, size);
         }
 
-        [AzureRetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AzureRetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanExternalReplicateRetiredAttachmentAndThenUploadToAzureAndGet(int attachmentsCount, int size)
@@ -173,7 +172,7 @@ namespace SlowTests.Server.Documents.Attachments
             await CanIndexWithRetiredAttachmentInternal(attachmentsCount, size);
         }
 
-        [AzureRetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AzureRetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanEtlWithRetiredAttachmentAndRetireOnDestination(int attachmentsCount, int size)
@@ -181,7 +180,7 @@ namespace SlowTests.Server.Documents.Attachments
             await CanEtlWithRetiredAttachmentAndRetireOnDestinationInternal(attachmentsCount, size);
         }
 
-        [AzureRetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AzureRetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanEtlRetiredAttachmentsToDestination(int attachmentsCount, int size)

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsAzureBase.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsAzureBase.cs
@@ -38,14 +38,14 @@ public abstract class RetiredAttachmentsAzureBase : RetiredAttachmentsHolder<Azu
         });
     }
 
-    public override async Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, AzureSettings settings, List<string> collections = null, string database = null)
+    public override async Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, AzureSettings settings, List<string> collections = null, string database = null, string id = null)
     {
         if (collections == null)
             collections = new List<string> { "Orders" };
         if (string.IsNullOrEmpty(database))
             database = store.Database;
-
-        var id = "conf-identifier-azure";
+        
+        id ??= "conf-identifier-azure";
         var config = new RetiredAttachmentsConfiguration()
         {
             Destinations = new Dictionary<string, RetiredAttachmentsDestinationConfiguration>
@@ -100,6 +100,12 @@ public abstract class RetiredAttachmentsAzureBase : RetiredAttachmentsHolder<Azu
             return;
 
         await AzureTests.DeleteObjects(settings, prefix: $"{settings.RemoteFolderName}", delimiter: string.Empty);
+    }
+
+    public override AzureSettings GetCloudSetting(string remoteFolderName, string caller = null)
+    {
+        var settings = Etl.GetAzureSettings(remoteFolderName, caller);
+        return settings;
     }
 
     protected override async Task WaitForTaskDelayIfNeeded()

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsHolder.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsHolder.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Retired;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Replication;
@@ -42,7 +43,8 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
     public abstract IAsyncDisposable CreateCloudSettings([CallerMemberName] string caller = null);
     protected abstract Task<List<FileInfoDetails>> GetBlobsFromCloudAndAssertForCount(TSettings settings, int expected, int timeout = 120_000);
     public abstract Task DeleteObjects(TSettings settings);
-    public abstract Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, TSettings settings, List<string> collections = null, string database = null);
+    public abstract Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, TSettings settings, List<string> collections = null, string database = null, string id = null);
+    public abstract TSettings GetCloudSetting(string remoteFolderName, [CallerMemberName] string caller = null);
 
     public Action<RetiredAttachmentsConfiguration> ModifyRetiredAttachmentsConfig = null;
 
@@ -354,7 +356,16 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
                     }
                 }, attachmentsCount, 30_000);
                 Assert.Equal(attachmentsCount, val3);
-                await AssertGetRetiredAttachmentsInBulk(replica, size, identifier, RetiredAttachmentFlags.None);
+
+                foreach (var retired in Attachments)
+                {
+                    var e = await Assert.ThrowsAsync<RavenException>(async () =>
+                        await replica.Operations.SendAsync(new GetAttachmentOperation(retired.DocumentId, retired.Name, AttachmentType.Document, null)));
+                    Assert.Contains($"Cannot get retired attachment '{retired.Name}' on document '{retired.DocumentId}' because it is doesn't have a RetiredAttachmentsConfiguration.", e.Message);
+                }
+
+                var identifier2 = await PutRetireAttachmentsConfiguration(replica, Settings);
+                await AssertGetRetiredAttachmentsInBulk(replica, size, identifier2, RetiredAttachmentFlags.Retired);
             }
         }
     }
@@ -412,9 +423,8 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
                 var database2 = (await GetDocumentDatabaseInstanceForAsync(store2.Database));
                 GetStorageAttachmentsMetadataFromAllAttachments(database2);
                 var identifier2 = await PutRetireAttachmentsConfiguration(store2, Settings);
-
+                Assert.Equal(identifier1, identifier2);
                 Assert.Equal(attachmentsCount, Attachments.Count);
-
                 // move in time & start retire
                 database2.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                 await database2.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
@@ -423,6 +433,59 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
             }
         }
     }
+
+    protected async Task CanExternalReplicateRetiredAttachmentAndThenUploadToCloudAndGet2(int attachmentsCount, int size)
+    {
+        using (var store1 = GetDocumentStore())
+        using (var store2 = GetDocumentStore())
+        await using (var holder = CreateCloudSettings())
+        {
+            int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+            var ids = new List<(string Id, string Collection)>();
+            var identifier1 = await PutRetireAttachmentsConfiguration(store1, Settings);
+            await CreateDocs(store1, docsCount, ids);
+            await PopulateDocsWithRandomAttachments(store1, identifier1, size, ids, attachmentsPerDoc);
+
+            await SetupReplicationAsync(store1, store2);
+            await EnsureReplicatingAsync(store1, store2);
+
+            var database2 = (await GetDocumentDatabaseInstanceForAsync(store2.Database));
+            GetStorageAttachmentsMetadataFromAllAttachments(database2);
+
+            Assert.Null(database2.RetireAttachmentsSender);
+            var settings = GetCloudSetting("RetiredAttachments", $"{store2.Database}-{Guid.NewGuid()}");
+
+            // create different config with other identifier
+            GetStorageAttachmentsMetadataFromAllAttachments(database2, settings);
+            var identifier2 = await PutRetireAttachmentsConfiguration(store2, settings, id: "my-cool-identifier322");
+            Assert.Equal("my-cool-identifier322", identifier2);
+            Assert.NotEqual(identifier1, identifier2);
+
+            Assert.Equal(attachmentsCount, Attachments.Count);
+
+            Assert.True(await WaitForValueAsync(() => database2.RetireAttachmentsSender != null, true));
+            // move in time & start retire
+
+            var retiredAt = Attachments.First().RetireParameters.At;
+
+            database2.Time.UtcDateTime = () => retiredAt.AddMinutes(1);
+            await database2.RetireAttachmentsSender!.RetireAttachments(int.MaxValue, int.MaxValue);
+            await GetBlobsFromCloudAndAssertForCount(Settings, 0, 15_000);
+
+            var config1 = await store2.Maintenance.SendAsync(new GetRetireAttachmentsConfigurationOperation());
+            var config2 = await store1.Maintenance.SendAsync(new GetRetireAttachmentsConfigurationOperation());
+            config1.Destinations[identifier1] = config2.Destinations[identifier1];
+            Assert.Equal(2, config1.Destinations.Count);
+            await store2.Maintenance.SendAsync(new ConfigureRetiredAttachmentsOperation(config1));
+
+            await database2.RetireAttachmentsSender!.RetireAttachments(int.MaxValue, int.MaxValue);
+            GetStorageAttachmentsMetadataFromAllAttachments(database2);
+
+            var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
+            await AssertAllRetiredAttachments(store2, cloudObjects, size, identifier1);
+        }
+    }
+
     protected async Task CanUploadRetiredAttachmentToCloudAndDeleteInTheSameTimeInternal(int attachmentsCount, int size, int attachmentsPerDoc)
     {
         await using (var holder = CreateCloudSettings())

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsHolderBase.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsHolderBase.cs
@@ -88,7 +88,6 @@ public abstract class RetiredAttachmentsHolderBase : ReplicationTestBase
 
         if (flags == RetiredAttachmentFlags.None)
         {
-            //TODO: egor this will change after we drop unwrapped attachments
             Assert.True(retired.RetireParameters.IsLocalAttachment());
         }
         else

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsS3Base.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsS3Base.cs
@@ -37,12 +37,12 @@ public abstract class RetiredAttachmentsS3Base : RetiredAttachmentsHolder<S3Sett
         });
     }
 
-    public override async Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, S3Settings settings, List<string> collections = null, string database = null)
+    public override async Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, S3Settings settings, List<string> collections = null, string database = null, string id = null)
     {
         if (string.IsNullOrEmpty(database))
             database = store.Database;
 
-        var id = "conf-identifier-s3";
+        id ??= "conf-identifier-s3";
         var config = new RetiredAttachmentsConfiguration()
         {
             Destinations = new Dictionary<string, RetiredAttachmentsDestinationConfiguration>()
@@ -63,6 +63,12 @@ public abstract class RetiredAttachmentsS3Base : RetiredAttachmentsHolder<S3Sett
         await store.Maintenance.ForDatabase(database).SendAsync(new ConfigureRetiredAttachmentsOperation(config));
 
         return id;
+    }
+
+    public override S3Settings GetCloudSetting(string remoteFolderName, string caller = null)
+    {
+        var settings = Etl.GetS3Settings(remoteFolderName, caller);
+        return settings;
     }
 
     protected override void AssertUploadRetiredAttachmentToCloudThenManuallyDeleteAndGetShouldThrowInternal(RavenException e)

--- a/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsBackupRestoreTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsBackupRestoreTests.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Backups;

--- a/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsSlowTests.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
@@ -538,15 +539,6 @@ namespace SlowTests.Server.Documents.Attachments
 
                     Assert.Equal(expected, totalCount);
 
-                    if (expected == 0)
-                    {
-                        Assert.Null(expired);
-                    }
-                    else
-                    {
-                        Assert.Equal(expected, expired.Count);
-                    }
-
                     action?.Invoke(expired);
                 }
             }
@@ -695,7 +687,7 @@ namespace SlowTests.Server.Documents.Attachments
 
         [AmazonS3RetryTheory]
         [InlineData(3, 3, 1)]
-      //  [InlineData(16, 3, 4)]
+        [InlineData(16, 3, 4)]
         public async Task CanUploadRetiredAttachmentsFromDifferentCollectionsToS3AndGetInBulk(int attachmentsCount, int size, int attachmentsPerDoc)
         {
             var collections = new List<string> { "Orders", "Products" };
@@ -704,14 +696,14 @@ namespace SlowTests.Server.Documents.Attachments
 
         [AmazonS3RetryTheory]
         [InlineData(3, 3, 1)]
- //       [InlineData(16, 3, 4)]
+        [InlineData(16, 3, 4)]
         public async Task CanUploadRetiredAttachmentsToS3AndGetInBulk(int attachmentsCount, int size, int attachmentsPerDoc)
         {
             await CanUploadRetiredAttachmentsToCloudAndGetInBulkInternal(attachmentsCount, size, attachmentsPerDoc);
         }
         [AmazonS3RetryTheory]
         [InlineData(3, 3, 1)]
-     //   [InlineData(16, 3, 4)]
+        [InlineData(16, 3, 4)]
         public async Task CanUploadRetiredAttachmentsToS3AndDeleteInBulk(int attachmentsCount, int size, int attachmentsPerDoc)
         {
             await CanUploadRetiredAttachmentsToCloudAndDeleteInBulkInternal(attachmentsCount, size, attachmentsPerDoc);
@@ -768,7 +760,7 @@ namespace SlowTests.Server.Documents.Attachments
             await CanUploadRetiredAttachmentToCloudFromBackupAndGet(attachmentsCount, size);
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanExternalReplicateRetiredAttachmentAndThenUploadToS3AndGet(int attachmentsCount, int size)
@@ -776,10 +768,110 @@ namespace SlowTests.Server.Documents.Attachments
             await CanExternalReplicateRetiredAttachmentAndThenUploadToCloudAndGet(attachmentsCount, size);
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
-        public async Task ExternalReplicationOfRetiredAttachmentToExternalDatabaseShouldUnwrap(int attachmentsCount, int size)
+        public async Task CanExternalReplicateRetiredAttachmentAndThenHaveNoRelevantDestination(int attachmentsCount, int size)
+        {
+            await CanExternalReplicateRetiredAttachmentAndThenUploadToCloudAndGet2(attachmentsCount, size);
+        }
+
+        [AmazonS3RetryTheory]
+        [InlineData(1, 3)]
+        [InlineData(64, 3)]
+        public async Task AddRetiredAttachmentThenExternalReplicateToDatabaseWithoutRetiredConfig(int attachmentsCount, int size)
+        {
+            using (var store1 = GetDocumentStore())
+            using (var store2 = GetDocumentStore())
+            {
+                await using (var holder = CreateCloudSettings())
+                {
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+                    var identifier = await PutRetireAttachmentsConfiguration(store1, Settings);
+                    await CreateDocs(store1, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(store1, identifier, size, ids, attachmentsPerDoc);
+
+                    await SetupReplicationAsync(store1, store2);
+                    await EnsureReplicatingAsync(store1, store2);
+
+                    var database2 = (await GetDocumentDatabaseInstanceForAsync(store2.Database));
+
+                    // I create new settings for destination database, so each db upload to different folder
+                    var settings = Etl.GetS3Settings(nameof(RetiredAttachments), $"{store2.Database}-{Guid.NewGuid()}");
+                    GetStorageAttachmentsMetadataFromAllAttachments(database2, settings);
+
+                    Assert.Equal(attachmentsCount, Attachments.Count);
+                    WaitForUserToContinueTheTest(store1);
+
+                    GetToRetireAttachmentsCount(database2, attachmentsCount);
+
+                    try
+                    {
+                        await PutRetireAttachmentsConfiguration(store2, settings);
+                        // move in time & start retire
+                        database2.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                        await database2.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+
+                        var cloudObjects = await GetBlobsFromCloudAndAssertForCount(settings, attachmentsCount, 15_000);
+                        await GetBlobsFromCloudAndAssertForCount(Settings, 0, 15_000);
+                        await AssertAllRetiredAttachments(store2, cloudObjects, size, identifier);
+
+                        var database1 = (await GetDocumentDatabaseInstanceForAsync(store1.Database));
+
+                        using (database1.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            var attachments = database1.DocumentsStorage.AttachmentsStorage.GetAllAttachments(context).ToList();
+                            Assert.Equal(attachmentsCount, attachments.Count);
+                            Assert.All(attachments, attachment => Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.None));
+                        }
+
+                        // replicate retired attachments to source
+                        await SetupReplicationAsync(store2, store1);
+                        await EnsureReplicatingAsync(store2, store1);
+
+
+                        using (database1.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            var attachments = database1.DocumentsStorage.AttachmentsStorage.GetAllAttachments(context).ToList();
+                            Assert.Equal(attachmentsCount, attachments.Count);
+
+                            // update the retired attachments configuration to be same as destination
+                            await PutRetireAttachmentsConfiguration(store1, settings);
+                          
+                            await Assert.AllAsync(attachments, async attachment =>
+                            {
+                                Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.Retired);
+                                // we cannot receive it using source retired attachment configuration
+                                var a = Attachments.FirstOrDefault(x => x.Key == attachment.Key);
+                                Assert.NotNull(a);
+                                attachment.Stream = a.Stream;
+
+                                // this sends GetAttachmentOperation and compares the result
+                                await GetAndCompareRetiredAttachment(store2, a.DocumentId, attachment.Name, attachment.Base64Hash.ToString(), attachment.ContentType,
+                                    (MemoryStream)attachment.Stream, size, identifier, RetiredAttachmentFlags.Retired);
+                            });
+
+                            // we replicated the retired attachment and overwrite the regular one, the replication should have deleted the stream
+                            var streams = database1.DocumentsStorage.AttachmentsStorage.GetAllAttachmentsStreamHashes(context).ToList();
+                            Assert.Equal(0, streams.Count);
+
+                        }
+                    }
+                    finally
+                    {
+                        await DeleteObjects(settings);
+                    }
+                }
+            }
+        }
+
+        [AmazonS3RetryTheory]
+        [InlineData(1, 3)]
+        [InlineData(64, 3)]
+        public async Task ExternalReplicationOfRetiredAttachmentToExternalDatabaseShouldNotUnwrap(int attachmentsCount, int size)
         {
             using (var store1 = GetDocumentStore())
             {
@@ -809,6 +901,14 @@ namespace SlowTests.Server.Documents.Attachments
 
                     foreach (var retired in Attachments)
                     {
+                        var e = await Assert.ThrowsAsync<RavenException>(async () =>
+                            await store2.Operations.SendAsync(new GetAttachmentOperation(retired.DocumentId, retired.Name, AttachmentType.Document, null)));
+                     Assert.Contains($"Cannot get retired attachment '{retired.Name}' on document '{retired.DocumentId}' because it is doesn't have a RetiredAttachmentsConfiguration.", e.Message);
+                    }
+
+                    await PutRetireAttachmentsConfiguration(store2, Settings);
+                    foreach (var retired in Attachments)
+                    {
                         Assert.Contains(cloudObjects, x => x.FullPath.Contains(retired.RetiredKey));
                         retired.Stream.Position = 0;
                         var attachment = await store2.Operations.SendAsync(new GetAttachmentOperation(retired.DocumentId, retired.Name, AttachmentType.Document, null));
@@ -817,7 +917,7 @@ namespace SlowTests.Server.Documents.Attachments
                         Assert.Equal(retired.ContentType, attachment.Details.ContentType);
                         Assert.Equal(retired.Name, attachment.Details.Name);
                         Assert.Equal(size, attachment.Details.Size);
-                        Assert.Equal(RetiredAttachmentFlags.None, attachment.Details.RetireParameters.Flags);
+                        Assert.Equal(RetiredAttachmentFlags.Retired, attachment.Details.RetireParameters.Flags);
                         Assert.NotNull(attachment.Details.RetireParameters.At);
                         using var retiredStream = new MemoryStream();
                         await attachment.Stream.CopyToAsync(retiredStream);
@@ -829,10 +929,10 @@ namespace SlowTests.Server.Documents.Attachments
             }
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
-        public async Task AddRetiredAttachmentThenExternalReplicateToDatabaseWithoutRetiredConfig_ShouldUnwrap(int attachmentsCount, int size)
+        public async Task AddRetiredAttachmentThenExternalReplicateToDatabaseWithoutRetiredConfig2(int attachmentsCount, int size)
         {
             using (var store1 = GetDocumentStore())
             using (var store2 = GetDocumentStore())
@@ -850,9 +950,8 @@ namespace SlowTests.Server.Documents.Attachments
 
                     var database2 = (await GetDocumentDatabaseInstanceForAsync(store2.Database));
 
-                    // I create new settings for destination database, so each db upload to different folder
-                    var settings = Etl.GetS3Settings(nameof(RetiredAttachments), $"{store2.Database}-{Guid.NewGuid()}");
-                    GetStorageAttachmentsMetadataFromAllAttachments(database2, settings);
+
+                    GetStorageAttachmentsMetadataFromAllAttachments(database2, Settings);
 
                     Assert.Equal(attachmentsCount, Attachments.Count);
 
@@ -861,16 +960,16 @@ namespace SlowTests.Server.Documents.Attachments
 
                     try
                     {
-                        var identifier2 = await PutRetireAttachmentsConfiguration(store2, settings);
+                        var identifier2 = await PutRetireAttachmentsConfiguration(store2, Settings);
                         // move in time & start retire
                         database2.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                         await database2.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
 
-                        var cloudObjects = await GetBlobsFromCloudAndAssertForCount(settings, attachmentsCount, 15_000);
+                        var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
                         await AssertAllRetiredAttachments(store2, cloudObjects, size, identifier2);
 
                         // on store 1 the attachments are still not retired, so we cannot get them
-                        await GetBlobsFromCloudAndAssertForCount(Settings, 0, 15_000);
+                        await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
 
                         var database1 = (await GetDocumentDatabaseInstanceForAsync(store1.Database));
 
@@ -894,19 +993,19 @@ namespace SlowTests.Server.Documents.Attachments
 
                             await Assert.AllAsync(attachments, async attachment =>
                             {
-                                Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.None);
+                                Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.Retired);
                                 // we cannot receive it using source retired attachment configuration
                                 var a = Attachments.FirstOrDefault(x => x.Key == attachment.Key);
                                 Assert.NotNull(a);
                                 attachment.Stream = a.Stream;
 
                                 // this sends GetAttachmentOperation and compares the result
-                                await GetAndCompareRetiredAttachment(store1, a.DocumentId, attachment.Name, attachment.Base64Hash.ToString(), attachment.ContentType, (MemoryStream)attachment.Stream, size, identifier1, RetiredAttachmentFlags.None);
+                                await GetAndCompareRetiredAttachment(store1, a.DocumentId, attachment.Name, attachment.Base64Hash.ToString(), attachment.ContentType, (MemoryStream)attachment.Stream, size, identifier1, RetiredAttachmentFlags.Retired);
                             });
 
                             // update the retired attachments configuration to be same as destination
                             // we still didn't retire the attachments on source, so we cannot get them
-                            await GetBlobsFromCloudAndAssertForCount(Settings, 0, 15_000);
+                            await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
 
                             // move in time & start retire
                             database1.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
@@ -926,7 +1025,7 @@ namespace SlowTests.Server.Documents.Attachments
                     }
                     finally
                     {
-                        await DeleteObjects(settings);
+                        await DeleteObjects(Settings);
                     }
                 }
             }
@@ -956,7 +1055,7 @@ namespace SlowTests.Server.Documents.Attachments
             await CanIndexWithRetiredAttachmentInternal(attachmentsCount, size);
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanEtlWithRetiredAttachmentAndRetireOnDestination(int attachmentsCount, int size)
@@ -964,7 +1063,7 @@ namespace SlowTests.Server.Documents.Attachments
             await CanEtlWithRetiredAttachmentAndRetireOnDestinationInternal(attachmentsCount, size);
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanEtlRetiredAttachmentsToDestination(int attachmentsCount, int size)
@@ -972,11 +1071,11 @@ namespace SlowTests.Server.Documents.Attachments
             await CanEtlRetiredAttachmentsToDestinationInternal(attachmentsCount, size);
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3, true)]
         [InlineData(1, 3, false)]
-     //   [InlineData(64, 3, true)]
-      //  [InlineData(64, 3, false)]
+        [InlineData(64, 3, true)]
+        [InlineData(64, 3, false)]
         public async Task CanEtlDeletedRetiredAttachmentsToDestination(int attachmentsCount, int size, bool retireOnReplica)
         {
             await using (var holder = CreateCloudSettings())
@@ -992,7 +1091,16 @@ namespace SlowTests.Server.Documents.Attachments
                     ModifyDatabaseName = s => $"{s}_destination"
                 }))
                 {
-                    var identifier1 = await CanUploadRetiredAttachmentToCloudAndGetInternal(attachmentsCount, size, store, docsCount, ids, attachmentsPerDoc);
+                    if (retireOnReplica)
+                    {
+                        var identifier11 = await PutRetireAttachmentsConfiguration(store, Settings);
+                        await CreateDocs(store, docsCount, ids);
+                        await PopulateDocsWithRandomAttachments(store, identifier11, size, ids, attachmentsPerDoc);
+                    }
+                    else
+                    {
+                        await CanUploadRetiredAttachmentToCloudAndGetInternal(attachmentsCount, size, store, docsCount, ids, attachmentsPerDoc);
+                    }
                     var taskName = "etl-test";
                     var csName = "cs-test";
 
@@ -1023,22 +1131,23 @@ namespace SlowTests.Server.Documents.Attachments
                     Assert.Equal(attachmentsCount, val4);
                     var identifier2 = await PutRetireAttachmentsConfiguration(replica, Settings);
 
-                    await AssertGetRetiredAttachmentsInBulk(replica, size, identifier2, RetiredAttachmentFlags.None);
-
                     if (retireOnReplica)
                     {
+                        await AssertGetRetiredAttachmentsInBulk(replica, size, identifier2, RetiredAttachmentFlags.None);
                         // move in time & start retire
                         replicaDb.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                         await replicaDb.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
 
                         var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
+                        var database2 = await Databases.GetDocumentDatabaseInstanceFor( replica);
+                        GetStorageAttachmentsMetadataFromAllAttachments(database2);
                         await AssertAllRetiredAttachments(replica, cloudObjects, size, identifier2);
 
                         var stats = replica.Maintenance.Send(new GetDetailedStatisticsOperation());
                         Assert.Equal(attachmentsCount, stats.CountOfRetiredAttachments);
-
                     }
 
+                    await AssertGetRetiredAttachmentsInBulk(replica, size, identifier2, RetiredAttachmentFlags.Retired);
 
                     foreach (var attachment in Attachments)
                     {
@@ -1057,7 +1166,6 @@ namespace SlowTests.Server.Documents.Attachments
                         var c = database.DocumentsStorage.AttachmentsStorage.GetAllAttachments(context).Count();
                         Assert.Equal(0, c); // we deleted the attachments from source, so we don't have them in storage
                     }
-
                     
                     var val3 = WaitForValue(() =>
                     {
@@ -1073,7 +1181,7 @@ namespace SlowTests.Server.Documents.Attachments
             }
         }
 
-        [AmazonS3RetryTheory(Skip = "TODO EGOR RavenDB-24604")]
+        [AmazonS3RetryTheory]
         [InlineData(1, 3)]
         [InlineData(64, 3)]
         public async Task CanExternalReplicateDeletedRetiredAttachmentsToDestination(int attachmentsCount, int size)
@@ -1122,15 +1230,25 @@ namespace SlowTests.Server.Documents.Attachments
 
                         await Assert.AllAsync(attachments, async attachment =>
                         {
-                            Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.None);
+                            Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.Retired);
+                            var a = Attachments.FirstOrDefault(x => x.Key == attachment.Key);
+                            Assert.NotNull(a);
+
+                            var e = await Assert.ThrowsAsync<RavenException>(async () => await store2.Operations.SendAsync(new GetAttachmentOperation(a.DocumentId, attachment.Name, AttachmentType.Document, null)));
+                            Assert.Contains($"Cannot get retired attachment '{attachment.Name}' on document '{a.DocumentId}' because it is doesn't have a RetiredAttachmentsConfiguration.", e.Message);
+                        });
+
+                        await PutRetireAttachmentsConfiguration(store2, Settings);
+                        await Assert.AllAsync(attachments, async attachment =>
+                        {
+                            Assert.True(attachment.RetireParameters.Flags == RetiredAttachmentFlags.Retired);
                             // we cannot receive it using source retired attachment configuration
                             var a = Attachments.FirstOrDefault(x => x.Key == attachment.Key);
                             Assert.NotNull(a);
                             attachment.Stream = a.Stream;
 
                             // this sends GetAttachmentOperation and compares the result
-                            await GetAndCompareRetiredAttachment(store2, a.DocumentId, attachment.Name, attachment.Base64Hash.ToString(), attachment.ContentType,
-                                (MemoryStream)attachment.Stream, size, identifier, RetiredAttachmentFlags.None);
+                            await GetAndCompareRetiredAttachment(store2, a.DocumentId, attachment.Name, attachment.Base64Hash.ToString(), attachment.ContentType, (MemoryStream)attachment.Stream, size, identifier, RetiredAttachmentFlags.Retired);
                         });
                     }
 
@@ -1138,10 +1256,8 @@ namespace SlowTests.Server.Documents.Attachments
                     Assert.Equal(attachmentsCount, stats.CountOfRetiredAttachments);
 
                     var stats2 = store2.Maintenance.Send(new GetDetailedStatisticsOperation());
-                    Assert.Equal(0, stats2.CountOfRetiredAttachments);
+                    Assert.Equal(attachmentsCount, stats2.CountOfRetiredAttachments);
                     Assert.Equal(attachmentsCount, stats2.CountOfAttachments);
-
-
 
                     foreach (var attachment in Attachments)
                     {

--- a/test/Tests.Infrastructure/AmazonS3RetryTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/AmazonS3RetryTheoryAttribute.cs
@@ -46,14 +46,11 @@ namespace Tests.Infrastructure
         {
             get
             {
-                ShouldSkip(out var skipMessage);
-
-                if (string.IsNullOrEmpty(skipMessage))
+                if (ShouldSkip(out var skipMessage))
                 {
-                    return base.Skip;
+                    return skipMessage;
                 }
-
-                return skipMessage;
+                return base.Skip;
             }
 
             set => base.Skip = value;

--- a/test/Tests.Infrastructure/AzureRetryTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/AzureRetryTheoryAttribute.cs
@@ -46,13 +46,12 @@ namespace Tests.Infrastructure
         {
             get
             {
-                var skipMessage = CloudAttributeHelper.TestIsMissingCloudCredentialEnvironmentVariable(EnvVariableMissing, AzureCredentialEnvironmentVariable, ParsingError, _azureSettings);
-                if (string.IsNullOrEmpty(skipMessage))
+                if (ShouldSkip(out var skipMessage))
                 {
-                    return base.Skip;
+                    return skipMessage;
                 }
 
-                return skipMessage;
+                return base.Skip;
             }
 
             set => base.Skip = value;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24604

### Additional description


This pull request introduces several improvements and refactorings.
The changes include the introduction of a status enum for retired attachments processing, improved configuration validation, and simplification of attachment and ETL logic.

**Key changes include:**

### Document Expiration and Archival Processing

* Introduced a `DocumentExpirationInfoStatus` enum (`Process`, `Skip`, `Delete`) to clearly indicate the processing state of each document in expiration/archival workflows. 
The `DocumentExpirationInfo` class now includes a `Status` property, and all related methods and command DTOs have been updated to handle and propagate this status. 
[[1]](diffhunk://#diff-e6b44ea53d9b3c8ed940c94f3c383e281d5d985990b1f6b7e84ca316828eb3c9R232-R259) [[2]](diffhunk://#diff-ea1a1601fb519081279f33d8ea0b51aa94109c1aea024ce27d0e50f7d0350352L37-R37) [[3]](diffhunk://#diff-ea1a1601fb519081279f33d8ea0b51aa94109c1aea024ce27d0e50f7d0350352L51-R57) [[4]](diffhunk://#diff-1878c054d9295db01212487cc062bbc9c91e4f187ed95a9f2b0ff09c492302e6L237-R237) [[5]](diffhunk://#diff-1878c054d9295db01212487cc062bbc9c91e4f187ed95a9f2b0ff09c492302e6L252-R258) [[6]](diffhunk://#diff-be34884e1bd779584e34af0721515c99e9c5358fd4a3663c19f8f72c1de29b9dL52-R61)
* Refactored the document handling logic in `AbstractBackgroundWorkStorage` to use the new status instead of relying on null checks or disposables, and added hooks for handling skipped items. [[1]](diffhunk://#diff-e6b44ea53d9b3c8ed940c94f3c383e281d5d985990b1f6b7e84ca316828eb3c9L116-R138) [[2]](diffhunk://#diff-e6b44ea53d9b3c8ed940c94f3c383e281d5d985990b1f6b7e84ca316828eb3c9L141-L186) [[3]](diffhunk://#diff-e6b44ea53d9b3c8ed940c94f3c383e281d5d985990b1f6b7e84ca316828eb3c9R34-R37) [[4]](diffhunk://#diff-eea63048bb212e02b2f31c218f4bdce579656446f08e9120ebd0df8ebc841974R52-R56) [[5]](diffhunk://#diff-be34884e1bd779584e34af0721515c99e9c5358fd4a3663c19f8f72c1de29b9dL52-R61)

### Retired Attachments and ETL

* Improved retired attachment handling in `AttachmentsStorage.PutDirect` to remove the attachment stream from the data file when the attachment is marked as retired.
* Simplified ETL logic by removing unnecessary code for resetting retired attachment flags in metadata and streamlining attachment processing in ETL scripts. [[1]](diffhunk://#diff-2067bd9fa382691dd8f24d99902becf8b6e6eff4a2313f3cb1e99274120dc73dL793-L807) [[2]](diffhunk://#diff-003fd89a09ed0663cd8754909cff86244da849184018cc7a8a0ffafab7cac28cL75-R80) [[3]](diffhunk://#diff-003fd89a09ed0663cd8754909cff86244da849184018cc7a8a0ffafab7cac28cL121-L195)

### Configuration Validation

* Enhanced configuration validation in `RetiredAttachmentsDestinationConfiguration.AssertConfiguration` by requiring the key to match the identifier and propagating the key for better error messages and validation. [[1]](diffhunk://#diff-4be63280793fb5a433cc61afe99c579c76a2213217173d8a11116965385094d6L86-R94) [[2]](diffhunk://#diff-6d06bab4e04d5b279bfc4bb04f633e945ebede7fc5780473dbece4ac7b64bae0L103-R103)

### Miscellaneous Improvements

* Cleaned up unused usings and abstract method declarations in `AbstractBackgroundWorkStorage`. [[1]](diffhunk://#diff-e6b44ea53d9b3c8ed940c94f3c383e281d5d985990b1f6b7e84ca316828eb3c9L16) [[2]](diffhunk://#diff-e6b44ea53d9b3c8ed940c94f3c383e281d5d985990b1f6b7e84ca316828eb3c9L221-L222)
* Improved attachment put logic in batch command handling to ensure correct hash and stream length are used for retired attachments.

These changes collectively improve the clarity, robustness, and maintainability of document expiration, archival, and attachment retirement workflows.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
