### PR TITLE
RavenDB-24902 Use Task.ContinueWith with the state where possible

### DIFF
--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
@@ -30,15 +30,17 @@ internal abstract class AbstractDatabaseConnectionState
         {
             var task = _firstSet.Task.IgnoreUnobservedExceptions();
 
-            connection.ContinueWith(t =>
+            connection.ContinueWith(static (t, firstSet) =>
             {
+                var tcs = (TaskCompletionSource<object>)firstSet;
+                
                 if (t.IsFaulted)
-                    _firstSet.TrySetException(t.Exception);
+                    tcs.TrySetException(t.Exception);
                 else if (t.IsCanceled)
-                    _firstSet.TrySetCanceled();
+                    tcs.TrySetCanceled();
                 else
-                    _firstSet.TrySetResult(null);
-            });
+                    tcs.TrySetResult(null);
+            }, _firstSet);
         }
         _connected = connection;
     }

--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
@@ -33,7 +33,7 @@ internal abstract class AbstractDatabaseConnectionState
             connection.ContinueWith(static (t, firstSet) =>
             {
                 var tcs = (TaskCompletionSource<object>)firstSet;
-                
+
                 if (t.IsFaulted)
                     tcs.TrySetException(t.Exception);
                 else if (t.IsCanceled)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
@@ -29,13 +29,13 @@ namespace Raven.Client.Documents.Session
             PendingLazyOperations.Add(operation);
             var lazyValue = new Lazy<Task<T>>(() =>
                 ExecuteAllPendingLazyOperationsAsync(token)
-                    .ContinueWith(t =>
+                    .ContinueWith(static (t, op) =>
                     {
                         if (t.Exception != null)
                             throw new InvalidOperationException("Could not perform add lazy operation", t.Exception);
 
-                        return GetOperationResult<T>(operation.Result);
-                    }, token));
+                        return GetOperationResult<T>(((ILazyOperation)op).Result);
+                    }, operation, token));
 
             if (onEval != null)
                 OnEvaluateLazy[operation] = theResult => onEval(GetOperationResult<T>(theResult));
@@ -47,17 +47,17 @@ namespace Raven.Client.Documents.Session
         {
             PendingLazyOperations.Add(operation);
             var lazyValue = new Lazy<Task<int>>(() => ExecuteAllPendingLazyOperationsAsync(token)
-                .ContinueWith(t =>
+                .ContinueWith(static (t, op) =>
                 {
                     if (t.Exception != null)
                         throw new InvalidOperationException("Could not perform lazy count", t.Exception);
                     
-                    var value = operation.QueryResult.TotalResults;
+                    var value = ((ILazyOperation)op).QueryResult.TotalResults;
                     if (value > int.MaxValue)
                         DocumentSession.ThrowWhenResultsAreOverInt32(value, nameof(AddLazyCountOperation), nameof(AddLazyLongCountOperation));
                     
                     return (int)value;
-                }, token));
+                }, operation, token));
 
             return lazyValue;
         }
@@ -66,13 +66,13 @@ namespace Raven.Client.Documents.Session
         {
             PendingLazyOperations.Add(operation);
             var lazyValue = new Lazy<Task<long>>(() => ExecuteAllPendingLazyOperationsAsync(token)
-                .ContinueWith(t =>
+                .ContinueWith(static (t, op) =>
                 {
                     if (t.Exception != null)
                         throw new InvalidOperationException("Could not perform lazy count", t.Exception);
                     
-                    return operation.QueryResult.TotalResults;
-                }, token));
+                    return ((ILazyOperation) op).QueryResult.TotalResults;
+                }, operation, token));
 
             return lazyValue;
         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1908,7 +1908,7 @@ namespace Raven.Client.Http
             }
 
             var nodeStatus = new NodeStatus(this, copy[i]);
-            return CheckNodeStatusCallback(nodeStatus).ContinueWith(t => nodeStatus.Dispose());
+            return CheckNodeStatusCallback(nodeStatus).ContinueWith(static (t, status) => ((NodeStatus)status).Dispose(), nodeStatus);
         }
 
         private async Task CheckNodeStatusCallback(NodeStatus nodeStatus)

--- a/src/Raven.Client/Util/WebSocketStream.cs
+++ b/src/Raven.Client/Util/WebSocketStream.cs
@@ -45,7 +45,7 @@ namespace Raven.Client.Util
                                                 WebSocketMessageType.Text, 
                                                 false,_cancellationToken);
             _activeWriteTasks.Add(sendTask);
-            sendTask.ContinueWith(t => _activeWriteTasks.TryRemove(t), _cancellationToken);
+            sendTask.ContinueWith(static (t, active) => ((ConcurrentSet<Task>)(active)).TryRemove(t), _activeWriteTasks, _cancellationToken);
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is <see langword="null" />.</exception>

--- a/src/Raven.Server/Utils/AsyncLock.cs
+++ b/src/Raven.Server/Utils/AsyncLock.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Utils
             var wait = _semaphore.WaitAsync();
             return wait.IsCompleted ?
                         _releaser :
-                        wait.ContinueWith((_, state) => (IDisposable)state,
+                        wait.ContinueWith(static (_, state) => (IDisposable)state,
                             _releaser.Result, CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24902/Use-Task.ContinueWith-with-the-state-where-possible

### Additional description

`Task.ContinueWith` has an overload that accepts an additional `state` parameter. This allows to create continuations that require no closure allocation. We should prefer this over a closure allocating version, whenever the state can be passed as a single object. There are just a few changes here, but the main one is the one on the client side with `Lazy`. It does not capture a closure now.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
