### PR TITLE
RavenDB-24848 Prefer CancellationToken.Register with state over closure allocating 

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -145,7 +145,7 @@ namespace Raven.Client.Documents.Smuggler
 
                 var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                var cancellationTokenRegistration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+                var cancellationTokenRegistration = token.Register(static (state, t) => ((TaskCompletionSource<object>)state).TrySetCanceled(t), tcs);
 
                 var command = new ExportCommand(RequestExecutor.Conventions, context, options, handleStreamResponse, operationId, tcs, getOperationIdCommand.NodeTag);
 
@@ -293,7 +293,7 @@ namespace Raven.Client.Documents.Smuggler
                 var operationId = getOperationIdCommand.Result;
 
                 var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var cancellationTokenRegistration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
+                var cancellationTokenRegistration = token.Register(static (state, t) => ((TaskCompletionSource<object>)state).TrySetCanceled(t), tcs);
 
                 var command = new ImportCommand(RequestExecutor.Conventions, context, options, stream, operationId, tcs, this, getOperationIdCommand.NodeTag);
 

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -144,7 +144,8 @@ namespace Raven.Client.Documents.Smuggler
                 var operationId = getOperationIdCommand.Result;
 
                 var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var cancellationTokenRegistration = token.Register(() => tcs.TrySetCanceled(token));
+
+                var cancellationTokenRegistration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
 
                 var command = new ExportCommand(RequestExecutor.Conventions, context, options, handleStreamResponse, operationId, tcs, getOperationIdCommand.NodeTag);
 
@@ -292,7 +293,7 @@ namespace Raven.Client.Documents.Smuggler
                 var operationId = getOperationIdCommand.Result;
 
                 var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var cancellationTokenRegistration = token.Register(() => tcs.TrySetCanceled(token));
+                var cancellationTokenRegistration = token.CanBeCanceled ? token.Register(() => tcs.TrySetCanceled(token)) : default;
 
                 var command = new ImportCommand(RequestExecutor.Conventions, context, options, stream, operationId, tcs, this, getOperationIdCommand.NodeTag);
 

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -350,8 +350,7 @@ namespace Raven.Client.Documents.Smuggler
             private readonly long _operationId;
             private readonly TaskCompletionSource<object> _tcs;
 
-            public ExportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerExportOptions options,
-                Func<Stream, Task> handleStreamResponse, long operationId, TaskCompletionSource<object> tcs, string nodeTag)
+            public ExportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerExportOptions options, Func<Stream, Task> handleStreamResponse, long operationId, TaskCompletionSource<object> tcs, string nodeTag)
             {
                 if (options == null)
                     throw new ArgumentNullException(nameof(options));
@@ -407,8 +406,7 @@ namespace Raven.Client.Documents.Smuggler
 
             public override bool IsReadRequest => false;
 
-            public ImportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerImportOptions options, Stream stream, long operationId,
-                TaskCompletionSource<object> tcs, DatabaseSmuggler parent, string nodeTag)
+            public ImportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerImportOptions options, Stream stream, long operationId, TaskCompletionSource<object> tcs, DatabaseSmuggler parent, string nodeTag)
             {
                 _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _stream = stream ?? throw new ArgumentNullException(nameof(stream));
@@ -434,14 +432,19 @@ namespace Raven.Client.Documents.Smuggler
 
                 var form = new MultipartFormDataContent
                 {
-                    {
-                        new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _options).ConfigureAwait(false), _conventions),
-                        Constants.Smuggler.ImportOptions
-                    },
-                    { new StreamContentWithConfirmation(_stream, _tcs, _parent), "file", "name" }
+                    {new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _options).ConfigureAwait(false), _conventions), Constants.Smuggler.ImportOptions},
+                    {new StreamContentWithConfirmation(_stream, _tcs, _parent), "file", "name"}
                 };
 
-                return new HttpRequestMessage { Headers = { TransferEncodingChunked = true }, Method = HttpMethod.Post, Content = form };
+                return new HttpRequestMessage
+                {
+                    Headers =
+                    {
+                        TransferEncodingChunked = true
+                    },
+                    Method = HttpMethod.Post,
+                    Content = form
+                };
             }
         }
 

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -29,7 +29,7 @@ namespace Raven.Client.Documents.Smuggler
         private RequestExecutor _requestExecutor;
         private RequestExecutor RequestExecutor => _requestExecutor ?? (_databaseName != null ? _requestExecutor = _getRequestExecutor(_databaseName) : null);
 
-        public DatabaseSmuggler(IDocumentStore store, string databaseName = null) 
+        public DatabaseSmuggler(IDocumentStore store, string databaseName = null)
             : this(store.Changes, store.GetRequestExecutor, databaseName ?? store.Database)
         {
         }
@@ -62,7 +62,7 @@ namespace Raven.Client.Documents.Smuggler
                 try
                 {
                     await handleStreamResponse(stream).ConfigureAwait(false);
-                    
+
                     tcs.TrySetResult(null);
                 }
                 catch (Exception e)
@@ -145,7 +145,7 @@ namespace Raven.Client.Documents.Smuggler
 
                 var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                var cancellationTokenRegistration = token.Register(static (state, t) => ((TaskCompletionSource<object>)state).TrySetCanceled(t), tcs);
+                var cancellationTokenRegistration = tcs.RegisterTryCancelOnToken(token);
 
                 var command = new ExportCommand(RequestExecutor.Conventions, context, options, handleStreamResponse, operationId, tcs, getOperationIdCommand.NodeTag);
 
@@ -243,6 +243,7 @@ namespace Raven.Client.Documents.Smuggler
                 var op = await ImportAsync(options, filePath, cancellationToken).ConfigureAwait(false);
                 await op.WaitForCompletionAsync().WithCancellation(cancellationToken).ConfigureAwait(false);
             }
+
             options.OperateOnTypes = oldOperateOnTypes;
 
             var lastFilePath = Path.Combine(fromDirectory, files.Last());
@@ -293,27 +294,27 @@ namespace Raven.Client.Documents.Smuggler
                 var operationId = getOperationIdCommand.Result;
 
                 var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var cancellationTokenRegistration = token.Register(static (state, t) => ((TaskCompletionSource<object>)state).TrySetCanceled(t), tcs);
+                var cancellationTokenRegistration = tcs.RegisterTryCancelOnToken(token);
 
                 var command = new ImportCommand(RequestExecutor.Conventions, context, options, stream, operationId, tcs, this, getOperationIdCommand.NodeTag);
 
                 var task = RequestExecutor.ExecuteAsync(command, context, sessionInfo: null, token: token);
                 requestTask = task
-                        .ContinueWith(t =>
+                    .ContinueWith(t =>
+                    {
+                        returnContext?.Dispose();
+                        cancellationTokenRegistration.Dispose();
+                        using (disposeStream)
                         {
-                            returnContext?.Dispose();
-                            cancellationTokenRegistration.Dispose();
-                            using (disposeStream)
+                            if (t.IsFaulted)
                             {
-                                if (t.IsFaulted)
-                                {
-                                    tcs.TrySetException(t.Exception);
+                                tcs.TrySetException(t.Exception);
 
-                                    if (Logger.IsErrorEnabled)
-                                        Logger.Error("Could not execute import", t.Exception);
-                                }
+                                if (Logger.IsErrorEnabled)
+                                    Logger.Error("Could not execute import", t.Exception);
                             }
-                        }, token);
+                        }
+                    }, token);
 
                 try
                 {
@@ -327,7 +328,6 @@ namespace Raven.Client.Documents.Smuggler
 
                 return new Operation(RequestExecutor, () => _getChanges(_databaseName, getOperationIdCommand.NodeTag), RequestExecutor.Conventions, operationId,
                     nodeTag: getOperationIdCommand.NodeTag, afterOperationCompleted: task);
-
             }
             catch (Exception e)
             {
@@ -350,7 +350,8 @@ namespace Raven.Client.Documents.Smuggler
             private readonly long _operationId;
             private readonly TaskCompletionSource<object> _tcs;
 
-            public ExportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerExportOptions options, Func<Stream, Task> handleStreamResponse, long operationId, TaskCompletionSource<object> tcs, string nodeTag)
+            public ExportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerExportOptions options,
+                Func<Stream, Task> handleStreamResponse, long operationId, TaskCompletionSource<object> tcs, string nodeTag)
             {
                 if (options == null)
                     throw new ArgumentNullException(nameof(options));
@@ -406,7 +407,8 @@ namespace Raven.Client.Documents.Smuggler
 
             public override bool IsReadRequest => false;
 
-            public ImportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerImportOptions options, Stream stream, long operationId, TaskCompletionSource<object> tcs, DatabaseSmuggler parent, string nodeTag)
+            public ImportCommand(DocumentConventions conventions, JsonOperationContext context, DatabaseSmugglerImportOptions options, Stream stream, long operationId,
+                TaskCompletionSource<object> tcs, DatabaseSmuggler parent, string nodeTag)
             {
                 _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _stream = stream ?? throw new ArgumentNullException(nameof(stream));
@@ -432,19 +434,14 @@ namespace Raven.Client.Documents.Smuggler
 
                 var form = new MultipartFormDataContent
                 {
-                    {new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _options).ConfigureAwait(false), _conventions), Constants.Smuggler.ImportOptions},
-                    {new StreamContentWithConfirmation(_stream, _tcs, _parent), "file", "name"}
+                    {
+                        new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _options).ConfigureAwait(false), _conventions),
+                        Constants.Smuggler.ImportOptions
+                    },
+                    { new StreamContentWithConfirmation(_stream, _tcs, _parent), "file", "name" }
                 };
 
-                return new HttpRequestMessage
-                {
-                    Headers =
-                    {
-                        TransferEncodingChunked = true
-                    },
-                    Method = HttpMethod.Post,
-                    Content = form
-                };
+                return new HttpRequestMessage { Headers = { TransferEncodingChunked = true }, Method = HttpMethod.Post, Content = form };
             }
         }
 

--- a/src/Raven.Client/Util/AsyncHelpers.cs
+++ b/src/Raven.Client/Util/AsyncHelpers.cs
@@ -275,5 +275,25 @@ namespace Raven.Client.Util
                 return this;
             }
         }
+
+        /// <summary>
+        /// Registers <paramref name="tcs"/> <see cref="TaskCompletionSource{TResult}.TrySetCanceled"/> on <paramref name="token"/> cancellation.
+        /// </summary>
+        internal static CancellationTokenRegistration RegisterTryCancelOnToken<TResult>(this TaskCompletionSource<TResult> tcs, CancellationToken token)
+        {
+            #if NETSTANDARD
+
+            return token.Register(() => tcs.TrySetCanceled(token));
+
+            #else
+
+            // Pass the tcs via the state
+            return token.Register(static (object state, CancellationToken t) =>
+            {
+                ((TaskCompletionSource<object>)state).TrySetCanceled(t);
+            }, tcs);
+
+            #endif
+        }
     }
 }

--- a/src/Raven.Client/Util/AsyncHelpers.cs
+++ b/src/Raven.Client/Util/AsyncHelpers.cs
@@ -288,9 +288,9 @@ namespace Raven.Client.Util
             #else
 
             // Pass the tcs via the state
-            return token.Register(static (object state, CancellationToken t) =>
+            return token.Register(static (state, t) =>
             {
-                ((TaskCompletionSource<object>)state).TrySetCanceled(t);
+                ((TaskCompletionSource<TResult>)state).TrySetCanceled(t);
             }, tcs);
 
             #endif

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -130,7 +130,6 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
         using (_connection)
         using (_tx)
         {
-
         }
     }
 
@@ -154,7 +153,7 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
             sp.Restart();
 
             using (var cmd = GetInsertCommand(tableName, pkName, itemToReplicate))
-            using (token.Register(cmd.Cancel))
+            using (token.Register(static state => ((DbCommand)state).Cancel(), cmd))
             {
                 token.ThrowIfCancellationRequested();
                 commandCallback?.Invoke(cmd);
@@ -242,7 +241,7 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
         for (int i = 0; i < toDelete.Count; i += maxParams)
         {
             using (var cmd = GetDeleteCommand(tableName, pkName, toDelete, i, parameterize, maxParams, out int countOfDeletes))
-            using (token.Register(cmd.Cancel))
+            using (token.Register(static state => ((DbCommand)state).Cancel(), cmd))
             {
                 commandCallback?.Invoke(cmd);
 
@@ -322,9 +321,9 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
     protected abstract void SetPrimaryKeyParamValue(RelationalDatabaseItem itemToReplicate, DbParameter pkParam);
 
     protected abstract (string StartSyntax, string EndSyntax) GetSyntaxAroundParameters(RelationalDatabaseItem itemToReplicate);
-    
+
     protected abstract string GetPostDeleteSyntax(RelationalDatabaseItem itemToDelete);
-        
+
     protected abstract string GetAfterDeleteWhereIdentifierBeforeInExtraSyntax();
 
     public RelationalDatabaseWriteStats Write(RelationalDatabaseTableWithRecords table, List<DbCommand> commands, CancellationToken token)
@@ -470,7 +469,7 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
     public DbCommand GetInsertCommand(string tableName, string pkName, RelationalDatabaseItem itemToReplicate)
     {
         var cmd = CreateCommand();
-        
+
         var sb = new StringBuilder("INSERT INTO ")
             .Append(GetTableNameString(tableName))
             .Append(" (")
@@ -565,4 +564,3 @@ public abstract class RelationalDatabaseWriterBase<TRelationalConnectionString, 
         return cmd;
     }
 }
-

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
@@ -68,7 +68,7 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
         clusterTransactionCommand.Timeout = Timeout.InfiniteTimeSpan; // we rely on the http token to cancel the command
 
         using (RequestHandler.ServerStore.Cluster.ClusterTransactionWaiter.CreateTask(id: options.TaskId, out var tcs))
-        await using (token.Register(() => tcs.TrySetCanceled()))
+        await using (token.Register(static state => ((TaskCompletionSource)state).TrySetCanceled(), tcs))
         {
             (long index, object result) = await RequestHandler.ServerStore.SendToLeaderAsync(clusterTransactionCommand, token);
             var array = await GetClusterTransactionDatabaseCommandsResults(result, clusterTransactionCommand.DatabaseCommandsCount, index, options, tcs.Task, token);

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
@@ -67,8 +67,8 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
         var clusterTransactionCommand = CreateClusterTransactionCommand(parsedCommands, options, raftRequestId);
         clusterTransactionCommand.Timeout = Timeout.InfiniteTimeSpan; // we rely on the http token to cancel the command
 
-        using (RequestHandler.ServerStore.Cluster.ClusterTransactionWaiter.CreateTask(id: options.TaskId, out var tcs))
-        await using (token.Register(static state => ((TaskCompletionSource)state).TrySetCanceled(), tcs))
+        using (RequestHandler.ServerStore.Cluster.ClusterTransactionWaiter.CreateTask(id: options.TaskId, out TaskCompletionSource<HashSet<string>> tcs))
+        await using (token.Register(static state => ((TaskCompletionSource<HashSet<string>>)state).TrySetCanceled(), tcs))
         {
             (long index, object result) = await RequestHandler.ServerStore.SendToLeaderAsync(clusterTransactionCommand, token);
             var array = await GetClusterTransactionDatabaseCommandsResults(result, clusterTransactionCommand.DatabaseCommandsCount, index, options, tcs.Task, token);

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
@@ -34,7 +34,8 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
                 tcpConnection.DatabaseContext.DatabaseShutdown)
         {
             _databaseContext = tcpConnection.DatabaseContext;
-            _tokenRegisterDisposable = CancellationTokenSource.Token.Register(() => _processor?.CurrentBatch?.SetCancel());
+            _tokenRegisterDisposable =
+                CancellationTokenSource.Token.Register(static (state) => ((OrchestratedSubscriptionConnection)state)._processor?.CurrentBatch?.SetCancel(), this);
             _dbIdsToRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _databaseContext.DatabaseRecord.Sharding.DatabaseId };
         }
 

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -116,7 +116,7 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
                 _state.Batches.Add(batch);
 
                 _state.NotifyHasMoreDocs();
-                await using (_processingCts.Token.Register(batch.SetCancel))
+                await using (_processingCts.Token.Register(static (state) => ((ShardedSubscriptionBatch)state).SetCancel(), batch))
                 {
                     // wait for ShardedSubscriptionConnection to redirect the batch to client worker
                     await batch.SendBatchToClientTcs.Task;

--- a/src/Raven.Server/Rachis/ClusterTransactionWaiter.cs
+++ b/src/Raven.Server/Rachis/ClusterTransactionWaiter.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Rachis
                 throw new InvalidOperationException($"Task with the id '{id}' was not found.");
             }
 
-            await using (token.Register(() => task.TrySetCanceled()))
+            await using (token.Register(static (state) => ((TaskCompletionSource<T>)state).TrySetCanceled(), task))
             {
                 return await task.Task.ConfigureAwait(false);
             }

--- a/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
@@ -74,7 +74,11 @@ public abstract class AbstractRaftIndexNotifications<TNotification> : IDisposabl
     {
         if (e != null)
         {
-            Errors.Enqueue(new ErrorHolder { Index = index, Exception = ExceptionDispatchInfo.Capture(e) });
+            Errors.Enqueue(new ErrorHolder
+            {
+                Index = index,
+                Exception = ExceptionDispatchInfo.Capture(e)
+            });
 
             if (Interlocked.Increment(ref _numberOfErrors) > 25)
             {

--- a/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
@@ -10,7 +10,7 @@ using Sparrow.Utils;
 namespace Raven.Server.ServerWide;
 
 public abstract class AbstractRaftIndexNotifications<TNotification> : IDisposable
-where TNotification : RaftIndexNotification
+    where TNotification : RaftIndexNotification
 {
     protected readonly ConcurrentQueue<ErrorHolder> Errors = new ConcurrentQueue<ErrorHolder>();
     private readonly ConcurrentQueue<TNotification> _recentNotifications = new ConcurrentQueue<TNotification>();
@@ -42,7 +42,7 @@ where TNotification : RaftIndexNotification
         }
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        await using (token.Register(() => tcs.TrySetResult()))
+        await using (token.Register(static (state) => ((TaskCompletionSource)state).TrySetResult(), tcs))
         {
             if (await WaitForTaskCompletion(index, new Lazy<Task>(tcs.Task)))
                 return;
@@ -74,11 +74,7 @@ where TNotification : RaftIndexNotification
     {
         if (e != null)
         {
-            Errors.Enqueue(new ErrorHolder
-            {
-                Index = index,
-                Exception = ExceptionDispatchInfo.Capture(e)
-            });
+            Errors.Enqueue(new ErrorHolder { Index = index, Exception = ExceptionDispatchInfo.Capture(e) });
 
             if (Interlocked.Increment(ref _numberOfErrors) > 25)
             {
@@ -112,7 +108,7 @@ where TNotification : RaftIndexNotification
                                              $"Last commit index is: {lastModifiedIndex}. " +
                                              $"Number of errors is: {_numberOfErrors}." + closingString);
     }
-    
+
     protected void ThrowApplyException(long index, Exception e)
     {
         throw new InvalidOperationException($"Index {index} was successfully committed, but the apply failed.", e);
@@ -144,6 +140,7 @@ where TNotification : RaftIndexNotification
                 .Append(notification.ToString())
                 .AppendLine();
         }
+
         return builder.ToString();
     }
 }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -286,7 +286,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         var tcpClient = connection.TcpClient;
                         var stream = connection.Stream;
                         using (tcpClient)
-                        using (_cts.Token.Register(tcpClient.Dispose))
+                        using (_cts.Token.Register(static (state) => ((TcpClient)state).Dispose(), tcpClient))
                         using (_contextPool.AllocateOperationContext(out JsonOperationContext contextForParsing))
                         using (_contextPool.AllocateOperationContext(out JsonOperationContext contextForBuffer))
                         using (contextForBuffer.GetMemoryBuffer(out var readBuffer))

--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -58,7 +58,7 @@ namespace Sparrow.Server
                   tcs.TrySetResult(t.Result);
               }, token);
 
-            await using (token.Register(() => tcs.TrySetCanceled(token)))
+            await using (token.Register(static (state, t) => ((TaskCompletionSource<bool>)state).TrySetCanceled(t), tcs))
             {
                 return await tcs.Task.ConfigureAwait(false);
             }

--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -20,7 +20,7 @@ namespace Sparrow.Server
 
         public AsyncManualResetEvent(CancellationToken token)
         {
-            _cancellationTokenRegistration = token.Register(() => _tcs.TrySetCanceled());
+            _cancellationTokenRegistration = token.Register(static (state) => ((TaskCompletionSource<bool>)state).TrySetCanceled(), _tcs);
             _cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             _token = _cts.Token;
         }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -806,7 +806,7 @@ namespace Sparrow.Json
             UnmanagedJsonParser parser = null;
             BlittableJsonDocumentBuilder builder = null;
             var generation = _generation;
-            var streamDisposer = token?.Register(stream.Dispose);
+            var streamDisposer = token?.Register(static (state) => ((Stream)state).Dispose(), stream);
             try
             {
                 parser = new UnmanagedJsonParser(this, _jsonParserState, documentId);

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -228,7 +228,11 @@ namespace Sparrow.LowMemory
 
                 _lowMemoryMonitor = monitor;
 
-                var thread = new Thread(MonitorMemoryUsage) { IsBackground = true, Name = NotificationThreadName };
+                var thread = new Thread(MonitorMemoryUsage) 
+                {
+                    IsBackground = true, 
+                    Name = NotificationThreadName
+                };
 
                 thread.Start();
 
@@ -282,8 +286,7 @@ namespace Sparrow.LowMemory
                         try
                         {
                             if (_logger.IsInfoEnabled)
-                                _logger.Info(
-                                    "Out of memory error in the low memory notification thread, will wait 5 seconds before trying to check memory status again. The system is likely running out of memory");
+                                _logger.Info("Out of memory error in the low memory notification thread, will wait 5 seconds before trying to check memory status again. The system is likely running out of memory");
                         }
                         catch
                         {

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -52,7 +52,6 @@ namespace Sparrow.LowMemory
 
         private void RunLowMemoryHandlers(bool isLowMemory, MemoryInfoResult memoryInfo, LowMemorySeverity lowMemorySeverity)
         {
-
             try
             {
                 try
@@ -113,6 +112,7 @@ namespace Sparrow.LowMemory
                             _inactiveHandlers.Add(lowMemoryHandler);
                     }
                 }
+
                 foreach (var x in _inactiveHandlers)
                 {
                     if (x == null)
@@ -228,15 +228,11 @@ namespace Sparrow.LowMemory
 
                 _lowMemoryMonitor = monitor;
 
-                var thread = new Thread(MonitorMemoryUsage)
-                {
-                    IsBackground = true,
-                    Name = NotificationThreadName
-                };
+                var thread = new Thread(MonitorMemoryUsage) { IsBackground = true, Name = NotificationThreadName };
 
                 thread.Start();
 
-                _cancellationTokenRegistration = shutdownNotification.Register(() => _shutdownRequested.Set());
+                _cancellationTokenRegistration = shutdownNotification.Register(static (state) => ((ManualResetEvent)state).Set(), _shutdownRequested);
             }
         }
 
@@ -286,7 +282,8 @@ namespace Sparrow.LowMemory
                         try
                         {
                             if (_logger.IsInfoEnabled)
-                                _logger.Info("Out of memory error in the low memory notification thread, will wait 5 seconds before trying to check memory status again. The system is likely running out of memory");
+                                _logger.Info(
+                                    "Out of memory error in the low memory notification thread, will wait 5 seconds before trying to check memory status again. The system is likely running out of memory");
                         }
                         catch
                         {
@@ -349,6 +346,7 @@ namespace Sparrow.LowMemory
                 memoryInfo = default;
                 totalUnmanagedAllocations = -1;
             }
+
             if (isLowMemory != LowMemorySeverity.None)
             {
                 if (LowMemoryState == false)
@@ -357,10 +355,9 @@ namespace Sparrow.LowMemory
                     {
                         if (_logger.IsInfoEnabled)
                         {
-
                             _logger.Info("Low memory detected, will try to reduce memory usage...");
-
                         }
+
                         AddLowMemEvent(LowMemReason.LowMemOnTimeoutChk, memoryInfo, totalUnmanagedAllocations);
                     }
                     catch (OutOfMemoryException)
@@ -368,6 +365,7 @@ namespace Sparrow.LowMemory
                         // nothing we can do, we'll wait and try again
                     }
                 }
+
                 LowMemoryState = true;
 
                 timeout = 500;
@@ -377,6 +375,7 @@ namespace Sparrow.LowMemory
                 {
                     isLowMemory = LowMemorySeverity.ExtremelyLow; // On linux we want two severity steps
                 }
+
                 _clearInactiveHandlersCounter = 0;
                 RunLowMemoryHandlers(true, memoryInfo, isLowMemory);
             }
@@ -389,6 +388,7 @@ namespace Sparrow.LowMemory
 
                     AddLowMemEvent(LowMemReason.BackToNormal, memoryInfo, totalUnmanagedAllocations);
                 }
+
                 LowMemoryState = false;
                 RunLowMemoryHandlers(false, memoryInfo, isLowMemory);
                 timeout = memoryInfo.AvailableMemory < LowMemoryThreshold * 2 ? 1000 : 5000;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24896/CancellationToken.Register-uses-the-closure-allocating-overload

### Additional description

This PR changes the majority of the `CancellationToken.Register` call-sites to use a non-allocating, state-passing overload of `CancellationToken.Register`. There are two versions of it used, one with the state only `Register(Action<object?> callback, object? state);` and the other, with the token passing `Register(Action<object?,System.Threading.CancellationToken> callback, object? state);`. Both allow to use `static` lambdas with no closure allocation.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
