### PR TITLE
RavenDB-24849 Client Configuration setting is ignored - always sent as disabled true [release/v7.0]

### DIFF
--- a/src/Raven.Studio/typescript/components/common/clientConfiguration/ClientConfigurationUtils.ts
+++ b/src/Raven.Studio/typescript/components/common/clientConfiguration/ClientConfigurationUtils.ts
@@ -49,10 +49,10 @@ export default class ClientConfigurationUtils {
         }));
     }
 
-    static mapToFormData(dto: ClientConfiguration, isGlobal: boolean): ClientConfigurationFormData {
+    static mapToFormData(dto: ClientConfiguration, overrideConfig = true): ClientConfigurationFormData {
         if (!dto) {
             return {
-                overrideConfig: isGlobal,
+                overrideConfig,
                 identityPartsSeparatorEnabled: false,
                 identityPartsSeparatorValue: null,
                 maximumNumberOfRequestsEnabled: false,
@@ -67,7 +67,7 @@ export default class ClientConfigurationUtils {
         }
 
         return {
-            overrideConfig: !dto.Disabled,
+            overrideConfig,
             identityPartsSeparatorEnabled: !!dto.IdentityPartsSeparator,
             identityPartsSeparatorValue: dto.IdentityPartsSeparator || null,
             maximumNumberOfRequestsEnabled: !!dto.MaxNumberOfRequestsPerSession,

--- a/src/Raven.Studio/typescript/components/common/clientConfiguration/useClientConfigurationFormSideEffects.tsx
+++ b/src/Raven.Studio/typescript/components/common/clientConfiguration/useClientConfigurationFormSideEffects.tsx
@@ -4,14 +4,9 @@ import { ClientConfigurationFormData } from "./ClientConfigurationValidation";
 
 export default function useClientConfigurationFormSideEffects(
     watch: UseFormWatch<ClientConfigurationFormData>,
-    setValue: UseFormSetValue<ClientConfigurationFormData>,
-    isShouldOverride: boolean
+    setValue: UseFormSetValue<ClientConfigurationFormData>
 ) {
     useEffect(() => {
-        if (isShouldOverride) {
-            setValue("overrideConfig", true, { shouldValidate: true });
-        }
-
         const { unsubscribe } = watch((values, { name }) => {
             if (name === "identityPartsSeparatorEnabled" && !values.identityPartsSeparatorEnabled) {
                 setValue("identityPartsSeparatorValue", null, { shouldValidate: true });
@@ -37,5 +32,5 @@ export default function useClientConfigurationFormSideEffects(
         });
 
         return () => unsubscribe();
-    }, [watch, setValue, isShouldOverride]);
+    }, [watch, setValue]);
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -52,12 +52,16 @@ export default function ClientDatabaseConfiguration() {
     });
 
     const asyncGetDefaultValues = useAsyncCallback(async () => {
-        const globalConfiguration = await asyncGetClientGlobalConfiguration.execute();
-        const clientConfiguration = await manageServerService.getClientConfiguration(databaseName);
+        try {
+            const globalConfiguration = await asyncGetClientGlobalConfiguration.execute();
+            const clientConfiguration = await manageServerService.getClientConfiguration(databaseName);
 
-        const overrideConfig = !globalConfiguration || (clientConfiguration && !clientConfiguration.Disabled);
+            const overrideConfig = !globalConfiguration || (clientConfiguration && !clientConfiguration.Disabled);
 
-        return ClientConfigurationUtils.mapToFormData(clientConfiguration, overrideConfig);
+            return ClientConfigurationUtils.mapToFormData(clientConfiguration, overrideConfig);
+        } catch {
+            return ClientConfigurationUtils.mapToFormData(null);
+        }
     });
 
     const isClusterAdminOrClusterNode = useAppSelector(accessManagerSelectors.isClusterAdminOrClusterNode);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import Spinner from "react-bootstrap/Spinner";
 import Card from "react-bootstrap/Card";
 import InputGroup from "react-bootstrap/InputGroup";
@@ -9,7 +9,7 @@ import Button from "react-bootstrap/Button";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import { FormCheckbox, FormInput, FormRadioToggleWithIcon, FormSelect, FormSwitch } from "components/common/Form";
 import { useServices } from "components/hooks/useServices";
-import { useAsync, useAsyncCallback } from "react-async-hook";
+import { useAsyncCallback } from "react-async-hook";
 import { LoadingView } from "components/common/LoadingView";
 import { LoadError } from "components/common/LoadError";
 import {
@@ -41,16 +41,31 @@ import { ConditionalPopover } from "components/common/ConditionalPopover";
 export default function ClientDatabaseConfiguration() {
     const { manageServerService } = useServices();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const asyncGetClientConfiguration = useAsyncCallback(manageServerService.getClientConfiguration);
-    const asyncGetClientGlobalConfiguration = useAsync(manageServerService.getGlobalClientConfiguration, []);
+
+    const asyncGetClientGlobalConfiguration = useAsyncCallback(async () => {
+        const globalConfigResult = await manageServerService.getGlobalClientConfiguration();
+        if (!globalConfigResult) {
+            return null;
+        }
+
+        return ClientConfigurationUtils.mapToFormData(globalConfigResult);
+    });
+
+    const asyncGetDefaultValues = useAsyncCallback(async () => {
+        const globalConfiguration = await asyncGetClientGlobalConfiguration.execute();
+        const clientConfiguration = await manageServerService.getClientConfiguration(databaseName);
+
+        const overrideConfig = !globalConfiguration || (clientConfiguration && !clientConfiguration.Disabled);
+
+        return ClientConfigurationUtils.mapToFormData(clientConfiguration, overrideConfig);
+    });
 
     const isClusterAdminOrClusterNode = useAppSelector(accessManagerSelectors.isClusterAdminOrClusterNode);
 
     const { handleSubmit, control, formState, watch, reset, setValue } = useForm<ClientConfigurationFormData>({
         resolver: clientConfigurationYupResolver,
         mode: "all",
-        defaultValues: async () =>
-            ClientConfigurationUtils.mapToFormData(await asyncGetClientConfiguration.execute(databaseName), false),
+        defaultValues: asyncGetDefaultValues.execute,
     });
 
     useDirtyFlag(formState.isDirty);
@@ -69,22 +84,9 @@ export default function ClientDatabaseConfiguration() {
         ],
     });
 
-    const globalConfig = useMemo(() => {
-        const globalConfigResult = asyncGetClientGlobalConfiguration.result;
-        if (!globalConfigResult) {
-            return null;
-        }
-
-        return ClientConfigurationUtils.mapToFormData(globalConfigResult, true);
-    }, [asyncGetClientGlobalConfiguration.result]);
-
     const formValues = useWatch({ control: control });
 
-    const isShouldOverride =
-        (asyncGetClientGlobalConfiguration.status === "success" && !globalConfig) ||
-        asyncGetClientGlobalConfiguration.status === "error";
-
-    useClientConfigurationFormSideEffects(watch, setValue, isShouldOverride);
+    useClientConfigurationFormSideEffects(watch, setValue);
 
     useEffect(() => {
         if (formState.isSubmitSuccessful) {
@@ -102,14 +104,16 @@ export default function ClientDatabaseConfiguration() {
     };
 
     const onRefresh = async () => {
-        reset(ClientConfigurationUtils.mapToFormData(await asyncGetClientConfiguration.execute(databaseName), false));
+        reset(await asyncGetDefaultValues.execute());
     };
 
-    if (asyncGetClientConfiguration.loading || asyncGetClientGlobalConfiguration.loading) {
+    const globalConfig = asyncGetClientGlobalConfiguration.result;
+
+    if (asyncGetDefaultValues.loading) {
         return <LoadingView />;
     }
 
-    if (asyncGetClientConfiguration.error) {
+    if (asyncGetDefaultValues.error) {
         return <LoadError error="Unable to load client configuration" refresh={onRefresh} />;
     }
 

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
@@ -41,7 +41,7 @@ export default function ClientGlobalConfiguration() {
         resolver: clientConfigurationYupResolver,
         mode: "all",
         defaultValues: async () =>
-            ClientConfigurationUtils.mapToFormData(await asyncGetGlobalClientConfiguration.execute(), true),
+            ClientConfigurationUtils.mapToFormData(await asyncGetGlobalClientConfiguration.execute()),
     });
 
     const loadBalancingDocsLink = useRavenLink({ hash: "GYJ8JA" });
@@ -49,7 +49,7 @@ export default function ClientGlobalConfiguration() {
 
     const formValues = useWatch({ control });
 
-    useClientConfigurationFormSideEffects(watch, setValue, true);
+    useClientConfigurationFormSideEffects(watch, setValue);
 
     useEffect(() => {
         if (formState.isSubmitSuccessful) {
@@ -77,7 +77,7 @@ export default function ClientGlobalConfiguration() {
     };
 
     const onRefresh = async () => {
-        reset(ClientConfigurationUtils.mapToFormData(await asyncGetGlobalClientConfiguration.execute(), true));
+        reset(ClientConfigurationUtils.mapToFormData(await asyncGetGlobalClientConfiguration.execute()));
     };
 
     if (asyncGetGlobalClientConfiguration.loading) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24849/Client-Configuration-setting-is-ignored-always-sent-as-disabled-true

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
