### PR TITLE
RavenDB-24858 - Added the `FindPropertyNameForIndexDefinition` convention as a workaround for an issue where `PropertyNameConverter` is not respected during index definition creation

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -388,6 +388,7 @@ namespace Raven.Client.Documents.Conventions
         private bool? _useHttpCompression;
         private HttpCompressionAlgorithm _httpCompressionAlgorithm;
         private Func<MemberInfo, string> _propertyNameConverter;
+        private Func<MemberInfo, string> _findPropertyNameForIndexDefinition;
         private Func<Type, bool> _typeIsKnownServerSide = _ => false;
         private Func<MemberInfo, bool> _shouldApplyPropertyNameConverter;
         private OperationStatusFetchMode _operationStatusFetchMode;
@@ -554,6 +555,22 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _propertyNameConverter = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a function to find the property name for a member when building an index definition from a LINQ expression.
+        /// </summary>
+        [Obsolete("This convention is a workaround for an issue where `PropertyNameConverter` is not respected during index definition creation. " +
+                  "A direct fix is a breaking change scheduled for RavenDB v8.0. " +
+                  "This temporary convention was added in v7.1 to address the problem and will be removed in v8.0.", error: false)]
+        public Func<MemberInfo, string> FindPropertyNameForIndexDefinition
+        {
+            get => _findPropertyNameForIndexDefinition;
+            set
+            {
+                AssertNotFrozen();
+                _findPropertyNameForIndexDefinition = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -272,7 +272,9 @@ namespace Raven.Client.Documents.Indexes
 
         private string GetPropertyName(MemberInfo memberInfo)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var propName = _conventions.FindPropertyNameForIndexDefinition?.Invoke(memberInfo);
+#pragma warning restore CS0618 // Type or member is obsolete
             if (propName != null)
                 return propName;
 

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
@@ -271,18 +272,22 @@ namespace Raven.Client.Documents.Indexes
 
         private string GetPropertyName(MemberInfo memberInfo)
         {
-            foreach (var customAttribute in memberInfo.GetCustomAttributes(true))
+            var propName = _conventions.FindPropertyNameForIndexDefinition?.Invoke(memberInfo);
+            if (propName != null)
+                return propName;
+
+            foreach (var customAttribute in memberInfo.GetCustomAttributes(inherit: true))
             {
-                string propName;
                 var customAttributeType = customAttribute.GetType();
                 if (typeof(JsonPropertyAttribute).Namespace != customAttributeType.Namespace)
                     continue;
+
                 switch (customAttributeType.Name)
                 {
-                    case "JsonPropertyAttribute":
+                    case nameof(JsonPropertyAttribute):
                         propName = ((dynamic)customAttribute).PropertyName;
                         break;
-                    case "DataMemberAttribute":
+                    case nameof(DataMemberAttribute):
                         propName = ((dynamic)customAttribute).Name;
                         break;
                     default:

--- a/test/SlowTests/Client/Indexing/Issues/RavenDB-24858.cs
+++ b/test/SlowTests/Client/Indexing/Issues/RavenDB-24858.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Indexing.Issues;
+
+public class RavenDB_24858 : RavenTestBase
+{
+    public RavenDB_24858(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Obsolete("The `FindPropertyNameForIndexDefinition` convention is a workaround for an issue where `PropertyNameConverter` is not respected during index definition creation. " +
+              "A direct fix is a breaking change scheduled for RavenDB v8.0. " +
+              "The `FindPropertyNameForIndexDefinition` temporary convention was added in v7.1 to address the problem and will be removed in v8.0.")]
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    public async Task FindPropertyNameForIndexDefinitionAsWorkaroundInsteadOfPropertyNameConverter_ShouldWork()
+    {
+        using var store = GetDocumentStore(new Options
+        {
+            ModifyDocumentStore = documentStore =>
+            {
+                documentStore.Conventions.FindPropertyNameForIndex = ConvertStripePropertyNamesForIndex;
+                documentStore.Conventions.FindPropertyNameForDynamicIndex = ConvertStripePropertyNamesForIndex;
+                documentStore.Conventions.FindPropertyNameForIndexDefinition = info => info.Name;
+                documentStore.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                {
+                    JsonContractResolver = new IgnoreJsonPropertyNamesForSomeNamespaceContractResolver()
+                };
+            }
+        });
+
+        using var session = store.OpenSession();
+        var someInstance = new SomeClass
+        {
+            SomePropertyWithJsonPropertyAttribute = "value 1",
+            SomePropertyWithoutJsonPropertyAttribute = "value 2"
+        };
+        session.Store(someInstance);
+        session.SaveChanges();
+
+        await new Index_SomeClass_ByExact_SomeProperty().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromSeconds(30));
+
+        var result = session.Query<SomeClass, Index_SomeClass_ByExact_SomeProperty>()
+            .Where(someClass =>
+                someClass.SomePropertyWithJsonPropertyAttribute == someInstance.SomePropertyWithJsonPropertyAttribute &&
+                someClass.SomePropertyWithoutJsonPropertyAttribute == someInstance.SomePropertyWithoutJsonPropertyAttribute,
+                exact: true)
+            .ToArray();
+
+        Assert.Single(result);
+        Assert.Equal(someInstance.SomePropertyWithJsonPropertyAttribute, result[0].SomePropertyWithJsonPropertyAttribute);
+        Assert.Equal(someInstance.SomePropertyWithoutJsonPropertyAttribute, result[0].SomePropertyWithoutJsonPropertyAttribute);
+    }
+
+    private static string ConvertStripePropertyNamesForIndex(Type indexedType, string _, string __, string jsonPropertyAttributeValue)
+    {
+        var propertyInfo = GetPropertyInfoByJsonPropertyValue(indexedType, jsonPropertyAttributeValue);
+        if (propertyInfo != null && IsSomeType(indexedType))
+            return propertyInfo.Name;
+
+        return jsonPropertyAttributeValue;
+    }
+
+    private static bool IsSomeType(Type type)
+    {
+        if (type == null)
+            return false;
+
+        return type.Namespace?.StartsWith("SlowTests.Client.Indexing.Issues", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static PropertyInfo GetPropertyInfoByJsonPropertyValue(Type type, string value)
+    {
+        var propertyInfo = type?.GetProperties().SingleOrDefault(info =>
+            info.CustomAttributes.Any(customAttributeData =>
+                customAttributeData.AttributeType == typeof(JsonPropertyAttribute) &&
+                customAttributeData.ConstructorArguments.Single().Value as string == value));
+
+        return propertyInfo == null
+            ? null
+            : type?.GetProperty(propertyInfo.Name, bindingAttr: BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+    }
+
+    public class IgnoreJsonPropertyNamesForSomeNamespaceContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+            if (IsSomeType(member.DeclaringType))
+                property.PropertyName = member.Name;
+
+            return property;
+        }
+    }
+
+    public class SomeClass
+    {
+        [JsonProperty("should_be_ignored")]
+        public string SomePropertyWithJsonPropertyAttribute { get; set; }
+
+        public string SomePropertyWithoutJsonPropertyAttribute { get; set; }
+    }
+
+    public class Index_SomeClass_ByExact_SomeProperty : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<SomeClass>
+    {
+        public Index_SomeClass_ByExact_SomeProperty()
+        {
+            Map = items => from item in items
+                select new
+                {
+                    SomePropertyWithJsonPropertyAttribute = item.SomePropertyWithJsonPropertyAttribute,
+                    SomePropertyWithoutJsonPropertyAttribute = item.SomePropertyWithoutJsonPropertyAttribute
+                };
+
+            Index(nameof(SomeClass.SomePropertyWithJsonPropertyAttribute), Raven.Client.Documents.Indexes.FieldIndexing.Exact);
+            Index(nameof(SomeClass.SomePropertyWithoutJsonPropertyAttribute), Raven.Client.Documents.Indexes.FieldIndexing.Exact);
+        }
+    }
+}

--- a/test/SlowTests/Client/Indexing/Issues/RavenDB-24858.cs
+++ b/test/SlowTests/Client/Indexing/Issues/RavenDB-24858.cs
@@ -19,9 +19,6 @@ public class RavenDB_24858 : RavenTestBase
     {
     }
 
-    [Obsolete("The `FindPropertyNameForIndexDefinition` convention is a workaround for an issue where `PropertyNameConverter` is not respected during index definition creation. " +
-              "A direct fix is a breaking change scheduled for RavenDB v8.0. " +
-              "The `FindPropertyNameForIndexDefinition` temporary convention was added in v7.1 to address the problem and will be removed in v8.0.")]
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
     public async Task FindPropertyNameForIndexDefinitionAsWorkaroundInsteadOfPropertyNameConverter_ShouldWork()
     {
@@ -31,7 +28,9 @@ public class RavenDB_24858 : RavenTestBase
             {
                 documentStore.Conventions.FindPropertyNameForIndex = ConvertStripePropertyNamesForIndex;
                 documentStore.Conventions.FindPropertyNameForDynamicIndex = ConvertStripePropertyNamesForIndex;
+#pragma warning disable CS0618 // Type or member is obsolete
                 documentStore.Conventions.FindPropertyNameForIndexDefinition = info => info.Name;
+#pragma warning restore CS0618 // Type or member is obsolete
                 documentStore.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
                 {
                     JsonContractResolver = new IgnoreJsonPropertyNamesForSomeNamespaceContractResolver()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24858

### Additional description

This pull request introduces a new convention, `FindPropertyNameForIndexDefinition`, as a non-breaking solution to the issue discussed in PR #21172.

**Problem:**
The original attempt to fix how `PropertyNameConverter` was handled in the `ExpressionStringBuilder` was identified as a potential breaking change. Users might rely on the existing behavior where `JsonPropertyAttribute` takes precedence.

**Solution:**
As suggested, this PR reverts the changes to `ExpressionStringBuilder.GetPropertyName` and instead introduces a new, high-priority convention specifically for index definition generation.

- **`DocumentConventions.FindPropertyNameForIndexDefinition`**: This new `Func<MemberInfo, string>` is checked at the very beginning of the property name resolution logic.
- If the function returns a non-null value, it is used as the property name, bypassing all other logic (`JsonPropertyAttribute`, etc.).
- If it returns `null`, the logic proceeds as it did before, preserving backward compatibility.

This provides a clean, opt-in mechanism for users who need to override property names during indexing (e.g., to ignore attributes from third-party libraries) without affecting existing users.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
