### PR TITLE
RavenDB-24864 - GenAI support for images & documents - handle 'RavenDB-24642' comments

### DIFF
--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -21,6 +21,16 @@ namespace Raven.Server.Documents.AI
     {
         public string Refusal;
         public string FinishReason;
+
+        public static void Throw(string refusal, string finishReason, string requestId)
+        {
+            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}'")
+            {
+                Refusal = refusal,
+                FinishReason = finishReason,
+                RequestId = requestId
+            };
+        }
     }
 
     public sealed class UnexpectedResponseException : AiException

--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -22,9 +22,9 @@ namespace Raven.Server.Documents.AI
         public string Refusal;
         public string FinishReason;
 
-        public static void Throw(string refusal, string finishReason, string requestId)
+        public static void Throw(string refusal, string responseContent, string finishReason, string requestId)
         {
-            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}'")
+            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}', response content: {responseContent}")
             {
                 Refusal = refusal,
                 FinishReason = finishReason,

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -20,6 +20,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Http;
 using Raven.Client.Json;
+using Raven.Server.Documents.ETL.Providers.AI;
 using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.Json;
 using Raven.Server.Utils;
@@ -27,7 +28,6 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
-using Raven.Server.Documents.ETL.Providers.AI.GenAi;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Raven.Server.Documents.AI;
@@ -149,10 +149,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             _ = choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal) || msg.TryGet(Constants.ResponseFields.Refusal, out refusal);
 
             //TODO: full output if we get here?
-            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}'")
-            {
-                Refusal = refusal, FinishReason = finishReason, RequestId = GetRequestId(response.Headers)
-            };
+            RefusedToAnswerException.Throw(refusal, finishReason, GetRequestId(response.Headers));
         }
 
         var result = context.Sync.ReadForMemory(content, "ai/output");
@@ -161,7 +158,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
     protected virtual Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token) => _client.SendAsync(request, token);
 
-    public async Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, List<GenAiAttachment> contextOutputAttachments, CancellationToken token)
+    public async Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, List<AiAttachment> attachments, CancellationToken token)
     {
         if (_forTestingPurposes?.SimulateFailureAsync != null)
             await _forTestingPurposes.SimulateFailureAsync(userPrompt);
@@ -176,10 +173,10 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         var msg2 = new DynamicJsonValue
         {
             [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
-            [Constants.RequestFields.Content] = contextOutputAttachments switch
+            [Constants.RequestFields.Content] = attachments switch
             {
                 null => userPrompt,
-                _ => CreateContentWithAttachments(userPrompt, contextOutputAttachments)
+                _ => CreateContentWithAttachments(userPrompt, attachments)
             }
         };
 
@@ -192,14 +189,14 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
     }
 
 
-    private DynamicJsonArray CreateContentWithAttachments(string context, List<GenAiAttachment> attachments)
+    private DynamicJsonArray CreateContentWithAttachments(string context, List<AiAttachment> attachments)
     {
         var content = new DynamicJsonArray
         {
             new DynamicJsonValue
             {
-                ["type"] = "text",
-                ["text"] = context
+                [Constants.AttachmentsRequestFields.Type] = Constants.AttachmentsRequestFields.TypeText,
+                [Constants.AttachmentsRequestFields.TypeText] = context
             }
         };
 
@@ -207,29 +204,32 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         {
             content.Add(attachment.Type switch
             {
-                "text/plain" => new DynamicJsonValue
+                Constants.AttachmentsRequestFields.MediaTypeTextPlain => new DynamicJsonValue
                 {
-                    ["type"] = "text",
-                    ["text"] = attachment.Data
+                    [Constants.AttachmentsRequestFields.Type] = Constants.AttachmentsRequestFields.TypeText,
+                    [Constants.AttachmentsRequestFields.TypeText] = attachment.DataAsBase64
                 },
-                "application/pdf" => new DynamicJsonValue
+                Constants.AttachmentsRequestFields.MediaTypeApplicationPdf => new DynamicJsonValue
                 {
-                    ["type"] = "file",
-                    ["file"] = new DynamicJsonValue
+                    [Constants.AttachmentsRequestFields.Type] = Constants.AttachmentsRequestFields.File,
+                    [Constants.AttachmentsRequestFields.File] = new DynamicJsonValue
                     {
-                        ["filename"] = attachment.Name,
-                        ["file_data"] = "data:application/pdf;base64," + attachment.Data
+                        [Constants.AttachmentsRequestFields.FileName] = attachment.Name,
+                        [Constants.AttachmentsRequestFields.FileData] = "data:application/pdf;base64," + attachment.DataAsBase64
                     }
                 },
-                "image/jpeg" or "image/png" or "image/gif" or "image/webp" => new DynamicJsonValue
+                Constants.AttachmentsRequestFields.MediaTypeImageJpeg or 
+                    Constants.AttachmentsRequestFields.MediaTypeImagePng or
+                    Constants.AttachmentsRequestFields.MediaTypeImageGif or 
+                    Constants.AttachmentsRequestFields.MediaTypeImageWebp => new DynamicJsonValue
                 {
-                    ["type"] = "image_url",
-                    ["image_url"] = new DynamicJsonValue
+                    [Constants.AttachmentsRequestFields.Type] = Constants.AttachmentsRequestFields.ImageUrl,
+                    [Constants.AttachmentsRequestFields.ImageUrl] = new DynamicJsonValue
                     {
-                        ["url"] = "data:" + attachment.Type + ";base64," + attachment.Data
+                        [Constants.AttachmentsRequestFields.Url] = "data:" + attachment.Type + ";base64," + attachment.DataAsBase64
                     }
                 },
-                _ => throw new InvalidOperationException("Unknown attachment type: " + attachment.Type)
+                _ => throw new InvalidOperationException($"Attachment '{attachment.Name}' has unknown type: {attachment.Type}")
             });
         }
 
@@ -751,6 +751,28 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string DefaultRelativeUri = "/v1/chat/completions";
             public const string ModelsUri = "/v1/models";
             public const string AuthorizationApiKeyProperty = "Bearer";
+
+            public const string AttachmentType = "Bearer";
+            public const string AttachmentData = "Bearer";
+        }
+
+        public static class AttachmentsRequestFields
+        {
+            public const string Type = "type";
+            public const string File = "file";
+            public const string FileName = "filename";
+            public const string FileData = "file_data";
+            public const string ImageUrl = "image_url";
+            public const string Url = "url";
+
+            public const string TypeText = "text";
+
+            public const string MediaTypeTextPlain = "text/plain";
+            public const string MediaTypeApplicationPdf = "application/pdf";
+            public const string MediaTypeImageJpeg = "image/jpeg";
+            public const string MediaTypeImagePng = "image/png";
+            public const string MediaTypeImageGif = "image/gif";
+            public const string MediaTypeImageWebp = "image/webp";
         }
     }
 

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -148,8 +148,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
             _ = choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal) || msg.TryGet(Constants.ResponseFields.Refusal, out refusal);
 
-            //TODO: full output if we get here?
-            RefusedToAnswerException.Throw(refusal, finishReason, GetRequestId(response.Headers));
+            RefusedToAnswerException.Throw(refusal, responseContent.ToString(), finishReason, GetRequestId(response.Headers));
         }
 
         var result = context.Sync.ReadForMemory(content, "ai/output");
@@ -751,9 +750,6 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string DefaultRelativeUri = "/v1/chat/completions";
             public const string ModelsUri = "/v1/models";
             public const string AuthorizationApiKeyProperty = "Bearer";
-
-            public const string AttachmentType = "Bearer";
-            public const string AttachmentData = "Bearer";
         }
 
         public static class AttachmentsRequestFields

--- a/src/Raven.Server/Documents/AI/IChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/IChatCompletionClient.cs
@@ -5,8 +5,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI;
-using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Raven.Server.Documents.ETL.Providers.AI;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI;
@@ -17,7 +16,7 @@ public interface IChatCompletionClient : IDisposable
         @"(?<value>\d+(?:\.\d+)?)(?<unit>ns|us|µs|ms|s|m|h)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant
     );
-    Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, List<GenAiAttachment> contextOutputAttachments,
+    Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, List<AiAttachment> contextOutputAttachments,
         CancellationToken token);
     
     Task<BlittableJsonReaderObject> GetResponseContentAsync(JsonOperationContext context, HttpResponseMessage response, CancellationToken token);

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -129,8 +129,6 @@ namespace Raven.Server.Documents.ETL
 
         protected abstract void AddLoadedAttachment(JsValue reference, string name, Attachment attachment);
 
-        protected virtual bool TryGetMissingAttachmentPlaceholder(string attachmentName, ref JsValue loadAttachmentReference, ref Attachment attachment) => true;
-
         protected abstract void AddLoadedCounter(JsValue reference, string name, long value);
         
         protected abstract void AddLoadedTimeSeries(JsValue reference, string name, IEnumerable<SingleResult> entries);
@@ -142,22 +140,48 @@ namespace Raven.Server.Documents.ETL
 
             var attachmentName = args[0].AsString();
             var loadAttachmentReference = CreateLoadAttachmentReference(attachmentName);
+
             Attachment attachment = null;
             if ((Current.Document.Flags & DocumentFlags.HasAttachments) == DocumentFlags.HasAttachments)
             {
-                attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(Context, Current.DocumentId, attachmentName, AttachmentType.Document, null);
-
-                if (attachment == null && TryGetMissingAttachmentPlaceholder(attachmentName, ref loadAttachmentReference, ref attachment) == false)
-                    return JsValue.Null;
+                attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(
+                    Context, Current.DocumentId, attachmentName, AttachmentType.Document, changeVector: null);
             }
-            else if (TryGetMissingAttachmentPlaceholder(attachmentName, ref loadAttachmentReference, ref attachment) == false)
+
+            // If not found – try to materialize according to policy
+            if (attachment == null)
             {
-                return JsValue.Null;
+                switch (MissingAttachmentOnLoadPolicy)
+                {
+                    case MissingAttachmentPolicy.ReturnNull:
+                        return JsValue.Null;
+
+                    case MissingAttachmentPolicy.ReturnEmpty:
+                        // If the attachment does not exist, its key is represented by a new instance of JsNull.
+                        // This ensures JavaScript receives a null value when the attachment is missing - allowing the user to handle the case explicitly (e.g., if (!attachment) { ... })
+                        // while still having access to the attachment's name after (we can extract it by the key - which is a NEW INSTANCE of JsNull).
+                        loadAttachmentReference = (JsNull)Activator.CreateInstance(typeof(JsNull), nonPublic: true);
+                        attachment = new Attachment
+                        {
+                            Name = Context.GetLazyString(attachmentName)
+                        };
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            $"Unexpected MissingAttachmentPolicy '{MissingAttachmentOnLoadPolicy}'. Only ReturnNull and ReturnEmpty are supported.");
+                }
             }
 
             AddLoadedAttachment(loadAttachmentReference, attachmentName, attachment);
-
             return loadAttachmentReference;
+        }
+
+        protected virtual MissingAttachmentPolicy MissingAttachmentOnLoadPolicy => MissingAttachmentPolicy.ReturnNull;
+
+        public enum MissingAttachmentPolicy
+        {
+            ReturnNull,
+            ReturnEmpty
         }
 
         private static JsValue CreateLoadAttachmentReference(string attachmentName)

--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -129,6 +129,8 @@ namespace Raven.Server.Documents.ETL
 
         protected abstract void AddLoadedAttachment(JsValue reference, string name, Attachment attachment);
 
+        protected virtual bool TryGetMissingAttachmentPlaceholder(string attachmentName, ref JsValue loadAttachmentReference, ref Attachment attachment) => true;
+
         protected abstract void AddLoadedCounter(JsValue reference, string name, long value);
         
         protected abstract void AddLoadedTimeSeries(JsValue reference, string name, IEnumerable<SingleResult> entries);
@@ -145,26 +147,17 @@ namespace Raven.Server.Documents.ETL
             {
                 attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(Context, Current.DocumentId, attachmentName, AttachmentType.Document, null);
 
-                if (attachment == null)
-                    UpdateEmptyAttachmentInfo();
+                if (attachment == null && TryGetMissingAttachmentPlaceholder(attachmentName, ref loadAttachmentReference, ref attachment) == false)
+                    return JsValue.Null;
             }
-            else
+            else if (TryGetMissingAttachmentPlaceholder(attachmentName, ref loadAttachmentReference, ref attachment) == false)
             {
-                UpdateEmptyAttachmentInfo();
+                return JsValue.Null;
             }
 
             AddLoadedAttachment(loadAttachmentReference, attachmentName, attachment);
 
             return loadAttachmentReference;
-
-            void UpdateEmptyAttachmentInfo()
-            {
-                loadAttachmentReference = (JsNull)Activator.CreateInstance(typeof(JsNull), true);
-                attachment = new Attachment()
-                {
-                    Name = Context.GetLazyString(attachmentName)
-                };
-            }
         }
 
         private static JsValue CreateLoadAttachmentReference(string attachmentName)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/AiAttachment.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/AiAttachment.cs
@@ -1,0 +1,39 @@
+﻿using Raven.Client.Util;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.ETL.Providers.AI;
+
+public class AiAttachment
+{
+    public string Name { get; set; }
+    public string Type { get; set; }
+    public string DataAsBase64 { get; set; }
+
+    public AiAttachment()
+    {
+        // for deserialization
+    }
+
+    public AiAttachment(string name, string type, string dataAsBase64)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(name, nameof(Name));
+        ValidationMethods.AssertNotNullOrEmpty(type, nameof(Type));
+        ValidationMethods.AssertNotNullOrEmpty(dataAsBase64, nameof(DataAsBase64));
+
+        Name = name;
+        Type = type;
+        DataAsBase64 = dataAsBase64;
+    }
+
+    public DynamicJsonValue ToJson()
+    {
+        var json = new DynamicJsonValue
+        {
+            [nameof(Name)] = Name,
+            [nameof(Type)] = Type,
+            [nameof(DataAsBase64)] = DataAsBase64
+        };
+
+        return json;
+    }
+}

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiResultItem.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using Raven.Client.Documents.Operations.AI;
 using System.Linq;
-using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Server.Documents.AI;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -44,7 +42,7 @@ public class ContextOutput
 {
     public BlittableJsonReaderObject Context { get; set; }
     
-    public List<GenAiAttachment> Attachments;
+    public List<AiAttachment> Attachments;
     public bool IsCached { get; set; }
     public string AiHash { get; set; }
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
@@ -1,40 +1,9 @@
 ﻿using System.Collections.Generic;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
 
-public class GenAiAttachment
-{
-    public string Name { get; set; }
-    public string Type { get; set; }
-    public string Data { get; set; }
-
-    public GenAiAttachment()
-    {
-        // for deserialization
-    }
-    public GenAiAttachment(string name, string type, string data)
-    {
-        Name = name;
-        Type = type;
-        Data = data;
-    }
-
-    public DynamicJsonValue ToJson()
-    {
-        var json = new DynamicJsonValue
-        {
-            [nameof(Name)] = Name,
-            [nameof(Type)] = Type,
-            [nameof(Data)] = Data
-        };
-
-        return json;
-    }
-}
-
 public record GenAiScriptResult(string DocumentId, BlittableJsonReaderObject Context, string AiHash, bool IsCached)
 {
-    public List<GenAiAttachment> Attachments;
+    public List<AiAttachment> Attachments;
 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -116,6 +116,17 @@ var ai = new AI();
         }
     }
 
+    protected override bool TryGetMissingAttachmentPlaceholder(string attachmentName, ref JsValue loadAttachmentReference, ref Attachment attachment)
+    {
+        // If the attachment does not exist, its key is represented by a new instance of JsNull.
+        loadAttachmentReference = (JsNull)Activator.CreateInstance(typeof(JsNull), true);
+        attachment = new Attachment()
+        {
+            Name = Context.GetLazyString(attachmentName)
+        };
+        return true;
+    }
+
     protected override void AddLoadedAttachment(JsValue reference, string name, Attachment attachment)
     {
         _attachments ??= [];
@@ -240,7 +251,7 @@ var ai = new AI();
                             throw new InvalidOperationException($"GenAI Task: attachment with reference '{reference}' was never loaded. ");
                         }
 
-                        result.Attachments.Add(new GenAiAttachment(filename, type, data));
+                        result.Attachments.Add(new AiAttachment(filename, type, data));
                     }
                 }
                 _currentRun.Add(result);

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -116,16 +116,7 @@ var ai = new AI();
         }
     }
 
-    protected override bool TryGetMissingAttachmentPlaceholder(string attachmentName, ref JsValue loadAttachmentReference, ref Attachment attachment)
-    {
-        // If the attachment does not exist, its key is represented by a new instance of JsNull.
-        loadAttachmentReference = (JsNull)Activator.CreateInstance(typeof(JsNull), true);
-        attachment = new Attachment()
-        {
-            Name = Context.GetLazyString(attachmentName)
-        };
-        return true;
-    }
+    protected override MissingAttachmentPolicy MissingAttachmentOnLoadPolicy => MissingAttachmentPolicy.ReturnEmpty;
 
     protected override void AddLoadedAttachment(JsValue reference, string name, Attachment attachment)
     {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -197,7 +197,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 Task<(string Result, AiUsage Usage)> task;
                 try
                 {
-                    task = _chatCompletionClient.CompleteAsync(Configuration.Prompt, json,Schema,  item.ContextOutput.Attachments, CancellationToken);
+                    task = _chatCompletionClient.CompleteAsync(Configuration.Prompt, json,Schema, item.ContextOutput.Attachments, CancellationToken);
                 }
                 catch (Exception e)
                 {

--- a/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
@@ -194,8 +194,8 @@ for(const comment of this.Comments)
         Assert.Equal("star.png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Name);
         Assert.Equal("image/png", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Type);
         Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
-        Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
+        Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.DataAsBase64);
+        Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.DataAsBase64);
 
         // Stage 2 : Send to model
         var sendToModel = await store.Maintenance.SendAsync(context, new TestGenAiSendToModelOperation(genAiContexts, config));
@@ -303,8 +303,8 @@ for(const comment of this.Comments)
         Assert.Equal("star.png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Name);
         Assert.Equal("image/png", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Type);
         Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
-        Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
+        Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.DataAsBase64);
+        Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.DataAsBase64);
 
 
         // Stage 2 : Send to model
@@ -448,7 +448,6 @@ for(const comment of this.Comments)
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/admin/ai/gen-ai/test";
-            // var bjro = _conventions.Serialization.DefaultConverter.ToBlittable(_testGenAiScript, ctx);
             var bjro = ctx.ReadObject(_testGenAiScript.ToJson(), "TestGenAiCommand_payload");
             return new HttpRequestMessage
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24864/GenAI-support-for-images-documents-handle-PR-comments

### Additional description

Handle comments:
https://github.com/ravendb/ravendb/pull/21039

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
