### PR TITLE
RavenDB-22767 Custom build on top of 6.2.8. Explicitly dispose read tx and add cancellation tokens to FlushAsync calls

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -197,6 +197,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         var clusterWideTx = parameters.TxMode == TransactionMode.ClusterWide;
         var result = await GetDocumentsByIdImplAsync(context, parameters.Ids, parameters.IncludePaths, revisions, parameters.Counters, timeSeries, parameters.CompareExchange, parameters.MetadataOnly, clusterWideTx, etag);
 
+        using var _ = result.ReadTransaction;
+
         if (result.StatusCode == HttpStatusCode.NotFound)
         {
             if (etag == HttpCache.NotFoundResponse)
@@ -297,6 +299,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
     protected async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> GetDocumentsAsync(TOperationContext context, long? etag, StartsWithParams startsWith, bool metadataOnly, string changeVector)
     {
         var result = await GetDocumentsImplAsync(context, etag, startsWith, changeVector);
+
+        using var _ = result.ReadTransaction;
 
         if (changeVector == result.Etag)
         {
@@ -489,6 +493,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         public string Etag { get; set; }
 
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
+
+        public DocumentsTransaction ReadTransaction;
     }
 
     protected sealed class DocumentsResult
@@ -500,6 +506,8 @@ internal abstract class AbstractDocumentHandlerProcessorForGet<TRequestHandler, 
         public ShardedPagingContinuation ContinuationToken { get; set; }
 
         public string Etag { get; set; }
+
+        public DocumentsTransaction ReadTransaction;
     }
 
     protected sealed class StartsWithParams

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -15,6 +15,7 @@ using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Queries.Revisions;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -23,13 +24,16 @@ namespace Raven.Server.Documents.Handlers.Processors.Documents;
 
 internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerProcessorForGet<DocumentHandler, DocumentsOperationContext, Document>
 {
+    private readonly OperationCancelToken _cts;
+
     public DocumentHandlerProcessorForGet(HttpMethod method, [NotNull] DocumentHandler requestHandler) : base(method, requestHandler)
     {
+        _cts = RequestHandler.CreateHttpRequestBoundOperationToken();
     }
 
     protected override bool SupportsShowingRequestInTrafficWatch => true;
 
-    protected override CancellationToken CancellationToken => RequestHandler.Database.DatabaseShutdown;
+    protected override CancellationToken CancellationToken => _cts.Token;
 
     protected override ValueTask<DocumentsByIdResult<Document>> GetDocumentsByIdImplAsync(
         DocumentsOperationContext context,
@@ -218,5 +222,12 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             Etag = databaseChangeVector,
             ReadTransaction = readTx
         });
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        _cts?.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -73,7 +73,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         }
 
         long lastModifiedIndex = RequestHandler.Database.ClusterWideTransactionIndexWaiter.LastIndex;
-        context.OpenReadTransaction();
+        var readTx = context.OpenReadTransaction();
 
         foreach (var id in ids)
         {
@@ -156,7 +156,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             RevisionIncludes = includeRevisions,
             CounterIncludes = includeCounters,
             TimeSeriesIncludes = includeTimeSeries,
-            CompareExchangeIncludes = includeCompareExchangeValues?.Results
+            CompareExchangeIncludes = includeCompareExchangeValues?.Results,
+            ReadTransaction = readTx
         });
     }
 
@@ -181,7 +182,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
     protected override ValueTask<DocumentsResult> GetDocumentsImplAsync(DocumentsOperationContext context, long? etag, StartsWithParams startsWith, string changeVector)
     {
-        context.OpenReadTransaction();
+        var readTx = context.OpenReadTransaction();
 
         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
 
@@ -214,7 +215,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         return new ValueTask<DocumentsResult>(new DocumentsResult
         {
             Documents = documents,
-            Etag = databaseChangeVector
+            Etag = databaseChangeVector,
+            ReadTransaction = readTx
         });
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3362,7 +3362,7 @@ namespace Raven.Server.Documents.Indexes
                     using (var indexTx = indexContext.OpenReadTransaction())
                     {
                         if (queryContext.AreTransactionsOpened() == false)
-                            queryContext.OpenReadTransaction();
+                            resultToFill.ReadTransactionDispose = queryContext.OpenReadTransaction();
 
                         // we have to open read tx for mapResults _after_ we open index tx
 
@@ -3375,6 +3375,8 @@ namespace Raven.Server.Documents.Indexes
                             isStale = IsStale(queryContext, indexContext, cutoffEtag?.DocEtag, cutoffEtag?.ReferenceEtag, cutoffEtag?.CompareExchangeReferenceEtag);
                             if (WillResultBeAcceptable(isStale, query, wait) == false)
                             {
+                                resultToFill.ReadTransactionDispose?.Dispose();
+                                resultToFill.ReadTransactionDispose = null;
                                 queryContext.CloseTransaction();
 
                                 Debug.Assert(query.WaitForNonStaleResultsTimeout != null);

--- a/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
@@ -107,8 +107,11 @@ namespace Raven.Server.Documents.Queries
        
         public abstract IRevisionIncludes GetRevisionIncludes();
 
+        public IDisposable ReadTransactionDispose;
+
         public virtual void Dispose()
         {
+            ReadTransactionDispose?.Dispose();
         }
     }
 }

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -63,8 +63,8 @@ namespace Sparrow.Json
         {
             DisposeInternal();
 
-            if (await FlushAsync().ConfigureAwait(false) > 0)
-                await _outputStream.FlushAsync().ConfigureAwait(false);
+            if (await FlushAsync(_cancellationToken).ConfigureAwait(false) > 0)
+                await _outputStream.FlushAsync(_cancellationToken).ConfigureAwait(false);
 
 #if !NETSTANDARD2_0
             await _stream.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767

### Additional description

Additional changes on top of  https://github.com/ravendb/ravendb/pull/21103

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
