### PR TITLE
RavenDB-24789 : AI Agent: Add alerts for an exceeded tool response

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
@@ -10,6 +10,18 @@ public class AiUsage : IDynamicJsonValueConvertible
     public int TotalTokens { get; set; }
     public int CachedTokens { get; set; }
 
+    public AiUsage()
+    {
+    }
+
+    public AiUsage(AiUsage other)
+    {
+        PromptTokens = other.PromptTokens;
+        CompletionTokens = other.CompletionTokens;
+        TotalTokens = other.TotalTokens;
+        CachedTokens = other.CachedTokens;
+    }
+
     internal void UpdateFrom(BlittableJsonReaderObject json)
     {
         json.TryGet("prompt_tokens", out int promptTokens);

--- a/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
@@ -10,18 +10,6 @@ public class AiUsage : IDynamicJsonValueConvertible
     public int TotalTokens { get; set; }
     public int CachedTokens { get; set; }
 
-    public AiUsage()
-    {
-    }
-
-    public AiUsage(AiUsage other)
-    {
-        PromptTokens = other.PromptTokens;
-        CompletionTokens = other.CompletionTokens;
-        TotalTokens = other.TotalTokens;
-        CachedTokens = other.CachedTokens;
-    }
-
     internal void UpdateFrom(BlittableJsonReaderObject json)
     {
         json.TryGet("prompt_tokens", out int promptTokens);

--- a/src/Raven.Server/Config/Categories/AiConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/AiConfiguration.cs
@@ -50,4 +50,9 @@ public sealed class AiConfiguration : ConfigurationCategory
     [ConfigurationEntry("Ai.Agent.Trimming.Summarization.SummarizationResultPrefix", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public string SummarizationResultPrefix { get; set; }
 
+
+    [Description("The recommanded token threshold for a tool response to the LLM. If the response exceeds this threshold, a notification will be raised.")]
+    [DefaultValue(10_000)]
+    [ConfigurationEntry("Ai.Agent.Tools.TokenUsageThreshold", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+    public int ToolsTokenUsageThreshold { get; set; }
 }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -943,6 +943,9 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string Required = "required";
             public const string Items = "items";
             public const string Description = "description";
+            public const string Id = "id";
+            public const string Function = "function";
+            public const string Arguments = "arguments";
 
             // Values
             public const string TypeObject = "object";

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -25,6 +23,7 @@ using Newtonsoft.Json;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Commands.MultiGet;
 using Raven.Client.Documents.Queries;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using ChatConstants = Raven.Server.Documents.AI.ChatCompletionClient.Constants;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents
@@ -104,7 +103,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
             try
             {
-                r = await TalkAsync(context, configuration, document, token: token);
+                r = await TalkAsync(context, configuration, conversationId, document, token: token);
             }
             catch (Exception e)
             {
@@ -141,7 +140,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
             try
             {
-                r = await StreamingTalkAsync(context, configuration, document, streamPropertyPath, async (data) =>
+                r = await StreamingTalkAsync(context, configuration, conversationId, document, streamPropertyPath, async (data) =>
                 {
                     while (true)
                     {
@@ -393,27 +392,29 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> StreamingTalkAsync(
             JsonOperationContext context,
             AiAgentConfiguration configuration,
+            string conversationId,
             ConversationDocument document,
             string firstStreamPropertyPath,
             Func<Memory<byte>, Task> streaming,
             CancellationToken token = default)
         {
             using var talker = new Talker(this, context, configuration, document, firstStreamPropertyPath, streaming);
-            return await RunInternalAsync(context, configuration, document, talker, token);
+            return await RunInternalAsync(context, configuration, conversationId, document, talker, token);
         }
         
         public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> TalkAsync(
             JsonOperationContext context,
             AiAgentConfiguration configuration,
+            string conversationId,
             ConversationDocument document,
             CancellationToken token = default)
         {
             using var talker = new Talker(this, context, configuration, document, firstStreamPropertyPath: null, streaming: null);
-            return await RunInternalAsync(context, configuration, document, talker, token);
+            return await RunInternalAsync(context, configuration, conversationId, document, talker, token);
         }
 
         private async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> RunInternalAsync(
-            JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document,
+            JsonOperationContext context, AiAgentConfiguration configuration, string conversationId, ConversationDocument document,
             Talker talker, CancellationToken token)
         {
             talker.Init();
@@ -425,6 +426,23 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 await talker.RunAsync(ContextPool,request, token);
                 talker.UpdateDocument();
 
+                var currentTurnTokens = talker.AiUsage.PromptTokens - document.CurrentUsage.PromptTokens;
+
+                if (currentTurnTokens > RequestHandler.Database.Configuration.Ai.ToolsTokenUsageThreshold)
+                {
+                    if (document.TryGetDetailsOfRecentToolCall(configuration, out var toolCalls))
+                    {
+                        ExceededTokenThresholdDetails.Add(
+                            RequestHandler.Database.NotificationCenter,
+                            configuration.Name,
+                            conversationId,
+                            currentTurnTokens,
+                            RequestHandler.Database.Configuration.Ai.ToolsTokenUsageThreshold,
+                            toolCalls
+                        );
+                    }
+                }
+
                 if (talker.ResponseType is AiResponseType.Result)
                     break;
 
@@ -435,6 +453,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             var history = await TryReduceChatSizeAsync(context, talker.Client, configuration, document, talker.AiUsage, token);
+            document.CurrentUsage = talker.AiUsage;
 
             return (talker.Result, document, history);
         }
@@ -540,6 +559,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     "system/msg"), usage);
 
             oldChat.UpdateUsage(usage);
+            oldChat.CurrentUsage = new AiUsage();
         }
 
         private bool TryGetUserTools(JsonOperationContext context, ConversationDocument document, AiAgentConfiguration configuration, List<AiToolCall> toolCalls)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -165,8 +165,6 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             throw new ArgumentException($"Missing HistoryDocuments in '{id}' conversation document");
         if (document.TryGet(nameof(TotalUsage), out BlittableJsonReaderObject usage) == false)
             throw new ArgumentException($"AI Usage in '{id}' conversation document");
-        if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsage) == false)
-            throw new ArgumentException($"AI Usage in '{id}' conversation document");
         if (document.TryGet(nameof(OpenActionCalls), out BlittableJsonReaderObject openToolCalls) == false)
             throw new ArgumentException($"Missing Open Tool Calls in '{id}' conversation document");
         if (document.TryGet(nameof(LastMessageAt), out DateTime lastMessageAt) == false)
@@ -175,7 +173,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             throw new ArgumentException($"Missing CreatedAt in '{id}' conversation document");
         if (document.TryGet(nameof(Expires), out TimeSpan? expires) == false)
             throw new ArgumentException($"Missing Expires in '{id}' conversation document");
-
+        
         var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
         {
@@ -183,18 +181,23 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             openTools.Add(callId, call);
         }
 
-        return new ConversationDocument(agent, parameters?.CloneOnTheSameContext())
+        var conversation =  new ConversationDocument(agent, parameters?.CloneOnTheSameContext())
         {
             Id = id,
             Messages = messages.Items.Select(m=>((BlittableJsonReaderObject)m).CloneOnTheSameContext()).ToList(),
             LinkedConversations = historyDocs.Items.Select(s => s.ToString()).ToList(),
             TotalUsage = JsonDeserializationClient.AiUsage(usage),
-            CurrentUsage = JsonDeserializationClient.AiUsage(currentUsage),
             OpenActionCalls = openTools,
             LastMessageAt = lastMessageAt,
             CreatedAt = createAt,
             Expires = expires,
         };
+
+        if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsageBlittable))
+        {
+            conversation.CurrentUsage = JsonDeserializationClient.AiUsage(currentUsageBlittable);
+        }
+        return conversation;
     }
 
     public static List<BlittableJsonReaderObject> GenerateTools(JsonOperationContext context, AiAgentConfiguration configuration)
@@ -271,51 +274,64 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public bool TryGetDetailsOfRecentToolCall(AiAgentConfiguration configuration, out List<ExceededTokenThresholdDetails.ToolCallDetails> toolCalls)
     {
         toolCalls = null;
+
+        var lastMessage = Messages.LastOrDefault();
+        if (lastMessage?.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray _) == true)
+            return false;
+
         for (var i = Messages.Count - 1; i >= 0; i--)
         {
             var m = Messages[i];
 
-            if (m.TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string r) && r == ChatCompletionClient.Constants.RequestFields.RoleUserValue)
+            if (m.TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string role) == false)
             {
-                break;
+                continue;
             }
 
-            if (r == ChatCompletionClient.Constants.RequestFields.RoleAssistantValue && m.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCallsArray))
+            switch (role)
             {
-                foreach (BlittableJsonReaderObject call in toolCallsArray)
-                {
-                    call.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Id, out string id);
-                    call.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Function, out BlittableJsonReaderObject function);
-                    function.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Name, out string name);
-                    function.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Arguments, out string arguments);
+                case ChatCompletionClient.Constants.RequestFields.RoleUserValue:
+                    return false;
 
-                    ToolType toolType;
-                    if (configuration.FindAction(name) != null)
+                case ChatCompletionClient.Constants.RequestFields.RoleAssistantValue:
+                    if (m.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCallsArray))
                     {
-                        toolType = ToolType.Action;
-                    }
-                    else if (configuration.FindQuery(name) != null)
-                    {
-                        toolType = ToolType.Query;
-                    }
-                    else
-                    {
-                        toolType = ToolType.Unknown;
-                    }
+                        toolCalls = [];
+                        foreach (BlittableJsonReaderObject call in toolCallsArray)
+                        {
+                            call.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Id, out string id);
+                            call.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Function, out BlittableJsonReaderObject function);
+                            function.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Name, out string name);
+                            function.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Arguments, out string arguments);
 
-                    toolCalls ??= new List<ExceededTokenThresholdDetails.ToolCallDetails>();
+                            ToolType toolType = GetToolType(configuration, name);
 
-                    toolCalls.Add(new ExceededTokenThresholdDetails.ToolCallDetails
-                    {
-                        Id = id,
-                        Name = name,
-                        Type = toolType,
-                        Arguments = arguments
-                    });
-                }
+                            toolCalls.Add(new ExceededTokenThresholdDetails.ToolCallDetails
+                            {
+                                Id = id,
+                                Name = name,
+                                Type = toolType,
+                                Arguments = arguments
+                            });
+                        }
+                        return true;
+                    }
+                    break;
+
+                default:
+                    continue;
             }
         }
 
-        return toolCalls?.Count > 0;
+        return false;
+    }
+
+    private static ToolType GetToolType(AiAgentConfiguration configuration, string name)
+    {
+        if (configuration.FindAction(name) != null)
+        {
+            return ToolType.Action;
+        }
+        return configuration.FindQuery(name) != null ? ToolType.Query : ToolType.Unknown;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -8,10 +8,10 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
-using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents;
 
@@ -24,6 +24,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public List<string> LinkedConversations = [];
     public Dictionary<string, AiAgentActionRequest> OpenActionCalls = [];
     public AiUsage TotalUsage = new AiUsage();
+    public AiUsage CurrentUsage = new AiUsage();
     public string ChangeVector;
     public string Id;
 
@@ -134,6 +135,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [nameof(LastMessageAt)] = LastMessageAt,
             [nameof(CreatedAt)] = CreatedAt,
             [nameof(Expires)] = Expires,
+            [nameof(CurrentUsage)] = CurrentUsage
         };
     }
     
@@ -163,6 +165,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             throw new ArgumentException($"Missing HistoryDocuments in '{id}' conversation document");
         if (document.TryGet(nameof(TotalUsage), out BlittableJsonReaderObject usage) == false)
             throw new ArgumentException($"AI Usage in '{id}' conversation document");
+        if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsage) == false)
+            throw new ArgumentException($"AI Usage in '{id}' conversation document");
         if (document.TryGet(nameof(OpenActionCalls), out BlittableJsonReaderObject openToolCalls) == false)
             throw new ArgumentException($"Missing Open Tool Calls in '{id}' conversation document");
         if (document.TryGet(nameof(LastMessageAt), out DateTime lastMessageAt) == false)
@@ -185,6 +189,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             Messages = messages.Items.Select(m=>((BlittableJsonReaderObject)m).CloneOnTheSameContext()).ToList(),
             LinkedConversations = historyDocs.Items.Select(s => s.ToString()).ToList(),
             TotalUsage = JsonDeserializationClient.AiUsage(usage),
+            CurrentUsage = JsonDeserializationClient.AiUsage(currentUsage),
             OpenActionCalls = openTools,
             LastMessageAt = lastMessageAt,
             CreatedAt = createAt,
@@ -261,5 +266,56 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         TotalUsage.PromptTokens += usage.PromptTokens;
         TotalUsage.CompletionTokens += usage.CompletionTokens;
         TotalUsage.CachedTokens += usage.CachedTokens;
+    }
+
+    public bool TryGetDetailsOfRecentToolCall(AiAgentConfiguration configuration, out List<ExceededTokenThresholdDetails.ToolCallDetails> toolCalls)
+    {
+        toolCalls = null;
+        for (var i = Messages.Count - 1; i >= 0; i--)
+        {
+            var m = Messages[i];
+
+            if (m.TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string r) && r == ChatCompletionClient.Constants.RequestFields.RoleUserValue)
+            {
+                break;
+            }
+
+            if (r == ChatCompletionClient.Constants.RequestFields.RoleAssistantValue && m.TryGet(ChatCompletionClient.Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCallsArray))
+            {
+                foreach (BlittableJsonReaderObject call in toolCallsArray)
+                {
+                    call.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Id, out string id);
+                    call.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Function, out BlittableJsonReaderObject function);
+                    function.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Name, out string name);
+                    function.TryGet(ChatCompletionClient.Constants.JsonSchemaFields.Arguments, out string arguments);
+
+                    ToolType toolType;
+                    if (configuration.FindAction(name) != null)
+                    {
+                        toolType = ToolType.Action;
+                    }
+                    else if (configuration.FindQuery(name) != null)
+                    {
+                        toolType = ToolType.Query;
+                    }
+                    else
+                    {
+                        toolType = ToolType.Unknown;
+                    }
+
+                    toolCalls ??= new List<ExceededTokenThresholdDetails.ToolCallDetails>();
+
+                    toolCalls.Add(new ExceededTokenThresholdDetails.ToolCallDetails
+                    {
+                        Id = id,
+                        Name = name,
+                        Type = toolType,
+                        Arguments = arguments
+                    });
+                }
+            }
+        }
+
+        return toolCalls?.Count > 0;
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -14,6 +14,8 @@ namespace Raven.Server.NotificationCenter.Notifications
         QueueSink_ConsumeError,
         QueueSink_ConsumerCreationError,
 
+        AiAgent_ExceededTokenThreshold,
+
         SqlEtl_ConnectionError,
         SqlEtl_ProviderError,
         

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/LargetToolResponseDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/LargetToolResponseDetails.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Raven.Server.Config;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.NotificationCenter.Notifications.Details
@@ -41,7 +42,9 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
 
         public static void Add(DatabaseNotificationCenter notificationCenter, string agentName, string conversationId, int tokenCount, int tokenThreshold, List<ToolCallDetails> toolCalls)
         {
-            var message = $"In conversation '{conversationId}', the AI Agent '{agentName}' sent a request with {tokenCount} tokens to the LLM, exceeding the threshold of {tokenThreshold} tokens.";
+            var configurationKey = RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold);
+            var message = $"In conversation '{conversationId}', the AI Agent '{agentName}' sent a request with {tokenCount} tokens to the LLM, exceeding the configured threshold of {tokenThreshold} tokens. " +
+                          $"You can adjust the limit by setting the '{configurationKey}' configuration value";
 
             var hasActionTools = toolCalls.Any(tc => tc.Type == ToolType.Action);
             var hasQueryTools = toolCalls.Any(tc => tc.Type == ToolType.Query);

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/LargetToolResponseDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/LargetToolResponseDetails.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public sealed class ExceededTokenThresholdDetails : INotificationDetails
+    {
+        private ExceededTokenThresholdDetails() { }
+
+        private ExceededTokenThresholdDetails(string agentName, string conversationId, int tokenCount, int tokenLimit, List<ToolCallDetails> toolCalls, string recommendation)
+        {
+            AgentName = agentName;
+            ConversationId = conversationId;
+            TokenCount = tokenCount;
+            TokenThreshold = tokenLimit;
+            ToolCalls = toolCalls;
+            Recommendation = recommendation;
+        }
+
+        public string AgentName { get; set; }
+        public string ConversationId { get; set; }
+        public int TokenCount { get; set; }
+        public int TokenThreshold { get; set; }
+        public List<ToolCallDetails> ToolCalls { get; set; }
+        public string Recommendation { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue(GetType())
+            {
+                [nameof(AgentName)] = AgentName,
+                [nameof(ConversationId)] = ConversationId,
+                [nameof(TokenCount)] = TokenCount,
+                [nameof(TokenThreshold)] = TokenThreshold,
+                [nameof(ToolCalls)] = new DynamicJsonArray(ToolCalls.Select(tc => tc.ToJson())),
+                [nameof(Recommendation)] = Recommendation
+            };
+        }
+
+        public static void Add(DatabaseNotificationCenter notificationCenter, string agentName, string conversationId, int tokenCount, int tokenThreshold, List<ToolCallDetails> toolCalls)
+        {
+            var message = $"In conversation '{conversationId}', the AI Agent '{agentName}' sent a request with {tokenCount} tokens to the LLM, exceeding the threshold of {tokenThreshold} tokens.";
+
+            var hasActionTools = toolCalls.Any(tc => tc.Type == ToolType.Action);
+            var hasQueryTools = toolCalls.Any(tc => tc.Type == ToolType.Query);
+
+            var recommendationBuilder = new StringBuilder();
+            if (hasActionTools)
+            {
+                recommendationBuilder.Append("For Action Tools: Consider making the content shorter or use a format that will reduce the total tokens count");
+            }
+
+            if (hasQueryTools)
+            {
+                if (recommendationBuilder.Length > 0)
+                {
+                    recommendationBuilder.Append(" | ");
+                }
+                recommendationBuilder.Append("For Query Tools: Consider using a limit or select fewer fields in your query from your documents to reduce the total size.");
+            }
+
+            var details = new ExceededTokenThresholdDetails
+            (
+                agentName,
+                conversationId,
+                tokenCount,
+                tokenThreshold,
+                toolCalls,
+                recommendationBuilder.ToString()
+                );
+
+            var alert = AlertRaised.Create(
+                notificationCenter.Database,
+                $"AI Agent '{agentName}': Exceeded Token Threshold",
+                message,
+                AlertType.AiAgent_ExceededTokenThreshold,
+                NotificationSeverity.Warning,
+                details: details);
+
+            notificationCenter.Add(alert);
+        }
+
+        public class ToolCallDetails : IDynamicJson
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public ToolType Type { get; set; }
+            public string Arguments { get; set; }
+
+            public DynamicJsonValue ToJson()
+            {
+                return new DynamicJsonValue
+                {
+                    [nameof(Id)] = Id,
+                    [nameof(Name)] = Name,
+                    [nameof(Type)] = Type.ToString(),
+                    [nameof(Arguments)] = Arguments
+                };
+            }
+        }
+    }
+}

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/ToolType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/ToolType.cs
@@ -1,0 +1,9 @@
+﻿namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public enum ToolType
+    {
+        Unknown = 0,
+        Action,
+        Query 
+    }
+}

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/ToolType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/ToolType.cs
@@ -2,7 +2,7 @@
 {
     public enum ToolType
     {
-        Unknown = 0,
+        Unknown,
         Action,
         Query 
     }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
@@ -93,7 +93,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
                     var conv = new ConversationDocument(agent.Name, parameters: parameters);
                     conv.Initialize(context, agent);
-                    var r = await processor.TalkAsync(context, agent, conv, CancellationToken.None);
+                    var r = await processor.TalkAsync(context, agent, conv.Id, conv, CancellationToken.None);
                     var response = r.Response.ToString();
 
                     Assert.Contains("my order", response);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
@@ -1,0 +1,251 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_24789 : RavenTestBase
+    {
+        public RavenDB_24789(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
+        public async Task ShouldRaiseServerAlertOnExceededActionToolResponse(Options options, GenAiConfiguration config)
+        {
+            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "50";
+
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentConfig = new AiAgentConfiguration("alert-tester", config.ConnectionStringName, "You are a test agent. Your only purpose is to call the 'get_long_text' tool, no matter what the user says.")
+            {
+                Actions =
+                [
+                    new AiAgentToolAction { Name = "get_long_text", Description = "A tool that returns a long string.", ParametersSampleObject = "{}" }
+                ],
+                SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+            };
+            var agent = await store.AI.CreateAgentAsync(agentConfig);
+
+            var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+            conversation.SetUserPrompt("Please run the tool.");
+
+            var longResponse = new StringBuilder(150);
+            for (var i = 0; i < 15; i++)
+            {
+                longResponse.Append("1234567890");
+            }
+
+            var result = await conversation.RunAsync<object>();
+            Assert.Equal(AiConversationResult.ActionRequired, result.Status);
+
+            foreach (var action in conversation.RequiredActions())
+            {
+                conversation.AddActionResponse(action.ToolId, longResponse.ToString());
+            }
+
+            await conversation.RunAsync<object>();
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            Assert.True(ValidateDatabaseAlert(db, expectActionTool: true, expectQueryTool: false));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
+        public async Task ShouldRaiseServerAlertOnExceededQueryToolResponse(Options options, GenAiConfiguration config)
+        {
+            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
+
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    await session.StoreAsync(new Product { Name = "Product/" + i});
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            var agentConfig = new AiAgentConfiguration("alert-tester", config.ConnectionStringName,
+                "You are a test agent. Your only purpose is to run the 'get_all_products' tool, no matter what the user says.")
+            {
+                Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "get_all_products", Query = "from Products", Description = "A tool that gets all products", ParametersSampleObject = "{}"
+                    }
+                ],
+                SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+            };
+            var agent = await store.AI.CreateAgentAsync(agentConfig);
+
+            var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+            conversation.SetUserPrompt("Please run the tool.");
+
+            await conversation.RunAsync<object>();
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            Assert.True(ValidateDatabaseAlert(db, expectActionTool: false, expectQueryTool: true));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
+        public async Task ShouldRaiseServerAlertWhenBothToolTypesAreCalled(Options options, GenAiConfiguration config)
+        {
+            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
+
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using (var session = store.OpenAsyncSession())
+            {
+
+                await session.StoreAsync(new Product { Name = "Product" });
+                await session.StoreAsync(new Order { Company = "company" });
+
+                await session.SaveChangesAsync();
+            }
+
+            var agentConfig = new AiAgentConfiguration("alert-tester", config.ConnectionStringName, "You are a test agent. Your only purpose is to call all four tools I gave you.")
+            {
+                Actions =
+                [
+                    new AiAgentToolAction { Name = "get_long_text_1", Description = "A tool that returns a long string.", ParametersSampleObject = "{}" },
+                    new AiAgentToolAction { Name = "get_long_text_2", Description = "Another tool that returns a long string.", ParametersSampleObject = "{}" }
+                ],
+                Queries =
+                [
+                    new AiAgentToolQuery { Name = "get_all_products", Query = "from Products", Description = "A tool that gets all products.", ParametersSampleObject = "{}" },
+                    new AiAgentToolQuery { Name = "get_all_orders", Query = "from Orders", Description = "A tool that gets all orders.", ParametersSampleObject = "{}" }
+                ],
+                SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+            };
+            var agent = await store.AI.CreateAgentAsync(agentConfig);
+
+            var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+            conversation.SetUserPrompt("Please run all the tools.");
+
+            var result = await conversation.RunAsync<object>();
+            Assert.Equal(AiConversationResult.ActionRequired, result.Status);
+
+            var longActionResponse = "a";
+
+            foreach (var action in conversation.RequiredActions())
+            {
+                conversation.AddActionResponse(action.ToolId, longActionResponse);
+            }
+
+            await conversation.RunAsync<object>();
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            Assert.True(ValidateDatabaseAlert(db, expectActionTool: true, expectQueryTool: true));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
+        public async Task ShouldNotRaiseAlertWhenUserMessageExceedsTokenLimitAfterToolCall(Options options, GenAiConfiguration config)
+        {
+            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
+
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentConfig = new AiAgentConfiguration("alert-tester", config.ConnectionStringName, "You are a test agent your only purpose is to run the tool I gave you.")
+            {
+                Actions = [new AiAgentToolAction { Name = "simple_tool", Description = "A simple tool.", ParametersSampleObject = "{}" }],
+                SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+            };
+            var agent = await store.AI.CreateAgentAsync(agentConfig);
+            var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+
+            conversation.SetUserPrompt("Please run the simple_tool.");
+            var result = await conversation.RunAsync<object>();
+            Assert.Equal(AiConversationResult.ActionRequired, result.Status);
+
+            foreach (var action in conversation.RequiredActions())
+            {
+                conversation.AddActionResponse(action.ToolId, "This is a small response.");
+            }
+            await conversation.RunAsync<object>();
+
+            var longUserMessage = new StringBuilder();
+            for (var i = 0; i < 5; i++)
+            {
+                longUserMessage.Append("This is a very long user message designed to exceed the token limit. ");
+            }
+            conversation.SetUserPrompt(longUserMessage.ToString());
+
+            await conversation.RunAsync<object>();
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            using (db.NotificationCenter.GetStored(out var actions))
+            {
+                Assert.Empty(actions);
+            }
+        }
+
+        private static bool ValidateDatabaseAlert(DocumentDatabase db, bool expectActionTool, bool expectQueryTool)
+        {
+            using (db.NotificationCenter.GetStored(out var actions))
+            {
+                var alert = actions.FirstOrDefault();
+                if (alert == null)
+                    return false;
+
+                if (alert.Json.TryGet("Details", out BlittableJsonReaderObject details) == false)
+                    return false;
+
+                if (details.TryGet("TokenCount", out int tokenCount) == false || details.TryGet("TokenThreshold", out int tokenThreshold) == false || tokenCount <= tokenThreshold)
+                    return false;
+
+                if (details.TryGet("ToolCalls", out BlittableJsonReaderArray toolCalls) == false || toolCalls.Length == 0)
+                    return false;
+
+                var actualToolTypes = new HashSet<string>();
+                foreach (BlittableJsonReaderObject toolCall in toolCalls)
+                {
+                    if (toolCall.TryGet("Type", out string toolTypeString))
+                    {
+                        actualToolTypes.Add(toolTypeString);
+                    }
+                }
+
+                var hasActionTool = actualToolTypes.Contains(ToolType.Action.ToString());
+                var hasQueryTool = actualToolTypes.Contains(ToolType.Query.ToString());
+
+                return hasActionTool == expectActionTool && hasQueryTool == expectQueryTool;
+            }
+        }
+
+        private class Order
+        {
+            public string Company { get; set; }
+        }
+
+        private class Product
+        {
+            public string Name { get; set; }
+            public string Description { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
-using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -28,7 +27,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = true, NightlyBuildRequired = false)]
         public async Task ShouldRaiseServerAlertOnExceededActionToolResponse(Options options, GenAiConfiguration config)
         {
-            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "50";
+            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
 
             using var store = GetDocumentStore(options);
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -44,21 +43,17 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = await store.AI.CreateAgentAsync(agentConfig);
 
             var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+
+            conversation.Handle<object>("get_long_text", args =>
+            {
+                var longResponse = new StringBuilder(250);
+                for (var i = 0; i < 25; i++)
+                {
+                    longResponse.Append("1234567890");
+                }
+                return longResponse.ToString();
+            });
             conversation.SetUserPrompt("Please run the tool.");
-
-            var longResponse = new StringBuilder(150);
-            for (var i = 0; i < 15; i++)
-            {
-                longResponse.Append("1234567890");
-            }
-
-            var result = await conversation.RunAsync<object>();
-            Assert.Equal(AiConversationResult.ActionRequired, result.Status);
-
-            foreach (var action in conversation.RequiredActions())
-            {
-                conversation.AddActionResponse(action.ToolId, longResponse.ToString());
-            }
 
             await conversation.RunAsync<object>();
 
@@ -143,17 +138,13 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = await store.AI.CreateAgentAsync(agentConfig);
 
             var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
-            conversation.SetUserPrompt("Please run all the tools.");
 
-            var result = await conversation.RunAsync<object>();
-            Assert.Equal(AiConversationResult.ActionRequired, result.Status);
-
-            var longActionResponse = "a";
-
-            foreach (var action in conversation.RequiredActions())
+            foreach (var action in agentConfig.Actions)
             {
-                conversation.AddActionResponse(action.ToolId, longActionResponse);
+                conversation.Handle<object>(action.Name, _ => "a");
             }
+
+            conversation.SetUserPrompt("Please run all the tools.");
 
             await conversation.RunAsync<object>();
 
@@ -178,25 +169,24 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = await store.AI.CreateAgentAsync(agentConfig);
             var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
 
-            conversation.SetUserPrompt("Please run the simple_tool.");
-            var result = await conversation.RunAsync<object>();
-            Assert.Equal(AiConversationResult.ActionRequired, result.Status);
-
-            foreach (var action in conversation.RequiredActions())
+            foreach (var action in agentConfig.Actions)
             {
-                conversation.AddActionResponse(action.ToolId, "This is a small response.");
+                conversation.Handle<object>(action.Name, _ => "short response");
             }
+            
+            conversation.SetUserPrompt("run the tool");
+
             await conversation.RunAsync<object>();
 
             var longUserMessage = new StringBuilder();
-            for (var i = 0; i < 5; i++)
+
+            for (var i = 0; i < 20; i++)
             {
                 longUserMessage.Append("This is a very long user message designed to exceed the token limit. ");
             }
             conversation.SetUserPrompt(longUserMessage.ToString());
 
             await conversation.RunAsync<object>();
-
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             using (db.NotificationCenter.GetStored(out var actions))
             {
@@ -245,7 +235,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         private class Product
         {
             public string Name { get; set; }
-            public string Description { get; set; }
         }
     }
 }

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -297,6 +297,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(QueueSinkErrorsDetails));
             scripter.AddType(typeof(CpuCreditsExhaustionWarning));
             scripter.AddType(typeof(ConflictPerformanceDetails));
+            scripter.AddType(typeof(ExceededTokenThresholdDetails));
 
             // subscriptions
             scripter.AddType(typeof(SubscriptionStatsCollector));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24789/AI-Agent-Add-alerts-for-an-exceeded-tool-response

### Additional description

New server-side alert that triggers when an AI Agent conversation exceeds a recommended token threshold before making a call to the LLM.

This helps users identify and debug conversations that are becoming inefficient or costly. The alert is raised in TalkAsync based on the final, accurate token count and includes:

The agent name, conversation ID, and token count.

A list of the specific tool calls (name, ID, and type) involved.

Recommendations to help users optimize their tool usage.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio-need to organize the alert details in a table like other alerts.
- [ ] No UI work is needed
