### PR TITLE
RavenDB-24702 AI Agent: display LinkedConversations, link to edit document and warnings

### DIFF
--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -812,7 +812,7 @@ class genUtils {
             return "0";
         }
 
-        return genUtils.formatNumberToStringFixed(tokens, 0);
+        return Number(tokens).toLocaleString();
     }
 
     static getNestedField(object: any, path: string) {

--- a/src/Raven.Studio/typescript/components/common/AiTokensUsagePopoverBody.tsx
+++ b/src/Raven.Studio/typescript/components/common/AiTokensUsagePopoverBody.tsx
@@ -1,0 +1,32 @@
+import genUtils from "common/generalUtils";
+
+interface AiTokensUsagePopoverBodyProps {
+    prompt: number;
+    completion: number;
+    cached: number;
+    total: number;
+}
+
+export default function AiTokensUsagePopoverBody({ prompt, completion, cached, total }: AiTokensUsagePopoverBodyProps) {
+    return (
+        <div>
+            <div className="hstack justify-content-between gap-3">
+                <span>Prompt tokens</span>
+                <span>{genUtils.formatAiTokens(prompt)}</span>
+            </div>
+            <div className="hstack justify-content-between gap-3">
+                <span>Completion tokens</span>
+                <span>{genUtils.formatAiTokens(completion)}</span>
+            </div>
+            <div className="hstack justify-content-between gap-3">
+                <span>Cached tokens</span>
+                <span>{genUtils.formatAiTokens(cached)}</span>
+            </div>
+            <hr className="my-1" />
+            <div className="hstack justify-content-between gap-3">
+                <span>Total tokens used</span>
+                <span>{genUtils.formatAiTokens(total)}</span>
+            </div>
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -19,6 +19,7 @@ import genUtils from "common/generalUtils";
 import Badge from "react-bootstrap/Badge";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import AiTokensUsagePopoverBody from "components/common/AiTokensUsagePopoverBody";
+import AiAgentLinkedConversationsDropdown from "../partials/AiAgentLinkedConversationsDropdown";
 
 export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatAiAgentQueryParams>) {
     const { handleSend, reloadForm, handleNewChat, chatForm, asyncGetDefaultValues, handleSubmit, runChat } =
@@ -31,6 +32,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
     const config = useAppSelector(chatAiAgentSelectors.config);
     const isRawData = useAppSelector(chatAiAgentSelectors.isRawData);
     const document = useAppSelector(chatAiAgentSelectors.document);
+    const conversationId = useAppSelector(chatAiAgentSelectors.conversationId);
 
     const title = config.data?.Name ?? "AI Agent";
 
@@ -68,6 +70,15 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
                     >
                         <Icon icon="plus" /> New chat
                     </Button>
+                    {conversationId && (
+                        <a
+                            href={appUrl.forEditDoc(conversationId, databaseName)}
+                            className="btn btn-secondary rounded-pill"
+                            target="_blank"
+                        >
+                            <Icon icon="document" /> Edit document
+                        </a>
+                    )}
                     <a className="btn btn-secondary rounded-pill" href={appUrl.forAiAgents(databaseName)}>
                         <Icon icon="cancel" /> Cancel
                     </a>
@@ -82,6 +93,9 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
                         Raw data
                     </Switch>
                     {document.data?.Parameters && <AiAgentParametersDropdown parameters={document.data.Parameters} />}
+                    {document.data?.LinkedConversations && (
+                        <AiAgentLinkedConversationsDropdown linkedConversations={document.data.LinkedConversations} />
+                    )}
                 </div>
             </div>
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -15,6 +15,10 @@ import { LoadingView } from "components/common/LoadingView";
 import ChatAiAgentFormBody from "./partials/ChatAiAgentFormBody";
 import AiAgentParametersDropdown from "../partials/AiAgentParametersDropdown";
 import useChatAiAgent, { ChatAiAgentQueryParams } from "./hooks/useChatAiAgent";
+import genUtils from "common/generalUtils";
+import Badge from "react-bootstrap/Badge";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import AiTokensUsagePopoverBody from "components/common/AiTokensUsagePopoverBody";
 
 export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatAiAgentQueryParams>) {
     const { handleSend, reloadForm, handleNewChat, chatForm, asyncGetDefaultValues, handleSubmit, runChat } =
@@ -27,6 +31,8 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
     const config = useAppSelector(chatAiAgentSelectors.config);
     const isRawData = useAppSelector(chatAiAgentSelectors.isRawData);
     const document = useAppSelector(chatAiAgentSelectors.document);
+
+    const title = config.data?.Name ?? "AI Agent";
 
     if (!queryParams?.agentId) {
         router.navigate(appUrl.forAiAgents(databaseName));
@@ -44,9 +50,12 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
     return (
         <div className="h-100 vstack">
             <div className="hstack justify-content-between align-items-start px-3 pt-3">
-                <h2 className="text-truncate w-50 mb-3" title={config.data?.Name}>
-                    <Icon icon="ai-agents" /> {config.data?.Name ?? "AI Agent"}{" "}
-                </h2>
+                <div className="hstack gap-2 w-50 mb-3 align-items-center">
+                    <h2 className="text-truncate m-0" title={title}>
+                        <Icon icon="ai-agents" /> {title}
+                    </h2>
+                    {document.data?.TotalUsage && <TotalUsageBadge usage={document.data.TotalUsage} />}
+                </div>
                 <ChatAiAgentInfoHub />
             </div>
             <div className="hstack mb-2 justify-content-between px-3">
@@ -100,5 +109,26 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
                 />
             </div>
         </div>
+    );
+}
+
+function TotalUsageBadge({ usage }: { usage: Raven.Client.Documents.Operations.AI.AiUsage }) {
+    return (
+        <Badge bg="info" pill>
+            <PopoverWithHoverWrapper
+                placement="bottom"
+                message={
+                    <AiTokensUsagePopoverBody
+                        prompt={usage.PromptTokens}
+                        completion={usage.CompletionTokens}
+                        cached={usage.CachedTokens}
+                        total={usage.TotalTokens}
+                    />
+                }
+            >
+                <Icon icon="info" />
+            </PopoverWithHoverWrapper>
+            Tokens used: {genUtils.formatAiTokens(usage.TotalTokens)}
+        </Badge>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -3,137 +3,30 @@ import { useAppUrls } from "components/hooks/useAppUrls";
 import { useAppDispatch, useAppSelector } from "components/store";
 import router from "plugins/router";
 import { chatAiAgentActions, chatAiAgentSelectors } from "./store/chatAiAgentSlice";
-import { useEffect } from "react";
 import { Icon } from "components/common/Icon";
 import ChatAiAgentInfoHub from "./partials/ChatAiAgentInfoHub";
-import { FormProvider, useForm, useWatch } from "react-hook-form";
-import { ChatAiAgentFormData, chatAiAgentYupResolver } from "./utils/chatAiAgentValidation";
-import { tryHandleSubmit } from "components/utils/common";
-import { AiAgentToolCall } from "../utils/aiAgentsTypes";
+import { FormProvider } from "react-hook-form";
 import SizeGetter from "components/common/SizeGetter";
 import { Switch } from "components/common/Checkbox";
 import Button from "react-bootstrap/Button";
 import classNames from "classnames";
-import { useAsyncCallback } from "react-async-hook";
-import { TimeInSeconds } from "common/constants/timeInSeconds";
 import { LoadError } from "components/common/LoadError";
 import { LoadingView } from "components/common/LoadingView";
-import { useServices } from "components/hooks/useServices";
-import { licenseSelectors } from "components/common/shell/licenseSlice";
-import { defaultItemsToProcess } from "components/pages/database/settings/documentExpiration/DocumentExpiration";
 import ChatAiAgentFormBody from "./partials/ChatAiAgentFormBody";
 import AiAgentParametersDropdown from "../partials/AiAgentParametersDropdown";
+import useChatAiAgent, { ChatAiAgentQueryParams } from "./hooks/useChatAiAgent";
 
-interface QueryParams {
-    agentId: string;
-    conversationId: string;
-    isHistory: boolean;
-}
+export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatAiAgentQueryParams>) {
+    const { handleSend, reloadForm, handleNewChat, chatForm, asyncGetDefaultValues, handleSubmit, runChat } =
+        useChatAiAgent(queryParams);
 
-export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<QueryParams>) {
     const dispatch = useAppDispatch();
     const { appUrl } = useAppUrls();
-    const { databasesService } = useServices();
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const config = useAppSelector(chatAiAgentSelectors.config);
     const isRawData = useAppSelector(chatAiAgentSelectors.isRawData);
-    const isDocumentExpirationEnabled = useAppSelector(chatAiAgentSelectors.isDocumentExpirationEnabled);
-    const isCommunityLicense = useAppSelector(licenseSelectors.licenseType) === "Community";
     const document = useAppSelector(chatAiAgentSelectors.document);
-
-    // Reset store on unmount
-    useEffect(() => {
-        return () => {
-            dispatch(chatAiAgentActions.reset());
-        };
-    }, []);
-
-    const asyncGetDefaultValues = useAsyncCallback<ChatAiAgentFormData>(async () => {
-        const isDocumentExpirationEnabled = await dispatch(
-            chatAiAgentActions.getIsDocumentExpirationEnabled(databaseName)
-        ).unwrap();
-
-        dispatch(chatAiAgentActions.conversationIdSet(queryParams?.conversationId));
-
-        const config = await dispatch(
-            chatAiAgentActions.getConfig({ databaseName, id: queryParams?.agentId })
-        ).unwrap();
-
-        if (queryParams?.conversationId) {
-            dispatch(chatAiAgentActions.getDocument({ databaseName, id: queryParams?.conversationId }));
-        }
-
-        return {
-            prompt: "",
-            parameters: config.Parameters.map((x) => ({ name: x.Name, value: "" })),
-            isEnableDocumentExpiration: !isDocumentExpirationEnabled,
-            isDocumentExpireInCustomizeEnabled: false,
-            persistenceConversationIdPrefix: "",
-            persistenceExpiresInSeconds: TimeInSeconds.Day * 30,
-        };
-    });
-
-    const areParametersRequired = !window.location.href.includes("conversationId");
-
-    const chatForm = useForm<ChatAiAgentFormData>({
-        resolver: chatAiAgentYupResolver,
-        defaultValues: asyncGetDefaultValues.execute,
-        context: {
-            areParametersRequired,
-        },
-    });
-
-    const reloadForm = async () => {
-        const result = await asyncGetDefaultValues.execute();
-        chatForm.reset(result);
-    };
-
-    const { control, handleSubmit, setValue } = chatForm;
-
-    const formValues = useWatch({
-        control,
-    });
-
-    const runChat = async (toolCallParameters?: AiAgentToolCall[]) => {
-        await dispatch(
-            chatAiAgentActions.runChat({
-                databaseName,
-                formValues,
-                toolCallParameters,
-                isDocumentExpirationEnabled: isDocumentExpirationEnabled.data,
-            })
-        ).unwrap();
-
-        setValue("prompt", "");
-    };
-
-    const handleSend = async () => {
-        return tryHandleSubmit(async () => {
-            if (
-                queryParams?.conversationId == null &&
-                isDocumentExpirationEnabled.status === "success" &&
-                !isDocumentExpirationEnabled.data &&
-                formValues.isEnableDocumentExpiration
-            ) {
-                await databasesService.saveExpirationConfiguration(databaseName, {
-                    Disabled: false,
-                    DeleteFrequencyInSec: isCommunityLicense ? minimumCommunityDeleteFrequencyInSec : null,
-                    MaxItemsToProcess: defaultItemsToProcess,
-                });
-            }
-
-            runChat();
-        });
-    };
-
-    const handleNewChat = () => {
-        dispatch(chatAiAgentActions.conversationIdSet(null));
-        dispatch(chatAiAgentActions.messagesSet([]));
-        dispatch(chatAiAgentActions.documentSet(null));
-        dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(false));
-        chatForm.reset();
-    };
 
     if (!queryParams?.agentId) {
         router.navigate(appUrl.forAiAgents(databaseName));
@@ -209,5 +102,3 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<Query
         </div>
     );
 }
-
-const minimumCommunityDeleteFrequencyInSec = TimeInSeconds.Day * 36;

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
@@ -1,0 +1,161 @@
+import { defaultItemsToProcess } from "components/pages/database/settings/documentExpiration/DocumentExpiration";
+import { chatAiAgentActions, chatAiAgentSelectors } from "../store/chatAiAgentSlice";
+import { tryHandleSubmit } from "components/utils/common";
+import { TimeInSeconds } from "common/constants/timeInSeconds";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useChanges } from "components/hooks/useChanges";
+import { useServices } from "components/hooks/useServices";
+import { useAppDispatch, useAppSelector } from "components/store";
+import { useEffect } from "react";
+import { useAsyncCallback } from "react-async-hook";
+import { useForm, useWatch } from "react-hook-form";
+import { AiAgentToolCall } from "../../utils/aiAgentsTypes";
+import { ChatAiAgentFormData, chatAiAgentYupResolver } from "../utils/chatAiAgentValidation";
+
+export interface ChatAiAgentQueryParams {
+    agentId: string;
+    conversationId: string;
+    isHistory: boolean;
+}
+
+export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
+    const dispatch = useAppDispatch();
+    const { databasesService } = useServices();
+    const { databaseChangesApi } = useChanges();
+
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const isDocumentExpirationEnabled = useAppSelector(chatAiAgentSelectors.isDocumentExpirationEnabled);
+    const isCommunityLicense = useAppSelector(licenseSelectors.licenseType) === "Community";
+    const document = useAppSelector(chatAiAgentSelectors.document);
+    const conversationId = useAppSelector(chatAiAgentSelectors.conversationId);
+    const isLoading = useAppSelector(chatAiAgentSelectors.isLoading);
+
+    // Reset store on unmount
+    useEffect(() => {
+        return () => {
+            dispatch(chatAiAgentActions.reset());
+        };
+    }, []);
+
+    const currentDocumentChangeVector = document.data?.["@metadata"]?.["@change-vector"];
+
+    // Watch for document changes
+    useEffect(() => {
+        if (databaseChangesApi) {
+            const watchDocument = databaseChangesApi.watchDocument(conversationId, (e) => {
+                if (isLoading || e.ChangeVector === currentDocumentChangeVector) {
+                    return;
+                }
+
+                if (e.Type === "Delete") {
+                    dispatch(chatAiAgentActions.isDocumentDeletedSet(true));
+                } else {
+                    dispatch(chatAiAgentActions.isDocumentChangedSet(true));
+                }
+            });
+
+            return () => {
+                watchDocument.off();
+            };
+        }
+    }, [databaseChangesApi, conversationId, currentDocumentChangeVector, isLoading]);
+
+    const asyncGetDefaultValues = useAsyncCallback<ChatAiAgentFormData>(async () => {
+        const isDocumentExpirationEnabled = await dispatch(
+            chatAiAgentActions.getIsDocumentExpirationEnabled(databaseName)
+        ).unwrap();
+
+        dispatch(chatAiAgentActions.conversationIdSet(queryParams?.conversationId));
+
+        const config = await dispatch(
+            chatAiAgentActions.getConfig({ databaseName, id: queryParams?.agentId })
+        ).unwrap();
+
+        if (queryParams?.conversationId) {
+            dispatch(chatAiAgentActions.getDocument({ databaseName, id: queryParams?.conversationId }));
+        }
+
+        return {
+            prompt: "",
+            parameters: config.Parameters.map((x) => ({ name: x.Name, value: "" })),
+            isEnableDocumentExpiration: !isDocumentExpirationEnabled,
+            isDocumentExpireInCustomizeEnabled: false,
+            persistenceConversationIdPrefix: "",
+            persistenceExpiresInSeconds: TimeInSeconds.Day * 30,
+        };
+    });
+
+    const areParametersRequired = !window.location.href.includes("conversationId");
+
+    const chatForm = useForm<ChatAiAgentFormData>({
+        resolver: chatAiAgentYupResolver,
+        defaultValues: asyncGetDefaultValues.execute,
+        context: {
+            areParametersRequired,
+        },
+    });
+
+    const reloadForm = async () => {
+        const result = await asyncGetDefaultValues.execute();
+        chatForm.reset(result);
+    };
+
+    const { control, handleSubmit, setValue } = chatForm;
+
+    const formValues = useWatch({
+        control,
+    });
+
+    const runChat = async (toolCallParameters?: AiAgentToolCall[]) => {
+        await dispatch(
+            chatAiAgentActions.runChat({
+                databaseName,
+                formValues,
+                toolCallParameters,
+                isDocumentExpirationEnabled: isDocumentExpirationEnabled.data,
+            })
+        ).unwrap();
+
+        setValue("prompt", "");
+    };
+
+    const handleSend = async () => {
+        return tryHandleSubmit(async () => {
+            if (
+                queryParams?.conversationId == null &&
+                isDocumentExpirationEnabled.status === "success" &&
+                !isDocumentExpirationEnabled.data &&
+                formValues.isEnableDocumentExpiration
+            ) {
+                await databasesService.saveExpirationConfiguration(databaseName, {
+                    Disabled: false,
+                    DeleteFrequencyInSec: isCommunityLicense ? minimumCommunityDeleteFrequencyInSec : null,
+                    MaxItemsToProcess: defaultItemsToProcess,
+                });
+            }
+
+            runChat();
+        });
+    };
+
+    const handleNewChat = () => {
+        dispatch(chatAiAgentActions.conversationIdSet(null));
+        dispatch(chatAiAgentActions.messagesSet([]));
+        dispatch(chatAiAgentActions.documentSet(null));
+        dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(false));
+        chatForm.reset();
+    };
+
+    return {
+        chatForm,
+        reloadForm,
+        handleSend,
+        handleNewChat,
+        handleSubmit,
+        runChat,
+        asyncGetDefaultValues,
+    };
+}
+
+const minimumCommunityDeleteFrequencyInSec = TimeInSeconds.Day * 36;

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
@@ -12,6 +12,10 @@ import { AiAgentToolCall } from "../../utils/aiAgentsTypes";
 import { chatAiAgentSelectors, chatAiAgentActions } from "../store/chatAiAgentSlice";
 import { ChatAiAgentFormData } from "../utils/chatAiAgentValidation";
 import ChatAiAgentPersistenceSection from "./ChatAiAgentPersistenceSection";
+import RichAlert from "components/common/RichAlert";
+import Button from "react-bootstrap/Button";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { useAppUrls } from "components/hooks/useAppUrls";
 
 interface ChatAiAgentFormBodyProps {
     height: number;
@@ -25,6 +29,8 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
 
     const messagesPanelRef = useRef<HTMLDivElement>(null);
 
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const conversationId = useAppSelector(chatAiAgentSelectors.conversationId);
     const hasScroll = useAppSelector(chatAiAgentSelectors.hasScroll);
     const messages = useAppSelector(chatAiAgentSelectors.messages);
     const config = useAppSelector(chatAiAgentSelectors.config);
@@ -32,6 +38,10 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
     const document = useAppSelector(chatAiAgentSelectors.document);
     const isLoading = useAppSelector(chatAiAgentSelectors.isLoading);
     const isWaitingForActionToolSubmit = useAppSelector(chatAiAgentSelectors.isWaitingForActionToolSubmit);
+    const isDocumentDeleted = useAppSelector(chatAiAgentSelectors.isDocumentDeleted);
+    const isDocumentChanged = useAppSelector(chatAiAgentSelectors.isDocumentChanged);
+
+    const { appUrl } = useAppUrls();
 
     const { control, handleSubmit } = useFormContext<ChatAiAgentFormData>();
 
@@ -58,6 +68,13 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
             });
         }
     }, [messages.length]);
+
+    const handleRefreshDocument = async () => {
+        await dispatch(chatAiAgentActions.getDocument({ databaseName, id: conversationId })).unwrap();
+        dispatch(chatAiAgentActions.isDocumentChangedSet(false));
+    };
+
+    const isPromptDisabled = isLoading || isWaitingForActionToolSubmit || isDocumentDeleted || isDocumentChanged;
 
     return (
         <>
@@ -112,6 +129,27 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
             {!isHistory && (
                 <div className="d-flex justify-content-center mt-3 px-3 pb-3">
                     <div className="w-100" style={{ maxWidth: "800px" }}>
+                        {isDocumentChanged && !isDocumentDeleted && (
+                            <RichAlert variant="warning" className="p-1 mb-2">
+                                This document has been updated. To see the latest version in chat,{" "}
+                                <Button variant="link" className="p-0 text-warning" onClick={handleRefreshDocument}>
+                                    click here to refresh
+                                </Button>
+                                .
+                            </RichAlert>
+                        )}
+                        {isDocumentDeleted && (
+                            <RichAlert variant="warning" className="p-1 mb-2">
+                                This document has been deleted,{" "}
+                                <a
+                                    href={appUrl.forDocuments("@conversations", databaseName)}
+                                    className="text-warning text-decoration-none"
+                                >
+                                    click here to see the recent conversations
+                                </a>
+                                .
+                            </RichAlert>
+                        )}
                         <div className="position-relative">
                             <FormInput
                                 type="textarea"
@@ -127,7 +165,7 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
                                         handleSubmit(handleSend)();
                                     }
                                 }}
-                                disabled={isLoading || isWaitingForActionToolSubmit}
+                                disabled={isPromptDisabled}
                             />
                             {formValues.prompt && (
                                 <ButtonWithSpinner
@@ -135,7 +173,7 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
                                     variant="secondary"
                                     icon="arrow-up"
                                     isSpinning={isLoading}
-                                    disabled={isLoading || isWaitingForActionToolSubmit}
+                                    disabled={isPromptDisabled}
                                     className="position-absolute rounded-pill"
                                     style={{ right: "10px", bottom: "10px", zIndex: 5 }}
                                 />

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -18,6 +18,8 @@ interface EditAiAgentState {
     isWaitingForActionToolSubmit: boolean;
     hasScroll: boolean;
     isDocumentExpirationEnabled: loadableData<boolean>;
+    isDocumentDeleted: boolean;
+    isDocumentChanged: boolean;
 }
 
 const initialState: EditAiAgentState = {
@@ -30,6 +32,8 @@ const initialState: EditAiAgentState = {
     isWaitingForActionToolSubmit: false,
     hasScroll: false,
     isDocumentExpirationEnabled: createIdleState(),
+    isDocumentDeleted: false,
+    isDocumentChanged: false,
 };
 
 export const chatAiAgentSlice = createSlice({
@@ -54,6 +58,12 @@ export const chatAiAgentSlice = createSlice({
         hasScrollSet: (state, action: PayloadAction<boolean>) => {
             state.hasScroll = action.payload;
         },
+        isDocumentDeletedSet: (state, action: PayloadAction<boolean>) => {
+            state.isDocumentDeleted = action.payload;
+        },
+        isDocumentChangedSet: (state, action: PayloadAction<boolean>) => {
+            state.isDocumentChanged = action.payload;
+        },
         reset: () => initialState,
     },
     extraReducers: (builder) => {
@@ -75,6 +85,7 @@ export const chatAiAgentSlice = createSlice({
             })
             .addCase(getDocument.fulfilled, (state, action) => {
                 state.document = createSuccessState(action.payload);
+                state.isDocumentChanged = false;
 
                 const messages: AiAgentMessage[] = action.payload.Messages.map((x: AiAgentDocMessage) =>
                     aiAgentsUtils.mapMessageFromDoc(x)
@@ -208,4 +219,6 @@ export const chatAiAgentSelectors = {
     isWaitingForActionToolSubmit: (state: RootState) => state.chatAiAgent.isWaitingForActionToolSubmit,
     hasScroll: (state: RootState) => state.chatAiAgent.hasScroll,
     isDocumentExpirationEnabled: (state: RootState) => state.chatAiAgent.isDocumentExpirationEnabled,
+    isDocumentDeleted: (state: RootState) => state.chatAiAgent.isDocumentDeleted,
+    isDocumentChanged: (state: RootState) => state.chatAiAgent.isDocumentChanged,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentLinkedConversationsDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentLinkedConversationsDropdown.tsx
@@ -1,0 +1,57 @@
+import { CustomDropdownToggle } from "components/common/Dropdown";
+import { Icon } from "components/common/Icon";
+import { useAppUrls } from "components/hooks/useAppUrls";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import Dropdown from "react-bootstrap/Dropdown";
+
+interface AiAgentLinkedConversationsDropdownProps {
+    linkedConversations: string[];
+}
+
+export default function AiAgentLinkedConversationsDropdown({
+    linkedConversations,
+}: AiAgentLinkedConversationsDropdownProps) {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { appUrl } = useAppUrls();
+
+    const existingLinkedConversations = linkedConversations.filter(Boolean);
+
+    if (existingLinkedConversations.length === 0) {
+        return null;
+    }
+
+    return (
+        <Dropdown>
+            <Dropdown.Toggle
+                title="Linked conversations"
+                variant="outline-info"
+                className="rounded-pill"
+                as={CustomDropdownToggle}
+            >
+                <Icon icon="documents" />
+                Linked conversations
+            </Dropdown.Toggle>
+            <Dropdown.Menu
+                style={{ maxWidth: "500px", maxHeight: "320px" }}
+                className="panel-bg-1 p-3 rounded-2 overflow-auto"
+            >
+                {existingLinkedConversations.filter(Boolean).map((docId) => (
+                    <Dropdown.Item
+                        href={appUrl.forEditDoc(docId, databaseName)}
+                        target="_blank"
+                        title={docId}
+                        className="text-truncate"
+                    >
+                        <span title={docId}>{getShortDocumentId(docId)}</span>
+                        <Icon icon="newtab" margin="ms-1" />
+                    </Dropdown.Item>
+                ))}
+            </Dropdown.Menu>
+        </Dropdown>
+    );
+}
+
+function getShortDocumentId(docId: string) {
+    return docId.split("/")[1].split("$")[0];
+}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -23,6 +23,7 @@ import queryCriteria from "models/database/query/queryCriteria";
 import savedQueriesStorage from "common/storage/savedQueriesStorage";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import AiTokensUsagePopoverBody from "components/common/AiTokensUsagePopoverBody";
 
 type ToolQuery = Raven.Client.Documents.Operations.AI.Agents.AiAgentToolQuery;
 type ToolAction = Raven.Client.Documents.Operations.AI.Agents.AiAgentToolAction;
@@ -303,25 +304,12 @@ function AgentMessage({
                     <div className="hstack text-muted">
                         <PopoverWithHoverWrapper
                             message={
-                                <div>
-                                    <div className="hstack justify-content-between gap-3">
-                                        <span>Prompt tokens</span>
-                                        <span>{genUtils.formatAiTokens(agentMessage.usage.PromptTokens)}</span>
-                                    </div>
-                                    <div className="hstack justify-content-between gap-3">
-                                        <span>Completion tokens</span>
-                                        <span>{genUtils.formatAiTokens(agentMessage.usage.CompletionTokens)}</span>
-                                    </div>
-                                    <div className="hstack justify-content-between gap-3">
-                                        <span>Cached tokens</span>
-                                        <span>{genUtils.formatAiTokens(agentMessage.usage.CachedTokens)}</span>
-                                    </div>
-                                    <hr className="my-1" />
-                                    <div className="hstack justify-content-between gap-3">
-                                        <span>Total tokens used</span>
-                                        <span>{genUtils.formatAiTokens(agentMessage.usage.TotalTokens)}</span>
-                                    </div>
-                                </div>
+                                <AiTokensUsagePopoverBody
+                                    prompt={agentMessage.usage.PromptTokens}
+                                    completion={agentMessage.usage.CompletionTokens}
+                                    cached={agentMessage.usage.CachedTokens}
+                                    total={agentMessage.usage.TotalTokens}
+                                />
                             }
                         >
                             <Icon icon="info" />

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
@@ -21,7 +21,7 @@ export default function AiAgentParametersDropdown({ parameters, isCompact = fals
             <Dropdown.Toggle
                 title="Parameters"
                 variant="outline-secondary"
-                className="rounded-pill text-reset"
+                className="rounded-pill"
                 as={CustomDropdownToggle}
                 isCaretHidden={isCompact}
             >

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/EditGenAiTaskTestResults.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/EditGenAiTaskTestResults.tsx
@@ -17,6 +17,7 @@ import AceUnifiedDiff from "components/common/ace/AceUnifiedDiff";
 import { Switch } from "components/common/Checkbox";
 import useBoolean from "components/hooks/useBoolean";
 import genUtils from "common/generalUtils";
+import AiTokensUsagePopoverBody from "components/common/AiTokensUsagePopoverBody";
 
 export default function EditGenAiTaskTestResults() {
     const dispatch = useAppDispatch();
@@ -114,25 +115,12 @@ function ModelUsage() {
         <div>
             <PopoverWithHoverWrapper
                 message={
-                    <div>
-                        <div className="hstack justify-content-between gap-3">
-                            <span>Prompt tokens</span>
-                            <span>{genUtils.formatAiTokens(modelUsage.data.promptTokens)}</span>
-                        </div>
-                        <div className="hstack justify-content-between gap-3">
-                            <span>Completion tokens</span>
-                            <span>{genUtils.formatAiTokens(modelUsage.data.completionTokens)}</span>
-                        </div>
-                        <div className="hstack justify-content-between gap-3">
-                            <span>Cached tokens</span>
-                            <span>{genUtils.formatAiTokens(modelUsage.data.cachedTokens)}</span>
-                        </div>
-                        <hr className="my-1" />
-                        <div className="hstack justify-content-between gap-3">
-                            <span>Total tokens used</span>
-                            <span>{genUtils.formatAiTokens(modelUsage.data.totalTokens)}</span>
-                        </div>
-                    </div>
+                    <AiTokensUsagePopoverBody
+                        prompt={modelUsage.data.promptTokens}
+                        completion={modelUsage.data.completionTokens}
+                        cached={modelUsage.data.cachedTokens}
+                        total={modelUsage.data.totalTokens}
+                    />
                 }
             >
                 <Badge bg="info">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24702/AI-Agent-display-HistoryDocuments-Parameters-and-total-Usage-on-chat-view
https://issues.hibernatingrhinos.com/issue/RavenDB-24741/AI-Agent-Link-to-the-conversation-document-from-the-chat-view
https://issues.hibernatingrhinos.com/issue/RavenDB-24860/AI-Agents-add-button-to-refresh-the-chat-when-document-has-been-modified

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
