### PR TITLE
RavenDB-24583 FormSelectAutocomplete - show all options on initial open

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -21,6 +21,8 @@ import { FormRangeProps } from "react-bootstrap/FormRange";
 import { InputType } from "../../../typings/_studio/react-bootstrap";
 import useUniqueId from "hooks/useUniqueId";
 import { FormGroupProps } from "react-bootstrap/FormGroup";
+import useBoolean from "components/hooks/useBoolean";
+import { FilterOptionOption } from "react-select/dist/declarations/src/filters";
 
 type FormElementProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> = Omit<
     ControllerProps<TFieldValues, TName>,
@@ -323,22 +325,43 @@ export function FormSelectAutocomplete<
         field: { onChange, value },
     } = useController({
         name: props.name,
+        control: props.control,
     });
 
-    const onInputChange = (value: string, action: InputActionMeta) => {
+    const { value: isInitialOpen, setValue: setIsInitialOpen } = useBoolean(false);
+
+    const valueAccessor = props.getOptionValue ?? ((option: any) => option.value);
+
+    const handleFilterOption = (option: FilterOptionOption<Option>, inputValue: string) => {
+        if (isInitialOpen) {
+            return true;
+        }
+
+        return valueAccessor(option).trim().toLowerCase().includes(inputValue.trim().toLowerCase());
+    };
+
+    const handleInputChange = (value: string, action: InputActionMeta) => {
         if (action?.action !== "input-blur" && action?.action !== "menu-close") {
             onChange(value);
+            setIsInitialOpen(false);
         }
+    };
+
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement, Element>) => {
+        e.target.selectionStart = value?.length ?? 0;
+        setIsInitialOpen(true);
     };
 
     return (
         <FormSelectCreatable<Option, IsMulti, Group, TFieldValues, TName>
-            inputValue={value}
-            onInputChange={onInputChange}
+            inputValue={value ?? ""}
+            onInputChange={handleInputChange}
             components={{ Input: InputNotHidden }}
             tabSelectsValue
             controlShouldRenderValue={false}
-            closeMenuOnSelect
+            filterOption={handleFilterOption}
+            onFocus={handleFocus}
+            blurInputOnSelect
             {...props}
         />
     );


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24583

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
