### PR TITLE
RavenDB-24803 Corax's Voron test: added seed from failed test.

### DIFF
--- a/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
+++ b/test/SlowTests/Voron/CompactTrees/FuzzyUpserts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FastTests.Voron;
+using SlowTests.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,18 +14,12 @@ namespace SlowTests.Voron.CompactTrees
         public FuzzyUpsertsTests(ITestOutputHelper output) : base(output)
         {
         }
-
-        public static IEnumerable<object[]> Configuration =>
-            new List<object[]>
-            {
-                new object[] { 500000, Random.Shared.Next(), 4096 },
-                new object[] { 100000, Random.Shared.Next(), 1024 },
-                new object[] { 10000, Random.Shared.Next(), 64 },
-            };
-
+        
         [RavenTheory(RavenTestCategory.Voron)]
-        [MemberData("Configuration")]
-        public void RandomUpsertsWithoutRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
+        [InlineDataWithRandomSeed(500000, 4096)]
+        [InlineDataWithRandomSeed(100000, 1024)]
+        [InlineDataWithRandomSeed(10000, 64)]
+        public void RandomUpsertsWithoutRemoves(int treeSize, int transactionSize = 10000, int randomSeed = 1337)
         {
             var currentState = new Dictionary<long, long>();
             var keys = new List<long>();
@@ -88,8 +83,11 @@ namespace SlowTests.Voron.CompactTrees
 
 
         [RavenTheory(RavenTestCategory.Voron)]
-        [MemberData("Configuration")]
-        public void RandomUpsertsWithRemoves(int treeSize, int randomSeed = 1337, int transactionSize = 10000)
+        [InlineDataWithRandomSeed(500000, 4096)]
+        [InlineDataWithRandomSeed(100000, 1024)]
+        [InlineDataWithRandomSeed(10000, 64)]
+        [InlineData(500000, 4096, 2002966381)]
+        public void RandomUpsertsWithRemoves(int treeSize, int transactionSize = 10000, int randomSeed = 1337)
         {
             var currentState = new Dictionary<long, long>();
             var currentKeys = new List<long>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24803 

### Additional description

- Added known seed from dump
- Use seed from InlineDataWithRandom for visibility in test run logs

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
