### PR TITLE
RavenDB-24811 Streaming support for AI Agents

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,6 +123,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.0" />
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.8" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,7 +123,7 @@
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.0" />
+    <PackageVersion Include="System.Net.ServerSentEvents" Version="9.0.8" />
     <PackageVersion Include="System.Numerics.Tensors" Version="9.0.8" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.8" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,9 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
     <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net8.0'">
+    <DefineConstants>$(DefineConstants);FEATURE_AI_AGENT_STREAMING_SUPPORT</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <IsAnyOS>true</IsAnyOS>
     <IsLinux64>false</IsLinux64>

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -86,7 +86,7 @@ internal class AiConversation : IAiConversationOperations
 
         _actionResponses.Add(new AiAgentActionResponse
         {
-            ToolId = toolId, 
+            ToolId = toolId,
             Content = actionResponse
         });
     }
@@ -108,7 +108,7 @@ internal class AiConversation : IAiConversationOperations
         Handle<TArgs>(actionName, (_, token) => action(token), aiHandleError);
     }
 
-    public void Handle<TArgs>(string actionName, Func<AiAgentActionRequest,TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError)
+    public void Handle<TArgs>(string actionName, Func<AiAgentActionRequest, TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError)
         where TArgs : class
     {
         Receive<TArgs>(actionName, (request, args) =>
@@ -120,11 +120,11 @@ internal class AiConversation : IAiConversationOperations
         }, aiHandleError);
     }
 
-    public void Handle<TArgs>(string actionName, Func<AiAgentActionRequest,TArgs, object> action, AiHandleErrorStrategy aiHandleError) where TArgs : class
+    public void Handle<TArgs>(string actionName, Func<AiAgentActionRequest, TArgs, object> action, AiHandleErrorStrategy aiHandleError) where TArgs : class
     {
         Receive<TArgs>(actionName, (request, args) =>
         {
-            var result =  action(request, args);
+            var result = action(request, args);
             AddActionResponse(request.ToolId, result);
             return Task.CompletedTask;
         }, aiHandleError);
@@ -162,12 +162,13 @@ internal class AiConversation : IAiConversationOperations
         var pathResult = pathProvider.GetPath(propertyToStream.Body);
         return StreamAsync<TAnswer>(pathResult.Path, streamedChunksCallback, token);
     }
+
     public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         while (true)
         {
             var r = await RunAsyncInternal<TAnswer>(propertyToStream, streamedChunksCallback, token).ConfigureAwait(false);
-            if (await HandleServerReply(r, token).ConfigureAwait(false))
+            if (await HandleServerReplyAsync(r, token).ConfigureAwait(false))
                 return r;
         }
     }
@@ -176,13 +177,13 @@ internal class AiConversation : IAiConversationOperations
     {
         while (true)
         {
-            var r = await RunAsyncInternal<TAnswer>(null, null, token).ConfigureAwait(false);
-            if (await HandleServerReply(r, token).ConfigureAwait(false))
+            var r = await RunAsyncInternal<TAnswer>(propertyToStream: null, streamedChunksCallback: null, token).ConfigureAwait(false);
+            if (await HandleServerReplyAsync(r, token).ConfigureAwait(false))
                 return r;
         }
     }
 
-    private async Task<bool> HandleServerReply<TAnswer>(AiAnswer<TAnswer> r, CancellationToken token)
+    private async Task<bool> HandleServerReplyAsync<TAnswer>(AiAnswer<TAnswer> r, CancellationToken token)
     {
         if (r.Status == AiConversationResult.Done)
             return true;
@@ -202,13 +203,13 @@ internal class AiConversation : IAiConversationOperations
                     else if (OnUnhandledAction is { } onUnhandledAction)
                     {
                         await onUnhandledAction(new UnhandledActionEventArgs(this, action, token)).ConfigureAwait(false);
-                    }
+            }
                     else
                     {
                         throw new InvalidOperationException(
                             $"There is no action defined for action '{action.Name}' on agent '{_agentId}' ({_conversationId}), but it was invoked by the model with: {action.Arguments}. " +
                             $"Did you forget to call {nameof(Receive)} or {nameof(Handle)}? You can also handle unexpected action invocations using the {nameof(OnUnhandledAction)} event.");
-                    }
+        }
                 }
             }
 
@@ -219,7 +220,7 @@ internal class AiConversation : IAiConversationOperations
 
     public event Func<UnhandledActionEventArgs, Task> OnUnhandledAction;
 
-    private async Task<AiAnswer<TAnswer>> RunAsyncInternal<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback,CancellationToken token = default)
+    private async Task<AiAnswer<TAnswer>> RunAsyncInternal<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         if (
             // if this is null, it is the first time we call RunAsync, so we are going to the server to get the pending actions
@@ -244,7 +245,7 @@ internal class AiConversation : IAiConversationOperations
 
             return new AiAnswer<TAnswer>
             {
-                Answer = r.Response, 
+                Answer = r.Response,
                 Status = _actionRequests.Count > 0 ? AiConversationResult.ActionRequired : AiConversationResult.Done
             };
         }
@@ -265,10 +266,10 @@ internal class AiConversation : IAiConversationOperations
         where TActionParametersSchema : class
     {
         private readonly AiConversation _conversation;
-        private readonly Func<AiAgentActionRequest,TActionParametersSchema, Task> _asyncAction;
+        private readonly Func<AiAgentActionRequest, TActionParametersSchema, Task> _asyncAction;
         private readonly AiHandleErrorStrategy _errorStrategy;
 
-        public AiActionContext(AiConversation conversation, Func<AiAgentActionRequest,TActionParametersSchema, Task> asyncAction, AiHandleErrorStrategy errorStrategy)
+        public AiActionContext(AiConversation conversation, Func<AiAgentActionRequest, TActionParametersSchema, Task> asyncAction, AiHandleErrorStrategy errorStrategy)
         {
             _conversation = conversation;
             _asyncAction = asyncAction;
@@ -297,7 +298,7 @@ internal class AiConversation : IAiConversationOperations
         {
             try
             {
-                await _asyncAction.Invoke(actionRequest,args).ConfigureAwait(false);
+                await _asyncAction.Invoke(actionRequest, args).ConfigureAwait(false);
             }
             catch (Exception e) when (_errorStrategy is AiHandleErrorStrategy.SendErrorsToModel)
             {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Exceptions;
 using Raven.Client.Util;
@@ -154,6 +156,12 @@ internal class AiConversation : IAiConversationOperations
 
     public AiAnswer<TAnswer> Run<TAnswer>() => AsyncHelpers.RunSync(() => RunAsync<TAnswer>());
 
+    public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
+    {
+        var pathProvider = new LinqPathProvider(_aiOperations._store.Conventions);
+        var pathResult = pathProvider.GetPath(propertyToStream.Body);
+        return StreamAsync<TAnswer>(pathResult.Path, streamedChunksCallback, token);
+    }
     public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         while (true)

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -154,26 +154,43 @@ internal class AiConversation : IAiConversationOperations
 
     public AiAnswer<TAnswer> Run<TAnswer>() => AsyncHelpers.RunSync(() => RunAsync<TAnswer>());
 
+    public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
+    {
+        while (true)
+        {
+            var r = await RunAsyncInternal<TAnswer>(propertyToStream, streamedChunksCallback, token).ConfigureAwait(false);
+            if (await HandleServerReply(r, token).ConfigureAwait(false))
+                return r;
+        }
+    }
+
     public async Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default)
     {
         while (true)
         {
-            var r = await RunAsyncInternal<TAnswer>(token).ConfigureAwait(false);
-            if (r.Status == AiConversationResult.Done)
+            var r = await RunAsyncInternal<TAnswer>(null, null, token).ConfigureAwait(false);
+            if (await HandleServerReply(r, token).ConfigureAwait(false))
                 return r;
+        }
+    }
 
-            if (_actionRequests.Count == 0)
-                throw new InvalidOperationException($"There are no action requests to process, but Status was {r.Status}, should not be possible.");
+    private async Task<bool> HandleServerReply<TAnswer>(AiAnswer<TAnswer> r, CancellationToken token)
+    {
+        if (r.Status == AiConversationResult.Done)
+            return true;
 
-            using (_aiOperations.AllocateOperationContext(out JsonOperationContext ctx))
+        if (_actionRequests.Count == 0)
+            throw new InvalidOperationException($"There are no action requests to process, but Status was {r.Status}, should not be possible.");
+
+        using (_aiOperations.AllocateOperationContext(out JsonOperationContext ctx))
+        {
+            foreach (var action in _actionRequests)
             {
-                foreach (var action in _actionRequests)
+                if (_invocations.TryGetValue(action.Name, out var invocation))
                 {
-                    if (_invocations.TryGetValue(action.Name, out var invocation))
-                    {
-                        // error handling here is expected to be done by the invocation based on the error strategy the user choose
-                        await invocation.Invoke(ctx, action, token).ConfigureAwait(false);
-                    }
+                    // error handling here is expected to be done by the invocation based on the error strategy the user choose
+                    await invocation.Invoke(ctx, action, token).ConfigureAwait(false);
+                }
                     else if (OnUnhandledAction is { } onUnhandledAction)
                     {
                         await onUnhandledAction(new UnhandledActionEventArgs(this, action, token)).ConfigureAwait(false);
@@ -187,16 +204,14 @@ internal class AiConversation : IAiConversationOperations
                 }
             }
 
-            // We have nothing to tell the server, but still have action requests pending
-            // we need to send those action requests to the caller that can handle them
-            if (_actionResponses.Count == 0)
-                return r; // note - this has ActionsRequired status
-        }
+        // We have nothing to tell the server, but still have action requests pending
+        // we need to send those action requests to the caller that can handle them
+        return _actionResponses.Count == 0;
     }
 
     public event Func<UnhandledActionEventArgs, Task> OnUnhandledAction;
 
-    private async Task<AiAnswer<TAnswer>> RunAsyncInternal<TAnswer>(CancellationToken token = default)
+    private async Task<AiAnswer<TAnswer>> RunAsyncInternal<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback,CancellationToken token = default)
     {
         if (
             // if this is null, it is the first time we call RunAsync, so we are going to the server to get the pending actions
@@ -210,7 +225,7 @@ internal class AiConversation : IAiConversationOperations
             };
         }
 
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _userPrompt, _actionResponses, _options, _changeVector);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _userPrompt, _actionResponses, _options, _changeVector, propertyToStream, streamedChunksCallback);
 
         try
         {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -156,6 +156,7 @@ internal class AiConversation : IAiConversationOperations
 
     public AiAnswer<TAnswer> Run<TAnswer>() => AsyncHelpers.RunSync(() => RunAsync<TAnswer>());
 
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
     public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         var pathProvider = new LinqPathProvider(_aiOperations._store.Conventions);
@@ -172,6 +173,7 @@ internal class AiConversation : IAiConversationOperations
                 return r;
         }
     }
+#endif
 
     public async Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default)
     {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -157,18 +157,18 @@ internal class AiConversation : IAiConversationOperations
     public AiAnswer<TAnswer> Run<TAnswer>() => AsyncHelpers.RunSync(() => RunAsync<TAnswer>());
 
 #if FEATURE_AI_AGENT_STREAMING_SUPPORT
-    public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
+    public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         var pathProvider = new LinqPathProvider(_aiOperations._store.Conventions);
-        var pathResult = pathProvider.GetPath(propertyToStream.Body);
+        var pathResult = pathProvider.GetPath(streamPropertyPath.Body);
         return StreamAsync<TAnswer>(pathResult.Path, streamedChunksCallback, token);
     }
 
-    public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
+    public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         while (true)
         {
-            var r = await RunAsyncInternal<TAnswer>(propertyToStream, streamedChunksCallback, token).ConfigureAwait(false);
+            var r = await RunAsyncInternal<TAnswer>(streamPropertyPath, streamedChunksCallback, token).ConfigureAwait(false);
             if (await HandleServerReplyAsync(r, token).ConfigureAwait(false))
                 return r;
         }
@@ -179,7 +179,7 @@ internal class AiConversation : IAiConversationOperations
     {
         while (true)
         {
-            var r = await RunAsyncInternal<TAnswer>(propertyToStream: null, streamedChunksCallback: null, token).ConfigureAwait(false);
+            var r = await RunAsyncInternal<TAnswer>(streamPropertyPath: null, streamedChunksCallback: null, token).ConfigureAwait(false);
             if (await HandleServerReplyAsync(r, token).ConfigureAwait(false))
                 return r;
         }
@@ -222,7 +222,7 @@ internal class AiConversation : IAiConversationOperations
 
     public event Func<UnhandledActionEventArgs, Task> OnUnhandledAction;
 
-    private async Task<AiAnswer<TAnswer>> RunAsyncInternal<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
+    private async Task<AiAnswer<TAnswer>> RunAsyncInternal<TAnswer>(string streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         if (
             // if this is null, it is the first time we call RunAsync, so we are going to the server to get the pending actions
@@ -236,7 +236,7 @@ internal class AiConversation : IAiConversationOperations
             };
         }
 
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _userPrompt, _actionResponses, _options, _changeVector, propertyToStream, streamedChunksCallback);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _userPrompt, _actionResponses, _options, _changeVector, streamPropertyPath, streamedChunksCallback);
 
         try
         {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -202,18 +202,18 @@ internal class AiConversation : IAiConversationOperations
                     // error handling here is expected to be done by the invocation based on the error strategy the user choose
                     await invocation.Invoke(ctx, action, token).ConfigureAwait(false);
                 }
-                    else if (OnUnhandledAction is { } onUnhandledAction)
-                    {
-                        await onUnhandledAction(new UnhandledActionEventArgs(this, action, token)).ConfigureAwait(false);
-            }
-                    else
-                    {
-                        throw new InvalidOperationException(
-                            $"There is no action defined for action '{action.Name}' on agent '{_agentId}' ({_conversationId}), but it was invoked by the model with: {action.Arguments}. " +
-                            $"Did you forget to call {nameof(Receive)} or {nameof(Handle)}? You can also handle unexpected action invocations using the {nameof(OnUnhandledAction)} event.");
-        }
+                else if (OnUnhandledAction is { } onUnhandledAction)
+                {
+                    await onUnhandledAction(new UnhandledActionEventArgs(this, action, token)).ConfigureAwait(false);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"There is no action defined for action '{action.Name}' on agent '{_agentId}' ({_conversationId}), but it was invoked by the model with: {action.Arguments}. " +
+                        $"Did you forget to call {nameof(Receive)} or {nameof(Handle)}? You can also handle unexpected action invocations using the {nameof(OnUnhandledAction)} event.");
                 }
             }
+        }
 
         // We have nothing to tell the server, but still have action requests pending
         // we need to send those action requests to the caller that can handle them

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -98,7 +98,7 @@ public interface IAiConversationOperations
     /// Sends the current prompt, processes any required actions, and awaits the agent’s reply while invoking the callback with streamed values.
     /// </summary>
     /// <typeparam name="TAnswer">The expected type of the content response.</typeparam>
-    /// <param name="propertyToStream">The property of the response to stream.</param>
+    /// <param name="streamPropertyPath">The property of the response to stream.</param>
     /// <param name="streamedChunksCallback">
     /// A callback function invoked with streamed value of the specified property.
     /// Must be a simple string property, *strongly* recommended that it would be the first one defined in the schema.
@@ -111,14 +111,14 @@ public interface IAiConversationOperations
     /// <item><see cref="AiConversationResult.Done"/> if the conversation has completed and a final answer is available.</item>
     /// </list>
     /// </returns>
-    Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default);
+    Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default);
 
     /// <summary>
     /// Asynchronously executes one “turn” of the conversation, streaming the specified property's value for immediate feedback.
     /// Sends the current prompt, processes any required actions, and awaits the agent’s reply while invoking the callback with streamed values.
     /// </summary>
     /// <typeparam name="TAnswer">The expected type of the content response.</typeparam>
-    /// <param name="propertyToStream">The property of the response to stream.</param>
+    /// <param name="streamPropertyPath">The property of the response to stream.</param>
     /// <param name="streamedChunksCallback">
     /// A callback function invoked with streamed value of the specified property.
     /// Must be a simple string property, *strongly* recommended that it would be the first one defined in the schema.
@@ -131,7 +131,7 @@ public interface IAiConversationOperations
     /// <item><see cref="AiConversationResult.Done"/> if the conversation has completed and a final answer is available.</item>
     /// </list>
     /// </returns>
-    Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> propertyToStream, Func<string, Task> streamedChunksCallback,
+    Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath, Func<string, Task> streamedChunksCallback,
         CancellationToken token = default);
 #endif
 

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -92,6 +92,7 @@ public interface IAiConversationOperations
     /// </returns>
     Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default);
 
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
     /// <summary>
     /// Asynchronously executes one “turn” of the conversation, streaming the specified property's value for immediate feedback.
     /// Sends the current prompt, processes any required actions, and awaits the agent’s reply while invoking the callback with streamed values.
@@ -132,7 +133,8 @@ public interface IAiConversationOperations
     /// </returns>
     Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> propertyToStream, Func<string, Task> streamedChunksCallback,
         CancellationToken token = default);
-    
+#endif
+
     /// <summary>
     /// Synchronously executes one turn of the conversation.
     /// </summary>

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -91,7 +92,46 @@ public interface IAiConversationOperations
     /// </returns>
     Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default);
 
+    /// <summary>
+    /// Asynchronously executes one “turn” of the conversation, streaming the specified property's value for immediate feedback.
+    /// Sends the current prompt, processes any required actions, and awaits the agent’s reply while invoking the callback with streamed values.
+    /// </summary>
+    /// <typeparam name="TAnswer">The expected type of the content response.</typeparam>
+    /// <param name="propertyToStream">The property of the response to stream.</param>
+    /// <param name="streamedChunksCallback">
+    /// A callback function invoked with streamed value of the specified property.
+    /// Must be a simple string property, *strongly* recommended that it would be the first one defined in the schema.
+    /// </param>
+    /// <param name="token">A <see cref="CancellationToken"/> used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{AiAnswer}"/> containing an <see cref="AiAnswer{TAnswer}"/> indicating the outcome of the turn:
+    /// <list type="bullet">
+    /// <item><see cref="AiConversationResult.ActionRequired"/> if the agent requires further interaction (e.g., pending tool requests).</item>
+    /// <item><see cref="AiConversationResult.Done"/> if the conversation has completed and a final answer is available.</item>
+    /// </list>
+    /// </returns>
     Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default);
+
+    /// <summary>
+    /// Asynchronously executes one “turn” of the conversation, streaming the specified property's value for immediate feedback.
+    /// Sends the current prompt, processes any required actions, and awaits the agent’s reply while invoking the callback with streamed values.
+    /// </summary>
+    /// <typeparam name="TAnswer">The expected type of the content response.</typeparam>
+    /// <param name="propertyToStream">The property of the response to stream.</param>
+    /// <param name="streamedChunksCallback">
+    /// A callback function invoked with streamed value of the specified property.
+    /// Must be a simple string property, *strongly* recommended that it would be the first one defined in the schema.
+    /// </param>
+    /// <param name="token">A <see cref="CancellationToken"/> used to cancel the operation.</param>
+    /// <returns>
+    /// A <see cref="Task{AiAnswer}"/> containing an <see cref="AiAnswer{TAnswer}"/> indicating the outcome of the turn:
+    /// <list type="bullet">
+    /// <item><see cref="AiConversationResult.ActionRequired"/> if the agent requires further interaction (e.g., pending tool requests).</item>
+    /// <item><see cref="AiConversationResult.Done"/> if the conversation has completed and a final answer is available.</item>
+    /// </list>
+    /// </returns>
+    Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> propertyToStream, Func<string, Task> streamedChunksCallback,
+        CancellationToken token = default);
     
     /// <summary>
     /// Synchronously executes one turn of the conversation.

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -91,6 +91,8 @@ public interface IAiConversationOperations
     /// </returns>
     Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default);
 
+    Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string propertyToStream, Func<string, Task> streamedChunksCallback, CancellationToken token = default);
+    
     /// <summary>
     /// Synchronously executes one turn of the conversation.
     /// </summary>

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -1,12 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
+using System.Net.ServerSentEvents;
+using System.Threading.Tasks;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Util;
+using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Sync;
 
 namespace Raven.Client.Documents.Operations.AI.Agents;
 public class RunConversationOperation<TSchema> : IMaintenanceOperation<ConversationResult<TSchema>>
@@ -18,6 +23,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly string _conversationId;
     private readonly List<AiAgentActionResponse> _actionResponses;
     private readonly string _changeVector;
+    private readonly string _propertyToStream;
+    private readonly Func<string, Task> _streamedChunksCallback;
 
     public RunConversationOperation(
         string agentId, 
@@ -25,10 +32,14 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         string userPrompt, 
         List<AiAgentActionResponse> actionResponses,
         AiConversationCreationOptions options, 
-        string changeVector)
+        string changeVector, 
+        string propertyToStream, 
+        Func<string, Task> streamedChunksCallback)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
         ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
+        PortableExceptions.ThrowIfNot<InvalidOperationException>(propertyToStream is null == streamedChunksCallback is null,
+            "Both propertyToStream and streamedChunksCallback must be specified together");
 
         _agentId = agentId;
         _conversationId = conversationId;
@@ -36,53 +47,55 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _changeVector = changeVector;
         _actionResponses = actionResponses;
         _options = options;
+        
+          
+        _propertyToStream = propertyToStream;
+        _streamedChunksCallback = streamedChunksCallback;
+
     }
 
     public RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new RunConversationOperationCommand(_conversationId, _agentId, _userPrompt, _actionResponses, _options, _changeVector, conventions);
+        return new RunConversationOperationCommand(this, conventions);
     }
 
     internal sealed class RunConversationOperationCommand : RavenCommand<ConversationResult<TSchema>>, IRaftCommand
     {
-        private readonly string _conversationId;
-        private readonly string _agentId;
-        private readonly string _prompt;
-        private readonly List<AiAgentActionResponse> _actionResponses;
-        private readonly string _changeVector;
-        private readonly AiConversationCreationOptions _options;
+        private readonly RunConversationOperation<TSchema> _parent;
         private readonly DocumentConventions _conventions;
 
-        public RunConversationOperationCommand(string conversationId, string agentId, string prompt,
-            List<AiAgentActionResponse> actionResponses, AiConversationCreationOptions options, string changeVector, DocumentConventions conventions)
+        public RunConversationOperationCommand(RunConversationOperation<TSchema> parent,DocumentConventions conventions)
         {
-            _conversationId = conversationId;
-            _agentId = agentId;
-            _prompt = prompt;
-            _actionResponses = actionResponses;
-            _changeVector = changeVector;
-            _options = options;
             _conventions = conventions;
+            _parent = parent;
+            if (parent._propertyToStream is not null)
+            {
+                ResponseType = RavenCommandResponseType.Raw;
+            }
         }
+        
         public override bool IsReadRequest => false;
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/ai/agent" +
-                  $"?conversationId={Uri.EscapeDataString(_conversationId)}&agentId={Uri.EscapeDataString(_agentId)}";
+                  $"?conversationId={Uri.EscapeDataString(_parent._conversationId)}&agentId={Uri.EscapeDataString(_parent._agentId)}";
 
-            if (_conversationId[_conversationId.Length - 1] == '|')
+            if (_parent._conversationId[_parent._conversationId.Length - 1] == '|')
             {
                 _raftId = Guid.NewGuid().ToString();
             }
 
-            if (_changeVector != null)
-                url += $"&changeVector={Uri.EscapeDataString(_changeVector)}";
+            if (_parent._changeVector != null)
+                url += $"&changeVector={Uri.EscapeDataString(_parent._changeVector)}";
 
+            if(_parent._propertyToStream is not null)
+                url += $"&streaming=true&propertyToStream={Uri.EscapeDataString(_parent._propertyToStream)}";
+            
             var body = new ConversionRequestBody
             {
-                ActionResponses = _actionResponses,
-                UserPrompt = _prompt,
-                CreationOptions = _options
+                ActionResponses = _parent._actionResponses,
+                UserPrompt = _parent._userPrompt,
+                CreationOptions = _parent._options
             };
 
             var request = new HttpRequestMessage
@@ -95,6 +108,21 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             };
 
             return request;
+        }
+
+        public override async Task SetResponseRawAsync(HttpResponseMessage response, Stream stream, JsonOperationContext context)
+        {
+            await foreach (var msg in SseParser.Create(stream).EnumerateAsync())
+            {
+                if (msg.EventType is "result")
+                {
+                    var final = context.Sync.ReadForMemory(msg.Data, "final/result");
+                    Result = ConversationResult<TSchema>.Convert(final, _conventions);
+                    break;
+                }
+                // streaming the output...
+                await _parent._streamedChunksCallback(msg.Data).ConfigureAwait(false);
+            }
         }
 
         public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
 using System.Net.ServerSentEvents;
+#endif
 using System.Threading.Tasks;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Conventions;
@@ -24,8 +26,11 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly string _conversationId;
     private readonly List<AiAgentActionResponse> _actionResponses;
     private readonly string _changeVector;
+
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
     private readonly string _propertyToStream;
     private readonly Func<string, Task> _streamedChunksCallback;
+#endif
 
     public RunConversationOperation(
         string agentId,
@@ -59,9 +64,13 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _actionResponses = actionResponses;
         _options = options;
 
-
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
         _propertyToStream = propertyToStream;
         _streamedChunksCallback = streamedChunksCallback;
+#else
+        if (propertyToStream != null)
+            throw new InvalidOperationException("AI Agent conversation streaming is not supported in your framework.");
+#endif
     }
 
     public RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
@@ -78,10 +87,13 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         {
             _conventions = conventions;
             _parent = parent;
+
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
             if (parent._propertyToStream is not null)
             {
                 ResponseType = RavenCommandResponseType.Raw;
             }
+#endif
         }
 
         public override bool IsReadRequest => false;
@@ -99,8 +111,10 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             if (_parent._changeVector != null)
                 url += $"&changeVector={Uri.EscapeDataString(_parent._changeVector)}";
 
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
             if (_parent._propertyToStream is not null)
                 url += $"&streaming=true&propertyToStream={Uri.EscapeDataString(_parent._propertyToStream)}";
+#endif
 
             var body = new ConversionRequestBody
             {
@@ -121,6 +135,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             return request;
         }
 
+#if FEATURE_AI_AGENT_STREAMING_SUPPORT
         public override async Task SetResponseRawAsync(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
             await foreach (var msg in SseParser.Create(stream).EnumerateAsync())
@@ -136,6 +151,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                 await _parent._streamedChunksCallback(msg.Data).ConfigureAwait(false);
             }
         }
+#endif
 
         public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
         {

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -14,6 +14,7 @@ using Sparrow.Json;
 using Sparrow.Json.Sync;
 
 namespace Raven.Client.Documents.Operations.AI.Agents;
+
 public class RunConversationOperation<TSchema> : IMaintenanceOperation<ConversationResult<TSchema>>
 {
     private readonly string _agentId;
@@ -27,13 +28,23 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly Func<string, Task> _streamedChunksCallback;
 
     public RunConversationOperation(
-        string agentId, 
-        string conversationId, 
-        string userPrompt, 
+        string agentId,
+        string conversationId,
+        string userPrompt,
         List<AiAgentActionResponse> actionResponses,
-        AiConversationCreationOptions options, 
-        string changeVector, 
-        string propertyToStream, 
+        AiConversationCreationOptions options,
+        string changeVector) : this(agentId, conversationId, userPrompt, actionResponses, options, changeVector, null, null)
+    {
+    }
+
+    public RunConversationOperation(
+        string agentId,
+        string conversationId,
+        string userPrompt,
+        List<AiAgentActionResponse> actionResponses,
+        AiConversationCreationOptions options,
+        string changeVector,
+        string propertyToStream,
         Func<string, Task> streamedChunksCallback)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
@@ -47,11 +58,10 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _changeVector = changeVector;
         _actionResponses = actionResponses;
         _options = options;
-        
-          
+
+
         _propertyToStream = propertyToStream;
         _streamedChunksCallback = streamedChunksCallback;
-
     }
 
     public RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
@@ -64,7 +74,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         private readonly RunConversationOperation<TSchema> _parent;
         private readonly DocumentConventions _conventions;
 
-        public RunConversationOperationCommand(RunConversationOperation<TSchema> parent,DocumentConventions conventions)
+        public RunConversationOperationCommand(RunConversationOperation<TSchema> parent, DocumentConventions conventions)
         {
             _conventions = conventions;
             _parent = parent;
@@ -73,8 +83,9 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                 ResponseType = RavenCommandResponseType.Raw;
             }
         }
-        
+
         public override bool IsReadRequest => false;
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/ai/agent" +
@@ -88,9 +99,9 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             if (_parent._changeVector != null)
                 url += $"&changeVector={Uri.EscapeDataString(_parent._changeVector)}";
 
-            if(_parent._propertyToStream is not null)
+            if (_parent._propertyToStream is not null)
                 url += $"&streaming=true&propertyToStream={Uri.EscapeDataString(_parent._propertyToStream)}";
-            
+
             var body = new ConversionRequestBody
             {
                 ActionResponses = _parent._actionResponses,
@@ -103,7 +114,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                 Method = HttpMethod.Post,
                 Content = new BlittableJsonContent(async stream =>
                 {
-                    await ctx.WriteAsync(stream, ctx.ReadObject(body.ToJson(),"conversation-params")).ConfigureAwait(false);
+                    await ctx.WriteAsync(stream, ctx.ReadObject(body.ToJson(), "conversation-params")).ConfigureAwait(false);
                 }, _conventions)
             };
 
@@ -120,6 +131,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                     Result = ConversationResult<TSchema>.Convert(final, _conventions);
                     break;
                 }
+
                 // streaming the output...
                 await _parent._streamedChunksCallback(msg.Data).ConfigureAwait(false);
             }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -28,7 +28,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly string _changeVector;
 
 #if FEATURE_AI_AGENT_STREAMING_SUPPORT
-    private readonly string _propertyToStream;
+    private readonly string _streamPropertyPath;
     private readonly Func<string, Task> _streamedChunksCallback;
 #endif
 
@@ -49,13 +49,13 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         List<AiAgentActionResponse> actionResponses,
         AiConversationCreationOptions options,
         string changeVector,
-        string propertyToStream,
+        string streamPropertyPath,
         Func<string, Task> streamedChunksCallback)
     {
         ValidationMethods.AssertNotNullOrEmpty(agentId, nameof(agentId));
         ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
-        PortableExceptions.ThrowIfNot<InvalidOperationException>(propertyToStream is null == streamedChunksCallback is null,
-            "Both propertyToStream and streamedChunksCallback must be specified together");
+        PortableExceptions.ThrowIfNot<InvalidOperationException>(streamPropertyPath is null == streamedChunksCallback is null,
+            "Both streamPropertyPath and streamedChunksCallback must be specified together");
 
         _agentId = agentId;
         _conversationId = conversationId;
@@ -65,10 +65,10 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _options = options;
 
 #if FEATURE_AI_AGENT_STREAMING_SUPPORT
-        _propertyToStream = propertyToStream;
+        _streamPropertyPath = streamPropertyPath;
         _streamedChunksCallback = streamedChunksCallback;
 #else
-        if (propertyToStream != null)
+        if (streamPropertyPath != null)
             throw new InvalidOperationException("AI Agent conversation streaming is not supported in your framework.");
 #endif
     }
@@ -89,7 +89,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             _parent = parent;
 
 #if FEATURE_AI_AGENT_STREAMING_SUPPORT
-            if (parent._propertyToStream is not null)
+            if (parent._streamPropertyPath is not null)
             {
                 ResponseType = RavenCommandResponseType.Raw;
             }
@@ -112,8 +112,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
                 url += $"&changeVector={Uri.EscapeDataString(_parent._changeVector)}";
 
 #if FEATURE_AI_AGENT_STREAMING_SUPPORT
-            if (_parent._propertyToStream is not null)
-                url += $"&streaming=true&propertyToStream={Uri.EscapeDataString(_parent._propertyToStream)}";
+            if (_parent._streamPropertyPath is not null)
+                url += $"&streaming=true&streamPropertyPath={Uri.EscapeDataString(_parent._streamPropertyPath)}";
 #endif
 
             var body = new ConversionRequestBody
@@ -142,7 +142,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             {
                 if (msg.EventType is "result")
                 {
-                    var final = context.Sync.ReadForMemory(msg.Data, "final/result");
+                    using var final = context.Sync.ReadForMemory(msg.Data, "final/result");
                     Result = ConversationResult<TSchema>.Convert(final, _conventions);
                     break;
                 }

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -129,6 +129,12 @@ namespace Raven.Client.Http
             }
         }
 
+        public virtual Task SetResponseRawAsync(HttpResponseMessage response, Stream stream, JsonOperationContext context)
+        {
+            SetResponseRaw(response, stream, context);
+            return Task.CompletedTask;
+        }
+
         public virtual void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
             throw new NotSupportedException($"When {nameof(ResponseType)} is set to Raw then please override this method to handle the response.");
@@ -189,7 +195,7 @@ namespace Raven.Client.Http
                 await using (var uncompressedStream = await RequestExecutor.ReadAsStreamUncompressedAsync(response).ConfigureAwait(false))
 #endif
                 await using (var stream = new StreamWithTimeout(uncompressedStream))
-                    SetResponseRaw(response, stream, context);
+                    await SetResponseRawAsync(response, stream, context).ConfigureAwait(false);
             }
             return ResponseDisposeHandling.Automatic;
         }

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -171,6 +171,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
     <PackageReference Include="Raven.CodeAnalysis" PrivateAssets="All" />
+    <PackageReference Include="System.Net.ServerSentEvents" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="System.Collections.Immutable" VersionOverride="8.0.0" />

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -171,7 +171,6 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
     <PackageReference Include="Raven.CodeAnalysis" PrivateAssets="All" />
-    <PackageReference Include="System.Net.ServerSentEvents" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="System.Collections.Immutable" VersionOverride="8.0.0" />
@@ -179,6 +178,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Net.ServerSentEvents" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -213,7 +213,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         ToolCallState toolCallState = new();
         BlittableJsonReaderObject message = null;
 
-        // need to contexts here because we run two parsing operations at once, first for each of the SSE events
+        // need two contexts here because we run two parsing operations at once, first for each of the SSE events
         // and then for the internal buffer that there are providing.
         using var ___ = contextPool.AllocateOperationContext(out JsonOperationContext parsingContext);
         // Note that here we iterate over blittable, whose scope is only the _single_ iteration we run, you need to copy

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -146,16 +146,19 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         public void AddAndReset()
         {
             if (_toolCallIndex == -1)
+            {
+                _id ??= new();
+                _type ??= new();
+                _name ??= new();
+                _arguments ??= new();
+
                 return;
+            }
             
             AllToolCalls ??= [];
             AllToolCalls.Add(new AiToolCall(_id.ToString(), _name.ToString(), _arguments.ToString()));
         
-            _id ??= new();
-            _type ??= new();
-            _name ??= new();
-            _arguments ??= new();
-
+     
             _toolCallIndex = -1;
             _id.Clear();
             _type.Clear();
@@ -273,7 +276,31 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         
         if (toolCallState.AllToolCalls?.Count >= 0)
         {
-            return new AiResponse(AiResponseType.Tool) { Message = message, ToolCalls = toolCallState.AllToolCalls, };
+            DynamicJsonArray toolCalls = new ();
+            foreach (var call in toolCallState.AllToolCalls)
+            {
+                toolCalls.Add(new DynamicJsonValue
+                {
+                    ["id"] = call.Id,
+                    ["type"] = "function",
+                    ["function"] = new DynamicJsonValue
+                    {
+                        ["name"] = call.Name,
+                        ["arguments"] = call.Arguments
+                    }
+                });
+            }
+            
+            return new AiResponse(AiResponseType.Tool)
+            {
+                Message = streamingContext.ReadObject(new DynamicJsonValue
+                {
+                    ["role"] = "assistant", 
+                    ["content"] = null,
+                    ["tool_calls"] = toolCalls 
+                }, "persisted/streamed/toolcalls"),
+                ToolCalls = toolCallState.AllToolCalls,
+            };
         }
    
         return new AiResponse(AiResponseType.Result)

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -173,7 +173,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
 
     public async Task<AiResponse> StreamingCompleteAsync(JsonOperationContext streamingContext, IMemoryContextPool contextPool,
-        string propertyToStream, HttpRequestMessage request,
+        string streamPropertyPath, HttpRequestMessage request,
         Func<Memory<byte>, Task> streamedPropertyCallback,
         AiUsage usage, CancellationToken token)
     {
@@ -182,7 +182,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         const int initialBufferSize = 64;
 
         using var __ = streamingContext.GetRawMemoryBuffer(initialBufferSize, out var streamedPropertyBuffer);
-        var parser = new SseStreamingJsonParser(streamingContext, propertyToStream);
+        var parser = new SseStreamingJsonParser(streamingContext, streamPropertyPath);
         var alreadySeen = 0;
         var sizeToStream = 0;
         parser.OnStringRead += (e) =>

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.ServerSentEvents;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -93,71 +95,296 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         _apiKey = apiKey;
     }
 
+    
+    private struct ToolCallState
+    {
+        private StringBuilder _id ;
+        private StringBuilder _type;
+        private StringBuilder _name;
+        private StringBuilder _arguments;
+
+        private int _toolCallIndex;
+        
+        public List<AiToolCall> AllToolCalls;
+
+        public ToolCallState()
+        {
+            _toolCallIndex = -1;
+        }
+        
+        public void Merge(BlittableJsonReaderObject toolCallChunk)
+        {
+            if (!toolCallChunk.TryGet("index", out int index))
+                return;
+            
+            if (index != _toolCallIndex)
+            {
+                AddAndReset();
+                _toolCallIndex = index;
+            }
+            if (toolCallChunk.TryGet("id", out string id))
+            {
+                _id.Append(id);
+            }
+            if (toolCallChunk.TryGet("type", out string type))
+            {
+                _type.Append(type);
+            }
+            if (toolCallChunk.TryGet("function", out BlittableJsonReaderObject functionChunk))
+            {
+                if (functionChunk.TryGet("name", out string nameChunk))
+                {
+                    _name.Append(nameChunk);
+                }
+                if (functionChunk.TryGet("arguments", out string argsChunk))
+                {
+                    _arguments.Append(argsChunk);
+                }
+            }
+        }
+        
+        public void AddAndReset()
+        {
+            if (_toolCallIndex == -1)
+                return;
+            
+            AllToolCalls ??= [];
+            AllToolCalls.Add(new AiToolCall(_id.ToString(), _name.ToString(), _arguments.ToString()));
+        
+            _id ??= new();
+            _type ??= new();
+            _name ??= new();
+            _arguments ??= new();
+
+            _toolCallIndex = -1;
+            _id.Clear();
+            _type.Clear();
+            _name.Clear();
+            _arguments.Clear();
+        }
+    }
+
+
+    public async Task<AiResponse> StreamingCompleteAsync(JsonOperationContext streamingContext, IMemoryContextPool contextPool, 
+        string propertyToStream, HttpRequestMessage request,
+        Func<Memory<byte>,Task> streamedPropertyCallback,
+        AiUsage usage, CancellationToken token)
+    {
+        AddDefaultHeaders(request);
+        // we use a small buffer size since we expect those to be "token" level updates, not very big ones
+        const int initialBufferSize = 64;
+
+        using var __ = streamingContext.GetRawMemoryBuffer(initialBufferSize,out var streamedPropertyBuffer);
+        var parser = new SseStreamingJsonParser(streamingContext, propertyToStream);
+        var alreadySeen = 0;
+        var sizeToStream = 0;
+        parser.OnStringRead += (e) =>
+        {
+            int size = e.SizeInBytes - alreadySeen;
+            if (size > streamedPropertyBuffer.SizeInBytes)
+            {
+                streamingContext.GrowAllocation(streamedPropertyBuffer, size - streamedPropertyBuffer.SizeInBytes);
+            }
+            unsafe
+            {
+                var read = e.CopyTo(alreadySeen, streamedPropertyBuffer.Address);
+                alreadySeen += read;
+                sizeToStream += read;
+            }
+        };
+
+        using var response = await SendStreamingRequestAsync(request, token);
+        if (response.IsSuccessStatusCode == false)
+        {
+            var responseContent = await GetResponseContentAsync(streamingContext, response, token);
+            HandleUnsuccessfulResponse(response, responseContent);
+            Debug.Assert(false, "we should never get here");
+        }
+        await using var responseStream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
+        //var s = Encoding.UTF8.GetString(((MemoryStream)responseStream).ToArray());
+        ToolCallState toolCallState = new();
+        BlittableJsonReaderObject message = null;
+     
+        // need to contexts here because we run two parsing operations at once, first for each of the SSE events
+        // and then for the internal buffer that there are providing.
+        using var ___ = contextPool.AllocateOperationContext(out JsonOperationContext parsingContext);
+        // Note that here we iterate over blittable, whose scope is only the _single_ iteration we run, you need to copy
+        // any data that you need out of them.
+        await foreach (var sseEvent in SseParser.Create(responseStream, (_, data) =>
+        {
+            unsafe
+            {
+                if (data.SequenceEqual("[DONE]"u8))
+                    return null;
+                fixed (byte* p = data)
+                {
+                    return parsingContext.ParseBuffer(p, data.Length, "msg", BlittableJsonDocumentBuilder.UsageMode.None);
+                }
+            }
+
+        }).EnumerateAsync(token))
+        {
+            using var _ = sseEvent.Data;
+
+            if (sseEvent.Data is null)// "[DONE]"
+            {
+                toolCallState.AddAndReset();
+                break;
+            }
+
+            if (sseEvent.Data.TryGet("usage", out BlittableJsonReaderObject streamedUsage) && streamedUsage is not null)
+            {
+                usage.UpdateFrom(streamedUsage);
+            }
+
+            if (sseEvent.Data.TryGet("choices", out BlittableJsonReaderArray choices) is false ||
+                choices.Length == 0)
+            {
+                continue;
+            }
+            var choice = (BlittableJsonReaderObject)choices[0];
+            if (choice.TryGet("delta", out BlittableJsonReaderObject delta))
+            {
+                if (delta.TryGet("content", out LazyStringValue content) && content?.Length > 0)
+                {
+                    toolCallState.AddAndReset();
+
+                    var final = parser.Process(content);
+                    if (sizeToStream is not 0)
+                    {
+                        await streamedPropertyCallback(streamedPropertyBuffer.AsMemory()[..sizeToStream]);
+                        sizeToStream = 0;
+                    }
+                    if (final is not null)
+                    {
+                        message = final;
+                    }
+                }
+
+                if (delta.TryGet("tool_calls", out BlittableJsonReaderArray toolCalls))
+                {
+                    foreach (BlittableJsonReaderObject toolCallChunk in toolCalls)
+                    {
+                        toolCallState.Merge(toolCallChunk);
+                    }
+                }
+            }
+        }
+        
+        if (toolCallState.AllToolCalls?.Count >= 0)
+        {
+            return new AiResponse(AiResponseType.Tool) { Message = message, ToolCalls = toolCallState.AllToolCalls, };
+        }
+   
+        return new AiResponse(AiResponseType.Result)
+        {
+            Message = streamingContext.ReadObject(new DynamicJsonValue
+            {
+                ["role"] = "assistant",
+                ["content"] = message!.ToString(),
+            }, "persisted/streamed/message"), 
+            Result = message,
+        };
+
+    }
+
     public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, CancellationToken token)
     {
         AddDefaultHeaders(request);
         using var response = await SendRequestAsync(request, token);
         var responseContent = await GetResponseContentAsync(context, response, token);
 
-        if (response.IsSuccessStatusCode == false)
+        var responseParser = new AiResponseParser(this, response, responseContent);
+        responseParser.EnsureSuccessfulResponse();
+        responseParser.ParseMessage(usage);
+        if (responseParser.TryParseToolCalls(out var tools))
         {
-            HandleUnsuccessfulResponse(response, responseContent);
+            return new AiResponse(AiResponseType.Tool) { ToolCalls = tools, Message =  responseParser.Message };
+        }
+        var result = responseParser.GetContent(context);
+        return new AiResponse(AiResponseType.Result) { Result = result, Message = responseParser.Message };
+    }
+
+    private struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response,BlittableJsonReaderObject responseContent)
+    {
+        public BlittableJsonReaderObject Message;
+        private string _content;
+        private BlittableJsonReaderObject _choice0;
+
+        public void EnsureSuccessfulResponse()
+        {
+            if (response.IsSuccessStatusCode)
+                return;
+            
+            client.HandleUnsuccessfulResponse(response, responseContent);
             Debug.Assert(false, "we should never get here");
         }
 
-        if (responseContent.TryGet(Constants.ResponseFields.Choices, out BlittableJsonReaderArray choices) == false || choices.Length == 0)
+        public void ParseMessage(AiUsage usage)
         {
-            throw new UnexpectedResponseException("No choices in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+            if (responseContent.TryGet(Constants.ResponseFields.Choices, out BlittableJsonReaderArray choices) == false || choices.Length == 0)
+            {
+                throw new UnexpectedResponseException("No choices in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+            }
+
+            _choice0 = (BlittableJsonReaderObject)choices[0];
+        
+            if (_choice0.TryGet(Constants.ResponseFields.Message, out Message) == false ||
+                Message.TryGet(Constants.ResponseFields.Content, out _content) == false)
+            {
+                throw new UnexpectedResponseException("No message/content property in choice: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+            }
+        
+            if (responseContent.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject usageJson) == false)
+                throw new UnexpectedResponseException("No choices property in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+        
+            usage.UpdateFrom(usageJson);
         }
 
-        var choice0 = (BlittableJsonReaderObject)choices[0];
-        
-        if (choice0.TryGet(Constants.ResponseFields.Message, out BlittableJsonReaderObject msg) == false ||
-            msg.TryGet(Constants.ResponseFields.Content, out string content) == false)
+        public bool TryParseToolCalls(out List<AiToolCall> toolCalls)
         {
-            throw new UnexpectedResponseException("No message/content property in choice: " + responseContent) { RequestId = GetRequestId(response.Headers) };
-        }
-        
-        if (responseContent.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject usageJson) == false)
-            throw new UnexpectedResponseException("No choices property in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
-        
-        usage.UpdateFrom(usageJson);
+            if (Message.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray calls) is false)
+            {
+                toolCalls = null;
+                return false;
+            }
 
-        if (msg.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray calls))
-        {
-            var resp = new AiResponse(AiResponseType.Tool) { ToolCalls = [], Message = msg };
+            toolCalls =  [];
             foreach (BlittableJsonReaderObject call in calls)
             {
                 if (call.TryGet("id", out string callId) is false ||
                     call.TryGet("function", out BlittableJsonReaderObject function) is false ||
                     function.TryGet("name", out string name) is false ||
                     function.TryGet("arguments", out string args) is false)
-                    throw new UnexpectedResponseException("Invalid function call: " + call.ToString())
+                    throw new UnexpectedResponseException("Invalid function call: " + call)
                     {
                         RequestId = GetRequestId(response.Headers)
                     };
-                resp.ToolCalls.Add(new AiToolCall(callId, name, args));
+                toolCalls.Add(new AiToolCall(callId, name, args));
+            }
+            return true;
+        }
+
+        public BlittableJsonReaderObject GetContent(JsonOperationContext context)
+        {
+            if (string.IsNullOrEmpty(_content))
+            {
+                _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
+                _choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal); 
+                //TODO: full output if we get here?
+                throw new RefusedToAnswerException("The request was refused by the model")
+                {
+                    Refusal = refusal, FinishReason = finishReason, RequestId = GetRequestId(response.Headers)
+                };
             }
 
-            return resp;
+            return context.Sync.ReadForMemory(_content, "ai/output");
         }
-
-        if (string.IsNullOrEmpty(content))
-        {
-            choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
-            choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal); 
-            //TODO: full output if we get here?
-            throw new RefusedToAnswerException("The request was refused by the model")
-            {
-                Refusal = refusal, FinishReason = finishReason, RequestId = GetRequestId(response.Headers)
-            };
-        }
-
-        var result = context.Sync.ReadForMemory(content, "ai/output");
-        return new AiResponse(AiResponseType.Result) { Result = result, Message = msg};
     }
 
     protected virtual Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token) => _client.SendAsync(request, token);
+    
+    protected virtual Task<HttpResponseMessage> SendStreamingRequestAsync(HttpRequestMessage request, CancellationToken token) => _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
 
     public async Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, CancellationToken token)
     {
@@ -184,9 +411,14 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
         return (results.Result.ToString(), usage);
     }
-    public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, string schema) => CreateCompletionRequest(ctx, messages, tools: null, useTools: false, schema);
+    public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, string schema) => CreateCompletionRequest(ctx, messages, tools: null, useTools: false, streaming: false, schema);
 
-    public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, List<BlittableJsonReaderObject> tools, bool useTools, string schema)
+    public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, 
+        List<BlittableJsonReaderObject> messages, 
+        List<BlittableJsonReaderObject> tools, 
+        bool useTools,
+        bool streaming,
+        string schema)
     {
         if (_model is null)
             throw new ArgumentNullException(nameof(_model));
@@ -201,7 +433,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                     return;
                 }
 
-                WriteCompletionRequestPayload(writer, ctx, messages, tools, useTools, schema);
+                WriteCompletionRequestPayload(writer, ctx, messages, tools, useTools, streaming, schema);
             }
         }, ConventionsToUse);
 
@@ -217,7 +449,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         return request;
     }
 
-    public void WriteCompletionRequestPayload(AsyncBlittableJsonTextWriter writer, JsonOperationContext ctx, IEnumerable<BlittableJsonReaderObject> messages, List<BlittableJsonReaderObject> tools, bool useTools, string schema)
+    public void WriteCompletionRequestPayload(AsyncBlittableJsonTextWriter writer, JsonOperationContext ctx, IEnumerable<BlittableJsonReaderObject> messages, List<BlittableJsonReaderObject> tools, bool useTools, bool streaming, string schema)
     {
         writer.WriteStartObject();
 
@@ -257,6 +489,19 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         writer.WritePropertyName(Constants.RequestFields.JsonSchema);
         writer.WriteObject(GetStructuredOutputSchemaAsBlittable());
         writer.WriteEndObject();
+        
+        if (streaming)
+        {
+            writer.WriteComma();
+            writer.WritePropertyName("stream");
+            writer.WriteBool(true);
+            writer.WriteComma();
+            writer.WritePropertyName("stream_options");
+            writer.WriteStartObject();
+            writer.WritePropertyName("include_usage");
+            writer.WriteBool(true);
+            writer.WriteEndObject();
+        }
 
         // Add Ollama-specific "think" parameter if specified
         if (_think.HasValue)
@@ -307,7 +552,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             request.Headers.TryAddWithoutValidation(Constants.RequestFields.OpenAiProject, _projectId);
     }
 
-    public virtual async Task<BlittableJsonReaderObject> GetResponseContentAsync(JsonOperationContext context, HttpResponseMessage response, CancellationToken token)
+    public async Task<BlittableJsonReaderObject> GetResponseContentAsync(JsonOperationContext context, HttpResponseMessage response, CancellationToken token)
     {
         await using (var responseStream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false))
         await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.AI;
 internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClientForTesting
 {
     public static readonly string EmptySchema = GetSchemaFromSampleObject("{}");
-    
+
     private readonly string _model;
     private readonly string _organizationId;
     private readonly string _projectId;
@@ -95,54 +95,58 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         _apiKey = apiKey;
     }
 
-    
+
     private struct ToolCallState
     {
-        private StringBuilder _id ;
+        private StringBuilder _id;
         private StringBuilder _type;
         private StringBuilder _name;
         private StringBuilder _arguments;
 
         private int _toolCallIndex;
-        
+
         public List<AiToolCall> AllToolCalls;
 
         public ToolCallState()
         {
             _toolCallIndex = -1;
         }
-        
+
         public void Merge(BlittableJsonReaderObject toolCallChunk)
         {
-            if (!toolCallChunk.TryGet("index", out int index))
+            if (!toolCallChunk.TryGet(Constants.ResponseFields.Index, out int index))
                 return;
-            
+
             if (index != _toolCallIndex)
             {
                 AddAndReset();
                 _toolCallIndex = index;
             }
-            if (toolCallChunk.TryGet("id", out string id))
+
+            if (toolCallChunk.TryGet(Constants.ResponseFields.Id, out string id))
             {
                 _id.Append(id);
             }
-            if (toolCallChunk.TryGet("type", out string type))
+
+            if (toolCallChunk.TryGet(Constants.ResponseFields.Type, out string type))
             {
                 _type.Append(type);
             }
-            if (toolCallChunk.TryGet("function", out BlittableJsonReaderObject functionChunk))
+
+            if (toolCallChunk.TryGet(Constants.ResponseFields.Function, out BlittableJsonReaderObject functionChunk))
             {
-                if (functionChunk.TryGet("name", out string nameChunk))
+                if (functionChunk.TryGet(Constants.ResponseFields.Name, out string nameChunk))
                 {
                     _name.Append(nameChunk);
                 }
-                if (functionChunk.TryGet("arguments", out string argsChunk))
+
+                if (functionChunk.TryGet(Constants.ResponseFields.Arguments, out string argsChunk))
                 {
                     _arguments.Append(argsChunk);
                 }
             }
         }
-        
+
         public void AddAndReset()
         {
             if (_toolCallIndex == -1)
@@ -154,11 +158,11 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
                 return;
             }
-            
+
             AllToolCalls ??= [];
             AllToolCalls.Add(new AiToolCall(_id.ToString(), _name.ToString(), _arguments.ToString()));
-        
-     
+
+
             _toolCallIndex = -1;
             _id.Clear();
             _type.Clear();
@@ -168,16 +172,16 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
     }
 
 
-    public async Task<AiResponse> StreamingCompleteAsync(JsonOperationContext streamingContext, IMemoryContextPool contextPool, 
+    public async Task<AiResponse> StreamingCompleteAsync(JsonOperationContext streamingContext, IMemoryContextPool contextPool,
         string propertyToStream, HttpRequestMessage request,
-        Func<Memory<byte>,Task> streamedPropertyCallback,
+        Func<Memory<byte>, Task> streamedPropertyCallback,
         AiUsage usage, CancellationToken token)
     {
         AddDefaultHeaders(request);
         // we use a small buffer size since we expect those to be "token" level updates, not very big ones
         const int initialBufferSize = 64;
 
-        using var __ = streamingContext.GetRawMemoryBuffer(initialBufferSize,out var streamedPropertyBuffer);
+        using var __ = streamingContext.GetRawMemoryBuffer(initialBufferSize, out var streamedPropertyBuffer);
         var parser = new SseStreamingJsonParser(streamingContext, propertyToStream);
         var alreadySeen = 0;
         var sizeToStream = 0;
@@ -188,6 +192,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             {
                 streamingContext.GrowAllocation(streamedPropertyBuffer, size - streamedPropertyBuffer.SizeInBytes);
             }
+
             unsafe
             {
                 var read = e.CopyTo(alreadySeen, streamedPropertyBuffer.Address);
@@ -203,52 +208,52 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             HandleUnsuccessfulResponse(response, responseContent);
             Debug.Assert(false, "we should never get here");
         }
+
         await using var responseStream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
-        //var s = Encoding.UTF8.GetString(((MemoryStream)responseStream).ToArray());
         ToolCallState toolCallState = new();
         BlittableJsonReaderObject message = null;
-     
+
         // need to contexts here because we run two parsing operations at once, first for each of the SSE events
         // and then for the internal buffer that there are providing.
         using var ___ = contextPool.AllocateOperationContext(out JsonOperationContext parsingContext);
         // Note that here we iterate over blittable, whose scope is only the _single_ iteration we run, you need to copy
         // any data that you need out of them.
         await foreach (var sseEvent in SseParser.Create(responseStream, (_, data) =>
-        {
-            unsafe
-            {
-                if (data.SequenceEqual("[DONE]"u8))
-                    return null;
-                fixed (byte* p = data)
-                {
-                    return parsingContext.ParseBuffer(p, data.Length, "msg", BlittableJsonDocumentBuilder.UsageMode.None);
-                }
-            }
-
-        }).EnumerateAsync(token))
+                       {
+                           unsafe
+                           {
+                               if (data.SequenceEqual("[DONE]"u8))
+                                   return null;
+                               fixed (byte* p = data)
+                               {
+                                   return parsingContext.ParseBuffer(p, data.Length, "msg", BlittableJsonDocumentBuilder.UsageMode.None);
+                               }
+                           }
+                       }).EnumerateAsync(token))
         {
             using var _ = sseEvent.Data;
 
-            if (sseEvent.Data is null)// "[DONE]"
+            if (sseEvent.Data is null) // "[DONE]"
             {
                 toolCallState.AddAndReset();
                 break;
             }
 
-            if (sseEvent.Data.TryGet("usage", out BlittableJsonReaderObject streamedUsage) && streamedUsage is not null)
+            if (sseEvent.Data.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject streamedUsage) && streamedUsage is not null)
             {
                 usage.UpdateFrom(streamedUsage);
             }
 
-            if (sseEvent.Data.TryGet("choices", out BlittableJsonReaderArray choices) is false ||
+            if (sseEvent.Data.TryGet(Constants.ResponseFields.Choices, out BlittableJsonReaderArray choices) is false ||
                 choices.Length == 0)
             {
                 continue;
             }
+
             var choice = (BlittableJsonReaderObject)choices[0];
-            if (choice.TryGet("delta", out BlittableJsonReaderObject delta))
+            if (choice.TryGet(Constants.ResponseFields.Delta, out BlittableJsonReaderObject delta))
             {
-                if (delta.TryGet("content", out LazyStringValue content) && content?.Length > 0)
+                if (delta.TryGet(Constants.ResponseFields.Content, out LazyStringValue content) && content?.Length > 0)
                 {
                     toolCallState.AddAndReset();
 
@@ -258,13 +263,14 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                         await streamedPropertyCallback(streamedPropertyBuffer.AsMemory()[..sizeToStream]);
                         sizeToStream = 0;
                     }
+
                     if (final is not null)
                     {
                         message = final;
                     }
                 }
 
-                if (delta.TryGet("tool_calls", out BlittableJsonReaderArray toolCalls))
+                if (delta.TryGet(Constants.ResponseFields.ToolCalls, out BlittableJsonReaderArray toolCalls))
                 {
                     foreach (BlittableJsonReaderObject toolCallChunk in toolCalls)
                     {
@@ -273,46 +279,45 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                 }
             }
         }
-        
+
         if (toolCallState.AllToolCalls?.Count >= 0)
         {
-            DynamicJsonArray toolCalls = new ();
+            DynamicJsonArray toolCalls = new();
             foreach (var call in toolCallState.AllToolCalls)
             {
                 toolCalls.Add(new DynamicJsonValue
                 {
-                    ["id"] = call.Id,
-                    ["type"] = "function",
-                    ["function"] = new DynamicJsonValue
+                    [Constants.ResponseFields.Id] = call.Id,
+                    [Constants.ResponseFields.Type] = Constants.ResponseFields.Function,
+                    [Constants.ResponseFields.Function] = new DynamicJsonValue
                     {
-                        ["name"] = call.Name,
-                        ["arguments"] = call.Arguments
+                        [Constants.ResponseFields.Name] = call.Name,
+                        [Constants.ResponseFields.Arguments] = call.Arguments
                     }
                 });
             }
-            
+
             return new AiResponse(AiResponseType.Tool)
             {
                 Message = streamingContext.ReadObject(new DynamicJsonValue
                 {
-                    ["role"] = "assistant", 
-                    ["content"] = null,
-                    ["tool_calls"] = toolCalls 
+                    [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
+                    [Constants.ResponseFields.Content] = null,
+                    [Constants.ResponseFields.ToolCalls] = toolCalls
                 }, "persisted/streamed/toolcalls"),
                 ToolCalls = toolCallState.AllToolCalls,
             };
         }
-   
+
         return new AiResponse(AiResponseType.Result)
         {
             Message = streamingContext.ReadObject(new DynamicJsonValue
             {
-                ["role"] = "assistant",
-                ["content"] = message!.ToString(),
-            }, "persisted/streamed/message"), 
+                [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
+                [Constants.ResponseFields.Content] = message!.ToString(),
+            }, "persisted/streamed/message"),
             Result = message,
         };
-
     }
 
     public async Task<AiResponse> CompleteAsync(JsonOperationContext context, HttpRequestMessage request, AiUsage usage, CancellationToken token)
@@ -326,13 +331,14 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         responseParser.ParseMessage(usage);
         if (responseParser.TryParseToolCalls(out var tools))
         {
-            return new AiResponse(AiResponseType.Tool) { ToolCalls = tools, Message =  responseParser.Message };
+            return new AiResponse(AiResponseType.Tool) { ToolCalls = tools, Message = responseParser.Message };
         }
+
         var result = responseParser.GetContent(context);
         return new AiResponse(AiResponseType.Result) { Result = result, Message = responseParser.Message };
     }
 
-    private struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response,BlittableJsonReaderObject responseContent)
+    private struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response, BlittableJsonReaderObject responseContent)
     {
         public BlittableJsonReaderObject Message;
         private string _content;
@@ -342,7 +348,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         {
             if (response.IsSuccessStatusCode)
                 return;
-            
+
             client.HandleUnsuccessfulResponse(response, responseContent);
             Debug.Assert(false, "we should never get here");
         }
@@ -355,16 +361,16 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             }
 
             _choice0 = (BlittableJsonReaderObject)choices[0];
-        
+
             if (_choice0.TryGet(Constants.ResponseFields.Message, out Message) == false ||
                 Message.TryGet(Constants.ResponseFields.Content, out _content) == false)
             {
                 throw new UnexpectedResponseException("No message/content property in choice: " + responseContent) { RequestId = GetRequestId(response.Headers) };
             }
-        
+
             if (responseContent.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject usageJson) == false)
                 throw new UnexpectedResponseException("No choices property in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
-        
+
             usage.UpdateFrom(usageJson);
         }
 
@@ -376,19 +382,20 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                 return false;
             }
 
-            toolCalls =  [];
+            toolCalls = [];
             foreach (BlittableJsonReaderObject call in calls)
             {
-                if (call.TryGet("id", out string callId) is false ||
-                    call.TryGet("function", out BlittableJsonReaderObject function) is false ||
-                    function.TryGet("name", out string name) is false ||
-                    function.TryGet("arguments", out string args) is false)
+                if (call.TryGet(Constants.ResponseFields.Id, out string callId) is false ||
+                    call.TryGet(Constants.ResponseFields.Function, out BlittableJsonReaderObject function) is false ||
+                    function.TryGet(Constants.ResponseFields.Name, out string name) is false ||
+                    function.TryGet(Constants.ResponseFields.Arguments, out string args) is false)
                     throw new UnexpectedResponseException("Invalid function call: " + call)
                     {
                         RequestId = GetRequestId(response.Headers)
                     };
                 toolCalls.Add(new AiToolCall(callId, name, args));
             }
+
             return true;
         }
 
@@ -397,7 +404,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             if (string.IsNullOrEmpty(_content))
             {
                 _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
-                _choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal); 
+                _choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal);
                 //TODO: full output if we get here?
                 throw new RefusedToAnswerException("The request was refused by the model")
                 {
@@ -410,7 +417,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
     }
 
     protected virtual Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token) => _client.SendAsync(request, token);
-    
+
     protected virtual Task<HttpResponseMessage> SendStreamingRequestAsync(HttpRequestMessage request, CancellationToken token) => _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
 
     public async Task<(string Result, AiUsage Usage)> CompleteAsync(string systemPrompt, string userPrompt, string schema, CancellationToken token)
@@ -438,11 +445,12 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
         return (results.Result.ToString(), usage);
     }
+
     public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, List<BlittableJsonReaderObject> messages, string schema) => CreateCompletionRequest(ctx, messages, tools: null, useTools: false, streaming: false, schema);
 
-    public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx, 
-        List<BlittableJsonReaderObject> messages, 
-        List<BlittableJsonReaderObject> tools, 
+    public HttpRequestMessage CreateCompletionRequest(JsonOperationContext ctx,
+        List<BlittableJsonReaderObject> messages,
+        List<BlittableJsonReaderObject> tools,
         bool useTools,
         bool streaming,
         string schema)
@@ -468,8 +476,8 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
         var request = new HttpRequestMessage
         {
-            Method = HttpMethod.Post, 
-            Content = content, 
+            Method = HttpMethod.Post,
+            Content = content,
             RequestUri = new Uri(Constants.RequestFields.DefaultRelativeUri, UriKind.Relative)
         };
 
@@ -516,16 +524,16 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         writer.WritePropertyName(Constants.RequestFields.JsonSchema);
         writer.WriteObject(GetStructuredOutputSchemaAsBlittable());
         writer.WriteEndObject();
-        
+
         if (streaming)
         {
             writer.WriteComma();
-            writer.WritePropertyName("stream");
+            writer.WritePropertyName(Constants.RequestFields.Stream);
             writer.WriteBool(true);
             writer.WriteComma();
-            writer.WritePropertyName("stream_options");
+            writer.WritePropertyName(Constants.RequestFields.StreamOptions);
             writer.WriteStartObject();
-            writer.WritePropertyName("include_usage");
+            writer.WritePropertyName(Constants.RequestFields.IncludeUsage);
             writer.WriteBool(true);
             writer.WriteEndObject();
         }
@@ -665,10 +673,10 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                         // TPM/RPM - should retry only for this exception
                         throw new
                             RateLimitException(message)
-                        {
-                            RetryAfter = retryAfter,
-                            RequestId = reqId
-                        };
+                            {
+                                RetryAfter = retryAfter,
+                                RequestId = reqId
+                            };
                     default:
                         throw new TooManyRequestsException(message)
                         {
@@ -689,6 +697,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         {
             return string.Empty;
         }
+
         return values.FirstOrDefault();
     }
 
@@ -746,6 +755,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                     return false;
             }
         }
+
         return true;
     }
 
@@ -760,7 +770,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         {
             return GetSchemaFromSampleObject(sampleObject);
         }
-       
+
         throw new InvalidOperationException("Missing output schema and sample object in configuration (there must be at least one of them)");
     }
 
@@ -902,6 +912,15 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string ErrorTypeInsufficientQuota = "insufficient_quota";
             public const string ErrorTypeTokens = "tokens";
             public const string ErrorTypeRequests = "requests";
+            
+            public const string Index = "index";
+            public const string Id = "id";
+            public const string Type = "type";
+            public const string Function = "function";
+            public const string Name = "name";
+            public const string Arguments = "arguments";
+            public const string Delta = "delta";
+            public const string Role = "role";
         }
 
         public static class Headers
@@ -965,7 +984,10 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string DefaultRelativeUri = "/v1/chat/completions";
             public const string ModelsUri = "/v1/models";
             public const string AuthorizationApiKeyProperty = "Bearer";
+            
+            public const string Stream = "stream";
+            public const string StreamOptions = "stream_options";
+            public const string IncludeUsage = "include_usage";
         }
     }
-
 }

--- a/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
+++ b/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
@@ -38,7 +38,7 @@ public unsafe class SseStreamingJsonParser : IDisposable
 
     public event Action<UnmanagedWriteBuffer>? OnStringRead;
 
-    private void OnStringReadInvoke(object? sender, UnmanagedWriteBuffer e)
+    private void OnStringReadInvoke(UnmanagedWriteBuffer e)
     {
         OnStringRead?.Invoke(e);
     }

--- a/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
+++ b/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using System;
+using System.Threading;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.AI;
+
+/// <summary>
+/// This is meant to allow us to parse partial JSON from LLM models.
+///
+/// We use the parser to build the JSON in an incremental, as well as
+/// to be able to stream a property from the JSON "as it is being parsed"
+/// to the caller. 
+/// </summary>
+public unsafe class SseStreamingJsonParser : IDisposable
+{
+    private readonly JsonOperationContext _context;
+    private readonly UnmanagedJsonParser _parser;
+    private readonly BlittableJsonDocumentBuilder _builder;
+
+    private long _totalSize;
+    private readonly int _maxSize;
+
+    public SseStreamingJsonParser(JsonOperationContext context, string property, int maxSize = int.MaxValue)
+    {
+        _context = context;
+        _maxSize = maxSize;
+
+        var jsonParserState = new JsonParserState();
+        _parser = new UnmanagedJsonParser(context, jsonParserState, "streaming/parsing");
+        _builder = new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.ForStreaming, "streaming/parsing", _parser, jsonParserState);
+        _builder.PropertyToWatchForStreaming = (property, OnStringReadInvoke);
+        _context.CachedProperties.NewDocument();
+        _builder.ReadObjectDocument();
+    }
+
+    public event Action<UnmanagedWriteBuffer>? OnStringRead;
+
+    private void OnStringReadInvoke(object? sender, UnmanagedWriteBuffer e)
+    {
+        OnStringRead?.Invoke(e);
+    }
+
+    public void Reset()
+    {
+        _context.CachedProperties.NewDocument();
+        _builder.ReadObjectDocument();
+    }
+
+    public BlittableJsonReaderObject? Process(LazyStringValue dataChunk, CancellationToken? token = null)
+    {
+        token?.ThrowIfCancellationRequested();
+
+        _totalSize += dataChunk.Length;
+        if (_totalSize > _maxSize)
+            throw new ArgumentException($"The maximum size allowed ({_maxSize}) has been exceeded, aborting");
+
+        _parser.SetBuffer(dataChunk.Buffer, dataChunk.Length);
+        if (_builder.Read())
+        {
+            _builder.FinalizeDocument();
+            return _builder.CreateReader();
+        }
+
+        return null;
+    }
+
+    public void Dispose()
+    {
+        _parser?.Dispose();
+        _builder?.Dispose();
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -320,39 +320,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected virtual ChatCompletionClient CreateClient(AiConnectionString connection) => ChatCompletionClient.CreateChatCompletionClient(ContextPool, connection);
 
-        public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> StreamingTalkAsync(
-            JsonOperationContext context,
-            AiAgentConfiguration configuration,
-            ConversationDocument document,
-            string firstPropertyToStream,
-            Func<Memory<byte>, Task> streaming,
-            CancellationToken token = default)
-        {
-            using var talker = new Talker(this, context, configuration, document);
-            talker.Init();
-
-            while (true)
-            {
-                using var request = talker.CreateCompletionRequest(streaming: true);
-
-                await talker.StreamAsync(ContextPool, request, firstPropertyToStream, streaming, token);
-                talker.UpdateDocument();
-
-                if (talker.ResponseType is AiResponseType.Result)
-                    break;
-
-                await HandleQueryToolCallsAsync(context, configuration, document, talker.ToolCalls);
-
-                if (TryGetUserTools(context, document, configuration, talker.ToolCalls))
-                    break; // we need to return the user tool requests to the client, so we can continue the conversation
-            }
-
-            var history = await TryReduceChatSizeAsync(context, talker.Client, configuration, document, talker.AiUsage, token);
-
-            return (talker.Result, document, history);
-        }
-
-        private class Talker(AbstractAiAgentProcessor processor, JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document) : IDisposable
+        private class Talker(AbstractAiAgentProcessor processor, JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document, string firstPropertyToStream, Func<Memory<byte>, Task> streaming) : IDisposable
         {
             private string _schema;
             private List<BlittableJsonReaderObject> _tools;
@@ -381,20 +349,35 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 _count = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
             }
 
-            public HttpRequestMessage CreateCompletionRequest(bool streaming)
+            public HttpRequestMessage CreateCompletionRequest()
             {
                 AiUsage = new();
-                return Client.CreateCompletionRequest(context, document.Messages, _tools, useTools: _count-- > 0, streaming, _schema);
+                return Client.CreateCompletionRequest(context, document.Messages, _tools, useTools: _count-- > 0, streaming != null, _schema);
             }
 
-            public async Task RunAsync(HttpRequestMessage request, CancellationToken token)
+            public async Task RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, CancellationToken token)
             {
-                _aiResponse = await Client.CompleteAsync(
-                    context,
-                    request,
-                    AiUsage,
-                    token
-                );
+                if (streaming is null)
+                {
+                    _aiResponse = await Client.CompleteAsync(
+                        context,
+                        request,
+                        AiUsage,
+                        token
+                    );
+                }
+                else
+                {
+                    _aiResponse = await Client.StreamingCompleteAsync(
+                        context,
+                        contextPool,
+                        firstPropertyToStream,
+                        request,
+                        streaming,
+                        AiUsage,
+                        token
+                    );
+                }
             }
 
             public void UpdateDocument()
@@ -403,39 +386,44 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 document.UpdateUsage(AiUsage);
             }
 
-            public async Task StreamAsync(IMemoryContextPool contextPool, HttpRequestMessage request, string propertyToStream, Func<Memory<byte>, Task> streamedPropertyCallback, CancellationToken token)
-            {
-                _aiResponse = await Client.StreamingCompleteAsync(
-                    context,
-                    contextPool,
-                    propertyToStream,
-                    request,
-                    streamedPropertyCallback,
-                    AiUsage,
-                    token
-                );
-            }
-
             public void Dispose()
             {
                 Client?.Dispose();
             }
         }
-
+        public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> StreamingTalkAsync(
+            JsonOperationContext context,
+            AiAgentConfiguration configuration,
+            ConversationDocument document,
+            string firstPropertyToStream,
+            Func<Memory<byte>, Task> streaming,
+            CancellationToken token = default)
+        {
+            using var talker = new Talker(this, context, configuration, document, firstPropertyToStream, streaming);
+            return await RunInternalAsync(context, configuration, document, talker, token);
+        }
+        
         public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> TalkAsync(
             JsonOperationContext context,
             AiAgentConfiguration configuration,
             ConversationDocument document,
             CancellationToken token = default)
         {
-            using var talker = new Talker(this, context, configuration, document);
+            using var talker = new Talker(this, context, configuration, document, firstPropertyToStream: null, streaming: null);
+            return await RunInternalAsync(context, configuration, document, talker, token);
+        }
+
+        private async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> RunInternalAsync(
+            JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document,
+            Talker talker, CancellationToken token)
+        {
             talker.Init();
 
             while (true)
             {
-                using var request = talker.CreateCompletionRequest(streaming: false);
+                using var request = talker.CreateCompletionRequest();
 
-                await talker.RunAsync(request, token);
+                await talker.RunAsync(ContextPool,request, token);
                 talker.UpdateDocument();
 
                 if (talker.ResponseType is AiResponseType.Result)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.Features;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Exceptions;
@@ -30,14 +34,9 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         protected AbstractAiAgentProcessor([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
         }
-
-        public async Task HandleRequest(
-            JsonOperationContext context, 
-            AiAgentConfiguration configuration, 
-            string conversationId, 
-            ConversationDocument document, 
-            RequestBody body,
-            CancellationToken token)
+        
+        private async Task<bool> TryHandleActionResponses(JsonOperationContext context, AiAgentConfiguration configuration, string conversationId, ConversationDocument document,
+            RequestBody body)
         {
             var hasActionResponse = body.ActionResponses is { Length: > 0 };
             var hasUserPrompt = string.IsNullOrEmpty(body.UserPrompt) == false;
@@ -71,12 +70,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 // ensuring we can recover if TalkAsync fails.
                 await TryPersistAsync(context, configuration, conversationId, document, history: null);
                 await WriteResponseAsync(context, conversationId, response: null, document);
-                return;
+                return false;
             }
 
             if (hasActionResponse == false && hasUserPrompt == false)
                 throw new InvalidOperationException($"Cannot have a conversation '{conversationId}' without open action calls or user prompt.");
-
+            
+            
             if (string.IsNullOrEmpty(body.UserPrompt) == false)
             {
                 document.AddMessage(context, context.ReadObject(new DynamicJsonValue
@@ -85,6 +85,21 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     ["content"] = body.UserPrompt
                 }, "user/msg"), usage: null);
             }
+
+            return true;
+        }
+
+
+        public async Task HandleRequest(
+            JsonOperationContext context, 
+            AiAgentConfiguration configuration, 
+            string conversationId, 
+            ConversationDocument document, 
+            RequestBody body,
+            CancellationToken token)
+        {
+            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false) 
+                return;
 
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
             try
@@ -100,11 +115,63 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             await WriteResponseAsync(context, conversationId, r.Response, r.Document);
         }
 
+        private static readonly byte[] ResultPrefix = "event: result\ndata: "u8.ToArray();
+        private static readonly byte[] DataPrefix = "data: "u8.ToArray();
+        private static readonly byte[] NewLinePostfix = "\n\n"u8.ToArray();
+
+        public async Task HandleStreamingRequest(
+            JsonOperationContext context, 
+            AiAgentConfiguration configuration, 
+            string conversationId, 
+            ConversationDocument document, 
+            RequestBody body,
+            CancellationToken token)
+        {
+            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false) 
+                return;
+            
+            var propertyToStream = RequestHandler.GetStringQueryString("propertyToStream");
+
+
+            HttpContext.Response.Headers.ContentType = "text/event-stream";
+            var feature = HttpContext.Features.Get<IHttpResponseBodyFeature>();
+            feature?.DisableBuffering();
+            
+            await using var responseStream = RequestHandler.ResponseBodyStream();
+            (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
+            try
+            {
+                r = await StreamingTalkAsync(context, configuration, document, propertyToStream, async (data) =>
+                {
+                    while (data.IsEmpty is false)
+                    {
+                        int nextLineBreak = data.Span.IndexOf((byte)'\n');
+                        int length = nextLineBreak >= 0 ? nextLineBreak + 1 : data.Length;
+                        await responseStream.WriteAsync(DataPrefix, token);
+                        await responseStream.WriteAsync(data[..length], token);
+                        data = data[length..];
+                    }
+                    await responseStream.WriteAsync(NewLinePostfix, token);
+                    await responseStream.FlushAsync(token);
+
+                }, token: token);
+            }
+            catch (Exception e)
+            {
+                throw new AiException($"Failed to 'talk' with the agent '{configuration.Identifier}' (streaming), conversation: '{conversationId}'.", e) { RequestId = null };
+            }
+
+            conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
+            await responseStream.WriteAsync(ResultPrefix, token);
+            await WriteResponseAsync(context, conversationId, r.Response, r.Document);
+            await responseStream.FlushAsync(token);
+        }
         public override async ValueTask ExecuteAsync()
         {
             using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
             var conversationId = RequestHandler.GetStringQueryString("conversationId");
             var agentId = RequestHandler.GetStringQueryString("agentId");
+            var streaming = RequestHandler.GetBoolValueQueryString("streaming", required:false) ?? false;
             var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
 
             using var _ = ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
@@ -170,7 +237,14 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 }
             }
 
-            await HandleRequest(context, configuration, conversationId, conversationDocument, body, token.Token);
+            if (streaming)
+            {
+                await HandleStreamingRequest(context, configuration, conversationId, conversationDocument, body, token.Token);
+            }
+            else
+            {
+                await HandleRequest(context, configuration, conversationId, conversationDocument, body, token.Token);
+            }
         }
 
         public async Task<RequestBody> ReadRequestBodyAsync(JsonOperationContext context, CancellationToken token)
@@ -229,91 +303,179 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected virtual ChatCompletionClient CreateClient(AiConnectionString connection) => ChatCompletionClient.CreateChatCompletionClient(ContextPool, connection);
 
-        public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> TalkAsync(JsonOperationContext context, AiAgentConfiguration configuration,
-            ConversationDocument document, CancellationToken token)
+         public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> StreamingTalkAsync(
+            JsonOperationContext context, 
+            AiAgentConfiguration configuration,
+            ConversationDocument document,
+            string firstPropertyToStream,
+            Func<Memory<byte>,Task>streaming, 
+            CancellationToken token = default)
         {
-            document.EnsureInitialized();
-
-            var conStr = GetAiConnectionString(configuration.ConnectionStringName);
-
-            var schema = ChatCompletionClient.GetSchemaForRequest(configuration.OutputSchema, configuration.SampleObject);
-
-            var tools = ConversationDocument.GenerateTools(context, configuration);
-
-            AiResponse aiResponse;
-            AiUsage aiUsage;
-            using var client = CreateClient(conStr);
-            var count = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+            using var talker = new Talker(this, context, configuration, document);
+            talker.Init();
             
             while (true)
             {
-                aiUsage = new();
-                using var request = client.CreateCompletionRequest(context, document.Messages, tools, useTools: count-- > 0, schema);
+                using var request = talker.CreateCompletionRequest(streaming: true);
 
-                aiResponse = await client.CompleteAsync(
-                    context,
-                    request,
-                    aiUsage,
-                    token
-                );
-
-                document.AddMessage(context, aiResponse.Message, aiUsage);
-                document.UpdateUsage(aiUsage);
-                if (aiResponse.Type is AiResponseType.Result)
+                await talker.Stream(ContextPool, request,firstPropertyToStream, streaming, token);
+                talker.UpdateDocument();
+                
+                if (talker.ResponseType is AiResponseType.Result)
                     break;
 
-                await HandleQueryToolCallsAsync(context, configuration, document, aiResponse);
+                await HandleQueryToolCallsAsync(context, configuration, document, talker.ToolCalls);
 
-                if (TryGetUserTools(context, document, configuration, aiResponse))
+                if (TryGetUserTools(context, document, configuration, talker.ToolCalls))
                     break; // we need to return the user tool requests to the client, so we can continue the conversation
             }
 
-            var history = await TryReduceChatSize();
+            var history = await TryReduceChatSize(context, talker.Client, configuration, document, talker.AiUsage, token);
 
-            return (aiResponse.Result, document, history);
+            return (talker.Result, document, history);
+        }
 
+        private class Talker(AbstractAiAgentProcessor processor, JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document) : IDisposable
+        {
+            private string _schema;
+            private List<BlittableJsonReaderObject> _tools;
+            private int _count;
+            private AiResponse _aiResponse;
 
-            async Task<BlittableJsonReaderObject> TryReduceChatSize()
+            public AiUsage AiUsage;
+            public ChatCompletionClient Client;
+            
+            public AiResponseType ResponseType => _aiResponse.Type;
+            public List<AiToolCall> ToolCalls => _aiResponse.ToolCalls;
+            
+            public BlittableJsonReaderObject Result => _aiResponse.Result;
+
+            public void Init()
             {
-                var reduction = configuration.ChatTrimming;
-                if (reduction == null || document.OpenActionCalls.Count > 0)
-                    return null;
+                document.EnsureInitialized();
 
-                TimeSpan? historyExpiration = reduction.History?.HistoryExpirationInSec == null
-                    ? null
-                    : TimeSpan.FromSeconds(reduction.History.HistoryExpirationInSec.Value);
+                var conStr = processor.GetAiConnectionString(configuration.ConnectionStringName);
 
-                if (reduction.Truncate != null)
+                _schema = ChatCompletionClient.GetSchemaForRequest(configuration.OutputSchema, configuration.SampleObject);
+
+                _tools = ConversationDocument.GenerateTools(context, configuration);
+
+                Client = processor.CreateClient(conStr);
+                _count = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+            }
+
+            public HttpRequestMessage CreateCompletionRequest(bool streaming)
+            {
+                AiUsage = new();
+                return Client.CreateCompletionRequest(context, document.Messages, _tools, useTools: _count-- > 0, streaming, _schema);
+            }
+
+            public async Task Run(HttpRequestMessage request, CancellationToken token)
+            {
+                _aiResponse = await Client.CompleteAsync(
+                    context,
+                    request,
+                    AiUsage,
+                    token
+                );
+            }
+
+            public void UpdateDocument()
+            {
+                document.AddMessage(context, _aiResponse.Message, AiUsage);
+                document.UpdateUsage(AiUsage);
+            }
+
+            public async Task Stream(IMemoryContextPool contextPool,HttpRequestMessage request, string propertyToStream,  Func<Memory<byte>,Task> streamedPropertyCallback, CancellationToken token)
+            {
+                _aiResponse = await Client.StreamingCompleteAsync(
+                    context,
+                    contextPool, 
+                    propertyToStream,
+                    request,                  
+                    streamedPropertyCallback,
+                    AiUsage,  
+                    token
+                );
+            }
+
+            public void Dispose()
+            {
+                Client?.Dispose();
+            }
+        }
+         
+        public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> TalkAsync(
+            JsonOperationContext context, 
+            AiAgentConfiguration configuration,
+            ConversationDocument document,
+            CancellationToken token = default)
+        {
+            using var talker = new Talker(this, context, configuration, document);
+            talker.Init();
+            
+            while (true)
+            {
+                using var request = talker.CreateCompletionRequest(streaming: false);
+
+                await talker.Run(request, token);
+                talker.UpdateDocument();
+                
+                if (talker.ResponseType is AiResponseType.Result)
+                    break;
+
+                await HandleQueryToolCallsAsync(context, configuration, document, talker.ToolCalls);
+
+                if (TryGetUserTools(context, document, configuration, talker.ToolCalls))
+                    break; // we need to return the user tool requests to the client, so we can continue the conversation
+            }
+
+            var history = await TryReduceChatSize(context, talker.Client, configuration, document, talker.AiUsage, token);
+
+            return (talker.Result, document, history);
+        }
+
+
+        async Task<BlittableJsonReaderObject> TryReduceChatSize(JsonOperationContext context, ChatCompletionClient client, AiAgentConfiguration configuration, ConversationDocument document,AiUsage aiUsage, CancellationToken token)
+        {
+            var reduction = configuration.ChatTrimming;
+            if (reduction == null || document.OpenActionCalls.Count > 0)
+                return null;
+
+            TimeSpan? historyExpiration = reduction.History?.HistoryExpirationInSec == null
+                ? null
+                : TimeSpan.FromSeconds(reduction.History.HistoryExpirationInSec.Value);
+
+            if (reduction.Truncate != null)
+            {
+                if (document.Messages.Count > reduction.Truncate.MessagesLengthBeforeTruncate)
                 {
-                    if (document.Messages.Count > reduction.Truncate.MessagesLengthBeforeTruncate)
-                    {
-                        var truncateCount = document.Messages.Count - reduction.Truncate.MessagesLengthAfterTruncate;
-                        truncateCount = int.Min(truncateCount, document.Messages.Count - 1); // prevent System.ArgumentException (out of bounds)
-                        if (truncateCount > 0)
-                        {
-                            var chatBefore = reduction.History == null ? null : document.ToHistoryBlittable(context, configuration, historyExpiration);
-                            document.Messages.RemoveRange(1, truncateCount);
-                            return chatBefore;
-                        }
-                    }
-                }
-                else if (reduction.Tokens != null)
-                {
-                    reduction.Tokens.MaxTokensBeforeSummarization = configuration.ChatTrimming.Tokens.MaxTokensBeforeSummarization ?? 
-                                                                    DefaultMaxTokensBeforeSummarization;
-                    reduction.Tokens.MaxTokensAfterSummarization = configuration.ChatTrimming.Tokens.MaxTokensAfterSummarization ?? 
-                                                                   DefaultMaxTokensAfterSummarization;
-
-                    if (aiUsage.TotalTokens > reduction.Tokens.MaxTokensBeforeSummarization)
+                    var truncateCount = document.Messages.Count - reduction.Truncate.MessagesLengthAfterTruncate;
+                    truncateCount = int.Min(truncateCount, document.Messages.Count - 1); // prevent System.ArgumentException (out of bounds)
+                    if (truncateCount > 0)
                     {
                         var chatBefore = reduction.History == null ? null : document.ToHistoryBlittable(context, configuration, historyExpiration);
-                        await SummarizeAsync(context, client, configuration, document, token);
+                        document.Messages.RemoveRange(1, truncateCount);
                         return chatBefore;
                     }
                 }
-
-                return null; // if reduction wasn't executed -> no history to persist (return null)
             }
+            else if (reduction.Tokens != null)
+            {
+                reduction.Tokens.MaxTokensBeforeSummarization = configuration.ChatTrimming.Tokens.MaxTokensBeforeSummarization ??
+                                                                DefaultMaxTokensBeforeSummarization;
+                reduction.Tokens.MaxTokensAfterSummarization = configuration.ChatTrimming.Tokens.MaxTokensAfterSummarization ??
+                                                               DefaultMaxTokensAfterSummarization;
+
+                if (aiUsage.TotalTokens > reduction.Tokens.MaxTokensBeforeSummarization)
+                {
+                    var chatBefore = reduction.History == null ? null : document.ToHistoryBlittable(context, configuration, historyExpiration);
+                    await SummarizeAsync(context, client, configuration, document, token);
+                    return chatBefore;
+                }
+            }
+
+            return null; // if reduction wasn't executed -> no history to persist (return null)
         }
 
         private async Task SummarizeAsync(JsonOperationContext context, ChatCompletionClient client, AiAgentConfiguration configuration, ConversationDocument oldChat, CancellationToken token)
@@ -356,7 +518,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             var usage = new AiUsage();
             var tools = ConversationDocument.GenerateTools(context, configuration);
-            using var request = client.CreateCompletionRequest(context, messages, tools, useTools: false, SummarizationOutputSchema);
+            using var request = client.CreateCompletionRequest(context, messages, tools, useTools: false, streaming: false, SummarizationOutputSchema);
             var result = await client.CompleteAsync(context, request, usage, token);
 
             if (result.Result.TryGet(nameof(SummarizationSampleObject.Answer), out string messagesSummary) == false)
@@ -377,9 +539,9 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             oldChat.UpdateUsage(usage);
         }
 
-        private bool TryGetUserTools(JsonOperationContext context, ConversationDocument document, AiAgentConfiguration configuration, AiResponse result)
+        private bool TryGetUserTools(JsonOperationContext context, ConversationDocument document, AiAgentConfiguration configuration, List<AiToolCall> toolCalls)
         {
-            foreach (var call in result.ToolCalls)
+            foreach (var call in toolCalls)
             {
                 if (configuration.FindAction(call.Name) == null)
                     continue;
@@ -448,12 +610,12 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
         }
 
-        public async Task HandleQueryToolCallsAsync(JsonOperationContext context, AiAgentConfiguration cfg, ConversationDocument document, AiResponse result)
+        public async Task HandleQueryToolCallsAsync(JsonOperationContext context, AiAgentConfiguration cfg, ConversationDocument document, List<AiToolCall> toolCalls)
         {
             DynamicJsonArray reqs = [];
             List<string> toolCallsIds = [];
             var queryUrl = $"/databases/{RequestHandler.DatabaseName}/queries";
-            foreach (var call in result.ToolCalls)
+            foreach (var call in toolCalls)
             {
                 var q = cfg.FindQuery(call.Name);
                 if (q is null)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -117,7 +117,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         private static readonly byte[] ResultPrefix = "event: result\ndata: "u8.ToArray();
         private static readonly byte[] DataPrefix = "data: "u8.ToArray();
-        private static readonly byte[] NewLinePostfix = "\n\n"u8.ToArray();
+        private static readonly byte[] TwoNewLinesEnd = "\n\n"u8.ToArray();
+        private static readonly byte[] NewLinePostfix = "\n"u8.ToArray();
 
         public async Task HandleStreamingRequest(
             JsonOperationContext context, 
@@ -143,14 +144,29 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             {
                 r = await StreamingTalkAsync(context, configuration, document, propertyToStream, async (data) =>
                 {
-                    while (data.IsEmpty is false)
+                    while (true)
                     {
                         int nextLineBreak = data.Span.IndexOf((byte)'\n');
-                        int length = nextLineBreak >= 0 ? nextLineBreak + 1 : data.Length;
+                        int length = nextLineBreak >= 0 ? nextLineBreak : data.Length;
+
                         await responseStream.WriteAsync(DataPrefix, token);
                         await responseStream.WriteAsync(data[..length], token);
-                        data = data[length..];
+                        await responseStream.WriteAsync(NewLinePostfix, token);
+
+                        if (nextLineBreak is -1) // wrote the entire thing, no line breaks
+                            break;
+                        
+                        data = data[(length + 1)..];
+                        if (data.IsEmpty is false)
+                            continue;
+                        
+                        // means that we had a line break in the end, so let's emit that
+                        await responseStream.WriteAsync(DataPrefix, token);
+                        await responseStream.WriteAsync(NewLinePostfix, token);
+                        break;
                     }
+                    
+                    // becomes the blank new line indicating we are done with this message
                     await responseStream.WriteAsync(NewLinePostfix, token);
                     await responseStream.FlushAsync(token);
 
@@ -163,8 +179,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
             await responseStream.WriteAsync(ResultPrefix, token);
-            await WriteResponseAsync(context, conversationId, r.Response, r.Document);
-            await responseStream.WriteAsync(NewLinePostfix, token);
+            await WriteResponseAsync(context, conversationId, r.Response, r.Document); // can have no new lines here
+            await responseStream.WriteAsync(TwoNewLinesEnd, token); // \n\n for end of message
             await responseStream.FlushAsync(token);
         }
         public override async ValueTask ExecuteAsync()
@@ -309,7 +325,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             AiAgentConfiguration configuration,
             ConversationDocument document,
             string firstPropertyToStream,
-            Func<Memory<byte>,Task>streaming, 
+            Func<Memory<byte>,Task> streaming, 
             CancellationToken token = default)
         {
             using var talker = new Talker(this, context, configuration, document);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         protected AbstractAiAgentProcessor([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
         }
-        
+
         private async Task<bool> TryHandleActionResponses(JsonOperationContext context, AiAgentConfiguration configuration, string conversationId, ConversationDocument document,
             RequestBody body)
         {
@@ -52,11 +52,11 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     if (document.OpenActionCalls.Remove(t.ToolId) == false)
                         throw new InvalidOperationException($"{t.ToolId} is an unknown action ID for conversation '{conversationId}'");
 
-                    document.AddMessage(context,context.ReadObject(
+                    document.AddMessage(context, context.ReadObject(
                         new DynamicJsonValue
                         {
-                            ["tool_call_id"] = t.ToolId, 
-                            ["role"] = "tool", 
+                            ["tool_call_id"] = t.ToolId,
+                            ["role"] = "tool",
                             ["content"] = t.Content
                         },
                         "user/tool"), usage: null);
@@ -75,13 +75,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             if (hasActionResponse == false && hasUserPrompt == false)
                 throw new InvalidOperationException($"Cannot have a conversation '{conversationId}' without open action calls or user prompt.");
-            
-            
+
+
             if (string.IsNullOrEmpty(body.UserPrompt) == false)
             {
                 document.AddMessage(context, context.ReadObject(new DynamicJsonValue
                 {
-                    ["role"] = "user", 
+                    ["role"] = "user",
                     ["content"] = body.UserPrompt
                 }, "user/msg"), usage: null);
             }
@@ -91,14 +91,14 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
 
         public async Task HandleRequest(
-            JsonOperationContext context, 
-            AiAgentConfiguration configuration, 
-            string conversationId, 
-            ConversationDocument document, 
+            JsonOperationContext context,
+            AiAgentConfiguration configuration,
+            string conversationId,
+            ConversationDocument document,
             RequestBody body,
             CancellationToken token)
         {
-            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false) 
+            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false)
                 return;
 
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
@@ -121,23 +121,23 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         private static readonly byte[] NewLinePostfix = "\n"u8.ToArray();
 
         public async Task HandleStreamingRequest(
-            JsonOperationContext context, 
-            AiAgentConfiguration configuration, 
-            string conversationId, 
-            ConversationDocument document, 
+            JsonOperationContext context,
+            AiAgentConfiguration configuration,
+            string conversationId,
+            ConversationDocument document,
             RequestBody body,
             CancellationToken token)
         {
-            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false) 
+            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false)
                 return;
-            
+
             var propertyToStream = RequestHandler.GetStringQueryString("propertyToStream");
 
 
             HttpContext.Response.Headers.ContentType = "text/event-stream";
             var feature = HttpContext.Features.Get<IHttpResponseBodyFeature>();
             feature?.DisableBuffering();
-            
+
             await using var responseStream = RequestHandler.ResponseBodyStream();
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
             try
@@ -155,21 +155,20 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
                         if (nextLineBreak is -1) // wrote the entire thing, no line breaks
                             break;
-                        
+
                         data = data[(length + 1)..];
                         if (data.IsEmpty is false)
                             continue;
-                        
+
                         // means that we had a line break in the end, so let's emit that
                         await responseStream.WriteAsync(DataPrefix, token);
                         await responseStream.WriteAsync(NewLinePostfix, token);
                         break;
                     }
-                    
+
                     // becomes the blank new line indicating we are done with this message
                     await responseStream.WriteAsync(NewLinePostfix, token);
                     await responseStream.FlushAsync(token);
-
                 }, token: token);
             }
             catch (Exception e)
@@ -183,12 +182,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             await responseStream.WriteAsync(TwoNewLinesEnd, token); // \n\n for end of message
             await responseStream.FlushAsync(token);
         }
+
         public override async ValueTask ExecuteAsync()
         {
             using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
             var conversationId = RequestHandler.GetStringQueryString("conversationId");
             var agentId = RequestHandler.GetStringQueryString("agentId");
-            var streaming = RequestHandler.GetBoolValueQueryString("streaming", required:false) ?? false;
+            var streaming = RequestHandler.GetBoolValueQueryString("streaming", required: false) ?? false;
             var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
 
             using var _ = ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
@@ -197,7 +197,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             ConversationDocument conversationDocument = null;
             AiAgentConfiguration configuration = GetAiAgentConfiguration(agentId);
 
-            using(context.OpenReadTransaction())
+            using (context.OpenReadTransaction())
             {
                 var conversation = RequestHandler.Database.DocumentsStorage.Get(context, conversationId);
                 if (conversation == null)
@@ -207,8 +207,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                         throw new ConcurrencyException(
                             $"The conversation '{conversationId}' doesn't exists.")
                         {
-                            ExpectedChangeVector = changeVector, 
-                            ActualChangeVector = string.Empty, 
+                            ExpectedChangeVector = changeVector,
+                            ActualChangeVector = string.Empty,
                             Id = conversationId
                         };
                     }
@@ -225,7 +225,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     {
                         conversationDocument.Expires = TimeSpan.FromSeconds(body.CreationOptions.ExpirationInSec.Value);
                     }
-                
+
                     conversationDocument.Initialize(context, configuration);
                 }
                 else
@@ -244,8 +244,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                             throw new ConcurrencyException(
                                 $"The conversation '{conversationId}' was updated and doesn't match the expected change vector. Reload the conversation and try again.")
                             {
-                                ExpectedChangeVector = changeVector, 
-                                ActualChangeVector = conversation.ChangeVector, 
+                                ExpectedChangeVector = changeVector,
+                                ActualChangeVector = conversation.ChangeVector,
                                 Id = conversationId
                             };
 
@@ -270,7 +270,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             body.TryGet(nameof(ConversionRequestBody.ActionResponses), out BlittableJsonReaderArray actionResponses);
             body.TryGet(nameof(ConversionRequestBody.UserPrompt), out string userPrompt);
             body.TryGet(nameof(ConversionRequestBody.CreationOptions), out BlittableJsonReaderObject optionsBlittable);
-            
+
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.ExpirationInSec), out int? conversationExpirationInSec);
 
@@ -281,8 +281,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             return new RequestBody
             {
-                ActionResponses = actionResponses, 
-                UserPrompt = userPrompt, 
+                ActionResponses = actionResponses,
+                UserPrompt = userPrompt,
                 Parameters = parameters,
                 CreationOptions = options
             };
@@ -320,24 +320,24 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected virtual ChatCompletionClient CreateClient(AiConnectionString connection) => ChatCompletionClient.CreateChatCompletionClient(ContextPool, connection);
 
-         public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> StreamingTalkAsync(
-            JsonOperationContext context, 
+        public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> StreamingTalkAsync(
+            JsonOperationContext context,
             AiAgentConfiguration configuration,
             ConversationDocument document,
             string firstPropertyToStream,
-            Func<Memory<byte>,Task> streaming, 
+            Func<Memory<byte>, Task> streaming,
             CancellationToken token = default)
         {
             using var talker = new Talker(this, context, configuration, document);
             talker.Init();
-            
+
             while (true)
             {
                 using var request = talker.CreateCompletionRequest(streaming: true);
 
-                await talker.Stream(ContextPool, request,firstPropertyToStream, streaming, token);
+                await talker.StreamAsync(ContextPool, request, firstPropertyToStream, streaming, token);
                 talker.UpdateDocument();
-                
+
                 if (talker.ResponseType is AiResponseType.Result)
                     break;
 
@@ -347,7 +347,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     break; // we need to return the user tool requests to the client, so we can continue the conversation
             }
 
-            var history = await TryReduceChatSize(context, talker.Client, configuration, document, talker.AiUsage, token);
+            var history = await TryReduceChatSizeAsync(context, talker.Client, configuration, document, talker.AiUsage, token);
 
             return (talker.Result, document, history);
         }
@@ -361,10 +361,10 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             public AiUsage AiUsage;
             public ChatCompletionClient Client;
-            
+
             public AiResponseType ResponseType => _aiResponse.Type;
             public List<AiToolCall> ToolCalls => _aiResponse.ToolCalls;
-            
+
             public BlittableJsonReaderObject Result => _aiResponse.Result;
 
             public void Init()
@@ -387,7 +387,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 return Client.CreateCompletionRequest(context, document.Messages, _tools, useTools: _count-- > 0, streaming, _schema);
             }
 
-            public async Task Run(HttpRequestMessage request, CancellationToken token)
+            public async Task RunAsync(HttpRequestMessage request, CancellationToken token)
             {
                 _aiResponse = await Client.CompleteAsync(
                     context,
@@ -403,15 +403,15 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 document.UpdateUsage(AiUsage);
             }
 
-            public async Task Stream(IMemoryContextPool contextPool,HttpRequestMessage request, string propertyToStream,  Func<Memory<byte>,Task> streamedPropertyCallback, CancellationToken token)
+            public async Task StreamAsync(IMemoryContextPool contextPool, HttpRequestMessage request, string propertyToStream, Func<Memory<byte>, Task> streamedPropertyCallback, CancellationToken token)
             {
                 _aiResponse = await Client.StreamingCompleteAsync(
                     context,
-                    contextPool, 
+                    contextPool,
                     propertyToStream,
-                    request,                  
+                    request,
                     streamedPropertyCallback,
-                    AiUsage,  
+                    AiUsage,
                     token
                 );
             }
@@ -421,23 +421,23 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Client?.Dispose();
             }
         }
-         
+
         public async Task<(BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History)> TalkAsync(
-            JsonOperationContext context, 
+            JsonOperationContext context,
             AiAgentConfiguration configuration,
             ConversationDocument document,
             CancellationToken token = default)
         {
             using var talker = new Talker(this, context, configuration, document);
             talker.Init();
-            
+
             while (true)
             {
                 using var request = talker.CreateCompletionRequest(streaming: false);
 
-                await talker.Run(request, token);
+                await talker.RunAsync(request, token);
                 talker.UpdateDocument();
-                
+
                 if (talker.ResponseType is AiResponseType.Result)
                     break;
 
@@ -447,13 +447,12 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     break; // we need to return the user tool requests to the client, so we can continue the conversation
             }
 
-            var history = await TryReduceChatSize(context, talker.Client, configuration, document, talker.AiUsage, token);
+            var history = await TryReduceChatSizeAsync(context, talker.Client, configuration, document, talker.AiUsage, token);
 
             return (talker.Result, document, history);
         }
 
-
-        async Task<BlittableJsonReaderObject> TryReduceChatSize(JsonOperationContext context, ChatCompletionClient client, AiAgentConfiguration configuration, ConversationDocument document,AiUsage aiUsage, CancellationToken token)
+        private async Task<BlittableJsonReaderObject> TryReduceChatSizeAsync(JsonOperationContext context, ChatCompletionClient client, AiAgentConfiguration configuration, ConversationDocument document, AiUsage aiUsage, CancellationToken token)
         {
             var reduction = configuration.ChatTrimming;
             if (reduction == null || document.OpenActionCalls.Count > 0)
@@ -679,8 +678,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     document.AddMessage(context, context.ReadObject(
                         new DynamicJsonValue
                         {
-                            ["tool_call_id"] = toolCallsIds[i], 
-                            ["role"] = "tool", 
+                            ["tool_call_id"] = toolCallsIds[i],
+                            ["role"] = "tool",
                             ["content"] = queryResult.ToString()
                         }, "tool-call/response"), usage: null);
                 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -131,8 +131,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false)
                 return;
 
-            var propertyToStream = RequestHandler.GetStringQueryString("propertyToStream");
-
+            var streamPropertyPath = RequestHandler.GetStringQueryString("streamPropertyPath");
 
             HttpContext.Response.Headers.ContentType = "text/event-stream";
             var feature = HttpContext.Features.Get<IHttpResponseBodyFeature>();
@@ -142,7 +141,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
             try
             {
-                r = await StreamingTalkAsync(context, configuration, document, propertyToStream, async (data) =>
+                r = await StreamingTalkAsync(context, configuration, document, streamPropertyPath, async (data) =>
                 {
                     while (true)
                     {
@@ -320,7 +319,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected virtual ChatCompletionClient CreateClient(AiConnectionString connection) => ChatCompletionClient.CreateChatCompletionClient(ContextPool, connection);
 
-        private class Talker(AbstractAiAgentProcessor processor, JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document, string firstPropertyToStream, Func<Memory<byte>, Task> streaming) : IDisposable
+        private class Talker(AbstractAiAgentProcessor processor, JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document, string firstStreamPropertyPath, Func<Memory<byte>, Task> streaming) : IDisposable
         {
             private string _schema;
             private List<BlittableJsonReaderObject> _tools;
@@ -371,7 +370,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     _aiResponse = await Client.StreamingCompleteAsync(
                         context,
                         contextPool,
-                        firstPropertyToStream,
+                        firstStreamPropertyPath,
                         request,
                         streaming,
                         AiUsage,
@@ -395,11 +394,11 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             JsonOperationContext context,
             AiAgentConfiguration configuration,
             ConversationDocument document,
-            string firstPropertyToStream,
+            string firstStreamPropertyPath,
             Func<Memory<byte>, Task> streaming,
             CancellationToken token = default)
         {
-            using var talker = new Talker(this, context, configuration, document, firstPropertyToStream, streaming);
+            using var talker = new Talker(this, context, configuration, document, firstStreamPropertyPath, streaming);
             return await RunInternalAsync(context, configuration, document, talker, token);
         }
         
@@ -409,7 +408,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             ConversationDocument document,
             CancellationToken token = default)
         {
-            using var talker = new Talker(this, context, configuration, document, firstPropertyToStream: null, streaming: null);
+            using var talker = new Talker(this, context, configuration, document, firstStreamPropertyPath: null, streaming: null);
             return await RunInternalAsync(context, configuration, document, talker, token);
         }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -164,6 +164,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
             await responseStream.WriteAsync(ResultPrefix, token);
             await WriteResponseAsync(context, conversationId, r.Response, r.Document);
+            await responseStream.WriteAsync(NewLinePostfix, token);
             await responseStream.FlushAsync(token);
         }
         public override async ValueTask ExecuteAsync()

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -207,6 +207,7 @@
     <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Net.ServerSentEvents" />
     <PackageReference Include="System.Private.Uri" />
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Runtime.Caching" />

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -435,7 +435,7 @@ namespace Sparrow.Json
             }
         }
     }
-
+    
     public sealed unsafe class AllocatedMemoryData
     {
         public int SizeInBytes;
@@ -444,6 +444,36 @@ namespace Sparrow.Json
         public JsonOperationContext Parent;
         public NativeMemory.ThreadStats AllocatingThread;
 
+        private MemoryManager _memoryManager;
+
+        public Memory<byte> AsMemory()
+        {
+            _memoryManager ??= new(this);
+            return _memoryManager.Memory;
+        }
+        
+        private class MemoryManager(AllocatedMemoryData parent) : MemoryManager<byte>
+        {
+            protected override void Dispose(bool disposing)
+            {
+                
+            }
+
+            public override Span<byte> GetSpan()
+            {
+                return new Span<byte>(parent.Address, parent.SizeInBytes);
+            }
+
+            public override MemoryHandle Pin(int elementIndex = 0)
+            {
+                return default;
+            }
+
+            public override void Unpin()
+            {
+            }
+        }
+        
         public AllocatedMemoryData(byte* address, int sizeInBytes)
         {
             SizeInBytes = sizeInBytes;

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -182,7 +182,7 @@ namespace Sparrow.Json
             base.Dispose();
         }
 
-        public (string Name, EventHandler<UnmanagedWriteBuffer> Handler) PropertyToWatchForStreaming; 
+        public (string Name, Action<UnmanagedWriteBuffer> Handler) PropertyToWatchForStreaming; 
 
         private bool ReadInternal<TWriteStrategy, TJsonParser, TStreamBehavior>() 
             where TWriteStrategy : IWriteStrategy
@@ -231,7 +231,13 @@ namespace Sparrow.Json
 
                                     if(typeof(TStreamBehavior) == typeof(WithStreaming) && property.Equals(PropertyToWatchForStreaming.Name))
                                     {
-                                        reader.OnStringRead = PropertyToWatchForStreaming.Handler;
+                                        Action<UnmanagedWriteBuffer> handler = PropertyToWatchForStreaming.Handler;
+                                        reader.OnStringRead = (buffer, partial) =>
+                                        {
+                                            handler(buffer);
+                                            if (partial is false) // we are done...
+                                                reader.OnStringRead = null;
+                                        };
                                         PropertyToWatchForStreaming = default; // we only do that for the _first_ property that match the name
                                     }
                                     

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -76,15 +76,20 @@ namespace Sparrow.Json
             {
                 UsageMode.None => reader switch
                 {
-                    ObjectJsonParser => ReadInternal<WriteNone, ObjectJsonParser>,
-                    UnmanagedJsonParser => ReadInternal<WriteNone, UnmanagedJsonParser>,
-                    _ => ReadInternal<WriteNone, IJsonParser>
+                    ObjectJsonParser => ReadInternal<WriteNone, ObjectJsonParser, NoStreaming>,
+                    UnmanagedJsonParser => ReadInternal<WriteNone, UnmanagedJsonParser, NoStreaming>,
+                    _ => ReadInternal<WriteNone, IJsonParser, NoStreaming>
+                },
+                UsageMode.ForStreaming => reader switch
+                {
+                    UnmanagedJsonParser => ReadInternal<WriteNone, UnmanagedJsonParser, WithStreaming>,
+                    _ => throw new NotSupportedException(),
                 },
                 _ => reader switch
                 {
-                    ObjectJsonParser => ReadInternal<WriteFull, ObjectJsonParser>,
-                    UnmanagedJsonParser => ReadInternal<WriteFull, UnmanagedJsonParser>,
-                    _ => ReadInternal<WriteFull, IJsonParser>
+                    ObjectJsonParser => ReadInternal<WriteFull, ObjectJsonParser, NoStreaming>,
+                    UnmanagedJsonParser => ReadInternal<WriteFull, UnmanagedJsonParser, NoStreaming>,
+                    _ => ReadInternal<WriteFull, IJsonParser, NoStreaming>
                 }
             };
         }
@@ -177,9 +182,12 @@ namespace Sparrow.Json
             base.Dispose();
         }
 
-        private unsafe bool ReadInternal<TWriteStrategy, TJsonParser>() 
+        public (string Name, EventHandler<UnmanagedWriteBuffer> Handler) PropertyToWatchForStreaming; 
+
+        private bool ReadInternal<TWriteStrategy, TJsonParser, TStreamBehavior>() 
             where TWriteStrategy : IWriteStrategy
             where TJsonParser : IJsonParser
+            where TStreamBehavior : IStreamingBehavior 
         {
             CachedProperties.PropertyName fakeProperty = null;
 
@@ -220,6 +228,13 @@ namespace Sparrow.Json
                                 if (state.CurrentTokenType == JsonParserToken.String)
                                 {
                                     var property = CreateLazyStringValueFromParserState();
+
+                                    if(typeof(TStreamBehavior) == typeof(WithStreaming) && property.Equals(PropertyToWatchForStreaming.Name))
+                                    {
+                                        reader.OnStringRead = PropertyToWatchForStreaming.Handler;
+                                        PropertyToWatchForStreaming = default; // we only do that for the _first_ property that match the name
+                                    }
+                                    
                                     currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
                                     currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
                                     currentState.State = ContinuationState.ReadPropertyValue;
@@ -597,9 +612,15 @@ namespace Sparrow.Json
         {
             throw new InvalidStartOfObjectException("Expected start of object, but got " + _state.CurrentTokenType + _reader.GenerateErrorState());
         }
+        
+        private interface IStreamingBehavior{}
+
+        private struct NoStreaming : IStreamingBehavior{}
+        
+        private struct WithStreaming : IStreamingBehavior{}
 
         private interface IWriteStrategy { }
-
+        
         private struct WriteFull : IWriteStrategy { }
 
         private struct WriteNone : IWriteStrategy { }
@@ -705,7 +726,8 @@ namespace Sparrow.Json
             ValidateDouble = 1,
             CompressStrings = 2,
             CompressSmallStrings = 4,
-            ToDisk = ValidateDouble | CompressStrings
+            ToDisk = ValidateDouble | CompressStrings,
+            ForStreaming = 32
         }
 
         public struct WriteToken(int position, BlittableJsonToken token)

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -183,6 +183,16 @@ namespace Sparrow.Json
             return new MemoryBuffer.ReturnBuffer(rawMemory, buffer, this);
         }
 
+        public unsafe MemoryBuffer.ReturnBuffer GetRawMemoryBuffer(int size, out AllocatedMemoryData buffer)
+        {
+            EnsureNotDisposed();
+
+            buffer = GetMemory(size);
+
+            return new MemoryBuffer.ReturnBuffer(buffer, this);
+        }
+        
+
         public sealed unsafe class MemoryBuffer
         {
             public const int DefaultSize = 32 * Constants.Size.Kilobyte;
@@ -318,6 +328,12 @@ namespace Sparrow.Json
 #if DEBUG
                     _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
 #endif
+                    _allocatedMemory = allocatedMemory ?? throw new ArgumentNullException(nameof(allocatedMemory));
+                    _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+                }
+
+                public ReturnBuffer(AllocatedMemoryData allocatedMemory, JsonOperationContext parent)
+                {
                     _allocatedMemory = allocatedMemory ?? throw new ArgumentNullException(nameof(allocatedMemory));
                     _parent = parent ?? throw new ArgumentNullException(nameof(parent));
                 }

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -230,6 +230,8 @@ namespace Sparrow.Json
             if (_string != null)
                 return string.Equals(_string, other, StringComparison.Ordinal);
 
+            if (other is null)
+                return false;
 
             var buffer = GetLazyStringTempComparisonBuffer(other.Length);
             fixed (char* pOther = other)

--- a/src/Sparrow/Json/Parsing/IJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/IJsonParser.cs
@@ -7,5 +7,6 @@ namespace Sparrow.Json.Parsing
         bool Read();
         void ValidateFloat();
         string GenerateErrorState();
+        EventHandler<UnmanagedWriteBuffer> OnStringRead { set; }
     }
 }

--- a/src/Sparrow/Json/Parsing/IJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/IJsonParser.cs
@@ -7,6 +7,7 @@ namespace Sparrow.Json.Parsing
         bool Read();
         void ValidateFloat();
         string GenerateErrorState();
-        EventHandler<UnmanagedWriteBuffer> OnStringRead { set; }
+        OnStringReadDelegate OnStringRead { set; }
     }
+    public delegate void OnStringReadDelegate(UnmanagedWriteBuffer buffer, bool partial);
 }

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -1069,5 +1069,10 @@ namespace Sparrow.Json.Parsing
             var last = _elements.LastOrDefault();
             return last?.ToString() ?? string.Empty;
         }
+
+        public  EventHandler<UnmanagedWriteBuffer> OnStringRead
+        {
+            set { throw new NotSupportedException(); }
+        }
     }
 }

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -1070,7 +1070,7 @@ namespace Sparrow.Json.Parsing
             return last?.ToString() ?? string.Empty;
         }
 
-        public  EventHandler<UnmanagedWriteBuffer> OnStringRead
+        public  OnStringReadDelegate OnStringRead
         {
             set { throw new NotSupportedException(); }
         }

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -50,7 +50,7 @@ namespace Sparrow.Json.Parsing
 
         private static readonly ParseNumberAction[] ParseNumberTable;
 
-        public EventHandler<UnmanagedWriteBuffer> OnStringRead
+        public OnStringReadDelegate OnStringRead
         {
             set => _onStringRead = value;
         }
@@ -734,7 +734,8 @@ namespace Sparrow.Json.Parsing
         private bool _parsingUnicode;
         private int _unicodeValue;
         private int _unicodeIndex;
-        private EventHandler<UnmanagedWriteBuffer> _onStringRead;
+
+        private OnStringReadDelegate _onStringRead;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool ParseString(ref uint currentPos)
@@ -834,15 +835,11 @@ namespace Sparrow.Json.Parsing
             }
 
         ReturnTrue:
-            if (_onStringRead is not null)
-            {
-                _onStringRead.Invoke(this, _unmanagedWriteBuffer);
-                _onStringRead = null; // once we are done parsing _a_ property, we clear this
-            }
+            _onStringRead?.Invoke(_unmanagedWriteBuffer, false);
             return true;
 
         ReturnFalse:
-            _onStringRead?.Invoke(this, _unmanagedWriteBuffer);
+            _onStringRead?.Invoke(_unmanagedWriteBuffer, true);
             return false;
         }
 

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -50,6 +50,11 @@ namespace Sparrow.Json.Parsing
 
         private static readonly ParseNumberAction[] ParseNumberTable;
 
+        public EventHandler<UnmanagedWriteBuffer> OnStringRead
+        {
+            set => _onStringRead = value;
+        }
+
         static UnmanagedJsonParser()
         {
             ParseStringTable = new byte[255];
@@ -729,6 +734,7 @@ namespace Sparrow.Json.Parsing
         private bool _parsingUnicode;
         private int _unicodeValue;
         private int _unicodeIndex;
+        private EventHandler<UnmanagedWriteBuffer> _onStringRead;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool ParseString(ref uint currentPos)
@@ -828,9 +834,15 @@ namespace Sparrow.Json.Parsing
             }
 
         ReturnTrue:
+            if (_onStringRead is not null)
+            {
+                _onStringRead.Invoke(this, _unmanagedWriteBuffer);
+                _onStringRead = null; // once we are done parsing _a_ property, we clear this
+            }
             return true;
 
         ReturnFalse:
+            _onStringRead?.Invoke(this, _unmanagedWriteBuffer);
             return false;
         }
 

--- a/src/Sparrow/Json/UnmanagedWriteBuffer.cs
+++ b/src/Sparrow/Json/UnmanagedWriteBuffer.cs
@@ -484,6 +484,25 @@ namespace Sparrow.Json
             head.Used++;
         }
 
+        public int CopyTo(int start, byte* pointer)
+        {
+            ThrowOnDisposed();
+
+            var whereToWrite = pointer + _head.AccumulatedSizeInBytes - start;
+            var copiedBytes = 0L;
+
+            for (var head = _head; head != null && whereToWrite > pointer; head = head.Previous)
+            {
+                long copy = Math.Min(head.Used, whereToWrite - pointer);
+                whereToWrite -= copy;
+                copiedBytes += copy;
+                Memory.Copy(whereToWrite, head.Address + head.Used - copy, copy);
+            }
+
+            return (int)copiedBytes;
+        }
+
+        
         public int CopyTo(byte* pointer)
         {
             ThrowOnDisposed();

--- a/src/Sparrow/Utils/TypeUtils.cs
+++ b/src/Sparrow/Utils/TypeUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Sparrow.Utils
 {
@@ -42,14 +43,15 @@ namespace Sparrow.Utils
                 return false;
 
             //prevent infinite loops
-            if (visited.Contains(obj))
+            if (!visited.Add(obj))
                 return false;
-
-            visited.Add(obj);
 
             var type = obj.GetType();
 
-            if (type.IsPointer || type.IsEnum || type.IsCOMObject || type.IsValueType || type == typeof(string)) //obviously not what we are looking for
+            if (type.IsPointer || type.IsEnum || type.IsCOMObject || 
+                type.IsValueType ||
+                type == typeof(string) || 
+                type.Assembly == typeof(object).Assembly) //obviously not what we are looking for
                 return false;
 
             if (obj is BlittableJsonReaderObject || obj is BlittableJsonReaderArray)

--- a/test/FastTests/OllamaThinkParameterTests.cs
+++ b/test/FastTests/OllamaThinkParameterTests.cs
@@ -53,7 +53,7 @@ namespace FastTests
             using (var stream = new MemoryStream())
             await using (var writer = new AsyncBlittableJsonTextWriter(context, stream))
             {
-                client.WriteCompletionRequestPayload(writer, context, [], [], true, ChatCompletionClient.EmptySchema);
+                client.WriteCompletionRequestPayload(writer, context, [], [], true, false, ChatCompletionClient.EmptySchema);
                 await writer.FlushAsync();
                 
                 capturedParameters = Encoding.UTF8.GetString(stream.ToArray());

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
@@ -73,7 +73,7 @@ public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
 
         chat.SetUserPrompt("Give me 15 real cities names, one per line");
         var sb = new StringBuilder();
-        var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>("Answer", s =>
+        var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>(x=>x.Answer, s =>
         {
             sb.Append(s);
             return Task.CompletedTask;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
@@ -48,7 +48,7 @@ public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
         var agent = new AiAgentConfiguration("my assistant", config.ConnectionStringName,
-            "Always call the 'whoami' tool before answering any queries")
+            "Always call the 'whoami' tool before answering any user prompts")
         {
             Actions = [
             new AiAgentToolAction

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
@@ -1,0 +1,93 @@
+﻿using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task CanStreamResults(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("my assistant", config.ConnectionStringName,
+            "Be helpful");
+
+        var identifier = (await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(identifier, "chats/",
+            new AiConversationCreationOptions());
+
+        chat.SetUserPrompt("Give me 15 real cities names, one per line");
+        var sb = new StringBuilder();
+        var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>("Answer", s =>
+        {
+            sb.Append(s);
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+        
+        Assert.Equal(result.Answer.Answer, sb.ToString());
+    }
+    
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, CheckCanConnect = false, NightlyBuildRequired = false)]
+    public async Task CanStreamResults_WithTools(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = new AiAgentConfiguration("my assistant", config.ConnectionStringName,
+            "Always call the 'whoami' tool before answering any queries")
+        {
+            Actions = [
+            new AiAgentToolAction
+            {
+                Name = "whoami",
+                ParametersSampleObject = "{}",
+                Description = "Describe who this user is, preferences, etc"
+            }]
+        };
+
+        var identifier = (await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(identifier, "chats/",
+            new AiConversationCreationOptions());
+        bool wasCalled = false;
+        AiAgentActionRequest actionRequest = null;
+        chat.Receive<object>("whoami", (a, args) =>
+        {
+            actionRequest = a;
+            wasCalled = true;
+        });
+
+        chat.SetUserPrompt("Give me 15 real cities names, one per line");
+        var sb = new StringBuilder();
+        var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>("Answer", s =>
+        {
+            sb.Append(s);
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+        Assert.Equal(AiConversationResult.ActionRequired,result.Status);
+        Assert.True(wasCalled);
+        Assert.Empty(sb.ToString());
+        chat.AddActionResponse(actionRequest.ToolId, "I'm batman");
+        
+        result = await chat.StreamAsync<AiAgentBasics.OutputSchema>("Answer", s =>
+        {
+            sb.Append(s);
+            return Task.CompletedTask;
+        }, CancellationToken.None);
+        Assert.Equal(result.Answer.Answer, sb.ToString());
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24811

### Additional description

This adds streaming support to AI agents, so you can run the following code:

```
var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>(x=>x.Answer, s =>
{
            await client.SendAsync(s);
}, CancellationToken.None);
```

I this mode, we'll stream the response from the model and send the contents of the `Answer` property to the caller ASAP.
This is meant to make it easier to build more responsive systems, especially if you have a lot of text to send back.

The underlying implementation from client to server is using Server Sent Event - I checked and in all the platforms that we care about, that is readily available.
I tried doing that with web sockets, but that called for a drastically different architecture, and this was we can reuse most of the code.

