### PR TITLE
RavenDB-24871 - Fix for `SlowTests.Server.Documents.PeriodicBackup.ClusterBackupTests.CompareExchangeTombstonesShouldNotBeCleanedIfNotBackedUpForLocalNode`

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using NCrontab.Advanced;
 using Raven.Client.Documents.Operations;
@@ -292,12 +293,21 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange)]
         public async Task CompareExchangeTombstonesShouldNotBeCleanedIfNotBackedUpForLocalNode()
         {
-            // A does full backup on compare exchanges, backup moves to B, cx deleted, B does full backup on their tombstones, backup moves back to A, A should still have the tombstones to back up
-            // they should not have been deleted by the observer because of A's low index should prevent it
-            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" }, };
+            var logBuilder = new StringBuilder();
+
+            // Node A does full backup on compare exchanges, backup moves to Node B, cx deleted, Node B does full backup on their tombstones, backup moves back to Node A, Node A should still have the tombstones to back up
+            // they should not have been deleted by the observer because of Node A's low index should prevent it
             var backupPath = NewDataPath(suffix: "BackupFolder");
+            if (Directory.Exists(backupPath))
+            {
+                Log($"Backup path '{backupPath}' already exists, deleting it.");
+                Directory.Delete(backupPath, recursive: true);
+            }
+
             var incrementalFrequency = "0 0 * * *";
-            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" }, };
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+            Log($"Leader node tag: {leader.ServerStore.NodeTag}");
 
             using (var store = GetDocumentStore(new Options { ReplicationFactor = 3, Server = leader }))
             {
@@ -306,10 +316,11 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     await session.StoreAsync(new User { Name = "Stav" }, "users/1");
                     await session.SaveChangesAsync();
                     var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
-                    Assert.True(exists);
+                    Assert.True(exists, UserMessageWithLog("Document 'users/1' was not replicated to all nodes in the cluster"));
                 }
 
                 var nextBackup = GetTimeUntilBackupNextOccurence(incrementalFrequency, DateTime.UtcNow);
+                Log($"Next backup in: {nextBackup}");
                 if (nextBackup < TimeSpan.FromSeconds(8))
                     await Task.Delay(nextBackup);
 
@@ -317,12 +328,14 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 var cmpxchngRes1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User { Name = "Stav1" }, 0));
                 var cmpxchngRes2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/2", new User { Name = "Stav2" }, 0));
                 var cmpxchngRes3 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/3", new User { Name = "Stav3" }, 0));
-                Assert.True(cmpxchngRes1.Successful);
-                Assert.True(cmpxchngRes2.Successful);
-                Assert.True(cmpxchngRes3.Successful);
+                Log($"Compare exchanges created: cmpxchngRes1.Index = {cmpxchngRes1.Index}, cmpxchngRes2.Index = {cmpxchngRes2.Index}, cmpxchngRes3.Index = {cmpxchngRes3.Index}");
+                Assert.True(cmpxchngRes1.Successful, UserMessageWithLog("PutCompareExchangeValueOperation for 'users/1' failed."));
+                Assert.True(cmpxchngRes2.Successful, UserMessageWithLog("PutCompareExchangeValueOperation for 'users/2' failed."));
+                Assert.True(cmpxchngRes3.Successful, UserMessageWithLog("PutCompareExchangeValueOperation for 'users/3' failed."));
 
                 var stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
-                Assert.Equal(3, stats.CountOfCompareExchange);
+                Log($"CountOfCompareExchange: {stats.CountOfCompareExchange}, CountOfCompareExchangeTombstones: {stats.CountOfCompareExchangeTombstones}");
+                Assert.True(stats.CountOfCompareExchange == 3, UserMessageWithLog($"CountOfCompareExchange should be 3 but was {stats.CountOfCompareExchange}."));
 
                 // node backs up compare exchanges
                 var config = new PeriodicBackupConfiguration()
@@ -336,42 +349,59 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     }
                 };
                 var taskId = await Backup.UpdateConfigAsync(leader, config, store);
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(taskId);
+
+                Log($"Backup task created with id: {taskId}");
                 var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, store.Database);
+                Log($"Original node responsible for backup: {originalNode}");
                 var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                Log($"Original node server: {originalNodeServer.ServerStore.NodeTag}");
                 var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+                Log($"Other node server: {otherNodeServer.ServerStore.NodeTag}");
 
                 // first backup will be full
                 await Backup.RunBackupAsync(originalNodeServer, taskId, store, isFullBackup: false);
 
                 // check the backup status
-                var backupStatus = await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId));
-                Assert.NotNull(backupStatus.Status);
-                Assert.Equal(originalNode, backupStatus.Status.NodeTag);
-                Assert.True(backupStatus.Status.IsFull);
+                var backupStatus = await WaitForNotNullAsync(async () =>
+                {
+                    var result = await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId));
+                    return result?.Status;
+                });
+                Assert.True(backupStatus != null, UserMessageWithLog("Backup status is null."));
+                Assert.True(originalNode == backupStatus.NodeTag, UserMessageWithLog($"Backup status node tag '{backupStatus.NodeTag}' does not match original node '{originalNode}'."));
+                Assert.True(backupStatus.IsFull, UserMessageWithLog("Backup status is not full."));
 
                 // assert number of directories
+                Assert.NotNull(backupPath);
                 var dirs = Directory.GetDirectories(backupPath);
-                Assert.Equal(1, dirs.Length);
+                Log($"Number of backup directories: {dirs.Length}, dirs: {string.Join(", ", dirs)}");
+                Assert.True(dirs.Length == 1, UserMessageWithLog($"Expected 1 backup directory but found {dirs.Length}."));
 
                 var nodesBackupDir = dirs[0];
                 var originalNodeFiles = Directory.GetFiles(nodesBackupDir);
-                Assert.Equal(1, originalNodeFiles.Length);
-                Assert.True(originalNodeFiles[0].Contains(originalNode));
+                Log($"Number of files in backup directory: {originalNodeFiles.Length}, files: {string.Join(", ", originalNodeFiles)}");
+                Assert.True(originalNodeFiles.Length == 1, UserMessageWithLog($"Expected 1 file in backup directory but found {originalNodeFiles.Length}."));
+                Assert.True(originalNodeFiles[0].Contains($"-{originalNode}-backup"), UserMessageWithLog($"Backup file '{originalNodeFiles[0]}' does not contain original node tag '{originalNode}'."));
 
                 // change responsible node to other node
                 config.TaskId = taskId;
                 config.MentorNode = otherNodeServer.ServerStore.NodeTag;
-                await Backup.UpdateConfigAsync(leader, config, store);
-                
+                var updatedTaskId = await Backup.UpdateConfigAsync(leader, config, store);
+                Log($"Backup task updated with new mentor node: {otherNodeServer.ServerStore.NodeTag}, taskId: {updatedTaskId} (original: {taskId})");
+
                 Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, differentThan: originalNode);
 
                 // delete compare exchanges -> tombstones created
                 var delRes1 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", cmpxchngRes1.Index));
                 var delRes2 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/2", cmpxchngRes2.Index));
                 var delRes3 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/3", cmpxchngRes3.Index));
-                Assert.True(delRes1.Successful);
-                Assert.True(delRes2.Successful);
-                Assert.True(delRes3.Successful);
+                Log($"Compare exchanges deleted: delRes1.Index = {delRes1.Index}, delRes2.Index = {delRes2.Index}, delRes3.Index = {delRes3.Index}");
+                Assert.True(delRes1.Successful, UserMessageWithLog("DeleteCompareExchangeValueOperation for 'users/1' failed."));
+                Assert.True(delRes2.Successful, UserMessageWithLog("DeleteCompareExchangeValueOperation for 'users/2' failed."));
+                Assert.True(delRes3.Successful, UserMessageWithLog("DeleteCompareExchangeValueOperation for 'users/3' failed."));
+
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(delRes3.Index);
 
                 // first backup on new node will be full - this includes the tombstones
                 await Backup.RunBackupAsync(otherNodeServer, taskId, store, isFullBackup: false);
@@ -383,26 +413,30 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
                     return status.NodeTag == otherNodeServer.ServerStore.NodeTag;
                 }, true, timeout: 70_000);
-                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
-                Assert.True(status.IsFull, "Backup wasn't full");
-                Assert.NotNull(status.LastFullBackup);
-                Assert.True(status.LastRaftIndex.LastEtag >= delRes3.Index, "tombstones raft index is not included in the backup");
+                Assert.True(res, UserMessageWithLog($"Backup status node tag '{status.NodeTag}' does not match other node '{otherNodeServer.ServerStore.NodeTag}'."));
+                Assert.True(status.IsFull, UserMessageWithLog("Backup wasn't full."));
+                Assert.True(status.LastFullBackup != null, UserMessageWithLog($"Last full backup is null."));
+                Assert.True(status.LastRaftIndex.LastEtag >= delRes3.Index, UserMessageWithLog($"Tombstones raft index was not included in the backup. Expected: {delRes3.Index}, Actual: {status.LastRaftIndex.LastEtag}."));
 
                 // assert number of directories grew
                 var otherNodeDir = Directory.GetDirectories(backupPath).Except(dirs).ToArray();
-                Assert.Equal(1, otherNodeDir.Length);
-                Assert.True(otherNodeDir[0].Contains(otherNodeServer.ServerStore.NodeTag));
+                Assert.True(otherNodeDir.Length == 1, UserMessageWithLog($"Expected 1 new backup directory but found {otherNodeDir.Length}."));
+                Assert.True(otherNodeDir[0].Contains($"-{otherNodeServer.ServerStore.NodeTag}-backup"), UserMessageWithLog($"New backup directory '{otherNodeDir[0]}' does not contain other node tag '{otherNodeServer.ServerStore.NodeTag}'."));
                 var otherNodeFiles = Directory.GetFiles(otherNodeDir[0]);
-                Assert.Equal(1, otherNodeFiles.Length);
+                Assert.True(otherNodeFiles.Length == 1, UserMessageWithLog($"Expected 1 file in new backup directory but found {otherNodeFiles.Length}."));
 
                 // run cx tombstone cleaner
                 await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
 
                 // tombstones should not have been deleted
                 stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
-                Assert.Equal(3, stats.CountOfCompareExchangeTombstones);
-                Assert.Equal(0, stats.CountOfCompareExchange);
+                Assert.True(stats.CountOfCompareExchangeTombstones == 3, UserMessageWithLog($"CountOfCompareExchangeTombstones should be 3 but was {stats.CountOfCompareExchangeTombstones}."));
+                Assert.True(stats.CountOfCompareExchange == 0, UserMessageWithLog($"CountOfCompareExchange should be 0 but was {stats.CountOfCompareExchange}."));
             }
+
+            return;
+            void Log(string textToLog) => logBuilder.AppendLine($"{DateTime.UtcNow:O}: {textToLog}");
+            string UserMessageWithLog(string message) => $"{message}{Environment.NewLine}Log:{Environment.NewLine}{logBuilder}";
         }
 
         [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange | RavenTestCategory.Sharding)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24871

### Additional description

The stability of the test has been improved by setting a wait for the compare-exchange deletion to propagate to all cluster nodes. Logging has been added to the test run to get more information in case additional problems with this test are identified.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
