### PR TITLE
RavenDB-24790 AI Agent: Show only the chat model type when creating a connection string from inside the agent definition

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
@@ -36,7 +36,7 @@ export default function useEditAiAgent(queryParams: QueryParams) {
 
     // Set connection strings view context on mount and reset store on unmount
     useEffect(() => {
-        dispatch(connectionStringsActions.viewContextSet("aiConnectionStrings"));
+        dispatch(connectionStringsActions.viewContextSet("aiTask"));
 
         return () => {
             dispatch(editAiAgentActions.reset());

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/ModelTypeField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/ModelTypeField.tsx
@@ -22,7 +22,10 @@ export default function ModelTypeField({ initialModelType }: ModelTypeFieldProps
     const formValues = useWatch({ control });
 
     const viewContext = useAppSelector(connectionStringSelectors.viewContext);
-    const isDisabled = viewContext === "aiConnectionStrings" && !!initialModelType;
+
+    const isChatVisible = viewContext !== "aiTask" || initialModelType !== "TextEmbeddings";
+    const isTextEmbeddingsVisible = viewContext !== "aiTask" || initialModelType !== "Chat";
+    const isAllVisible = isChatVisible && isTextEmbeddingsVisible;
 
     return (
         <div className="mb-2">
@@ -33,24 +36,26 @@ export default function ModelTypeField({ initialModelType }: ModelTypeFieldProps
                 </PopoverWithHoverWrapper>
             </FormLabel>
             <div className="d-flex gap-2">
-                <ClickableCard
-                    icon="llm"
-                    title="Chat"
-                    description="Conversational AI and content generation model"
-                    className="w-50"
-                    isSelected={formValues.modelType === "Chat"}
-                    onClick={() => setValue("modelType", "Chat")}
-                    isDisabled={isDisabled}
-                />
-                <ClickableCard
-                    icon="document2"
-                    title="Text embeddings"
-                    description="Embedding generation model for vector search and similarity comparison"
-                    className="w-50"
-                    isSelected={formValues.modelType === "TextEmbeddings"}
-                    onClick={() => setValue("modelType", "TextEmbeddings")}
-                    isDisabled={isDisabled}
-                />
+                {isChatVisible && (
+                    <ClickableCard
+                        icon="llm"
+                        title="Chat"
+                        description="Conversational AI and content generation model"
+                        className={isAllVisible ? "w-50" : "w-100"}
+                        isSelected={formValues.modelType === "Chat"}
+                        onClick={() => setValue("modelType", "Chat")}
+                    />
+                )}
+                {isTextEmbeddingsVisible && (
+                    <ClickableCard
+                        icon="document2"
+                        title="Text embeddings"
+                        description="Embedding generation model for vector search and similarity comparison"
+                        className={isAllVisible ? "w-50" : "w-100"}
+                        isSelected={formValues.modelType === "TextEmbeddings"}
+                        onClick={() => setValue("modelType", "TextEmbeddings")}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
@@ -20,7 +20,7 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import DatabaseUtils from "components/utils/DatabaseUtils";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
-export type ConnectionStringsViewContext = "connectionStrings" | "aiConnectionStrings";
+export type ConnectionStringsViewContext = "connectionStrings" | "aiConnectionStrings" | "aiTask";
 
 interface ConnectionStringsState {
     loadStatus: loadStatus;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTask.tsx
@@ -43,7 +43,7 @@ export default function EditGenAiTask({ queryParams }: ReactQueryParamsProps<Que
             dispatch(editGenAiTaskActions.sourceViewSet(queryParams.sourceView));
         }
 
-        dispatch(connectionStringsActions.viewContextSet("aiConnectionStrings"));
+        dispatch(connectionStringsActions.viewContextSet("aiTask"));
 
         return () => {
             dispatch(editGenAiTaskActions.reset());

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -110,7 +110,7 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
         super.activate(args);
         const deferred = $.Deferred<void>();
 
-        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("aiConnectionStrings"));
+        storeCompat.globalDispatch(connectionStringsSlice.connectionStringsActions.viewContextSet("aiTask"));
         this.sourceView(args.sourceView);
         
         this.loadPossibleMentors();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24790/AI-Agent-Show-only-the-chat-model-type-when-creating-a-connection-string-from-inside-the-agent-definition

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
