### PR TITLE
RavenDB-24867 - GenAI support for images & documents - passing base64 directly

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using Jint;
 using Jint.Native;
 using Jint.Native.Function;
@@ -240,6 +241,8 @@ var ai = new AI();
                         {
                             //if we arrive here we probably didn't pass through loadAttachment() function
                             data = reference.ToString();
+                            if (type != "text/plain" && Base64Regex.Matches(data).Count == 0)
+                                throw new InvalidOperationException($"Attachment '{filename}' must be loaded or base64 string (on type {type})");
                         }
 
                         result.Attachments.Add(new AiAttachment(filename, type, data));
@@ -249,7 +252,9 @@ var ai = new AI();
             }
         }
     }
-    
+
+    public static readonly Regex Base64Regex = new(@"^[a-zA-Z0-9+/]*={0,2}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static bool ShouldSendContext(string hash, string taskIdentifier, Document doc)
     {
         if (doc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -22,6 +22,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Platform;
+using AttachmentsRequestConstants = Raven.Server.Documents.AI.ChatCompletionClient.Constants.AttachmentsRequestFields;
 
 namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
 
@@ -185,7 +186,7 @@ var ai = new AI();
                 if (data.IsNull() == false)
                     attachmentsHashes.Add(_attachments?.TryGetValue(data, out var attachment) is true ? attachment?.Base64Hash.ToString() : data.AsString());
 
-                attachmentsHashes.Add(attachmentObj.GetOwnProperty("type").Value.AsString());
+                attachmentsHashes.Add(attachmentObj.GetOwnProperty(AttachmentsRequestConstants.Type).Value.AsString());
             }
             
             string hash = CalculateHash(context, attachmentsHashes);
@@ -206,7 +207,7 @@ var ai = new AI();
                         var attachmentObj = current.AsObject();
                         var reference = attachmentObj.GetOwnProperty("data").Value;
                         var data = string.Empty;
-                        string type = attachmentObj.GetOwnProperty("type").Value.AsString();
+                        string type = attachmentObj.GetOwnProperty(AttachmentsRequestConstants.Type).Value.AsString();
                         string filename = "unknown.name";
 
                         // TODO: we aren't being really efficient here in terms of allocations / memory
@@ -217,12 +218,12 @@ var ai = new AI();
                             if (reference.IsNull())
                             {
                                 data = $"File '{filename}' (of type '{type}') could not be loaded: attachment not found";
-                                type = "text/plain";
+                                type = AttachmentsRequestConstants.MediaTypeTextPlain;
                             }
                             else
                             {
                                 using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
-                                if (type == "text/plain")
+                                if (type == AttachmentsRequestConstants.MediaTypeTextPlain)
                                 {
                                     attachment.Stream.CopyTo(memoryStream);
                                 }
@@ -241,7 +242,7 @@ var ai = new AI();
                         {
                             //if we arrive here we probably didn't pass through loadAttachment() function
                             data = reference.ToString();
-                            if (type != "text/plain" && Base64Regex.IsMatch(data) == false)
+                            if (type != AttachmentsRequestConstants.MediaTypeTextPlain && IsBase64(data) == false)
                                 throw new InvalidOperationException($"Attachment must be loaded or base64 string (on type {type})");
                         }
 
@@ -253,7 +254,9 @@ var ai = new AI();
         }
     }
 
-    public static readonly Regex Base64Regex = new(@"^[a-zA-Z0-9+/]*={0,2}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex Base64Regex = new(@"^[a-zA-Z0-9+/]*={0,2}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static bool IsBase64(string data) => data.Length % 4 == 0 && Base64Regex.IsMatch(data);
 
     private static bool ShouldSendContext(string hash, string taskIdentifier, Document doc)
     {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -241,8 +241,8 @@ var ai = new AI();
                         {
                             //if we arrive here we probably didn't pass through loadAttachment() function
                             data = reference.ToString();
-                            if (type != "text/plain" && Base64Regex.Matches(data).Count == 0)
-                                throw new InvalidOperationException($"Attachment '{filename}' must be loaded or base64 string (on type {type})");
+                            if (type != "text/plain" && Base64Regex.IsMatch(data) == false)
+                                throw new InvalidOperationException($"Attachment must be loaded or base64 string (on type {type})");
                         }
 
                         result.Attachments.Add(new AiAttachment(filename, type, data));

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -254,9 +255,8 @@ var ai = new AI();
         }
     }
 
-    private static readonly Regex Base64Regex = new(@"^[a-zA-Z0-9+/]*={0,2}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static bool IsBase64(string data) => data.Length % 4 == 0 && Base64Regex.IsMatch(data);
+    private static bool IsBase64(string data) => string.IsNullOrEmpty(data) == false && data.Length % 4 == 0 && Base64.IsValid(data);
+    
 
     private static bool ShouldSendContext(string hash, string taskIdentifier, Document doc)
     {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -239,7 +239,7 @@ var ai = new AI();
                         else
                         {
                             //if we arrive here we probably didn't pass through loadAttachment() function
-                            throw new InvalidOperationException($"GenAI Task: attachment with reference '{reference}' was never loaded. ");
+                            data = reference.ToString();
                         }
 
                         result.Attachments.Add(new AiAttachment(filename, type, data));

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -255,7 +255,7 @@ var ai = new AI();
         }
     }
 
-    private static bool IsBase64(string data) => string.IsNullOrEmpty(data) == false && data.Length % 4 == 0 && Base64.IsValid(data);
+    private static bool IsBase64(string data) => string.IsNullOrEmpty(data) == false && Base64.IsValid(data);
     
 
     private static bool ShouldSendContext(string hash, string taskIdentifier, Document doc)

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
@@ -11,8 +11,6 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Json;
-using Raven.Server.Documents;
-using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -112,7 +110,7 @@ ai.genContext({}).withPng(img1);
             Assert.False(item1.ImageDescriptions.Any(d => d.Description == marker.Description));
             var item2Changed = item2.ImageDescriptions.Any(d => d.Description == marker.Description) == false;
             if (withNullAttachments)
-                Assert.True(item2Changed || ValidateRefusalNotification(db));
+                Assert.True(item2Changed || ValidateErrorNotification(db, "The request was refused by the model"));
             else
                 Assert.False(item2Changed);
         }
@@ -249,7 +247,7 @@ ai.genContext({
             Assert.False(transaction1.Summary.Any(d => d.Notes == marker.Notes));
             var transaction2Changed = transaction2.Summary.Any(d => d.Notes == marker.Notes) == false;
             if (withNullAttachments)
-                Assert.True(transaction2Changed || ValidateRefusalNotification(db));
+                Assert.True(transaction2Changed || ValidateErrorNotification(db, "The request was refused by the model"));
             else
                 Assert.False(transaction2Changed);
         }
@@ -351,7 +349,7 @@ ai.genContext({})
 
             Assert.False(item1.FileDescriptions.Any(d => d.Description == marker.Description));
             var item2Changed = item2.FileDescriptions.Any(d => d.Description == marker.Description) == false;
-            Assert.True(item2Changed || ValidateRefusalNotification(db));
+            Assert.True(item2Changed || ValidateErrorNotification(db, "The request was refused by the model"));
         }
     }
 
@@ -559,22 +557,6 @@ for(const comment of this.Comments)
             }
 
             return null;
-        }
-    }
-
-    private static bool ValidateRefusalNotification(DocumentDatabase db)
-    {
-        using (db.NotificationCenter.GetStored(out var actions))
-        {
-            var jsonAlerts = actions.ToList();
-            if (jsonAlerts.Count == 0)
-                return false;
-            var bjro = jsonAlerts.First().Json;
-
-            return bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
-                   details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
-                   errors.Length > 0 &&
-                   errors.First().ToString()!.Contains("The request was refused by the model");
         }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
@@ -104,46 +104,6 @@ ai.genContext({})
             }
         }
 
-
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false, Data = new object[] { "png" })]
-        public async Task CanUseImageActualName(Options options, GenAiConfiguration config, string format)
-        {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
-
-            config.Prompt = "Describe the following images" + NonEmptyAnswerHint;
-            config.Collection = "Items";
-            config.SampleObject = JsonConvert.SerializeObject(new
-            {
-                ImageDescriptions = new[]
-                {
-                    new { Description = "Detailed description of the image", SafeForWork = true, Tags = new[] { "matching tags for the image" } }
-                }
-            });
-            config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
-            config.GenAiTransformation = new GenAiTransformation { Script = @"
-ai.genContext({})
-    .withPng('image.png');
-" };
-
-            await store.Maintenance.SendAsync(new AddGenAiOperation(config));
-            var etl = Etl.WaitForEtlToComplete(store);
-            var marker = new ImageDescription("None" + Guid.NewGuid(), false, new string[] { "None" });
-            using (var session = store.OpenAsyncSession())
-            {
-                await session.StoreAsync(new Item(marker), FirstItemId);
-                await using var file1 = GetEmbeddedImgStream(format);
-
-                session.Advanced.Attachments.Store(FirstItemId, "image.png", file1);
-                await session.SaveChangesAsync();
-            }
-            etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30));
-
-            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            Assert.True(ValidateRefusalNotification(db, "was never loaded."));
-        }
-
         [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false, Data = new object[] { "png" })]
         public async Task ShouldNotifyOnInvalidImage(Options options, GenAiConfiguration config, string format)

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Server.Documents;
-using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -94,7 +91,7 @@ ai.genContext({})
             Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
         
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            Assert.False(ValidateRefusalNotification(db));
+            Assert.False(ValidateErrorNotification(db, string.Empty));
             using (var session = store.OpenAsyncSession())
             {
                 var item1 = await session.LoadAsync<Item>(FirstItemId);
@@ -149,23 +146,7 @@ ai.genContext({})
             Assert.False(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
 
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            Assert.True(ValidateRefusalNotification(db, "You uploaded an unsupported image."));
-        }
-
-        private static bool ValidateRefusalNotification(DocumentDatabase db, string msg = "")
-        {
-            using (db.NotificationCenter.GetStored(out var actions))
-            {
-                var jsonAlerts = actions.ToList();
-                if (jsonAlerts.Count == 0)
-                    return false;
-                var bjro = jsonAlerts.First().Json;
-
-                return bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
-                       details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
-                       errors.Length > 0 &&
-                       errors.First().ToString()!.Contains(msg);
-            }
+            Assert.True(ValidateErrorNotification(db, "You uploaded an unsupported image."));
         }
 
         private static Stream GetEmbeddedImgStream(string format)

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
@@ -103,6 +103,45 @@ ai.genContext({})
 
         [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false, Data = new object[] { "png" })]
+        public async Task CanUseImageActualName(Options options, GenAiConfiguration config, string format)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Prompt = "Describe the following images" + NonEmptyAnswerHint;
+            config.Collection = "Items";
+            config.SampleObject = JsonConvert.SerializeObject(new
+            {
+                ImageDescriptions = new[]
+                {
+                    new { Description = "Detailed description of the image", SafeForWork = true, Tags = new[] { "matching tags for the image" } }
+                }
+            });
+            config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
+            config.GenAiTransformation = new GenAiTransformation { Script = @"
+ai.genContext({})
+    .withPng('image.png');
+" };
+
+            await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+            var etl = Etl.WaitForEtlToComplete(store);
+            var marker = new ImageDescription("None" + Guid.NewGuid(), false, new string[] { "None" });
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Item(marker), FirstItemId);
+                await using var file1 = GetEmbeddedImgStream(format);
+
+                session.Advanced.Attachments.Store(FirstItemId, "image.png", file1);
+                await session.SaveChangesAsync();
+            }
+            etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30));
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            Assert.True(ValidateErrorNotification(db, $"Attachment must be loaded or base64 string (on type image/png)"));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false, Data = new object[] { "png" })]
         public async Task ShouldNotifyOnInvalidImage(Options options, GenAiConfiguration config, string format)
         {
             using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
@@ -15,6 +15,7 @@ using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
 using Raven.Client.Util;
+using Raven.Server.Documents;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
 using Raven.Server.ServerWide.Context;
@@ -38,20 +39,95 @@ public class RavenDB_24867(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
-    public async Task PndAsBase64Directly(Options options, GenAiConfiguration config)
+    public async Task PngAsBase64Directly(Options options, GenAiConfiguration config)
     {
         string script = 
             $"const heart = '{HeartPngBase64}'; const star = '{StarPngBase64}'; " +
             @"
-let ctx = ai.genContext({});
+if (this.Name === 'shahar') {
+    ai.genContext({}).withPng(heart);
+    return;
+}
 
+if (this.Name === 'aviv') {
+    ai.genContext({}).withPng(star);
+    return;
+}
+";
+
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images." + NonEmptyAnswerHint;
+        config.Collection = "Users";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            ImageDescriptions = new[]
+            {
+                new { Description = "Detailed description of the image", SafeForWork = true, Tags = new[] { "matching tags for the image" } }
+            }
+        });
+        config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
+        config.GenAiTransformation = new GenAiTransformation { Script = script };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        var marker = new[] { new ImageDescription("None" + Guid.NewGuid(), false, null) };
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User()
+            {
+                Id = "Users/1",
+                Name = "shahar",
+                ImageDescriptions = marker
+            });
+            await session.StoreAsync(new User()
+            {
+                Id = "Users/2",
+                Name = "aviv",
+                ImageDescriptions = marker
+            });            
+            await session.StoreAsync(new User()
+            {
+                Id = "Users/3",
+                Name = "karmel",
+                ImageDescriptions = marker
+            });
+
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var user1 = await session.LoadAsync<User>("Users/1");
+            var user2 = await session.LoadAsync<User>("Users/2");
+            var user3 = await session.LoadAsync<User>("Users/3");
+
+            Assert.NotEqual(marker[0].Description, user1.ImageDescriptions[0].Description);
+            Assert.NotEqual(marker[0].Description, user2.ImageDescriptions[0].Description);
+            Assert.Equal(marker[0].Description, user3.ImageDescriptions[0].Description);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task PngNotAsBase64ShouldThrow(Options options, GenAiConfiguration config)
+    {
+        string script =
+            $"const heart = '{HeartPngBase64}'; " +
+            @"
 if (this.Name === 'Shahar') {
-    ctx.withPng(heart);
+    ai.genContext({}).withPng(heart);
     return;
 }
 
 if (this.Name === 'Aviv') {
-    ctx.withPng(star);
+    ai.genContext({}).withPng('This is a star');
     return;
 }
 ";
@@ -90,7 +166,7 @@ if (this.Name === 'Aviv') {
                 Id = "Users/2",
                 Name = "Aviv",
                 ImageDescriptions = marker
-            });            
+            });
             await session.StoreAsync(new User()
             {
                 Id = "Users/3",
@@ -108,10 +184,37 @@ if (this.Name === 'Aviv') {
             var user1 = await session.LoadAsync<User>("Users/1");
             var user2 = await session.LoadAsync<User>("Users/2");
             var user3 = await session.LoadAsync<User>("Users/3");
-
+        
             Assert.NotEqual(marker[0].Description, user1.ImageDescriptions[0].Description);
-            Assert.NotEqual(marker[0].Description, user2.ImageDescriptions[0].Description);
+            Assert.Equal(marker[0].Description, user2.ImageDescriptions[0].Description);
             Assert.Equal(marker[0].Description, user3.ImageDescriptions[0].Description);
+        }
+
+        var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+        Assert.True(ValidateErrorNotification(db, "Users/2", "Attachment 'unknown.name' must be loaded or base64 string (on type image/png)"));
+    }
+
+    private static bool ValidateErrorNotification(DocumentDatabase db, string id, string err)
+    {
+        using (db.NotificationCenter.GetStored(out var actions))
+        {
+            var jsonAlerts = actions.ToList();
+            if (jsonAlerts.Count == 0)
+                return false;
+            var bjro = jsonAlerts.First().Json;
+
+            if (bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
+                details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
+                errors.Length > 0)
+            {
+                var firstErr = errors.First() as BlittableJsonReaderObject;
+                return firstErr!= null && 
+                       firstErr.TryGet("DocumentId", out string documentId) && 
+                       firstErr.TryGet("Error", out string error) &&
+                       documentId == id && error.Contains(err);
+            }
+            
+            return false;
         }
     }
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
@@ -1,25 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Http;
-using Raven.Client.Json;
-using Raven.Client.Json.Serialization;
-using Raven.Client.Util;
-using Raven.Server.Documents;
-using Raven.Server.Documents.ETL.Providers.AI.GenAi;
-using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
-using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -38,7 +23,7 @@ public class RavenDB_24867(ITestOutputHelper output) : RavenTestBase(output)
         " ;Always provide a valid structured response matching the schema (if you have no answer or an empty answer - please return default values instead)";
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
     public async Task PngAsBase64Directly(Options options, GenAiConfiguration config)
     {
         string script = 
@@ -108,14 +93,14 @@ if (this.Name === 'aviv') {
             var user2 = await session.LoadAsync<User>("Users/2");
             var user3 = await session.LoadAsync<User>("Users/3");
 
-            Assert.NotEqual(marker[0].Description, user1.ImageDescriptions[0].Description);
-            Assert.NotEqual(marker[0].Description, user2.ImageDescriptions[0].Description);
+            Assert.True(user1.ImageDescriptions == null || user1.ImageDescriptions.Length == 0 || marker[0].Description != user1.ImageDescriptions[0].Description); // changed
+            Assert.True(user2.ImageDescriptions == null || user2.ImageDescriptions.Length == 0 || marker[0].Description != user2.ImageDescriptions[0].Description); // changed
             Assert.Equal(marker[0].Description, user3.ImageDescriptions[0].Description);
         }
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
     public async Task PngNotAsBase64ShouldThrow(Options options, GenAiConfiguration config)
     {
         string script =
@@ -185,37 +170,13 @@ if (this.Name === 'Aviv') {
             var user2 = await session.LoadAsync<User>("Users/2");
             var user3 = await session.LoadAsync<User>("Users/3");
         
-            Assert.NotEqual(marker[0].Description, user1.ImageDescriptions[0].Description);
+            Assert.True(user1.ImageDescriptions == null || user1.ImageDescriptions.Length == 0 || marker[0].Description != user1.ImageDescriptions[0].Description); // changed
             Assert.Equal(marker[0].Description, user2.ImageDescriptions[0].Description);
             Assert.Equal(marker[0].Description, user3.ImageDescriptions[0].Description);
         }
 
         var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-        Assert.True(ValidateErrorNotification(db, "Users/2", "Attachment 'unknown.name' must be loaded or base64 string (on type image/png)"));
-    }
-
-    private static bool ValidateErrorNotification(DocumentDatabase db, string id, string err)
-    {
-        using (db.NotificationCenter.GetStored(out var actions))
-        {
-            var jsonAlerts = actions.ToList();
-            if (jsonAlerts.Count == 0)
-                return false;
-            var bjro = jsonAlerts.First().Json;
-
-            if (bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
-                details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
-                errors.Length > 0)
-            {
-                var firstErr = errors.First() as BlittableJsonReaderObject;
-                return firstErr!= null && 
-                       firstErr.TryGet("DocumentId", out string documentId) && 
-                       firstErr.TryGet("Error", out string error) &&
-                       documentId == id && error.Contains(err);
-            }
-            
-            return false;
-        }
+        Assert.True(ValidateErrorNotification(db, "Attachment must be loaded or base64 string (on type image/png)", "Users/2"));
     }
 
     private class User

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_24867(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const string HeartPngBase64 =
+"iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=";
+
+    private const string StarPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAYAAAA6/NlyAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAB59JREFUeJzdmweMFVUUhn+asPQmrNKbiKhEKZoooCuyGFA6xEAgsqi0xJAgGMQQUZqAgpSIIgQCBgKIoC4QkCZSDIIgVRBW2lKUtvR2PP/cebNv+2N35t3ISb7kheybe/43d+5pA2DHyikNLK0ddcuv9FJGKEUs+xIVK6/MVzYrtS37EhV7Ubmk3FVet+xL4JZP+UQRl2+UB6x6FLBVUDYhVfA+3OeHV4JyPl8+SMGCjuCbynDLPgVqPyhSty6keXPvLm+H2er3ncUoF/Pnh/TrBxk5ElK4sCP4tvKQZd8CsTaKVK0KWbUKsmcPpH597y6/ifvsLpdRvlakQwfI1auQO3cgffp4ghOVylY99NkaKn8rMnkyRMSwYIF3eDEuv2TXRX/tXUXq1IHs2pUq+PBhSNOm3l0eb9lH36ys8pMigwdDrlxJFXzrFmTCBE/wNqWGVU99sleVk4qsXp0qNgTvOIzgCzBFxf/eZipStizk9u2Mgknt2p7o7y37mmdj+ZfM2NuzZ+ZiyaBBkEKFHMEpSmnLPufJmihSrhxk3rysBa9cCalSxbvLr1j2OddWWBmtOGnkhQtZC755E9KmjSd4ulLCque5tCeVvSwUxozJWmyI6dMhBQo4go8pz1r2PVfWU7lbvjxk48acBe/YAalRw7vL71j2PYMx7+WWZYytqtRVnlaaKfFKJ2WLIv37Q1JSchZ8/Tpk2DBP8O9KB5juCM+Bx9112B6KyavztV1HWyrtle7KW8pAZZgySpmkzIDpUCxVVis/u6JY3v2h7FcOw2zJ0zC1rixdCrl7N2fBZP16TzC/e0pJUv5U9rjrbFU2KquU71x/vlA+VT5WBiv9lTeUjjAH4AswjwjT20cpuLOSjNQuhG8UKQI5fz4yseTaNUipUr77cQcmqTmEsGYDt83a8D+sXBnSpIk5YVu3hnTpYmIptyhTxOHDIePGQaZNg8yaBVm4EJKYCFm7FrJtG2TvXsjx45GLDXH0KGTnTsjmzSZcLVkCmTvXrDN+PGTECBO3WVPTn/btIfHxJidv0MDk6xUrZhDNVlI7hJWgBWCew8TQVqxXD7JsGeTIEciJE5AzZ8zdYi7MMBLpNg2CGzcgly8bf06dghw7ZgqRffsgy5dD2rZNc3cPKs8ji2YhOw8/hn6Zdu0g+/fbE3avJCdD+vb1srZQQdIiM6HhVlzprVznl8qUMVkSKxvbgrKCu42PAbspYdv4I+XBnMSGjDkw2y48cSU2FjJjhtlGtsVltr35nPO8cYX+q0xVSkYqNmScATE8OaVdhQqQsWPtC0zP7NmQmjU9seycfODu0lxbFZi4x9GIcyImJdkXykN06FAIU1dX7BHlCfjUDKyjLFFusAfVqRNk+3Z7Yg8cgPTuDSle3GvzroFJnHy1msocRVjfNmxo5wQ/dw4SF+c1/8hyBDiu4XZhG+YsFytZEjJzZtadDD/hSbx4sZlauEIvKp8rBYMSGzIG8LdhUjWpVg0yalTa5pzfMCSyvRsm9oQyBOZNgqhYIZiqiEWCMzLh6CQI0ayiGHaKFfPEXlW6woeqKTcWC3dARnr1MhMFP7fxgAHmzHDXWKc8Y0NouLHwYArnJPN+59gJCZ5YlqAsY63PoFhj7lBk4kT/tzSfXRjBu5R6VpW6xkL7TtGikC1b/Be8davJ8mASn06WtTrGToOT3rGW9Vswr9mypXeXR1rW6uTbnBY4jQKeqH4LZnEwZIgnmAdk4HE3O+NMlwW2TJ3qv9gQK1Z4grmW1RYuF09hP/ngweAEnzzp9axZDfW1Kbif4oxJInWecZrFOrmXmF2pkneXv7Qp+Dcg+0FZOGzs9ehhMjPCz+xDRfLd7t3TbGsrxvbJDaZ8kyZl7yxTzjVrII0aeW/uOLU1PzdubPrRfO8ju2twcB4T4/Wsy9oQHEenOR7ZsCFrRy9dMglJ2HSQDq9TNrifnQJkypTsW0j8wfh37jWaRVssiwcn/rZqZUJHegfZyuWd4w8S1pXga4etYcIZeQ1mmuD8DXvKmzZl3jBkk75FC+86bKhHNTxVgulhOzEyvXNMFlg91aqV5nUGdkweSecoPzNdXAZzAjslIBvuPJnTX3fgQO96HLPERlEvGsEdz8yfnzGEcFLBMYvrHEtIzqiye+54Hnyo/MPvME3t2BFy9mzaa8+Z412Tr0A9FajCdMaBlZPj8o06OsPnj9M/TvuRWrd+C/MGbaQWGgRcg9seHj06dT7FUBb2PkiCz5qyNU4SnVnO6dOQ3bsh3bpBSpTwnOEkcZDycC6uzS7p+8pfvFbp0qZpeOiQmSx07uytMcUnLTkaOw2/cNGuXSGLFplw4zrBcHMAJgPLy6HCNhJnw0nudZ1cnXMjng3uv3H4VywPa0RsrH85u3XCRFj3kB3/PkpRH9cqBbNT2MNy4nb16t56nIrE+7hWlsYXzW4hdYbD543/YYPD5yD+lwrv4svKTrhx24Wzr/cCWC+DfRa2KIV/BdOoD9rYe16AtD/2gqAXZcLBnjS7/b8qz8EkENEyngvsofFQ5HnBkBdoj4tJApMI3uXHglwoB6NovtLIuF01yIV4SDAGR+V0zMH40jnL07h7+dJ/6BKDgg9Udu4AAAAASUVORK5CYII=";
+
+    private const string NonEmptyAnswerHint =
+        " ;Always provide a valid structured response matching the schema (if you have no answer or an empty answer - please return default values instead)";
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task PndAsBase64Directly(Options options, GenAiConfiguration config)
+    {
+        string script = 
+            $"const heart = '{HeartPngBase64}'; const star = '{StarPngBase64}'; " +
+            @"
+let ctx = ai.genContext({});
+
+if (this.Name === 'Shahar') {
+    ctx.withPng(heart);
+    return;
+}
+
+if (this.Name === 'Aviv') {
+    ctx.withPng(star);
+    return;
+}
+";
+
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Describe the following images." + NonEmptyAnswerHint;
+        config.Collection = "Users";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            ImageDescriptions = new[]
+            {
+                new { Description = "Detailed description of the image", SafeForWork = true, Tags = new[] { "matching tags for the image" } }
+            }
+        });
+        config.UpdateScript = @"this.ImageDescriptions = $output.ImageDescriptions;";
+        config.GenAiTransformation = new GenAiTransformation { Script = script };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        var marker = new[] { new ImageDescription("None" + Guid.NewGuid(), false, null) };
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User()
+            {
+                Id = "Users/1",
+                Name = "Shahar",
+                ImageDescriptions = marker
+            });
+            await session.StoreAsync(new User()
+            {
+                Id = "Users/2",
+                Name = "Aviv",
+                ImageDescriptions = marker
+            });            
+            await session.StoreAsync(new User()
+            {
+                Id = "Users/3",
+                Name = "Karmel",
+                ImageDescriptions = marker
+            });
+
+            await session.SaveChangesAsync();
+        }
+
+        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var user1 = await session.LoadAsync<User>("Users/1");
+            var user2 = await session.LoadAsync<User>("Users/2");
+            var user3 = await session.LoadAsync<User>("Users/3");
+
+            Assert.NotEqual(marker[0].Description, user1.ImageDescriptions[0].Description);
+            Assert.NotEqual(marker[0].Description, user2.ImageDescriptions[0].Description);
+            Assert.Equal(marker[0].Description, user3.ImageDescriptions[0].Description);
+        }
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public ImageDescription[] ImageDescriptions { get; set; }
+    }
+    public record ImageDescription(string Description, bool SafeForWork, string[] Tags);
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -32,6 +32,7 @@ using Raven.Server.Exceptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Collections;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Operations;
 using Xunit;
@@ -1244,6 +1245,29 @@ namespace FastTests
                 ms.Seek(0, SeekOrigin.Begin);
 
                 return new StreamReader(ms, Encoding.UTF8).ReadToEnd();
+            }
+        }
+
+        public static bool ValidateErrorNotification(DocumentDatabase db, string err, string id = null)
+        {
+            using (db.NotificationCenter.GetStored(out var actions))
+            {
+                var jsonAlerts = actions.ToList();
+                if (jsonAlerts.Count == 0)
+                    return false;
+                var bjro = jsonAlerts.First().Json;
+
+                if (bjro.TryGet("Details", out BlittableJsonReaderObject details) &&
+                    details.TryGet("Errors", out BlittableJsonReaderArray errors) &&
+                    errors.Length > 0)
+                {
+                    var firstErr = errors.First() as BlittableJsonReaderObject;
+                    return firstErr != null &&
+                           (id == null || (firstErr.TryGet("DocumentId", out string documentId) && documentId == id)) &&
+                           firstErr.TryGet("Error", out string error) && error.Contains(err);
+                }
+
+                return false;
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24867/GenAI-support-for-images-documents-passing-base64-directly

### Additional description

Add support for passing the file content (as base64 string) directly on the `with` methods.
For example:
```
genCtx.withPng('iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGHaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49J++7vycgaWQ9J1c1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCc/Pg0KPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyI+PHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj48cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0idXVpZDpmYWY1YmRkNS1iYTNkLTExZGEtYWQzMS1kMzNkNzUxODJmMWIiIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIj48dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPjwvcmRmOkRlc2NyaXB0aW9uPjwvcmRmOlJERj48L3g6eG1wbWV0YT4NCjw/eHBhY2tldCBlbmQ9J3cnPz4slJgLAAAA1ElEQVRYR+2WORLDIAxF5Rwhvcvc/0Ap0+cKpMID4gtJmK3IqzwYfb2Rl+EIIQRayIMvzObQJvA9X9f18/PO7kl4akSBNATBg737I1BAC4vEUOt+AiKFgCesBS6QvYSjmxPosfwruAS42UjSXvtMYBV/gX0E+A9iJGmvfSawikxgxmPgPfaaAAHDnqDsQmA2UACZ3kXKhAJUKWihliUKkFJoRcuoCpAhoIalVhUgYxDHWmMSIEcgOfcWp2IL0vHN0zhinkAKaoTWLDRNoCdNE+jJcoEf1VNdHhBR9pYAAAAASUVORK5CYII=');
```

can also pass text, for example:
```
genCtx.withText('Example 1');
```


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
