### PR TITLE
RavenDB-24942 use Avx512F.VL if possible for the inner loop of XXhash

### DIFF
--- a/src/Sparrow/Hashing.Streamed.cs
+++ b/src/Sparrow/Hashing.Streamed.cs
@@ -64,10 +64,7 @@ namespace Sparrow
                             context.BufferSize += Alignment;
                         }
                         
-                        context.Current.V1 = v[0];
-                        context.Current.V2 = v[1];
-                        context.Current.V3 = v[2];
-                        context.Current.V4 = v[3];
+                        v.StoreUnsafe(ref context.Current.V1);
                     }
                     else
 #endif

--- a/src/Sparrow/Hashing.Streamed.cs
+++ b/src/Sparrow/Hashing.Streamed.cs
@@ -50,7 +50,7 @@ namespace Sparrow
                     if (context.BufferSize + size >= Alignment)
                     {
 #if NET8_0_OR_GREATER
-                    if (Avx512F.VL.IsSupported)
+                    if (AdvInstructionSet.X86.IsSupportedAvx512Basic)
                     {
                         Vector256<ulong> v = Vector256.LoadUnsafe(ref context.Current.V1);
                         while (buffer <= limit)

--- a/src/Sparrow/Hashing.Streamed.cs
+++ b/src/Sparrow/Hashing.Streamed.cs
@@ -1,6 +1,10 @@
 using Sparrow.Binary;
 using System;
 using System.Runtime.CompilerServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace Sparrow
 {
@@ -8,8 +12,6 @@ namespace Sparrow
     {
         internal static class Streamed
         {
-            
-
             internal unsafe struct XXHash64Context
             {
                 public ulong Seed;
@@ -47,26 +49,50 @@ namespace Sparrow
 
                     if (context.BufferSize + size >= Alignment)
                     {
-                        ulong v1 = context.Current.V1;
-                        ulong v2 = context.Current.V2;
-                        ulong v3 = context.Current.V3;
-                        ulong v4 = context.Current.V4;
-
+#if NET8_0_OR_GREATER
+                    if (Avx512F.VL.IsSupported)
+                    {
+                        Vector256<ulong> v = Vector256.LoadUnsafe(ref context.Current.V1);
                         while (buffer <= limit)
                         {
-                            v1 = Bits.RotateLeft64(v1 + ((ulong*)buffer)[0] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                            v2 = Bits.RotateLeft64(v2 + ((ulong*)buffer)[1] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                            v3 = Bits.RotateLeft64(v3 + ((ulong*)buffer)[2] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                            v4 = Bits.RotateLeft64(v4 + ((ulong*)buffer)[3] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-
+                            v = Vector256.Multiply(
+                                Avx512F.VL.RotateLeft(
+                                    Vector256.Add(
+                                        Vector256.Multiply(Vector256.LoadUnsafe(ref Unsafe.AsRef<ulong>(buffer)), XXHash64Constants.PRIME64_2), v), 31),
+                                XXHash64Constants.PRIME64_1);
                             buffer += 4 * sizeof(ulong);
                             context.BufferSize += Alignment;
                         }
+                        
+                        context.Current.V1 = v[0];
+                        context.Current.V2 = v[1];
+                        context.Current.V3 = v[2];
+                        context.Current.V4 = v[3];
+                    }
+                    else
+#endif
+                        {
+                            ulong v1 = context.Current.V1;
+                            ulong v2 = context.Current.V2;
+                            ulong v3 = context.Current.V3;
+                            ulong v4 = context.Current.V4;
 
-                        context.Current.V1 = v1;
-                        context.Current.V2 = v2;
-                        context.Current.V3 = v3;
-                        context.Current.V4 = v4;
+                            while (buffer <= limit)
+                            {
+                                v1 = Bits.RotateLeft64(v1 + ((ulong*)buffer)[0] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                                v2 = Bits.RotateLeft64(v2 + ((ulong*)buffer)[1] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                                v3 = Bits.RotateLeft64(v3 + ((ulong*)buffer)[2] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                                v4 = Bits.RotateLeft64(v4 + ((ulong*)buffer)[3] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+
+                                buffer += 4 * sizeof(ulong);
+                                context.BufferSize += Alignment;
+                            }
+
+                            context.Current.V1 = v1;
+                            context.Current.V2 = v2;
+                            context.Current.V3 = v3;
+                            context.Current.V4 = v4;
+                        }
                     }
 
                     for (int i = 0; i < context.LeftoverCount; i++)
@@ -125,13 +151,13 @@ namespace Sparrow
 
                             if (buffer + 4 <= bEnd)
                             {
-                                h64 = Bits.RotateLeft64(h64 ^(*(uint*)buffer * XXHash64Constants.PRIME64_1), 23) * XXHash64Constants.PRIME64_2 + XXHash64Constants.PRIME64_3;
+                                h64 = Bits.RotateLeft64(h64 ^ (*(uint*)buffer * XXHash64Constants.PRIME64_1), 23) * XXHash64Constants.PRIME64_2 + XXHash64Constants.PRIME64_3;
                                 buffer += 4;
                             }
 
                             while (buffer < bEnd)
                             {
-                                h64 = Bits.RotateLeft64(h64 ^(*buffer * XXHash64Constants.PRIME64_5), 11) * XXHash64Constants.PRIME64_1;
+                                h64 = Bits.RotateLeft64(h64 ^ (*buffer * XXHash64Constants.PRIME64_5), 11) * XXHash64Constants.PRIME64_1;
                                 buffer++;
                             }
                         }

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -328,7 +328,7 @@ namespace Sparrow
                     Unsafe.SkipInit(out ulong v4);
 
 #if NET8_0_OR_GREATER
-                    if (Avx512F.VL.IsSupported)
+                    if (AdvInstructionSet.X86.IsSupportedAvx512Basic)
                     {
                         Vector256<ulong> v = Vector256.Create(
                             seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2,
@@ -455,7 +455,7 @@ namespace Sparrow
                     Unsafe.SkipInit(out ulong v4);
 
 #if NET8_0_OR_GREATER
-                    if (Avx512F.VL.IsSupported)
+                    if (AdvInstructionSet.X86.IsSupportedAvx512Basic)
                     {
                         Vector256<ulong> v = Vector256.Create(
                             seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2,

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -3,6 +3,10 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 using System.Text;
 
 namespace Sparrow
@@ -40,7 +44,6 @@ namespace Sparrow
         /// <remarks>The 32bits and 64bits hashes for the same data are different. In short those are 2 entirely different algorithms</remarks>
         internal static class XXHash32
         {
-
             // TODO: Check if it is better to have ReadOnlySpan built on top of pointer or the other way around. 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static uint CalculateInline(ReadOnlySpan<byte> source, uint seed = 0)
@@ -76,8 +79,7 @@ namespace Sparrow
                         v4 = Bits.RotateLeft32(v4 + Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref buffer, 3 * sizeof(uint))) * XXHash32Constants.PRIME32_2, 13) * XXHash32Constants.PRIME32_1;
 
                         buffer = ref Unsafe.AddByteOffset(ref buffer, 4 * sizeof(uint));
-                    }
-                    while (Unsafe.IsAddressLessThan(ref buffer, ref limit));
+                    } while (Unsafe.IsAddressLessThan(ref buffer, ref limit));
 
                     h32 = Bits.RotateLeft32(v1, 1) + Bits.RotateLeft32(v2, 7) + Bits.RotateLeft32(v3, 12) + Bits.RotateLeft32(v4, 18);
                 }
@@ -144,9 +146,9 @@ namespace Sparrow
                 return CalculateInline<TCharacterModifier>(buffer, seed);
             }
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static uint CalculateInline<TCharacterModifier>(string buffer, uint seed = 0) where TCharacterModifier : struct, ICharacterModifier
-            {                
+            {
                 unchecked
                 {
                     uint h32;
@@ -155,7 +157,7 @@ namespace Sparrow
 
                     uint position = 0;
                     if (len >= 8)
-                    {                        
+                    {
                         uint v1 = seed + XXHash32Constants.PRIME32_1 + XXHash32Constants.PRIME32_2;
                         uint v2 = seed + XXHash32Constants.PRIME32_2;
                         uint v3 = seed + 0;
@@ -180,8 +182,7 @@ namespace Sparrow
                             v2 *= XXHash32Constants.PRIME32_1;
                             v3 *= XXHash32Constants.PRIME32_1;
                             v4 *= XXHash32Constants.PRIME32_1;
-                        }
-                        while (position <= limit);
+                        } while (position <= limit);
 
                         h32 = Bits.RotateLeft32(v1, 1) + Bits.RotateLeft32(v2, 7) + Bits.RotateLeft32(v3, 12) + Bits.RotateLeft32(v4, 18);
                     }
@@ -212,7 +213,7 @@ namespace Sparrow
                     h32 ^= h32 >> 16;
 
                     return h32;
-                }                
+                }
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -274,6 +275,7 @@ namespace Sparrow
                     key = key * 2862933555777941757UL + 1;
                     j = (long)((b + 1) * ((1L << 31) / ((double)(key >> 33) + 1)));
                 }
+
                 return b;
             }
         }
@@ -305,28 +307,61 @@ namespace Sparrow
                     source = Array.Empty<byte>();
 
                 ref byte start = ref MemoryMarshal.GetReference(source);
-                
+
                 ref byte buffer = ref start;
 
                 if (len >= 32)
                 {
                     ref byte limit = ref Unsafe.AddByteOffset(ref start, len - 32 + 1);
 
-                    ulong v1 = seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2;
-                    ulong v2 = seed + XXHash64Constants.PRIME64_2;
-                    ulong v3 = seed + 0;
-                    ulong v4 = seed - XXHash64Constants.PRIME64_1;
+                    Unsafe.SkipInit(out ulong v1);
+                    Unsafe.SkipInit(out ulong v2);
+                    Unsafe.SkipInit(out ulong v3);
+                    Unsafe.SkipInit(out ulong v4);
 
-                    do
+#if NET8_0_OR_GREATER
+                    if (Avx512F.VL.IsSupported)
                     {
-                        v1 = Bits.RotateLeft64(v1 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 0 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                        v2 = Bits.RotateLeft64(v2 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 1 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                        v3 = Bits.RotateLeft64(v3 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 2 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                        v4 = Bits.RotateLeft64(v4 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 3 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                        Vector256<ulong> v = Vector256.Create(
+                            seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2,
+                            seed + XXHash64Constants.PRIME64_2,
+                            seed + 0,
+                            seed - XXHash64Constants.PRIME64_1);
+        
+                        do
+                        {
+                            v = Vector256.Multiply(
+                                Avx512F.VL.RotateLeft(
+                                    Vector256.Add(
+                                        Vector256.Multiply(Vector256.LoadUnsafe(ref Unsafe.As<byte,ulong>(ref buffer)), XXHash64Constants.PRIME64_2), v), 31),
+                                XXHash64Constants.PRIME64_1);
+                             buffer = ref Unsafe.AddByteOffset(ref buffer, 4 * sizeof(ulong));
+                        }
+                        while (Unsafe.IsAddressLessThan(ref buffer, ref limit));
 
-                        buffer = ref Unsafe.AddByteOffset(ref buffer, 4 * sizeof(ulong));
+                        v1 = v[0];
+                        v2 = v[1];
+                        v3 = v[2];
+                        v4 = v[3];
                     }
-                    while (Unsafe.IsAddressLessThan(ref buffer, ref limit));
+                    else
+#endif
+                    {
+                        v1 = seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2;
+                        v2 = seed + XXHash64Constants.PRIME64_2;
+                        v3 = seed + 0;
+                        v4 = seed - XXHash64Constants.PRIME64_1;
+
+                        do
+                        {
+                            v1 = Bits.RotateLeft64(v1 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 0 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                            v2 = Bits.RotateLeft64(v2 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 1 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                            v3 = Bits.RotateLeft64(v3 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 2 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                            v4 = Bits.RotateLeft64(v4 + Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref buffer, 3 * sizeof(ulong))) * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+
+                            buffer = ref Unsafe.AddByteOffset(ref buffer, 4 * sizeof(ulong));
+                        } while (Unsafe.IsAddressLessThan(ref buffer, ref limit));
+                    }
 
                     h64 = Bits.RotateLeft64(v1, 1) + Bits.RotateLeft64(v2, 7) + Bits.RotateLeft64(v3, 12) + Bits.RotateLeft64(v4, 18);
 
@@ -377,7 +412,7 @@ namespace Sparrow
                 {
                     h64 ^= buffer * XXHash64Constants.PRIME64_5;
                     h64 = Bits.RotateLeft64(h64, 11) * XXHash64Constants.PRIME64_1;
-                    
+
                     buffer = ref Unsafe.AddByteOffset(ref buffer, sizeof(byte));
                 }
 
@@ -405,21 +440,54 @@ namespace Sparrow
                 {
                     byte* limit = bEnd - 32;
 
-                    ulong v1 = seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2;
-                    ulong v2 = seed + XXHash64Constants.PRIME64_2;
-                    ulong v3 = seed + 0;
-                    ulong v4 = seed - XXHash64Constants.PRIME64_1;
+                    Unsafe.SkipInit(out ulong v1);
+                    Unsafe.SkipInit(out ulong v2);
+                    Unsafe.SkipInit(out ulong v3);
+                    Unsafe.SkipInit(out ulong v4);
 
-                    do
+#if NET8_0_OR_GREATER
+                    if (Avx512F.VL.IsSupported)
                     {
-                        v1 = Bits.RotateLeft64(v1 + ((ulong*)buffer)[0] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                        v2 = Bits.RotateLeft64(v2 + ((ulong*)buffer)[1] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                        v3 = Bits.RotateLeft64(v3 + ((ulong*)buffer)[2] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
-                        v4 = Bits.RotateLeft64(v4 + ((ulong*)buffer)[3] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                        Vector256<ulong> v = Vector256.Create(
+                            seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2,
+                            seed + XXHash64Constants.PRIME64_2,
+                            seed + 0,
+                            seed - XXHash64Constants.PRIME64_1);
+        
+                        do
+                        {
+                            v = Vector256.Multiply(
+                                Avx512F.VL.RotateLeft(
+                                    Vector256.Add(
+                                        Vector256.Multiply(Vector256.LoadUnsafe(ref Unsafe.AsRef<ulong>(buffer)), XXHash64Constants.PRIME64_2), v), 31),
+                                XXHash64Constants.PRIME64_1);
+                            buffer += 4 * sizeof(ulong);
+                        }
+                        while (buffer <= limit);
 
-                        buffer += 4 * sizeof(ulong);
+                        v1 = v[0];
+                        v2 = v[1];
+                        v3 = v[2];
+                        v4 = v[3];
                     }
-                    while (buffer <= limit);
+                    else
+#endif
+                    {
+                        v1 = seed + XXHash64Constants.PRIME64_1 + XXHash64Constants.PRIME64_2;
+                        v2 = seed + XXHash64Constants.PRIME64_2;
+                        v3 = seed + 0;
+                        v4 = seed - XXHash64Constants.PRIME64_1;
+
+                        do
+                        {
+                            v1 = Bits.RotateLeft64(v1 + ((ulong*)buffer)[0] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                            v2 = Bits.RotateLeft64(v2 + ((ulong*)buffer)[1] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                            v3 = Bits.RotateLeft64(v3 + ((ulong*)buffer)[2] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+                            v4 = Bits.RotateLeft64(v4 + ((ulong*)buffer)[3] * XXHash64Constants.PRIME64_2, 31) * XXHash64Constants.PRIME64_1;
+
+                            buffer += 4 * sizeof(ulong);
+                        } while (buffer <= limit);
+                    }
 
                     h64 = Bits.RotateLeft64(v1, 1) + Bits.RotateLeft64(v2, 7) + Bits.RotateLeft64(v3, 12) + Bits.RotateLeft64(v4, 18);
 
@@ -505,7 +573,7 @@ namespace Sparrow
                 return CalculateInline(buffer, seed);
             }
 
-            
+
             public static ulong Calculate(byte[] buf, int len = -1, ulong seed = 0)
             {
                 var buffer = buf.AsSpan();
@@ -635,7 +703,7 @@ namespace Sparrow
                 // Related GitHub pull request: dotnet/coreclr#1830
                 ulong ux = (ulong)x;
                 ulong shift5 = (ux << 10) | (ux >> 54);
-                return (long) (shift5 + ux) ^ y;
+                return (long)(shift5 + ux) ^ y;
             }
 
             /// <summary>
@@ -926,7 +994,7 @@ namespace Sparrow
 
                 return low ^ high;
             }
-            
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static uint CalculateInline<TCharacterModifier>(ReadOnlySpan<char> buffer, ulong seed = 0x5D70D359C498B3F8ul) where TCharacterModifier : struct, ICharacterModifier
             {
@@ -961,7 +1029,7 @@ namespace Sparrow
                 TCharacterModifier modifier = default(TCharacterModifier);
                 return (uint)modifier.Modify(buffer[position + 1]) << 16 | modifier.Modify(buffer[position]);
             }
-            
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static uint CharToUInt32<TCharacterModifier>(ReadOnlySpan<char> buffer, int position) where TCharacterModifier : struct, ICharacterModifier
             {
@@ -980,6 +1048,5 @@ namespace Sparrow
                 high = Bits.RotateLeft32(high, 19);
             }
         }
-
     }
 }

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -242,11 +242,19 @@ namespace Sparrow
             }
         }
 
+        [StructLayout(LayoutKind.Explicit, Size = sizeof(ulong) * 4)]
         internal struct XXHash64Values
         {
+            [FieldOffset(0 * sizeof(ulong))]
             public ulong V1;
+
+            [FieldOffset(1 * sizeof(ulong))]
             public ulong V2;
+
+            [FieldOffset(2 * sizeof(ulong))]
             public ulong V3;
+
+            [FieldOffset(3 * sizeof(ulong))]
             public ulong V4;
         }
 

--- a/src/Sparrow/Hashing.cs
+++ b/src/Sparrow/Hashing.cs
@@ -338,6 +338,7 @@ namespace Sparrow
         
                         do
                         {
+                            // Vector256.LoadUnsafe uses vmovups, which allows memory operand to be unaligned
                             v = Vector256.Multiply(
                                 Avx512F.VL.RotateLeft(
                                     Vector256.Add(
@@ -464,6 +465,7 @@ namespace Sparrow
         
                         do
                         {
+                            // Vector256.LoadUnsafe uses vmovups, which allows memory operand to be unaligned
                             v = Vector256.Multiply(
                                 Avx512F.VL.RotateLeft(
                                     Vector256.Add(


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24942/Vectorize-XXhash64

### Additional description

This PR vectorizes the inner loop of `XXHash64` if `Avx512F.VL` is supported (meaning .NET 8 and above and a proper CPU). `VL` allows for various length rotations that makes the inner part of the loop a fold of a few vector operations. Looks like a potential 25% gain.

#### Before

| Method                    | Mean     | Error   | StdDev  | Ratio | Code Size |
|-------------------------- |---------:|--------:|--------:|------:|----------:|
| XXHash64_RawPointer       | 426.9 ns | 4.99 ns | 4.67 ns |  0.70 |     827 B |
| XXHash64_FixedPointer     | 424.9 ns | 5.57 ns | 5.21 ns |  0.70 |     880 B |
| XXHash64_FixedSpan        | 422.7 ns | 2.10 ns | 1.86 ns |  0.69 |     917 B |
| XXHash64_Span             | 419.2 ns | 0.74 ns | 0.57 ns |  0.69 |     840 B |
| XXHash64_SpanFromPointer  | 421.5 ns | 4.15 ns | 3.88 ns |  0.69 |     869 B |
| XXHash64_StreamedWhole    | 423.6 ns | 1.63 ns | 1.27 ns |  0.69 |   1,123 B |
| XXHash64_StreamedMultiple | 428.6 ns | 6.49 ns | 6.07 ns |  0.70 |   1,531 B |
| XXHash64_Reference        | 611.1 ns | 2.95 ns | 2.46 ns |  1.00 |     735 B |

#### After

| Method                    | Mean     | Error   | StdDev  | Ratio | Code Size |
|-------------------------- |---------:|--------:|--------:|------:|----------:|
| XXHash64_RawPointer       | 294.3 ns | 3.89 ns | 3.64 ns |  0.48 |     667 B |
| XXHash64_FixedPointer     | 293.7 ns | 2.01 ns | 1.78 ns |  0.48 |     734 B |
| XXHash64_FixedSpan        | 292.6 ns | 0.48 ns | 0.40 ns |  0.48 |     769 B |
| XXHash64_Span             | 292.6 ns | 1.10 ns | 0.86 ns |  0.48 |     678 B |
| XXHash64_SpanFromPointer  | 291.2 ns | 1.11 ns | 0.98 ns |  0.48 |     720 B |
| XXHash64_StreamedWhole    | 328.0 ns | 0.56 ns | 0.44 ns |  0.54 |   1,030 B |
| XXHash64_StreamedMultiple | 339.3 ns | 3.79 ns | 3.55 ns |  0.56 |   1,353 B |
| XXHash64_Reference        | 608.4 ns | 0.84 ns | 0.74 ns |  1.00 |     735 B |

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Only for .NET 8.0 up that has `Avx512F.VL` supported
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
