### PR TITLE
RavenDB-24803 Disable Corax's Voron tests.

### DIFF
--- a/test/SlowTests/Voron/CompactTrees/CompactTreeSlowTests.cs
+++ b/test/SlowTests/Voron/CompactTrees/CompactTreeSlowTests.cs
@@ -15,7 +15,7 @@ public class CompactTreeSlowTests : StorageTest
     {
     }
 
-    [RavenFact(RavenTestCategory.Voron)]
+    [RavenFact(RavenTestCategory.Voron, Skip = "Corax test")]
     public void CanStoreLargeNumberOfItemsInRandomlyOrder()
     {
         const int Size = 400000;
@@ -41,7 +41,7 @@ public class CompactTreeSlowTests : StorageTest
     }
 
 
-    [RavenFact(RavenTestCategory.Voron)]
+    [RavenFact(RavenTestCategory.Voron, Skip = "Corax test")]
     public void CanDeleteLargeNumberOfItemsInRandomOrder()
     {
         const int Size = 400000;
@@ -75,7 +75,7 @@ public class CompactTreeSlowTests : StorageTest
         }
     }
 
-    [RavenTheory(RavenTestCategory.Voron)]
+    [RavenTheory(RavenTestCategory.Voron, Skip = "Corax test")]
     [InlineData(400000, 1337)]
     [InlineDataWithRandomSeed(400000)]
     public void CanDeleteLargeNumberOfItemsInRandomInsertionOrder(int size, int random)
@@ -126,7 +126,7 @@ public class CompactTreeSlowTests : StorageTest
     }
 
 
-    [RavenFact(RavenTestCategory.Voron)]
+    [RavenFact(RavenTestCategory.Voron, Skip = "Corax test")]
     public void CanDeleteLargeNumberOfItemsFromStart()
     {
         const int Size = 400000;
@@ -160,7 +160,7 @@ public class CompactTreeSlowTests : StorageTest
     }
 
 
-    [RavenFact(RavenTestCategory.Voron)]
+    [RavenFact(RavenTestCategory.Voron, Skip = "Corax test")]
     public void CanDeleteLargeNumberOfItemsFromEnd()
     {
         const int Size = 400000;
@@ -194,7 +194,7 @@ public class CompactTreeSlowTests : StorageTest
     }
 
 
-    [RavenFact(RavenTestCategory.Voron)]
+    [RavenFact(RavenTestCategory.Voron, Skip = "Corax test")]
     public void CanStoreLargeNumberOfItemsInSequentialOrder()
     {
         const int Size = 400000;

--- a/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
+++ b/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Voron.CompactTrees
             };
 
         [RavenTheory(RavenTestCategory.Voron)]
-        [MemberData("Configuration")]
+        [MemberData("Configuration", Skip = "Corax test")]
         public void RandomUpsertsWithoutRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
         {
             var currentState = new Dictionary<long, long>();
@@ -93,7 +93,7 @@ namespace SlowTests.Voron.CompactTrees
 
 
         [RavenTheory(RavenTestCategory.Voron)]
-        [MemberData("Configuration")]
+        [MemberData("Configuration", Skip = "Corax test")]
         public void RandomUpsertsWithRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
         {
             var currentState = new Dictionary<long, long>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24803

### Additional description

Disable Corax's Voron tests.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
