### PR TITLE
RavenDB-24848 Send a full database report regardless of changes at certain intervals.

### DIFF
--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -139,5 +139,11 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(256)]
         [ConfigurationEntry("Cluster.MaxClusterTransactionBatchSize", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxClusterTransactionsBatchSize { get; set; }
+        
+        [Description("EXPERT: Peroid of time to send a full database report (in minutes) regardless of changes.")]
+        [DefaultValue(5)]
+        [TimeUnit(TimeUnit.Minutes)]
+        [ConfigurationEntry("Cluster.LastFullTimeReportInMin", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting LastFullTimeReport { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -140,10 +140,10 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Cluster.MaxClusterTransactionBatchSize", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxClusterTransactionsBatchSize { get; set; }
         
-        [Description("EXPERT: Peroid of time to send a full database report (in minutes) regardless of changes.")]
+        [Description("EXPERT: Period of time to send a full database report (in minutes) regardless of changes.")]
         [DefaultValue(5)]
         [TimeUnit(TimeUnit.Minutes)]
-        [ConfigurationEntry("Cluster.LastFullTimeReportInMin", ConfigurationEntryScope.ServerWideOnly)]
-        public TimeSetting LastFullTimeReport { get; set; }
+        [ConfigurationEntry("Cluster.FullReportIntervalInMin", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting FullReportInterval { get; set; }
     }
 }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -254,9 +254,9 @@ namespace Raven.Server.ServerWide.Maintenance
                         }
 
                         report.Status = DatabaseStatus.Loaded;
+                        var now = dbInstance.Time.GetUtcNow();
                         try
                         {
-                            var now = dbInstance.Time.GetUtcNow();
                             FillReplicationInfo(dbInstance, report);
                             FillClusterInfo(ctx, report, dbInstance);
 
@@ -294,10 +294,12 @@ namespace Raven.Server.ServerWide.Maintenance
 
                             // Check if anything has changed.
                             if (SupportedFeatures.Heartbeats.SendChangesOnly &&
-                                prevDatabaseReport != null && prevDatabaseReport.EnvironmentsHash == report.EnvironmentsHash)
+                                prevDatabaseReport != null && prevDatabaseReport.EnvironmentsHash == report.EnvironmentsHash
+                                && now - prevDatabaseReport.LastFullReport < _server.Configuration.Cluster.LastFullTimeReport.AsTimeSpan)
                             {
                                 // Nothing changed. Send a lightweight NoChange report.
                                 report.Status = DatabaseStatus.NoChange;
+                                report.LastFullReport = prevDatabaseReport.LastFullReport;
                                 result[dbName] = report;
                                 continue;
                             }
@@ -338,6 +340,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             report.Error = e.ToString();
                         }
 
+                        report.LastFullReport = now;
                         result[dbName] = report;
                     }
                 }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -295,7 +295,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             // Check if anything has changed.
                             if (SupportedFeatures.Heartbeats.SendChangesOnly &&
                                 prevDatabaseReport != null && prevDatabaseReport.EnvironmentsHash == report.EnvironmentsHash
-                                && now - prevDatabaseReport.LastFullReport < _server.Configuration.Cluster.LastFullTimeReport.AsTimeSpan)
+                                && now - prevDatabaseReport.LastFullReport < _server.Configuration.Cluster.FullReportInterval.AsTimeSpan)
                             {
                                 // Nothing changed. Send a lightweight NoChange report.
                                 report.Status = DatabaseStatus.NoChange;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -132,6 +132,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
         public long LastTransactionId; // this is local, so we don't serialize it
         public long EnvironmentsHash; // this is local, so we don't serialize it
+        public DateTime LastFullReport; // this is local, so we don't serialize it
 
         internal static long GetPeriodicBackupStatusesHash(Dictionary<long, PeriodicBackupStatusReport> periodicBackupStatusReports)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24848

### Additional description

 Send a full database report regardless of changes at certain intervals. This is useful for updating last query time mechanism and setting an index as idle etc.

In order to save network traffic & calculations we have a mechanism that detects there is no change:
```
                                // Nothing changed. Send a lightweight NoChange report.
                                report.Status = DatabaseStatus.NoChange;
```
However, this will not update the LastQueryTime, which can lead to an index not being set as `IDLE` after a certain point in time.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
