### PR TITLE
RavenDB-24606 - upload attachments to cloud using tasks

### DIFF
--- a/src/Raven.Server/Documents/Attachments/AttachmentUploadToCloudHolder.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentUploadToCloudHolder.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.Attachments;
+
+public class AttachmentUploadToCloudHolder
+{
+    public readonly Task UploadTask;
+    public readonly AbstractBackgroundWorkStorage.DocumentExpirationInfo Doc;
+    public readonly long AttachmentSize;
+
+    public AttachmentUploadToCloudHolder(Task uploadTask, AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, long attachmentSize)
+    {
+        UploadTask = uploadTask;
+        Doc = doc;
+        AttachmentSize = attachmentSize;
+    }
+}

--- a/src/Raven.Server/Documents/Attachments/AttachmentUploadToCloudHolder.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentUploadToCloudHolder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Raven.Server.Documents.Attachments;
@@ -10,8 +11,12 @@ public class AttachmentUploadToCloudHolder
 
     public AttachmentUploadToCloudHolder(Task uploadTask, AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, long attachmentSize)
     {
-        UploadTask = uploadTask;
-        Doc = doc;
+        UploadTask = uploadTask ?? throw new ArgumentNullException(nameof(uploadTask));
+        Doc = doc ?? throw new ArgumentNullException(nameof(doc));
+
+        if (attachmentSize < 0)
+            throw new ArgumentOutOfRangeException(nameof(attachmentSize), "Attachment size cannot be negative.");
+
         AttachmentSize = attachmentSize;
     }
 }

--- a/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
@@ -21,6 +21,7 @@ namespace Raven.Server.Documents.Attachments;
 public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUploadToCloudHolder>
 {
     private readonly short _concurrentThreads;
+    private readonly string _backupDescription;
     private static long _bigAttachmentSize => GetAttachmentSizeThreshold();
 
     public Action<AttachmentUploadToCloudHolder> OnSuccessAction;
@@ -30,11 +31,12 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
         base(settings, retentionPolicyParameters: null, logger, backupResult: GenerateUploadResult(), onProgress: progress => { }, taskCancelToken)
     {
         _concurrentThreads = settings.ConcurrentThreads;
+        _backupDescription =  $"{nameof(AttachmentUploader)} for identifier '{_settings.TaskName}'";
     }
 
     public override string GetBackupDescription()
     {
-        return $"{nameof(AttachmentUploader)} for identifier '{_settings.TaskName}'";
+        return _backupDescription;
     }
 
     public IDictionary<string, string> GetObjectMetadata(string folderName, string objKeyName)
@@ -57,7 +59,7 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
         Task task = CreateUploadTaskInternal(database, attachmentStream, objKeyName, attachmentLength);
         task.Start();
 
-        _threads.Add(new AttachmentUploadToCloudHolder(task, doc, attachmentLength));
+        _threads.AddLast(new AttachmentUploadToCloudHolder(task, doc, attachmentLength));
     }
 
     private Task CreateUploadTaskInternal(DocumentDatabase database, Stream attachmentStream, string objKeyName, long attachmentLength)
@@ -103,18 +105,20 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
             // Create a timeout task for the polling interval
             await Task.Delay(512);
 
-            // Remove all completed tasks (not just the first one found)
-            for (int i = _threads.Count - 1; i >= 0; i--)
+            var current = _threads.First;
+            while (current != null)
             {
                 if (token.Token.IsCancellationRequested)
-                {
                     return false;
+
+                var next = current.Next; // Store next before potential removal
+
+                if (AssertTaskStateAndInvokeAction(current.Value))
+                {
+                    _threads.Remove(current); // O(1) operation for LinkedListNode
                 }
 
-                if (AssertTaskStateAndInvokeAction(_threads[i]))
-                {
-                    _threads.RemoveAt(i);
-                }
+                current = next;
             }
         }
 
@@ -134,7 +138,7 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
             {
                 OnSuccessAction?.Invoke(task);
             }
-            else if (task.UploadTask.IsFaulted && task.UploadTask.Exception != null)
+            else if (task.UploadTask.IsFaulted)
             {
                 if (_logger.IsErrorEnabled)
                 {
@@ -142,6 +146,13 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
                 }
 
                 OnExceptionAction?.Invoke(task);
+            }
+            else if (task.UploadTask.IsCanceled)
+            {
+                if (_logger.IsDebugEnabled)
+                {
+                    _logger.Debug($"Upload task of retired attachment '{task.Doc.LowerId}' with identifier '{task.Doc.Id}' was canceled.");
+                }
             }
 
             return true;

--- a/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Util;
@@ -18,14 +16,14 @@ using Size = Sparrow.Size;
 
 namespace Raven.Server.Documents.Attachments;
 
-public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUploadToCloudHolder>
+public class AttachmentUploader : MultipleFileUploaderBase<AttachmentUploadToCloudHolder>
 {
     private readonly short _concurrentThreads;
     private readonly string _backupDescription;
-    private static long _bigAttachmentSize => GetAttachmentSizeThreshold();
+    private static readonly long _bigAttachmentSizeInBytes = GetAttachmentSizeThreshold();
 
-    public Action<AttachmentUploadToCloudHolder> OnSuccessAction;
-    public Action<AttachmentUploadToCloudHolder> OnExceptionAction;
+    public Action<AttachmentUploadToCloudHolder> OnSuccess;
+    public Action<AttachmentUploadToCloudHolder> OnException;
 
     public AttachmentUploader(UploaderSettings settings, RavenLogger logger, OperationCancelToken taskCancelToken) :
         base(settings, retentionPolicyParameters: null, logger, backupResult: GenerateUploadResult(), onProgress: progress => { }, taskCancelToken)
@@ -54,7 +52,7 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
         }
     }
 
-    public void CreateUploadTask(DocumentDatabase database, AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, Stream attachmentStream, string objKeyName, long attachmentLength, CancellationToken token)
+    public void CreateUploadTask(DocumentDatabase database, AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, Stream attachmentStream, string objKeyName, long attachmentLength)
     {
         Task task = CreateUploadTaskInternal(database, attachmentStream, objKeyName, attachmentLength);
         task.Start();
@@ -64,7 +62,7 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
 
     private Task CreateUploadTaskInternal(DocumentDatabase database, Stream attachmentStream, string objKeyName, long attachmentLength)
     {
-        var taskOptions = attachmentLength > _bigAttachmentSize
+        var taskOptions = attachmentLength > _bigAttachmentSizeInBytes
             ? TaskCreationOptions.LongRunning
             : TaskCreationOptions.RunContinuationsAsynchronously;
 
@@ -91,15 +89,15 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
 
     public async Task<bool> WaitForFinishedTasksIfNeededAsync(Stopwatch sp, OperationCancelToken token)
     {
+        if (RetireAttachmentsSender.CanContinueBatch(_logger, sp, totalUploaded: 0, token) == false)
+            return false;
+
         if (_threads.Count < _concurrentThreads)
             return true;
 
         while (_threads.Count >= _concurrentThreads)
         {
-            if (token.Token.IsCancellationRequested)
-                return false;
-
-            if (sp.ElapsedMilliseconds > RetireAttachmentsSender.ReadTransactionMaxOpenTimeInMs)
+            if (RetireAttachmentsSender.CanContinueBatch(_logger, sp, totalUploaded: 0, token) == false)
                 return false;
 
             // Create a timeout task for the polling interval
@@ -136,7 +134,7 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
         {
             if (task.UploadTask.IsCompletedSuccessfully)
             {
-                OnSuccessAction?.Invoke(task);
+                OnSuccess?.Invoke(task);
             }
             else if (task.UploadTask.IsFaulted)
             {
@@ -145,7 +143,7 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
                     _logger.Error($"Upload task of retired attachment '{task.Doc.LowerId}' with identifier '{task.Doc.Id}' failed.", task.UploadTask.Exception);
                 }
 
-                OnExceptionAction?.Invoke(task);
+                OnException?.Invoke(task);
             }
             else if (task.UploadTask.IsCanceled)
             {
@@ -167,7 +165,15 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
         {
             TaskCancelToken.Token.ThrowIfCancellationRequested();
 
-            AsyncHelpers.RunSync(() => t.UploadTask);
+            try
+            {
+                AsyncHelpers.RunSync(() => t.UploadTask);
+            }
+            catch
+            {
+                // we assert the task state below
+            }
+
             AssertTaskStateAndInvokeAction(t);
         }
 
@@ -177,15 +183,15 @@ public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUplo
     private static long GetAttachmentSizeThreshold()
     {
         if (PlatformDetails.Is32Bits)
-            return 64 * 1024 * 1024;
+            return 16 * Sparrow.Global.Constants.Size.Megabyte; // 16 MB for smaller 32-bit systems
 
         if (MemoryInformation.TotalPhysicalMemory >= new Size(64, SizeUnit.Gigabytes)) // 64+ GB RAM
-            return 512 * 1024 * 1024; // 512 MB
+            return 512 * Sparrow.Global.Constants.Size.Megabyte; // 512 MB
         else if (MemoryInformation.TotalPhysicalMemory >= new Size(32, SizeUnit.Gigabytes)) // 32+ GB RAM
-            return 256 * 1024 * 1024; // 256 MB
+            return 256 * Sparrow.Global.Constants.Size.Megabyte; // 256 MB
         else if (MemoryInformation.TotalPhysicalMemory >= new Size(16, SizeUnit.Gigabytes)) // 16+ GB RAM  
-            return 128 * 1024 * 1024; // 128 MB
+            return 128 * Sparrow.Global.Constants.Size.Megabyte; // 128 MB
         else
-            return 64 * 1024 * 1024;  // 64 MB for smaller 64-bit systems
+            return 64 * Sparrow.Global.Constants.Size.Megabyte;  // 64 MB for smaller 64-bit systems
     }
 }

--- a/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
+using Raven.Server.ServerWide;
+using Sparrow;
+using Sparrow.Platform;
+using Sparrow.Server.Logging;
+using Sparrow.Server.LowMemory;
+using Size = Sparrow.Size;
+
+namespace Raven.Server.Documents.Attachments;
+
+public sealed class AttachmentUploader : MultipleFileUploaderBase<AttachmentUploadToCloudHolder>
+{
+    private readonly short _concurrentThreads;
+    private static long _bigAttachmentSize => GetAttachmentSizeThreshold();
+
+    public Action<AttachmentUploadToCloudHolder> OnSuccessAction;
+    public Action<AttachmentUploadToCloudHolder> OnExceptionAction;
+
+    public AttachmentUploader(UploaderSettings settings, RavenLogger logger, OperationCancelToken taskCancelToken) :
+        base(settings, retentionPolicyParameters: null, logger, backupResult: GenerateUploadResult(), onProgress: progress => { }, taskCancelToken)
+    {
+        _concurrentThreads = settings.ConcurrentThreads;
+    }
+
+    public override string GetBackupDescription()
+    {
+        return $"{nameof(AttachmentUploader)} for identifier '{_settings.TaskName}'";
+    }
+
+    public IDictionary<string, string> GetObjectMetadata(string folderName, string objKeyName)
+    {
+        switch (_destination)
+        {
+            case BackupConfiguration.BackupDestination.AmazonS3:
+                return GetObjectMetadataFromS3(_settings.S3Settings, folderName, objKeyName);
+
+            case BackupConfiguration.BackupDestination.Azure:
+                return GetObjectMetadataFromAzure(_settings.AzureSettings, folderName, objKeyName);
+
+            default:
+                throw new ArgumentOutOfRangeException($"Missing implementation for direct upload destination '{_destination}'");
+        }
+    }
+
+    public void CreateUploadTask(DocumentDatabase database, AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, Stream attachmentStream, string objKeyName, long attachmentLength, CancellationToken token)
+    {
+        Task task = CreateUploadTaskInternal(database, attachmentStream, objKeyName, attachmentLength);
+        task.Start();
+
+        _threads.Add(new AttachmentUploadToCloudHolder(task, doc, attachmentLength));
+    }
+
+    private Task CreateUploadTaskInternal(DocumentDatabase database, Stream attachmentStream, string objKeyName, long attachmentLength)
+    {
+        var taskOptions = attachmentLength > _bigAttachmentSize
+            ? TaskCreationOptions.LongRunning
+            : TaskCreationOptions.RunContinuationsAsynchronously;
+
+        var task = new Task(() =>
+        {
+            using (attachmentStream)
+            using (var stream = StreamForBackupDestination(database, string.Empty, objKeyName))
+            {
+                if (_logger.IsDebugEnabled)
+                {
+                    _logger.Debug($"Starting the upload of retired attachment '{objKeyName}' on {GetBackupDescription()}.");
+                }
+
+                attachmentStream.CopyTo(stream);
+
+                TaskCancelToken.Token.ThrowIfCancellationRequested();
+            }
+        },
+        TaskCancelToken.Token,
+        taskOptions);
+
+        return task;
+    }
+
+    public async Task<bool> WaitForFinishedTasksIfNeededAsync(Stopwatch sp, OperationCancelToken token)
+    {
+        if (_threads.Count < _concurrentThreads)
+            return true;
+
+        while (_threads.Count >= _concurrentThreads)
+        {
+            if (token.Token.IsCancellationRequested)
+                return false;
+
+            if (sp.ElapsedMilliseconds > RetireAttachmentsSender.ReadTransactionMaxOpenTimeInMs)
+                return false;
+
+            // Create a timeout task for the polling interval
+            await Task.Delay(512);
+
+            // Remove all completed tasks (not just the first one found)
+            for (int i = _threads.Count - 1; i >= 0; i--)
+            {
+                if (token.Token.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                if (AssertTaskStateAndInvokeAction(_threads[i]))
+                {
+                    _threads.RemoveAt(i);
+                }
+            }
+        }
+
+        if (token.Token.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool AssertTaskStateAndInvokeAction(AttachmentUploadToCloudHolder task)
+    {
+        if (task.UploadTask.IsCompleted)
+        {
+            if (task.UploadTask.IsCompletedSuccessfully)
+            {
+                OnSuccessAction?.Invoke(task);
+            }
+            else if (task.UploadTask.IsFaulted && task.UploadTask.Exception != null)
+            {
+                if (_logger.IsErrorEnabled)
+                {
+                    _logger.Error($"Upload task of retired attachment '{task.Doc.LowerId}' with identifier '{task.Doc.Id}' failed.", task.UploadTask.Exception);
+                }
+
+                OnExceptionAction?.Invoke(task);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public override void Execute()
+    {
+        foreach (var t in _threads)
+        {
+            TaskCancelToken.Token.ThrowIfCancellationRequested();
+
+            AsyncHelpers.RunSync(() => t.UploadTask);
+            AssertTaskStateAndInvokeAction(t);
+        }
+
+        _threads.Clear();
+    }
+
+    private static long GetAttachmentSizeThreshold()
+    {
+        if (PlatformDetails.Is32Bits)
+            return 64 * 1024 * 1024;
+
+        if (MemoryInformation.TotalPhysicalMemory >= new Size(64, SizeUnit.Gigabytes)) // 64+ GB RAM
+            return 512 * 1024 * 1024; // 512 MB
+        else if (MemoryInformation.TotalPhysicalMemory >= new Size(32, SizeUnit.Gigabytes)) // 32+ GB RAM
+            return 256 * 1024 * 1024; // 256 MB
+        else if (MemoryInformation.TotalPhysicalMemory >= new Size(16, SizeUnit.Gigabytes)) // 16+ GB RAM  
+            return 128 * 1024 * 1024; // 128 MB
+        else
+            return 64 * 1024 * 1024;  // 64 MB for smaller 64-bit systems
+    }
+}

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -24,6 +24,7 @@ using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data;
+using Voron.Data.BTrees;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.DocumentsStorage;
@@ -1048,10 +1049,21 @@ namespace Raven.Server.Documents
         public static long GetAttachmentStreamLength(DocumentsOperationContext context, Slice hashSlice)
         {
             var tree = context.Transaction.InnerTransaction.ReadTree(AttachmentsSlice);
+            return GetAttachmentStreamLength(tree, hashSlice);
+        }
+
+        private static long GetAttachmentStreamLength(Tree tree, Slice hashSlice)
+        {
             var info = tree.GetStreamInfo(hashSlice, false);
             if (info == null)
                 return -1;
             return info->TotalSize;
+        }
+
+        public (Stream Stream, long Size) GetAttachmentStreamAndLength(DocumentsOperationContext context, Slice hashSlice)
+        {
+            Tree tree = context.Transaction.InnerTransaction.ReadTree(AttachmentsSlice);
+            return (tree.ReadStream(hashSlice), GetAttachmentStreamLength(tree, hashSlice));
         }
 
         public static Attachment TableValueToAttachment(DocumentsOperationContext context, ref TableValueReader tvr)

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/OlaptEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/OlaptEtl.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
             Metrics = OlapMetrics;
             _operationCancelToken = new OperationCancelToken(Database.DatabaseShutdown, CancellationToken);
 
-            _uploaderSettings = UploaderSettings.GenerateUploaderSetting(database, Name, Configuration.Connection.S3Settings, Configuration.Connection.AzureSettings, Configuration.Connection.GlacierSettings, Configuration.Connection.GoogleCloudSettings, Configuration.Connection.FtpSettings);
+            _uploaderSettings = UploaderSettings.GenerateUploaderSettingsForOlap(database, Name, Configuration.Connection.S3Settings, Configuration.Connection.AzureSettings, Configuration.Connection.GlacierSettings, Configuration.Connection.GoogleCloudSettings, Configuration.Connection.FtpSettings);
 
             UpdateTimer(LastProcessState.LastBatchTime);
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RetiredBulkPostAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RetiredBulkPostAttachmentStrategyProcessor.cs
@@ -18,9 +18,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies
             IGetAttachmentStrategy.CheckAttachmentFlagAndConfigurationAndThrowIfNeededInternal(context, RequestHandler.Database, attachment, documentId, name, "bulk");
         }
 
-        public override async Task<Stream> GetAttachmentStream(DirectFileDownloader downloader, Attachment attachment)
+        public override Task<Stream> GetAttachmentStream(DirectFileDownloader downloader, Attachment attachment)
         {
-            return await RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.StreamForDownloadDestinationInternal(downloader,
+            return RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.StreamForDownloadDestinationInternal(downloader,
                 attachment.Base64Hash.ToString());
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicAttachment.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Operations.Attachments;
 using Raven.Server.Documents.Attachments;
 using Raven.Server.Documents.Indexes.Static.Attachments;
 using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 
 namespace Raven.Server.Documents.Indexes.Static
 {

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentObjectInstance.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScript/AttachmentObjectInstance.cs
@@ -9,6 +9,7 @@ using Jint.Runtime.Interop;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 
 namespace Raven.Server.Documents.Indexes.Static.JavaScript
 {

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
@@ -11,12 +11,12 @@ using Raven.Client.Extensions;
 using Raven.Client.Util;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.Documents.PeriodicBackup.Azure;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
 using Raven.Server.Documents.PeriodicBackup.Retention;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 using Sparrow;
-using Sparrow.Logging;
 using Sparrow.Server.Logging;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
@@ -25,7 +25,7 @@ using Size = Sparrow.Size;
 
 namespace Raven.Server.Documents.PeriodicBackup
 {
-    public sealed class BackupUploader : FileUploaderBase
+    public sealed class BackupUploader : MultipleFileUploaderBase<PoolOfThreads.LongRunningWork>
     {
         public BackupUploader(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult, Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) :
             base(settings, retentionPolicyParameters, logger, backupResult, onProgress, taskCancelToken)
@@ -50,6 +50,21 @@ namespace Raven.Server.Documents.PeriodicBackup
             Execute();
         }
 
+        public override void Execute()
+        {
+            _threads.ForEach(x => x.Join(int.MaxValue));
+
+            if (_exceptions.IsEmpty == false)
+            {
+                if (_exceptions.Count == 1)
+                    throw _exceptions.First();
+
+                if (_exceptions.All(x => x is OperationCanceledException))
+                    throw _exceptions.First();
+
+                throw new AggregateException(_exceptions);
+            }
+        }
 
         public void ExecuteDelete()
         {
@@ -224,6 +239,41 @@ namespace Raven.Server.Documents.PeriodicBackup
                     _exceptions.Add(exception ?? new InvalidOperationException(error, e));
                 }
             }, null, ThreadNames.ForUploadBackupFile(threadName, _settings.DatabaseName, targetName, _settings.TaskName));
+
+            _threads.Add(thread);
+        }
+
+        private void CreateDeletionTaskIfNeeded<T>(T settings, Action<T, string, string> deleteFromServer, string targetName, string folderName, string fileName)
+            where T : BackupSettings
+        {
+            if (BackupConfiguration.CanBackupUsing(settings) == false)
+                return;
+
+            var threadInfo = ThreadNames.ForDeleteBackupFile($"Delete backup file of database '{_settings.DatabaseName}' from {targetName} (task: '{_settings.TaskName}')", _settings.DatabaseName, targetName, _settings.TaskName);
+            var thread = PoolOfThreads.GlobalRavenThreadPool.LongRunning(_ =>
+            {
+                try
+                {
+                    ThreadHelper.TrySetThreadPriority(ThreadPriority.BelowNormal, threadInfo.FullName, _logger);
+                    NativeMemory.EnsureRegistered();
+
+                    AddInfo($"Starting the delete of backup file from {targetName}.");
+                    deleteFromServer(settings, folderName, fileName);
+                }
+                catch (Exception e)
+                {
+                    var extracted = e.ExtractSingleInnerException();
+                    var error = $"Failed to delete the backup file from {targetName}.";
+                    Exception exception = null;
+                    if (extracted is OperationCanceledException)
+                    {
+                        // shutting down or HttpClient timeout
+                        exception = TaskCancelToken.Token.IsCancellationRequested ? extracted : new TimeoutException(error, e);
+                    }
+
+                    _exceptions.Add(exception ?? new InvalidOperationException(error, e));
+                }
+            }, null, threadInfo);
 
             _threads.Add(thread);
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupUploader.cs
@@ -52,7 +52,10 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         public override void Execute()
         {
-            _threads.ForEach(x => x.Join(int.MaxValue));
+            foreach (var x in _threads)
+            {
+                x.Join(int.MaxValue);
+            }
 
             if (_exceptions.IsEmpty == false)
             {
@@ -84,7 +87,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 var key = CombinePathAndKey(settings.RemoteFolderName);
                 client.PutObject(key, stream, new Dictionary<string, string>
                 {
-                    { "Description", GetArchiveDescription() }
+                    { Description, GetBackupDescription() }
                 });
 
                 if (_logger.IsInfoEnabled)
@@ -139,7 +142,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 var key = CombinePathAndKey(settings.RemoteFolderName);
                 client.PutBlob(key, stream, new Dictionary<string, string>
                 {
-                    { "Description", GetArchiveDescription() }
+                    { Description, GetBackupDescription() }
                 });
 
                 if (_logger.IsInfoEnabled)
@@ -160,7 +163,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 var key = CombinePathAndKey(settings.RemoteFolderName);
                 client.UploadObject(key, stream, new Dictionary<string, string>
                 {
-                    { "Description", GetArchiveDescription() }
+                    { Description, GetBackupDescription() }
                 });
 
                 if (_logger.IsInfoEnabled)
@@ -240,7 +243,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 }
             }, null, ThreadNames.ForUploadBackupFile(threadName, _settings.DatabaseName, targetName, _settings.TaskName));
 
-            _threads.Add(thread);
+            _threads.AddLast(thread);
         }
 
         private void CreateDeletionTaskIfNeeded<T>(T settings, Action<T, string, string> deleteFromServer, string targetName, string folderName, string fileName)
@@ -275,17 +278,17 @@ namespace Raven.Server.Documents.PeriodicBackup
                 }
             }, null, threadInfo);
 
-            _threads.Add(thread);
+            _threads.AddLast(thread);
         }
 
-        private string GetArchiveDescription()
+        public override string GetBackupDescription()
         {
             var backupType = _settings.BackupType;
             string description;
 
             if (backupType.HasValue)
             {
-                description = GetBackupDescription();
+                description = base.GetBackupDescription();
             }
             else
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectDownload/DirectFileDownloader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectDownload/DirectFileDownloader.cs
@@ -1,44 +1,32 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Restore;
-using Raven.Server.Documents.PeriodicBackup.Retention;
 using Raven.Server.ServerWide;
-using Sparrow.Logging;
-using Sparrow.Server.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.DirectDownload;
 
-public sealed class DirectFileDownloader : FileUploaderBase, IDisposable
+public sealed class DirectFileDownloader : FileUploaderDownloaderBase, IDisposable
 {
-    private readonly BackupConfiguration.BackupDestination _destination;
-    private IRestoreSource _restoreSource = null;
-    public DirectFileDownloader(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult, Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) :
-        base(settings, retentionPolicyParameters, logger, backupResult, onProgress, taskCancelToken)
+    private IRestoreSource _restoreSource;
+    public DirectFileDownloader(UploaderSettings settings, OperationCancelToken taskCancelToken) : base(settings, taskCancelToken)
     {
-        _destination = settings.Destination;
     }
 
-    internal async Task<Stream> StreamForDownloadDestination(DocumentDatabase database, string folderName, string fileName)
+    internal Task<Stream> StreamForDownloadDestination(DocumentDatabase database, string folderName, string fileName)
     {
         switch (_destination)
         {
             case BackupConfiguration.BackupDestination.AmazonS3:
                 _restoreSource = new DownloadFromS3(new RestoreFromS3Configuration() { Settings = _settings.S3Settings, }, database.Configuration.Backup, TaskCancelToken.Token);
-                return await _restoreSource.GetStream(CombinePathAndKey(_settings.S3Settings.RemoteFolderName, folderName, fileName));
+                return _restoreSource.GetStream(CombinePathAndKey(_settings.S3Settings.RemoteFolderName, folderName, fileName));
             case BackupConfiguration.BackupDestination.Azure:
-                _restoreSource =  new DownloadFromAzure(new RestoreFromAzureConfiguration() { Settings = _settings.AzureSettings, }, database.Configuration.Backup, TaskCancelToken.Token);
-                return await _restoreSource.GetStream(CombinePathAndKey(_settings.AzureSettings.RemoteFolderName, folderName, fileName));
+                _restoreSource = new DownloadFromAzure(new RestoreFromAzureConfiguration() { Settings = _settings.AzureSettings, }, database.Configuration.Backup, TaskCancelToken.Token);
+                return _restoreSource.GetStream(CombinePathAndKey(_settings.AzureSettings.RemoteFolderName, folderName, fileName));
             default:
                 throw new ArgumentOutOfRangeException($"Missing implementation for direct upload destination '{_destination}'");
         }
-    }
-
-    public override string GetBackupDescription()
-    {
-        return $"{nameof(DirectFileDownloader)}";
     }
 
     public void Dispose()

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/BackupDestinationStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/BackupDestinationStream.cs
@@ -11,7 +11,6 @@ public struct BackupDestinationStream : IDisposable
 
     public void Dispose()
     {
-        FileUploader?.Reset();
         Stream?.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectFileUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectFileUploader.cs
@@ -23,7 +23,7 @@ public class DirectFileUploader : FileUploaderBase
         _backupDescription = _isFullBackup ? fullBackupText : "Incremental backup";
     }
 
-    internal Stream StreamForBackupDestination(DocumentDatabase database, string folderName, string fileName)
+    internal virtual Stream StreamForBackupDestination(DocumentDatabase database, string folderName, string fileName)
     {
         switch (_destination)
         {

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectFileUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectFileUploader.cs
@@ -13,9 +13,14 @@ namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
 
 public class DirectFileUploader : FileUploaderBase
 {
+    private readonly string _backupDescription;
+    protected static readonly string Description = "Description";
+
     public DirectFileUploader(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult, Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) :
         base(settings, retentionPolicyParameters, logger, backupResult, onProgress, taskCancelToken)
     {
+        var fullBackupText = settings.BackupType == BackupType.Backup ? "Full backup" : "A snapshot";
+        _backupDescription = _isFullBackup ? fullBackupText : "Incremental backup";
     }
 
     internal Stream StreamForBackupDestination(DocumentDatabase database, string folderName, string fileName)
@@ -45,7 +50,7 @@ public class DirectFileUploader : FileUploaderBase
             Key = CombinePathAndKey(remoteFolderName, folderName, fileName),
             Metadata = new Dictionary<string, string>
             {
-                { "Description", GetBackupDescription() }
+                { Description, GetBackupDescription() }
             },
             IsFullBackup = _isFullBackup,
             RetentionPolicyParameters = _retentionPolicyParameters,
@@ -57,7 +62,6 @@ public class DirectFileUploader : FileUploaderBase
 
     public virtual string GetBackupDescription()
     {
-        var fullBackupText = _settings.BackupType == BackupType.Backup ? "Full backup" : "A snapshot";
-        return _isFullBackup ? fullBackupText : "Incremental backup";
+        return _backupDescription;
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectFileUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectFileUploader.cs
@@ -1,32 +1,21 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Extensions;
-using Raven.Client.Util;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.Documents.PeriodicBackup.Retention;
 using Raven.Server.ServerWide;
-using Raven.Server.Utils;
 using Sparrow.Server.Logging;
-using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
 
-public sealed class DirectFileUploader : FileUploaderBase
+public class DirectFileUploader : FileUploaderBase
 {
-    private readonly short _concurrentThreads;
-    private readonly BackupConfiguration.BackupDestination _destination;
-
     public DirectFileUploader(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult, Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) :
         base(settings, retentionPolicyParameters, logger, backupResult, onProgress, taskCancelToken)
     {
-        _destination = settings.Destination;
-        _concurrentThreads = settings.ConcurrentThreads;
     }
 
     internal Stream StreamForBackupDestination(DocumentDatabase database, string folderName, string fileName)
@@ -66,133 +55,9 @@ public sealed class DirectFileUploader : FileUploaderBase
         };
     }
 
-    public override string GetBackupDescription()
+    public virtual string GetBackupDescription()
     {
-        return $"{nameof(DirectFileUploader)}";
+        var fullBackupText = _settings.BackupType == BackupType.Backup ? "Full backup" : "A snapshot";
+        return _isFullBackup ? fullBackupText : "Incremental backup";
     }
-
-    public void AddDelete(string folderName, string fileName)
-    {
-        switch (_destination)
-        {
-            case BackupConfiguration.BackupDestination.AmazonS3:
-                CreateLongRunningDeleteThread(_settings.S3Settings, DeleteFromS3, S3Name, folderName, fileName, 
-                    ThreadNames.ForDeleteRetiredAttachment(ThreadName(S3Name), _settings.DatabaseName, S3Name, _settings.TaskName));
-                break;
-
-            case BackupConfiguration.BackupDestination.Azure:
-                var threadInfo = ThreadNames.ForDeleteRetiredAttachment(ThreadName(AzureName), _settings.DatabaseName, AzureName, _settings.TaskName);
-                CreateLongRunningDeleteThread(_settings.AzureSettings, DeleteFromAzure, AzureName, folderName, fileName, threadInfo);
-                break;
-
-            default:
-                throw new ArgumentOutOfRangeException($"Missing implementation for direct upload destination '{_destination}'");
-        }
-    }
-
-    public IDictionary<string, string> GetObjectMetadata(string folderName, string objKeyName)
-    {
-        switch (_destination)
-        {
-            case BackupConfiguration.BackupDestination.AmazonS3:
-                return GetObjectMetadataFromS3(_settings.S3Settings, folderName, objKeyName);
-
-            case BackupConfiguration.BackupDestination.Azure:
-                return GetObjectMetadataFromAzure(_settings.AzureSettings, folderName, objKeyName);
-
-            default:
-                throw new ArgumentOutOfRangeException($"Missing implementation for direct upload destination '{_destination}'");
-        }
-    }
-
-    private string ThreadName(string name)
-    {
-        return $"Delete retired attachment of database '{_settings.DatabaseName}' from {name} (task: '{_settings.TaskName}')";
-    }
-
-    public void CreateUploadTask(DocumentDatabase database, Stream attachmentStream, string objKeyName, CancellationToken token)
-    {
-        var targetName = _destination == BackupConfiguration.BackupDestination.AmazonS3 ? S3Name : AzureName;
-        var threadName = $"Upload retired attachment '{objKeyName}' of database '{_settings.DatabaseName}' from {targetName} (task: '{_settings.TaskName}')";
-        var thread = PoolOfThreads.GlobalRavenThreadPool.LongRunning(_ =>
-        {
-            try
-            {
-                ThreadHelper.TrySetThreadPriority(ThreadPriority.BelowNormal, threadName, _logger);
-                Sparrow.Utils.NativeMemory.EnsureRegistered();
-
-                AddInfo($"Starting the upload of retired attachment '{objKeyName}'.");
-
-                using (attachmentStream)
-                using (var stream = StreamForBackupDestination(database, string.Empty, objKeyName))
-                    attachmentStream.CopyTo(stream);
-
-            }
-            catch (Exception e)
-            {
-                var extracted = e.ExtractSingleInnerException();
-                var error = $"Failed the {threadName}.";
-                Exception exception = null;
-                if (extracted is OperationCanceledException)
-                {
-                    // shutting down or HttpClient timeout
-                    exception = TaskCancelToken.Token.IsCancellationRequested ? extracted : new TimeoutException(error, e);
-                }
-
-                _exceptions.Add(exception ?? new InvalidOperationException(error, e));
-            }
-        }, null, ThreadNames.ForUploadRetiredAttachment(threadName, _settings.DatabaseName, targetName, _settings.TaskName));
-
-        _threads.Add(thread);
-    }
-
-    public bool TryCleanFinishedThreads(Stopwatch sp, OperationCancelToken token)
-    {
-        if (_threads.Count < _concurrentThreads)
-            return true;
-
-        var cleaned = false;
-        while (cleaned == false)
-        {
-            if (token.Token.IsCancellationRequested)
-                return false;
-
-            if (sp.ElapsedMilliseconds > RetireAttachmentsSender.ReadTransactionMaxOpenTimeInMs)
-            {
-                return false;
-            }
-
-            for (int i = _threads.Count - 1; i >= 0; i--)
-            {
-                if (_threads[i].Join(128))
-                {
-                    cleaned = true;
-                    _threads.RemoveAt(i);
-                }
-
-            }
-        }
-
-        if (_exceptions.IsEmpty == false)
-        {
-            // we should rethrow the actual exceptions when we will dispose this class.
-            token.Cancel();
-            return false;
-        }
-
-
-        return true;
-    }
-
-    public IDisposable Initialize()
-    {
-        return new DisposableAction(Reset);
-    }
-
-    public void Reset()
-    {
-        Execute();
-        _threads.Clear();
-    }
-
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadBackupTask.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.ServerWide;
-using Sparrow.Logging;
 using Sparrow.Server.Logging;
 
 namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
@@ -15,7 +14,7 @@ public class DirectUploadBackupTask : BackupTask
 
     protected override BackupDestinationStream GetUploaderForBackupDestination(string filePath, string folderName, string fileName)
     {
-        var uploaderSettings = UploaderSettings.GenerateUploaderSettingForBackup(Database, Configuration, _taskName, _isServerWide, _backupToLocalFolder, OnBackupException);
+        var uploaderSettings = UploaderSettings.GenerateUploaderSettingsForBackup(Database, Configuration, _taskName, _isServerWide, _backupToLocalFolder, OnBackupException);
         var backupUploader = new DirectFileUploader(uploaderSettings, RetentionPolicyParameters, _logger, BackupResult, _onProgress, TaskCancelToken);
         return new BackupDestinationStream()
         {

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/MultipleFileUploaderBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/MultipleFileUploaderBase.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup.Retention;
+using Raven.Server.ServerWide;
+using Sparrow.Collections;
+using Sparrow.Server.Logging;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public abstract class MultipleFileUploaderBase<T> : DirectFileUploader
+{
+    protected readonly List<T> _threads;
+    protected readonly ConcurrentSet<Exception> _exceptions;
+
+    protected MultipleFileUploaderBase(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult,
+        Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) :
+        base(settings, retentionPolicyParameters, logger, backupResult, onProgress, taskCancelToken)
+    {
+        _threads = new List<T>();
+        _exceptions = new ConcurrentSet<Exception>();
+    }
+
+    public abstract void Execute();
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/MultipleFileUploaderBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/MultipleFileUploaderBase.cs
@@ -11,14 +11,14 @@ namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
 
 public abstract class MultipleFileUploaderBase<T> : DirectFileUploader
 {
-    protected readonly List<T> _threads;
+    protected readonly LinkedList<T> _threads;
     protected readonly ConcurrentSet<Exception> _exceptions;
 
     protected MultipleFileUploaderBase(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult,
         Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) :
         base(settings, retentionPolicyParameters, logger, backupResult, onProgress, taskCancelToken)
     {
-        _threads = new List<T>();
+        _threads = new LinkedList<T>();
         _exceptions = new ConcurrentSet<Exception>();
     }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/FileUploaderBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/FileUploaderBase.cs
@@ -1,36 +1,23 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Extensions;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
 using Raven.Server.Documents.PeriodicBackup.Retention;
 using Raven.Server.ServerWide;
-using Raven.Server.Utils;
-using Sparrow.Collections;
-using Sparrow.Logging;
 using Sparrow.Server.Logging;
-using Sparrow.Server.Utils;
-using Sparrow.Utils;
 
 namespace Raven.Server.Documents.PeriodicBackup;
 
-public abstract class FileUploaderBase
+public abstract class FileUploaderBase : FileUploaderDownloaderBase
 {
-    public readonly OperationCancelToken TaskCancelToken;
-
     protected readonly bool _isFullBackup;
     protected readonly Action<IOperationProgress> _onProgress;
     protected readonly RetentionPolicyBaseParameters _retentionPolicyParameters;
     protected readonly BackupResult _backupResult;
-    protected readonly UploaderSettings _settings;
     protected readonly RavenLogger _logger;
-    protected readonly List<PoolOfThreads.LongRunningWork> _threads;
-    protected readonly ConcurrentSet<Exception> _exceptions;
 
     protected const string AzureName = "Azure";
     protected const string S3Name = "S3";
@@ -38,102 +25,19 @@ public abstract class FileUploaderBase
     protected const string GoogleCloudName = "Google Cloud";
     protected const string FtpName = "FTP";
 
-    protected FileUploaderBase(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult,
-        Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken)
+    protected FileUploaderBase(UploaderSettings settings, RetentionPolicyBaseParameters retentionPolicyParameters, RavenLogger logger, BackupResult backupResult, Action<IOperationProgress> onProgress, OperationCancelToken taskCancelToken) : base(settings, taskCancelToken)
     {
-        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _onProgress = onProgress;
         _backupResult = backupResult;
-
         _retentionPolicyParameters = retentionPolicyParameters;
-
         _isFullBackup = retentionPolicyParameters?.IsFullBackup ?? false;
-
         _logger = logger;
-        TaskCancelToken = taskCancelToken;
-        _threads = new List<PoolOfThreads.LongRunningWork>();
-        _exceptions = new ConcurrentSet<Exception>();
-    }
-
-    public virtual string CombinePathAndKey(string path, string folderName, string fileName)
-    {
-        if (path?.EndsWith('/') == true)
-            path = path[..^1];
-
-        var prefix = string.IsNullOrWhiteSpace(path) == false ? $"{path}/" : string.Empty;
-        prefix = string.IsNullOrWhiteSpace(folderName) == false ? $"{prefix}{folderName}/" : prefix;
-
-        return $"{prefix}{fileName}";
-    }
-
-    public virtual string GetBackupDescription()
-    {
-        var fullBackupText = _settings.BackupType == BackupType.Backup ? "Full backup" : "A snapshot";
-        return _isFullBackup ? fullBackupText : "Incremental backup";
     }
 
     protected void AddInfo(string message)
     {
         _backupResult.AddInfo(message);
         _onProgress.Invoke(_backupResult.Progress);
-    }
-
-    protected void Execute()
-    {
-        _threads.ForEach(x => x.Join(int.MaxValue));
-
-        if (_exceptions.IsEmpty == false)
-        {
-            if (_exceptions.Count == 1)
-                throw _exceptions.First();
-
-            if (_exceptions.All(x => x is OperationCanceledException))
-                throw _exceptions.First();
-
-            throw new AggregateException(_exceptions);
-        }
-    }
-
-    protected void CreateDeletionTaskIfNeeded<T>(T settings, Action<T, string,string> deleteFromServer, string targetName, string folderName, string fileName)
-        where T : BackupSettings
-    {
-        if (BackupConfiguration.CanBackupUsing(settings) == false)
-            return;
-
-        var threadInfo = ThreadNames.ForDeleteBackupFile($"Delete backup file of database '{_settings.DatabaseName}' from {targetName} (task: '{_settings.TaskName}')", _settings.DatabaseName, targetName, _settings.TaskName);
-        PoolOfThreads.LongRunningWork thread = CreateLongRunningDeleteThread(settings, deleteFromServer, targetName, folderName, fileName, threadInfo);
-
-        _threads.Add(thread);
-    }
-
-    protected PoolOfThreads.LongRunningWork CreateLongRunningDeleteThread<T>(T settings, Action<T, string, string> deleteFromServer, string targetName, string folderName, string fileName,
-        ThreadNames.ThreadInfo threadInfo) where T : BackupSettings
-    {
-        var thread = PoolOfThreads.GlobalRavenThreadPool.LongRunning(_ =>
-        {
-            try
-            {
-                ThreadHelper.TrySetThreadPriority(ThreadPriority.BelowNormal, threadInfo.FullName, _logger);
-                NativeMemory.EnsureRegistered();
-
-                AddInfo($"Starting the delete of backup file from {targetName}.");
-                deleteFromServer(settings, folderName, fileName);
-            }
-            catch (Exception e)
-            {
-                var extracted = e.ExtractSingleInnerException();
-                var error = $"Failed to delete the backup file from {targetName}.";
-                Exception exception = null;
-                if (extracted is OperationCanceledException)
-                {
-                    // shutting down or HttpClient timeout
-                    exception = TaskCancelToken.Token.IsCancellationRequested ? extracted : new TimeoutException(error, e);
-                }
-
-                _exceptions.Add(exception ?? new InvalidOperationException(error, e));
-            }
-        }, null, threadInfo);
-        return thread;
     }
 
     protected void DeleteFromS3(S3Settings settings, string folderName, string fileName)

--- a/src/Raven.Server/Documents/PeriodicBackup/FileUploaderDownloaderBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/FileUploaderDownloaderBase.cs
@@ -1,0 +1,30 @@
+using System;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Documents.PeriodicBackup;
+
+public abstract class FileUploaderDownloaderBase
+{
+    public readonly OperationCancelToken TaskCancelToken;
+    internal readonly BackupConfiguration.BackupDestination _destination;
+    protected readonly UploaderSettings _settings;
+
+    protected FileUploaderDownloaderBase(UploaderSettings settings, OperationCancelToken taskCancelToken)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _destination = settings.Destination;
+        TaskCancelToken = taskCancelToken;
+    }
+
+    protected string CombinePathAndKey(string path, string folderName, string fileName)
+    {
+        if (path?.EndsWith('/') == true)
+            path = path[..^1];
+
+        var prefix = string.IsNullOrWhiteSpace(path) == false ? $"{path}/" : string.Empty;
+        prefix = string.IsNullOrWhiteSpace(folderName) == false ? $"{prefix}{folderName}/" : prefix;
+
+        return $"{prefix}{fileName}";
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/UploaderSettings.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/UploaderSettings.cs
@@ -31,7 +31,7 @@ public sealed class UploaderSettings
     internal BackupConfiguration.BackupDestination Destination;
     public short ConcurrentThreads { get; set; }
 
-    public static UploaderSettings GenerateUploaderSetting(DocumentDatabase database, string taskName, S3Settings s3Settings, AzureSettings azureSettings, GlacierSettings glacierSettings, GoogleCloudSettings googleCloudSettings, FtpSettings ftpSettings)
+    public static UploaderSettings GenerateUploaderSettingsForOlap(DocumentDatabase database, string taskName, S3Settings s3Settings, AzureSettings azureSettings, GlacierSettings glacierSettings, GoogleCloudSettings googleCloudSettings, FtpSettings ftpSettings)
     {
         return new UploaderSettings(database.Configuration.Backup)
         {
@@ -50,29 +50,22 @@ public sealed class UploaderSettings
         };
     }
 
-    public static UploaderSettings GenerateDirectUploaderSetting(DocumentDatabase database, string taskName, S3Settings s3Settings, AzureSettings azureSettings, GlacierSettings glacierSettings, GoogleCloudSettings googleCloudSettings, FtpSettings ftpSettings, short concurrentThreads)
+    public static UploaderSettings GenerateDirectUploaderSettingsForAttachments(DocumentDatabase database, string taskName, S3Settings s3Settings, AzureSettings azureSettings, short concurrentThreads)
     {
-        var destination = BackupConfigurationHelper.DestinationForDirectUpload(database.Configuration.Backup, s3Settings, azureSettings, glacierSettings, googleCloudSettings, ftpSettings);
         return new UploaderSettings(database.Configuration.Backup)
         {
             S3Settings = BackupTask.GetBackupConfigurationFromScript(s3Settings, x => JsonDeserializationServer.S3Settings(x),
                 database, updateServerWideSettingsFunc: null, serverWide: false),
             AzureSettings = BackupTask.GetBackupConfigurationFromScript(azureSettings, x => JsonDeserializationServer.AzureSettings(x),
                 database, updateServerWideSettingsFunc: null, serverWide: false),
-            GlacierSettings = BackupTask.GetBackupConfigurationFromScript(glacierSettings, x => JsonDeserializationServer.GlacierSettings(x),
-                database, updateServerWideSettingsFunc: null, serverWide: false),
-            GoogleCloudSettings = BackupTask.GetBackupConfigurationFromScript(googleCloudSettings, x => JsonDeserializationServer.GoogleCloudSettings(x),
-                database, updateServerWideSettingsFunc: null, serverWide: false),
-            FtpSettings = BackupTask.GetBackupConfigurationFromScript(ftpSettings, x => JsonDeserializationServer.FtpSettings(x),
-                database, updateServerWideSettingsFunc: null, serverWide: false),
             DatabaseName = database.Name,
             TaskName = taskName,
-            Destination = destination,
+            Destination = BackupConfigurationHelper.DestinationForDirectUpload(database.Configuration.Backup, s3Settings, azureSettings, glacierSettings: null, googleCloudSettings: null, ftpSettings: null),
             ConcurrentThreads = concurrentThreads
         };
     }
 
-    public static UploaderSettings GenerateUploaderSettingForBackup(DocumentDatabase database, BackupConfiguration configuration, string taskName, bool isServerWide, bool backupToLocalFolder,
+    public static UploaderSettings GenerateUploaderSettingsForBackup(DocumentDatabase database, BackupConfiguration configuration, string taskName, bool isServerWide, bool backupToLocalFolder,
         Action backupException)
     {
         var destination = BackupConfigurationHelper.GetBackupDestinationForDirectUpload(backupToLocalFolder, configuration, database.Configuration.Backup);

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -18,7 +18,7 @@ using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TcpHandlers;
-using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -21,7 +21,7 @@ using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Documents.TransactionMerger.Commands;
-using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -22,7 +22,7 @@ using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.TcpHandlers;
-using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 using Raven.Server.Json;
 using Raven.Server.Logging;
 using Raven.Server.NotificationCenter;

--- a/src/Raven.Server/Documents/RetireAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RetireAttachmentsSender.cs
@@ -204,6 +204,9 @@ namespace Raven.Server.Documents
                                 }
                                 else
                                 {
+                                    // we cannot continue the batch, need to dispose the attachment stream
+                                    await attachmentStream.DisposeAsync();
+
                                     if (Logger.IsDebugEnabled)
                                         Logger.Debug($"Timed out waiting for free slot to upload retired attachments with '{doc.LowerId}', ReadTransactionMaxOpenTimeInMs: {duration.ElapsedMilliseconds > ReadTransactionMaxOpenTimeInMs}, IsCancellationRequested: {_token.Token.IsCancellationRequested}, the upload will happen on next iteration.");
                                 }

--- a/src/Raven.Server/Documents/RetireAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RetireAttachmentsSender.cs
@@ -4,14 +4,14 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide;
 using Raven.Server.Background;
+using Raven.Server.Documents.Attachments;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.PeriodicBackup;
-using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.Exceptions.Attachments;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -85,6 +85,7 @@ namespace Raven.Server.Documents
 
                     Stopwatch duration;
                     var retired = new Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo>();
+                    var exceptions = new List<UploadAttachmentException>();
 
                     using (var tx = context.OpenReadTransaction())
                     using (_database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.Initialize(context))
@@ -107,7 +108,7 @@ namespace Raven.Server.Documents
                             return totalCount;
                         }
 
-                        var directUploaders = new Dictionary<string, DirectFileUploader>();
+                        var directUploaders = new Dictionary<string, AttachmentUploader>();
 
                         try
                         {
@@ -130,7 +131,6 @@ namespace Raven.Server.Documents
                                     retired.Enqueue(doc);
                                     continue;
                                 }
-
 
                                 // get uploader for the attachment
                                 if (directUploaders.TryGetValue(doc.Id, out var directUpload) == false)
@@ -160,9 +160,21 @@ namespace Raven.Server.Documents
                                     }
 
                                     // create new uploader for the attachment
-                                    directUploaders[doc.Id] = directUpload = new DirectFileUploader(UploaderSettings.GenerateDirectUploaderSetting(_database, nameof(RetireAttachmentsSender),
-                                            destination.S3Settings, destination.AzureSettings, glacierSettings: null, googleCloudSettings: null, ftpSettings: null, ConcurrentThreadsNumber), retentionPolicyParameters: null, Logger,
-                                        FileUploaderBase.GenerateUploadResult(), onProgress: ProgressNotification, _token);
+                                    directUpload = new AttachmentUploader(UploaderSettings.GenerateDirectUploaderSettingsForAttachments(_database, doc.Id, destination.S3Settings, destination.AzureSettings, ConcurrentThreadsNumber), Logger, _token)
+                                    {
+                                        OnSuccessAction = x =>
+                                        {
+                                            totalUploaded += x.AttachmentSize;
+                                            retired.Enqueue(x.Doc);
+                                        },
+                                        OnExceptionAction = x =>
+                                        {
+                                            var key = x.Doc.LowerId.ToString();
+                                            exceptions.Add(new UploadAttachmentException(x.Doc.Id, key, $"Upload task of retired attachment with key '{key}' and identifier '{x.Doc.Id}' failed.", x.UploadTask.Exception));
+                                        }
+                                    };
+
+                                    directUploaders[doc.Id] = directUpload;
                                 }
 
                                 using var hashSliceDisposable = _database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.ExtractHashSliceFromAttachmentId(context, doc.LowerId, out Slice hashSlice);
@@ -175,8 +187,10 @@ namespace Raven.Server.Documents
                                     continue;
                                 }
 
+                                _token.ThrowIfCancellationRequested();
+
                                 // the attachment stream is disposed by the directUpload
-                                var attachmentStream = _database.DocumentsStorage.AttachmentsStorage.GetAttachmentStream(context, hashSlice);
+                                var (attachmentStream, attachmentLength) = _database.DocumentsStorage.AttachmentsStorage.GetAttachmentStreamAndLength(context, hashSlice);
                                 if (attachmentStream == null)
                                 {
                                     // attachment was deleted, need to remote it from retired tree
@@ -184,33 +198,15 @@ namespace Raven.Server.Documents
                                     continue;
                                 }
 
-                                if (directUpload.TryCleanFinishedThreads(duration, _token))
+                                if (await directUpload.WaitForFinishedTasksIfNeededAsync(duration, _token))
                                 {
-                                    directUpload.CreateUploadTask(_database, attachmentStream, hash, CancellationToken);
-
-                                    totalUploaded += attachmentStream.Length;
-                                    retired.Enqueue(doc);
+                                    directUpload.CreateUploadTask(_database, doc, attachmentStream, hash, attachmentLength, CancellationToken);
                                 }
                                 else
                                 {
                                     if (Logger.IsDebugEnabled)
-                                        Logger.Debug($"Timed out waiting for free thread to PutRetire retired attachments with '{doc.LowerId}', ReadTransactionMaxOpenTimeInMs: {duration.ElapsedMilliseconds > ReadTransactionMaxOpenTimeInMs}, IsCancellationRequested: {_token.Token.IsCancellationRequested}, the PutRetire will happen on next iteration.");
+                                        Logger.Debug($"Timed out waiting for free slot to upload retired attachments with '{doc.LowerId}', ReadTransactionMaxOpenTimeInMs: {duration.ElapsedMilliseconds > ReadTransactionMaxOpenTimeInMs}, IsCancellationRequested: {_token.Token.IsCancellationRequested}, the upload will happen on next iteration.");
                                 }
-                            }
-
-                            if (toRetire.Count != retired.Count)
-                            {
-                                // we had skipped items
-                                if (Logger.IsDebugEnabled)
-                                    Logger.Debug($"Skipping retiring of '{toRetire.Count - retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
-                            }
-
-                            if (retired.Count == 0)
-                            {
-                                if (Logger.IsDebugEnabled)
-                                    Logger.Debug($"Skipping retiring whole batch of '{retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
-
-                                continue;
                             }
                         }
                         finally
@@ -218,16 +214,56 @@ namespace Raven.Server.Documents
                             // Wait for all direct uploaders to finish
                             foreach (var uploader in directUploaders.Values)
                             {
-                                uploader.Reset();
+                                _token.ThrowIfCancellationRequested();
+
+                                uploader.Execute();
                             }
+                        }
+
+                        if (toRetire.Count != retired.Count)
+                        {
+                            // we had skipped items
+                            if (Logger.IsDebugEnabled)
+                                Logger.Debug($"Skipping retiring of '{toRetire.Count - retired.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
+                        }
+
+                        if (retired.Count == 0)
+                        {
+                            if (Logger.IsDebugEnabled)
+                                Logger.Debug($"Skipping retiring whole batch of '{toRetire.Count:#,#;;0}' attachments, Uploaded: {new Size(totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRetire.Select(x => retired.Contains(x) == false))}");
+
+
+                            if (exceptions.Count == 0)
+                            {
+                                continue;
+                            }
+
+                            // we have exceptions and nothing was retired, we need to throw
+                            throw new AggregateException("Failed to upload all attachments.", exceptions);
                         }
                     }
 
                     var command = new UpdateRetiredAttachmentsCommand(retired, _database, currentTime);
                     await _database.TxMerger.Enqueue(command);
 
-                    if (Logger.IsDebugEnabled)
-                        Logger.Debug($"Successfully retired '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms.");
+                    if (Logger.IsInfoEnabled)
+                    {
+                        if (exceptions.Count == 0)
+                        {
+                            Logger.Info($"Successfully retired whole batch of '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms. Total uploaded data: {Client.Util.Size.Humane(totalUploaded)}.");
+                        }
+                        else
+                        {
+                            var msg =
+                                $"Successfully retired partial batch of '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms. Total uploaded data: {Client.Util.Size.Humane(totalUploaded)}.";
+
+                            msg += $" Failed to upload '{exceptions.Count:#,#;;0}' attachments:{Environment.NewLine}{
+                                string.Join(Environment.NewLine, exceptions.OrderByDescending(x => x.Identifier)
+                                    .Select(x => $"Identifier: '{x.Identifier}', AttachmentKey: {x.Key}"))}";
+
+                            Logger.Info(msg);
+                        }
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -262,11 +298,6 @@ namespace Raven.Server.Documents
             }
 
             return true;
-        }
-
-        private void ProgressNotification(IOperationProgress progress)
-        {
-
         }
 
         internal sealed class UpdateRetiredAttachmentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>

--- a/src/Raven.Server/Documents/RetireAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RetireAttachmentsSender.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Backups;
@@ -43,7 +44,7 @@ namespace Raven.Server.Documents
             Configuration = retiredAttachmentsConfiguration;
             _database = database;
             _retirePeriod = TimeSpan.FromSeconds(Configuration?.RetireFrequencyInSec ?? DefaultRetireFrequencyInSec);
-            _token = new OperationCancelToken(Cts.Token);
+            _token = new OperationCancelToken(CancellationToken);
         }
 
         protected override Task DoWork()
@@ -99,9 +100,7 @@ namespace Raven.Server.Documents
 
                         var options = new BackgroundWorkParameters(context, currentTime, dbRecord, _database.ServerStore.NodeTag, batchSize, maxItemsToProcess);
 
-                        Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo> toRetire =
-                            _database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.GetDocuments(options, ref totalCount, out duration,
-                                CancellationToken);
+                        var toRetire = _database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.GetDocuments(options, ref totalCount, out duration, _token.Token);
 
                         if (toRetire == null || toRetire.Count == 0)
                         {
@@ -117,7 +116,7 @@ namespace Raven.Server.Documents
                             {
                                 _token.ThrowIfCancellationRequested();
 
-                                if (CanContinueBatch(Logger, duration, totalUploaded) == false)
+                                if (CanContinueBatch(Logger, duration, totalUploaded, _token) == false)
                                 {
                                     break;
                                 }
@@ -162,12 +161,12 @@ namespace Raven.Server.Documents
                                     // create new uploader for the attachment
                                     directUpload = new AttachmentUploader(UploaderSettings.GenerateDirectUploaderSettingsForAttachments(_database, doc.Id, destination.S3Settings, destination.AzureSettings, ConcurrentThreadsNumber), Logger, _token)
                                     {
-                                        OnSuccessAction = x =>
+                                        OnSuccess = x =>
                                         {
                                             totalUploaded += x.AttachmentSize;
                                             retired.Enqueue(x.Doc);
                                         },
-                                        OnExceptionAction = x =>
+                                        OnException = x =>
                                         {
                                             var key = x.Doc.LowerId.ToString();
                                             exceptions.Add(new UploadAttachmentException(x.Doc.Id, key, $"Upload task of retired attachment with key '{key}' and identifier '{x.Doc.Id}' failed.", x.UploadTask.Exception));
@@ -200,7 +199,7 @@ namespace Raven.Server.Documents
 
                                 if (await directUpload.WaitForFinishedTasksIfNeededAsync(duration, _token))
                                 {
-                                    directUpload.CreateUploadTask(_database, doc, attachmentStream, hash, attachmentLength, CancellationToken);
+                                    directUpload.CreateUploadTask(_database, doc, attachmentStream, hash, attachmentLength);
                                 }
                                 else
                                 {
@@ -251,20 +250,21 @@ namespace Raven.Server.Documents
 
                     if (Logger.IsInfoEnabled)
                     {
+                        var uploadedSizeText = Client.Util.Size.Humane(totalUploaded);
+                        var retiredCount = command.RetiredCount;
+                        var elapsedMs = duration.ElapsedMilliseconds;
+
                         if (exceptions.Count == 0)
                         {
-                            Logger.Info($"Successfully retired whole batch of '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms. Total uploaded data: {Client.Util.Size.Humane(totalUploaded)}.");
+                            Logger.Info($"Successfully retired {retiredCount:#,#;;0} attachments in {elapsedMs:#,#;;0} ms. Total uploaded: {uploadedSizeText}");
                         }
                         else
                         {
-                            var msg =
-                                $"Successfully retired partial batch of '{command.RetiredCount:#,#;;0}' attachments in '{duration.ElapsedMilliseconds:#,#;;0}' ms. Total uploaded data: {Client.Util.Size.Humane(totalUploaded)}.";
+                            var failedCount = exceptions.Count;
+                            var failureDetails = BuildFailureDetails(exceptions);
 
-                            msg += $" Failed to upload '{exceptions.Count:#,#;;0}' attachments:{Environment.NewLine}{
-                                string.Join(Environment.NewLine, exceptions.OrderByDescending(x => x.Identifier)
-                                    .Select(x => $"Identifier: '{x.Identifier}', AttachmentKey: {x.Key}"))}";
-
-                            Logger.Info(msg);
+                            Logger.Info($"Partially retired {retiredCount:#,#;;0} attachments in {elapsedMs:#,#;;0} ms. Total uploaded: {uploadedSizeText}. " +
+                                        $"Failed to upload {failedCount:#,#;;0} attachments:{Environment.NewLine}{failureDetails}");
                         }
                     }
                 }
@@ -282,7 +282,22 @@ namespace Raven.Server.Documents
             return totalCount;
         }
 
-        private static bool CanContinueBatch(RavenLogger logger, Stopwatch duration, long totalUploaded)
+        private static string BuildFailureDetails(List<UploadAttachmentException> exceptions)
+        {
+            if (exceptions.Count == 0)
+                return string.Empty;
+
+            var sb = new StringBuilder(exceptions.Count * 64); // Pre-allocate reasonable capacity
+
+            foreach (var ex in exceptions.OrderByDescending(x => x.Identifier))
+            {
+                sb.AppendLine($"Identifier: '{ex.Identifier}', AttachmentKey: {ex.Key}");
+            }
+
+            return sb.ToString().TrimEnd();
+        }
+
+        internal static bool CanContinueBatch(RavenLogger logger, Stopwatch duration, long totalUploaded, OperationCancelToken token)
         {
             if (duration.ElapsedMilliseconds > ReadTransactionMaxOpenTimeInMs)
             {
@@ -290,8 +305,8 @@ namespace Raven.Server.Documents
                     logger.Info($"Stop handling retired attachments to cloud due to long read tx open time: '{duration.ElapsedMilliseconds}'.");
 
                 return false;
-
             }
+
             if (totalUploaded >= BatchSizeInBytes)
             {
                 if (logger.IsInfoEnabled)
@@ -299,6 +314,9 @@ namespace Raven.Server.Documents
 
                 return false;
             }
+
+            if (token.Token.IsCancellationRequested)
+                return false;
 
             return true;
         }

--- a/src/Raven.Server/Documents/RetiredAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RetiredAttachmentsStorage.cs
@@ -375,15 +375,15 @@ public class RetiredAttachmentsStorage : AbstractBackgroundWorkStorage
         if (destination.Disabled)
             throw new InvalidOperationException($"Cannot get retired attachment '{attachment.Key}' because destination for '{attachment.RetireParameters.Identifier}' is disabled.");
 
-        var settings = UploaderSettings.GenerateDirectUploaderSetting(Database, nameof(AttachmentHandlerProcessorForGetAttachment), destination.S3Settings, destination.AzureSettings, glacierSettings: null, googleCloudSettings: null, ftpSettings: null, concurrentThreads: 8);
-        return new DirectFileDownloader(settings, retentionPolicyParameters: null, _logger, FileUploaderBase.GenerateUploadResult(), progress => { }, tcs);
+        var settings = UploaderSettings.GenerateDirectUploaderSettingsForAttachments(Database, nameof(AttachmentHandlerProcessorForGetAttachment), destination.S3Settings, destination.AzureSettings, concurrentThreads: 8);
+        return new DirectFileDownloader(settings, tcs);
     }
 
-    public async Task<Stream> StreamForDownloadDestinationInternal(DirectFileDownloader downloader, string objKeyName)
+    public Task<Stream> StreamForDownloadDestinationInternal(DirectFileDownloader downloader, string objKeyName)
     {
         var folderName = string.Empty;
 
-        return await downloader.StreamForDownloadDestination(Database, folderName, objKeyName);
+        return downloader.StreamForDownloadDestination(Database, folderName, objKeyName);
     }
 
     private static unsafe LazyStringValue GetStringFromIdSlice(DocumentsOperationContext context, Slice identifierSlice)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -13,6 +13,7 @@ using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 using Raven.Server.ServerWide.Commands.Sharding;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Exceptions/Attachments/MissingAttachmentException.cs
+++ b/src/Raven.Server/Exceptions/Attachments/MissingAttachmentException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Raven.Server.Exceptions
+namespace Raven.Server.Exceptions.Attachments
 {
     [Serializable]
     internal sealed class MissingAttachmentException : Exception

--- a/src/Raven.Server/Exceptions/Attachments/RetiredAttachmentIndexingException.cs
+++ b/src/Raven.Server/Exceptions/Attachments/RetiredAttachmentIndexingException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Raven.Server.Exceptions
+﻿namespace Raven.Server.Exceptions.Attachments
 {
     public sealed class RetiredAttachmentIndexingException : CriticalIndexingException
     {

--- a/src/Raven.Server/Exceptions/Attachments/UploadAttachmentException.cs
+++ b/src/Raven.Server/Exceptions/Attachments/UploadAttachmentException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Raven.Server.Exceptions.Attachments
+{
+    [Serializable]
+    internal sealed class UploadAttachmentException : Exception
+    {
+        public readonly string Identifier;
+        public readonly string Key;
+
+        public UploadAttachmentException()
+        {
+        }
+
+        public UploadAttachmentException(string message) : base(message)
+        {
+        }
+
+        public UploadAttachmentException(string identifier, string key, string message, Exception innerException) : base(message, innerException)
+        {
+            Identifier = identifier;
+            Key = key;
+        }
+    }
+}

--- a/src/Sparrow.Server/Utils/ThreadNames.cs
+++ b/src/Sparrow.Server/Utils/ThreadNames.cs
@@ -216,22 +216,6 @@ public static class ThreadNames
         };
     }
 
-    public static ThreadInfo ForUploadRetiredAttachment(string threadName, string dbName, string targetName, string taskName)
-    {
-        return new ThreadInfo(threadName)
-        {
-            Details = new ThreadDetails.UploadRetiredAttachment(dbName, targetName)
-        };
-    }
-
-    public static ThreadInfo ForDeleteRetiredAttachment(string threadName, string dbName, string targetName, string taskName)
-    {
-        return new ThreadInfo(threadName)
-        {
-            Details = new ThreadDetails.DeleteRetiredAttachment(dbName, targetName)
-        };
-    }
-
     public sealed class ThreadDetails
     {
         public interface IThreadDetails
@@ -633,41 +617,6 @@ public static class ThreadNames
                 return $"ClstrTx {_db}";
             }
         }
-
-        public sealed class UploadRetiredAttachment : IThreadDetails
-        {
-            private readonly string _dbName;
-            private readonly string _targetName;
-
-            public UploadRetiredAttachment(string dbName, string targetName)
-            {
-                _dbName = dbName;
-                _targetName = targetName;
-            }
-
-            public string GetShortName()
-            {
-                return $"UpRetAtt {_dbName} to {_targetName}";
-            }
-        }
-
-        public sealed class DeleteRetiredAttachment : IThreadDetails
-        {
-            private readonly string _dbName;
-            private readonly string _targetName;
-
-            public DeleteRetiredAttachment(string dbName, string targetName)
-            {
-                _dbName = dbName;
-                _targetName = targetName;
-            }
-
-            public string GetShortName()
-            {
-                return $"DelRetAtt {_dbName} to {_targetName}";
-            }
-        }
-
     }
 
     public sealed class ThreadInfo

--- a/test/SlowTests/Issues/RavenDB_24488.cs
+++ b/test/SlowTests/Issues/RavenDB_24488.cs
@@ -10,7 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Attachments.Retired;
 using Raven.Client.Documents.Operations.Indexes;
-using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 using SlowTests.Server.Documents.Attachments;
 using Tests.Infrastructure;
 using Xunit;

--- a/test/SlowTests/Server/Documents/Attachments/AttachmentUploaderTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/AttachmentUploaderTests.cs
@@ -1,0 +1,896 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config.Categories;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Attachments;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Logging;
+using Raven.Server.ServerWide;
+using Sparrow.Collections;
+using Sparrow.Logging;
+using Sparrow.Server;
+using Sparrow.Server.Logging;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.Attachments
+{
+    public class AttachmentUploaderTests : RavenTestBase
+    {
+        public AttachmentUploaderTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /// <summary>
+        /// Mock stream that fails on specified operations for testing failure scenarios
+        /// </summary>
+        private class FailingStream : MemoryStream
+        {
+            private readonly bool _failOnRead;
+            private readonly bool _failOnWrite;
+            private readonly bool _failOnDispose;
+            private readonly Exception _exceptionToThrow;
+
+            public FailingStream(byte[] buffer, bool failOnRead = false, bool failOnWrite = false, bool failOnDispose = false, Exception exceptionToThrow = null)
+                : base(buffer)
+            {
+                _failOnRead = failOnRead;
+                _failOnWrite = failOnWrite;
+                _failOnDispose = failOnDispose;
+                _exceptionToThrow = exceptionToThrow ?? new InvalidOperationException("Simulated stream failure");
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (_failOnRead)
+                    throw _exceptionToThrow;
+                return base.Read(buffer, offset, count);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (_failOnWrite)
+                    throw _exceptionToThrow;
+                base.Write(buffer, offset, count);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (_failOnDispose && disposing)
+                    throw _exceptionToThrow;
+                base.Dispose(disposing);
+            }
+        }
+
+        /// <summary>
+        /// Mock uploader that exposes internal state for testing
+        /// </summary>
+        private class TestableAttachmentUploader : AttachmentUploader, IDisposable
+        {
+            public TestableAttachmentUploader(UploaderSettings settings, RavenLogger logger, OperationCancelToken taskCancelToken)
+                : base(settings, logger, taskCancelToken)
+            {
+                _disposables = new ConcurrentSet<IDisposable>();
+            }
+
+            public int ThreadsCount => _threads.Count;
+            public LinkedList<AttachmentUploadToCloudHolder> GetThreads() => _threads;
+
+            public void ClearThreads() => _threads.Clear();
+            public ConcurrentSet<IDisposable> _disposables;
+            internal override Stream StreamForBackupDestination(DocumentDatabase database, string folderName, string fileName)
+            {
+
+                var d = new MemoryStream();
+                _disposables.Add(d);
+                return d;
+            }
+
+            public void Dispose()
+            {
+
+                foreach (var d in _disposables)
+                {
+                    try
+                    {
+                        d.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task WaitForFinishedTasksIfNeededAsync_ShouldReturnFalse_WhenCancellationTokenIsRequested()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var tokenSource = new CancellationTokenSource();
+            var operationToken = new OperationCancelToken(tokenSource.Token);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+            var stopwatch = Stopwatch.StartNew();
+
+            // Act - Cancel the token immediately
+            tokenSource.Cancel();
+            var result = await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task CreateUploadTask_ShouldHandleCancellation_WhenCancellationTokenIsRequestedDuringUpload()
+        {
+            // Arrange
+            using var allocator = new ByteStringContext(new SharedMultipleUseFlag());
+
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var tokenSource = new CancellationTokenSource();
+            var operationToken = new OperationCancelToken(tokenSource.Token);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+            using var _ = CreateMockDocumentExpirationInfo(allocator, out var doc);
+            using var attachmentStream = new SlowStream(new byte[] { 1, 2, 3, 4, 5 }, delayMs: 2000);
+
+            // Act
+            uploader.CreateUploadTask(null, doc, attachmentStream, "test-hash", 5);
+
+            // Cancel the token before the task completes
+            tokenSource.Cancel();
+
+            // Assert
+            Assert.Equal(1, uploader.ThreadsCount);
+
+            // Wait a bit for the task to process the cancellation
+
+            var threads = uploader.GetThreads();
+            var task = threads.First().UploadTask;
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+
+            Assert.True(task.IsCompleted, "task.IsCompleted");
+            Assert.True(task.IsCanceled, "task.IsCanceled");
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task CreateUploadTask_ShouldHandleStreamFailure_WhenStreamThrowsException()
+        {
+            // Arrange
+            using var allocator = new ByteStringContext(new SharedMultipleUseFlag());
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+            using var _ = CreateMockDocumentExpirationInfo(allocator, out var doc);
+
+            var exceptionToThrow = new IOException("Simulated IO failure");
+            using var failingStream = new FailingStream(new byte[] { 1, 2, 3 }, failOnRead: true, exceptionToThrow: exceptionToThrow);
+
+            var successCallbackInvoked = false;
+            var exceptionCallbackInvoked = false;
+            Exception caughtException = null;
+
+            uploader.OnSuccess = _ => successCallbackInvoked = true;
+            uploader.OnException = holder =>
+            {
+                exceptionCallbackInvoked = true;
+                caughtException = holder.UploadTask.Exception;
+            };
+
+            // Act
+            uploader.CreateUploadTask(null, doc, failingStream, "test-hash", 3);
+
+            // Wait for the task to complete
+            var threads = uploader.GetThreads();
+            var task = threads.First().UploadTask;
+
+            uploader.Execute();
+
+            await Task.WhenAny(task, Task.Delay(15000));
+            Assert.Equal(TaskStatus.Faulted, task.Status);
+
+            var x = await Assert.ThrowsAsync<IOException>(async () => await task);
+
+            // Wait for completion
+
+            Assert.NotNull(x);
+            Assert.Contains("Simulated IO failure", x.Message);
+            Assert.True(task.IsCompleted);
+            Assert.True(task.IsFaulted);
+            Assert.False(successCallbackInvoked);
+            Assert.True(exceptionCallbackInvoked);
+            Assert.NotNull(caughtException);
+            Assert.Contains("Simulated IO failure", caughtException.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task AssertTaskStateAndInvokeAction_ShouldInvokeSuccessCallback_WhenTaskCompletesSuccessfully()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+            using var allocator = new ByteStringContext(new SharedMultipleUseFlag());
+            using var _ = CreateMockDocumentExpirationInfo(allocator, out var doc);
+            using var attachmentStream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+            var successCallbackInvoked = false;
+            var exceptionCallbackInvoked = false;
+
+            uploader.OnSuccess = _ => successCallbackInvoked = true;
+            uploader.OnException = _ => exceptionCallbackInvoked = true;
+
+            // Act
+            uploader.CreateUploadTask(null, doc, attachmentStream, "test-hash", 3);
+
+            // Wait for completion
+            var threads = uploader.GetThreads();
+            var task = threads.First().UploadTask;
+            await task;
+
+            // Process the completed task
+            uploader.Execute();
+
+            // Assert
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.True(successCallbackInvoked);
+            Assert.False(exceptionCallbackInvoked);
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task AssertTaskStateAndInvokeAction_ShouldNotInvokeExceptionCallback_WhenTaskIsCanceled()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var tokenSource = new CancellationTokenSource();
+            var operationToken = new OperationCancelToken(tokenSource.Token);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+            using var allocator = new ByteStringContext(new SharedMultipleUseFlag());
+            using var _ = CreateMockDocumentExpirationInfo(allocator, out var doc);
+            using var attachmentStream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+            var successCallbackInvoked = false;
+            var exceptionCallbackInvoked = false;
+            uploader.OnSuccess = _ => successCallbackInvoked = true;
+            uploader.OnException = _ => exceptionCallbackInvoked = true;
+
+            // Act
+            uploader.CreateUploadTask(null, doc, attachmentStream, "test-hash", 3);
+
+            // Cancel immediately
+            tokenSource.Cancel();
+
+            // Wait for completion
+            var threads = uploader.GetThreads();
+            var task = threads.First().UploadTask;
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+
+            // Process the completed task
+            var stopwatch = Stopwatch.StartNew();
+            await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+
+            // Assert
+            Assert.True(task.IsCompleted, "task.IsCompleted");
+            Assert.True(task.IsCanceled, "task.IsCanceled");
+            Assert.False(successCallbackInvoked);
+            Assert.False(exceptionCallbackInvoked);
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task CreateUploadTask_ShouldDisposeStream_EvenWhenExceptionOccurs()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+            using var allocator = new ByteStringContext(new SharedMultipleUseFlag());
+            using var _ = CreateMockDocumentExpirationInfo(allocator, out var doc);
+
+            var streamDisposed = false;
+            using var disposableStream = new DisposableTestStream(new byte[] { 1, 2, 3 });
+
+            disposableStream.OnDispose = () => streamDisposed = true;
+
+            // Make stream throw on read to simulate failure
+            disposableStream.ShouldFailOnRead = true;
+
+            // Act
+            uploader.CreateUploadTask(null, doc, disposableStream, "test-hash", 3);
+
+            // Wait for the task to complete (should fail)
+            var threads = uploader.GetThreads();
+            var task = threads.First().UploadTask;
+
+            await Assert.ThrowsAsync<IOException>(async () => await task);
+            // Give a moment for disposal to occur
+            Thread.Sleep(100);
+
+            // Assert
+            Assert.True(streamDisposed, "Stream should be disposed even when exception occurs");
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task CreateUploadTask_ShouldNotLeakStreams_WhenMultipleTasksAreCreated()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+
+            var streamDisposeCount = 0;
+            var totalStreams = 10;
+
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                for (int i = 0; i < totalStreams; i++)
+                {
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"doc-{i}");
+                    var disposableStream = new DisposableTestStream(new byte[] { 1, 2, 3, (byte)i });
+                    list.Add(disposable);
+                    list.Add(disposableStream);
+                    disposableStream.OnDispose = () => Interlocked.Increment(ref streamDisposeCount);
+
+                    uploader.CreateUploadTask(null, doc, disposableStream, $"hash-{i}", 4);
+                }
+
+                // Wait for all tasks to complete
+                var threads = uploader.GetThreads();
+                var tasks = threads.Select(t => t.UploadTask).ToArray();
+                await Task.WhenAll(tasks);
+                // Give time for disposal
+                Thread.Sleep(500);
+
+                // Assert
+                Assert.Equal(totalStreams, streamDisposeCount);
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task WaitForFinishedTasksIfNeededAsync_ShouldHandleConcurrentModification_WhenTasksCompleteWhileIterating()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+
+            var completedTasksCount = 0;
+            uploader.OnSuccess = _ => Interlocked.Increment(ref completedTasksCount);
+
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                // Create multiple quick-completing tasks
+                for (int i = 0; i < 5; i++)
+                {
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"doc-{i}");
+                    var stream = new MemoryStream(new byte[] { (byte)i });
+                    list.Add(disposable);
+                    list.Add(stream);
+                    uploader.CreateUploadTask(null, doc, stream, $"hash-{i}", 1);
+                }
+
+                // Act - Process tasks while they might be completing
+                var stopwatch = Stopwatch.StartNew();
+                var result = await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+
+                // Wait a bit more for any remaining tasks
+                Thread.Sleep(100);
+                await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+
+                // Assert
+                Assert.True(result);
+                Assert.True(completedTasksCount > 0, "At least some tasks should have completed");
+                Assert.True(uploader.ThreadsCount <= 5, "Thread count should not exceed original count");
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task WaitForFinishedTasksIfNeededAsync_ShouldSafelyRemoveNodes_WhenIteratingLinkedList()
+        {
+            // Arrange
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+
+            // Create a mix of quick and slow tasks
+            var quickTasks = 3;
+            var slowTasks = 2;
+
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                // Quick tasks (complete fast)
+                for (int i = 0; i < quickTasks; i++)
+                {
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"quick-{i}");
+                    var stream = new MemoryStream(new byte[] { (byte)i });
+                    list.Add(disposable);
+                    list.Add(stream);
+                    uploader.CreateUploadTask(null, doc, stream, $"hash-quick-{i}", 1);
+                }
+
+                // Slow tasks (take longer to complete)
+                for (int i = 0; i < slowTasks; i++)
+                {
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"slow-{i}");
+                    var stream = new SlowStream(new byte[] { (byte)(i + 100) }, delayMs: 1000);
+                    list.Add(disposable);
+                    list.Add(stream);
+                    uploader.CreateUploadTask(null, doc, stream, $"hash-slow-{i}", 1);
+                }
+
+                var initialCount = uploader.ThreadsCount;
+                Assert.Equal(quickTasks + slowTasks, initialCount);
+
+                // Act - Process while some tasks are still running
+                var stopwatch = Stopwatch.StartNew();
+                await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+
+                var countAfterFirstPass = uploader.ThreadsCount;
+
+                // Wait for remaining tasks and process again
+                Thread.Sleep(1500); // Give slow tasks time to complete
+                await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+
+                var finalCount = uploader.ThreadsCount;
+
+                // Assert
+                Assert.True(countAfterFirstPass < initialCount, "Some tasks should have been removed in first pass");
+                Assert.True(finalCount <= countAfterFirstPass, "More tasks should have been removed in second pass");
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task HighVolumeConcurrentUploads_ShouldHandleStress_WithoutMemoryLeaks()
+        {
+            // Arrange
+
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+
+            var totalTasks = 100;
+            var completedCount = 0;
+            var failedCount = 0;
+
+            uploader.OnSuccess = _ => Interlocked.Increment(ref completedCount);
+            uploader.OnException = _ => Interlocked.Increment(ref failedCount);
+
+            var memoryBefore = GC.GetTotalMemory(true);
+
+            // Act - Create many concurrent upload tasks
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                var tasks = new List<Task>();
+                for (int i = 0; i < totalTasks; i++)
+                {
+                    var taskIndex = i;
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"stress-doc-{taskIndex}");
+                    var task = Task.Run(() =>
+                    {
+                        var data = new byte[1024]; // 1KB per attachment
+                        new Random(taskIndex).NextBytes(data);
+                        var stream = new MemoryStream(data);
+                        list.Add(disposable);
+                        list.Add(stream);
+
+                        uploader.CreateUploadTask(null, doc, stream, $"hash-{taskIndex}", data.Length);
+                    });
+                    tasks.Add(task);
+                }
+
+                await Task.WhenAll(tasks);
+
+                // Process all uploads
+                var stopwatch = Stopwatch.StartNew();
+                while (uploader.ThreadsCount > 0 && stopwatch.ElapsedMilliseconds < 30000) // 30 second timeout
+                {
+                    await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+                    await Task.Delay(100);
+
+                    if (uploader.ThreadsCount < 8)
+                        break;
+                }
+
+                uploader.Execute();
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+
+            var memoryAfter = GC.GetTotalMemory(true);
+            var memoryDelta = memoryAfter - memoryBefore;
+
+            // Assert
+            Assert.True(completedCount + failedCount >= totalTasks * 0.9, "At least 90% of tasks should complete");
+            Assert.Equal(0, uploader.ThreadsCount);
+            Assert.True(memoryDelta < totalTasks * 4096, $"Memory usage should be reasonable, but was: {memoryDelta} < {totalTasks * 4096} "); // Allow 4KB per task overhead
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task ConcurrentUploadAndCancellation_ShouldHandleGracefully()
+        {
+            // Arrange
+
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var tokenSource = new CancellationTokenSource();
+            var operationToken = new OperationCancelToken(tokenSource.Token);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+
+            var totalTasks = 50;
+            var processedCount = 0;
+
+            uploader.OnSuccess = _ => Interlocked.Increment(ref processedCount);
+            uploader.OnException = _ => Interlocked.Increment(ref processedCount);
+
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                // Act - Start creating tasks and cancel partway through
+                var creationTask = Task.Run(async () =>
+                {
+                    for (int i = 0; i < totalTasks; i++)
+                    {
+                        if (tokenSource.Token.IsCancellationRequested)
+                            break;
+
+                        var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"concurrent-{i}");
+                        var stream = new MemoryStream(new byte[] { (byte)i, (byte)(i >> 8) });
+                        list.Add(disposable);
+                        list.Add(stream);
+
+                        uploader.CreateUploadTask(null, doc, stream, $"hash-{i}", 2);
+
+                        await Task.Delay(10); // Small delay between creations
+                    }
+                });
+
+                // Cancel after half the tasks have been created
+                await Task.Delay(totalTasks * 5); // Give time for some tasks to be created
+                tokenSource.Cancel();
+
+                await creationTask;
+
+                // Wait for processing to complete
+                var timeout = TimeSpan.FromSeconds(10);
+                var startTime = DateTime.UtcNow;
+                while (uploader.ThreadsCount > 0 && DateTime.UtcNow - startTime < timeout)
+                {
+                    try
+                    {
+                        var stopwatch = Stopwatch.StartNew();
+                        await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    await Task.Delay(50);
+
+                    if (uploader.ThreadsCount < 8)
+                        break;
+                }
+
+                // Assert
+                Assert.True(processedCount >= 0, "Some tasks should have been processed");
+                // Note: Exact counts depend on timing, so we just ensure no crashes occurred
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task NetworkTimeoutScenario_ShouldHandleSlowStreams()
+        {
+            // Arrange
+
+            var settings = CreateMockUploaderSettings();
+            var logger = RavenLogManager.Instance.CreateNullLogger();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, logger, operationToken);
+
+            var completedCount = 0;
+            var timeoutCount = 0;
+
+            uploader.OnSuccess = _ => Interlocked.Increment(ref completedCount);
+            uploader.OnException = holder =>
+            {
+                if (holder.UploadTask.Exception?.InnerException is TimeoutException)
+                    Interlocked.Increment(ref timeoutCount);
+            };
+
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                // Act - Create tasks with very slow streams (simulating network timeouts)
+                for (int i = 0; i < 5; i++)
+                {
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"timeout-{i}");
+                    var slowStream = new SlowStream(new byte[100], delayMs: 2000); // 2 second delays
+
+                    list.Add(disposable);
+                    list.Add(slowStream);
+                    uploader.CreateUploadTask(null, doc, slowStream, $"hash-{i}", 100);
+                }
+
+                // Process with timeout
+                var stopwatch = Stopwatch.StartNew();
+                var maxWaitTime = TimeSpan.FromSeconds(10);
+
+                while (uploader.ThreadsCount > 0 && stopwatch.Elapsed < maxWaitTime)
+                {
+                    await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+                    await Task.Delay(100);
+
+                    if (uploader.ThreadsCount < 8)
+                        break;
+                }
+                uploader.Execute();
+                // Assert
+                Assert.True(completedCount + timeoutCount > 0, "Some tasks should have completed or timed out");
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task MemoryPressureTest_ShouldHandleLargeAttachments()
+        {
+            // Arrange
+
+            var settings = CreateMockUploaderSettings();
+            var operationToken = new OperationCancelToken(CancellationToken.None);
+
+            using var uploader = new TestableAttachmentUploader(settings, RavenLogManager.Instance.CreateNullLogger(), operationToken);
+
+            var largeAttachmentSize = 1024 * 1024; // 1MB
+            var attachmentCount = 10;
+            var completedCount = 0;
+
+            uploader.OnSuccess = _ => Interlocked.Increment(ref completedCount);
+
+            var memoryBefore = GC.GetTotalMemory(true);
+            var list = new ConcurrentSet<IDisposable>();
+            var allocator = new ByteStringContext(new SharedMultipleUseFlag(), 4096);
+            list.Add(allocator);
+            try
+            {
+                // Act - Create tasks with large attachments
+                for (int i = 0; i < attachmentCount; i++)
+                {
+                    var disposable = CreateMockDocumentExpirationInfo(allocator, out var doc, $"large-{i}");
+                    var largeData = new byte[largeAttachmentSize];
+                    new Random(i).NextBytes(largeData);
+                    var stream = new MemoryStream(largeData);
+                    list.Add(disposable);
+                    list.Add(stream);
+
+                    uploader.CreateUploadTask(null, doc, stream, $"hash-{i}", largeAttachmentSize);
+                }
+
+                // Process uploads
+                var stopwatch = Stopwatch.StartNew();
+                while (uploader.ThreadsCount > 0 && stopwatch.ElapsedMilliseconds < 30000)
+                {
+                    await uploader.WaitForFinishedTasksIfNeededAsync(stopwatch, operationToken);
+                    await Task.Delay(100);
+
+                    if (uploader.ThreadsCount < 8)
+                        break;
+                }
+
+                uploader.Execute();
+            }
+            finally
+            {
+                foreach (var disposable in list)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch
+                    {
+                        // dont care
+                    }
+                }
+            }
+
+            var memoryAfter = GC.GetTotalMemory(true);
+            var memoryUsed = memoryAfter - memoryBefore;
+
+            // Assert
+            Assert.True(completedCount > 0, "Some large attachments should have been processed");
+            Assert.True(memoryUsed < attachmentCount * largeAttachmentSize * 2.2, $"Memory usage should be reasonable for large attachments, but was: {memoryUsed} < {attachmentCount * largeAttachmentSize * 2}");
+        }
+
+        private UploaderSettings CreateMockUploaderSettings()
+        {
+            return new UploaderSettings(new BackupConfiguration())
+            {
+                ConcurrentThreads = 4,
+                TaskName = "test-uploader",
+
+                // Add other required settings based on UploaderSettings implementation
+            };
+        }
+
+        private IDisposable CreateMockDocumentExpirationInfo(ByteStringContext allocator, out AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, string id = "test-doc")
+        {
+            // This would need to be implemented based on the actual DocumentExpirationInfo structure
+            // For now, returning a mock implementation
+            var disposable = Slice.From(allocator, id, out var input);
+            doc = new AbstractBackgroundWorkStorage.DocumentExpirationInfo(
+               Slices.Empty, // LowerId - would need proper Slice implementation
+               input, // Id - would need proper Slice implementation  
+               id,
+               AbstractBackgroundWorkStorage.DocumentExpirationInfoStatus.Process
+           );
+
+            return disposable;
+        }
+
+        private class DisposableTestStream : MemoryStream
+        {
+            public Action OnDispose { get; set; }
+            public bool ShouldFailOnRead { get; set; }
+
+            public DisposableTestStream(byte[] buffer) : base(buffer) { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (ShouldFailOnRead)
+                    throw new IOException("Simulated read failure");
+                return base.Read(buffer, offset, count);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                    OnDispose?.Invoke();
+                base.Dispose(disposing);
+            }
+        }
+
+        private class SlowStream : MemoryStream
+        {
+            private readonly int _delayMs;
+
+            public SlowStream(byte[] buffer, int delayMs) : base(buffer)
+            {
+                _delayMs = delayMs;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                Thread.Sleep(_delayMs);
+                return base.Read(buffer, offset, count);
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -28,7 +28,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
-using Raven.Server.Exceptions;
+using Raven.Server.Exceptions.Attachments;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Collections;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24606

### Additional description

This pull request introduces a new `AttachmentUploader` class for handling attachment uploads, refactors backup uploader classes to support multiple concurrent uploads, and improves stream handling and task management for backup and attachment operations. The changes enhance modularity, concurrency, and error handling across backup and attachment upload/download workflows.

**Attachment and Backup Upload Improvements:**

- Introduced `AttachmentUploader` as a new class for uploading attachments with concurrency control, error handling, and support for multiple destinations. This class manages upload tasks, tasks cleanup, and error aggregation. 

**Direct Upload/Download Refactoring:**

- Refactored `DirectFileUploader` and `DirectFileDownloader` to use new base classes (`FileUploaderBase`, `FileUploaderDownloaderBase`) for better code reuse and modularity. Simplified constructors and removed unnecessary fields. 
- Changed the `StreamForDownloadDestination` method in `DirectFileDownloader` to return a `Task<Stream>` directly, removing unnecessary `async/await` usage. 

**Attachment Storage and Stream Handling:**

- Added new methods to `AttachmentsStorage` for retrieving both the stream and length of an attachment efficiently, improving code clarity and reducing duplicate logic. 
- Cleaned up the disposal logic in `BackupDestinationStream` to avoid unnecessary resets. 

These changes collectively improve concurrency, modularity, and robustness in the backup and attachment upload/download subsystems.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
