### PR TITLE
RavenDB-24875: Remove counterproductive optimizations for .Net 9.0+

### DIFF
--- a/src/Raven.Client/Documents/Queries/HashCalculator.cs
+++ b/src/Raven.Client/Documents/Queries/HashCalculator.cs
@@ -26,9 +26,9 @@ namespace Raven.Client.Documents.Queries
 
         public ulong GetHash()
         {
-            _buffer.EnsureSingleChunk(out var ptr, out var size);
+            _buffer.EnsureSingleChunk(out var ptr, out var used);
 
-            return Hashing.XXHash64.Calculate(ptr, (ulong)size);
+            return Hashing.XXHash64.Calculate(ptr, (ulong)used);
         }
 
         public void Write(float f)

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -52,12 +52,12 @@ namespace Sparrow.Json
 
         public unsafe BlittableJsonReaderObject CreateReader()
         {
-            _unmanagedWriteBuffer.EnsureSingleChunk(out byte* ptr, out int size);
+            _unmanagedWriteBuffer.EnsureSingleChunk(out byte* ptr, out int used);
             
-            _lastSize = size;
+            _lastSize = used;
             var reader = new BlittableJsonReaderObject(
                 ptr,
-                size,
+                used,
                 _context,
                 (UnmanagedWriteBuffer)(object)_unmanagedWriteBuffer);
 
@@ -225,13 +225,9 @@ namespace Sparrow.Json
             // the unmanaged writer. This is a trade-off between stack usage and performance.
             var requiredMetadataBufferSize = maxPropertySize * properties.Count + VariableSizeEncoding.MaximumSizeOf<int>();
 
-            // PERF: If the amount of properties is bigger than 512, we are facing a real outlier. This may happen
-            // when we store a large dictionary. Therefore, we want to just deal with it differently than face a stackoverflow
-            // even though the probability is quite low.
-            Span<byte> metadataBuffer = properties.Count < 512 ? 
-                                            stackalloc byte[requiredMetadataBufferSize] : 
-                                            new byte[requiredMetadataBufferSize];
-
+            // Use ReserveSpace for all property counts - zero allocations!
+            Span<byte> metadataBuffer = _unmanagedWriteBuffer.ReserveSpace(requiredMetadataBufferSize);
+            
             // Write object metadata
             ref byte metadataStartPtr = ref MemoryMarshal.GetReference(metadataBuffer);
             ref byte metadataPtr = ref Unsafe.Add(ref metadataStartPtr, VariableSizeEncoding.Write(metadataBuffer, properties.Count));
@@ -253,7 +249,7 @@ namespace Sparrow.Json
             }
             
             int length = (int)Unsafe.ByteOffset(ref metadataStartPtr, ref metadataPtr);
-            _unmanagedWriteBuffer.Write(metadataBuffer.Slice(0, length));
+            _unmanagedWriteBuffer.CommitSpace(length);
             _position += length;
 
             return new WriteToken(objectMetadataStart, objectToken);
@@ -355,9 +351,8 @@ namespace Sparrow.Json
             var propertyArrayOffsetValueByteSize = SetOffsetSizeFlag(ref propertiesSizeMetadata, propertyNamesOffset);
 
             int maxPropertiesBufferLength = sizeof(byte) + propertiesDiscovered * sizeof(int);
-            Span<byte> propertiesBuffer = propertiesDiscovered < 512 ? 
-                                                stackalloc byte[maxPropertiesBufferLength] :
-                                                new byte[maxPropertiesBufferLength];
+            // Use ReserveSpace for all property counts - zero allocations!
+            Span<byte> propertiesBuffer = _unmanagedWriteBuffer.ReserveSpace(maxPropertiesBufferLength);
 
             ref byte propertiesStartPtr = ref MemoryMarshal.GetReference(propertiesBuffer);
             ref byte propertiesPtr = ref propertiesStartPtr;
@@ -378,7 +373,7 @@ namespace Sparrow.Json
 
             // Write property names offsets in the actual buffer.
             int length = (int)(Unsafe.ByteOffset(ref propertiesStartPtr, ref propertiesPtr));
-            _unmanagedWriteBuffer.Write(propertiesBuffer.Slice(0, length));
+            _unmanagedWriteBuffer.CommitSpace(length);
             _position += length;
 
             return propertiesStart;
@@ -546,128 +541,7 @@ namespace Sparrow.Json
             // Then take the first byte and calculate the distance to the end and write it.
             _unmanagedWriteBuffer.Write(destPtr, (int)(destEnd - destPtr));
         }
-
-#if NET7_0_OR_GREATER
-
-        public static byte[] ByteActionTable =>
-        [
-            // 0-31: Control characters (action = 2)
-            2, 2, 2, 2, 2, 2, 2, 2, // 0-7
-            1, 1, 1, 2, 1, 1, 2, 2, // 8-15 (\b, \t, \n, _, \f, \r)
-            2, 2, 2, 2, 2, 2, 2, 2, // 16-23
-            2, 2, 2, 2, 2, 2, 2, 2, // 24-31
-
-            // 32-63: Mostly normal characters (action = 0), except " at 34
-            0, 0, 1, 0, 0, 0, 0, 0, // 32-39 (space, !, ", #, $, %, &, ')
-            0, 0, 0, 0, 0, 0, 0, 0, // 40-47 ((, ), *, +, ,, -, ., /)
-            0, 0, 0, 0, 0, 0, 0, 0, // 48-55 (0-7)
-            0, 0, 0, 0, 0, 0, 0, 0, // 56-63 (8-9, :, ;, <, =, >, ?)
-
-            // 64-95: Normal characters (action = 0), except \ at 92
-            0, 0, 0, 0, 0, 0, 0, 0, // 64-71 (@, A-G)
-            0, 0, 0, 0, 0, 0, 0, 0, // 72-79 (H-O)
-            0, 0, 0, 0, 0, 0, 0, 0, // 80-87 (P-W)
-            0, 0, 0, 0, 1, 0, 0, 0, // 88-95 (X, Y, Z, [, \, ], ^, _)
-
-            // 96-127: Normal characters (action = 0)
-            0, 0, 0, 0, 0, 0, 0, 0, // 96-103 (`, a-h)
-            0, 0, 0, 0, 0, 0, 0, 0, // 104-111 (i-p)
-            0, 0, 0, 0, 0, 0, 0, 0, // 112-119 (q-x)
-            0, 0, 0, 0, 0, 0, 0, 0, // 120-127 (y-z, {, |, }, ~, DEL)
-
-            // 128-255: UTF-8 continuation bytes or high ASCII (action = 0)
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        ];
-
-        [SkipLocalsInit]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe int WriteValueFromStack(ReadOnlySpan<byte> str, out BlittableJsonToken token)
-        {
-            // This should never trigger, if it does it mean the caller was modified incorrectly.
-            Debug.Assert(str.Length < 512);
-
-            int* escapePositions = stackalloc int[str.Length]; // Max escapes: one per char
-            byte* buffer = stackalloc byte[str.Length * 6]; // Max size: 6 bytes per char
-
-            byte* current = buffer; // Pointer to current position in output buffer
-            int escapeCount = 0; // Number of simple escapes
-            int lastEscape = 0; // Position after last escape for distance calculation
-
-            // Get references for input string
-            ref byte startRef = ref MemoryMarshal.GetReference(str);
-            ref byte endRef = ref Unsafe.Add(ref startRef, str.Length); // Reference just past the end
-            ref byte currentRef = ref startRef;
-
-            // Process string using reference arithmetic
-            while (Unsafe.IsAddressGreaterThan(ref endRef, ref currentRef))
-            {
-                byte value = currentRef; // Read current byte
-                byte action = ByteActionTable[value];
-
-                if (action == 0) // No escape
-                {
-                    *current = value;
-                    current++;
-                }
-                else if (action == 1) // Simple escape
-                {
-                    *current = value;
-                    int escapePos = (int)(current - buffer); // Current offset in output
-                    escapePositions[escapeCount] = escapePos - lastEscape;
-                    lastEscape = escapePos + 1;
-                    escapeCount++;
-                    current++;
-                }
-                else // action == 2, Control character
-                {
-                    *(ushort*)current = '\\' | ('u' << 8); // Write "\u"
-                    *(int*)(current + 2) = AbstractBlittableJsonTextWriter.ControlCodeEscapes[value]; // 4 hex digits
-                    current += 6; // Advance past 6 bytes
-                }
-
-                currentRef = ref Unsafe.Add(ref currentRef, 1); // Move to next byte in input
-            }
-
-            Debug.Assert((current - buffer) <= str.Length * 6, "We check that even a full escape characters string would respect this property.");
-
-            token = BlittableJsonToken.String;
-            int startPos = _position;
-
-            int length = (int)(current - buffer);
-
-            int posCount = 0;
-            posCount += WriteVariableSizeInt(length); // Write length prefix
-            _unmanagedWriteBuffer.Write(buffer, length); // Write the string data
-            posCount += length;
-
-            Debug.Assert(str.Length >= escapeCount, "We check that even a full escape characters string would respect this property.");
-
-            posCount += WriteVariableSizeInt(escapeCount); // Write escape positions count
-            for (int i = 0; i < escapeCount; i++)
-                posCount += WriteVariableSizeInt(escapePositions[i]); // Write escape position sequence
-
-            _position += posCount;
-
-            return startPos;
-        }
-
-        [SkipLocalsInit]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int WriteValueFromStack(ReadOnlySpan<char> str, out BlittableJsonToken token)
-        {
-            Span<byte> strBuffer = stackalloc byte[Encodings.Utf8.GetMaxByteCount(str.Length)];
-            var stringSize = Encodings.Utf8.GetBytes(str, strBuffer);
-            return WriteValueFromStack(strBuffer.Slice(0, stringSize), out token);
-        }
-#endif
-
+        
         private unsafe int WriteValueFromHeap(ReadOnlySpan<byte> str, out BlittableJsonToken token, UsageMode mode = UsageMode.None)
         {
             _intBuffer ??= new FastList<int>();
@@ -699,16 +573,6 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int WriteValue(ReadOnlySpan<byte> str, out BlittableJsonToken token, UsageMode mode = UsageMode.None)
         {
-#if NET7_0_OR_GREATER
-            if (str.Length <= 256 && mode is not (UsageMode.CompressSmallStrings or UsageMode.CompressStrings))
-            {
-                // PERF: Since we know the size, we can actually do this much more efficiently. 
-                // even more if the caller is an actual string constant, which will cause the call to be inlined
-                // as a constant value.
-                return WriteValueFromStack(str, out token);
-            }
-#endif
-
             // PERF: This is the unoptimized version.
             return WriteValueFromHeap(str, out token, mode);
         }
@@ -725,16 +589,6 @@ namespace Sparrow.Json
         public int WriteValue(string str, out BlittableJsonToken token, UsageMode mode = UsageMode.None)
 #endif
         {
-#if NET7_0_OR_GREATER
-            if (str.Length <= 256 && mode is (UsageMode.None or UsageMode.ValidateDouble))
-            {
-                // PERF: Since we know the size, we can actually do this much more efficiently. 
-                // even more if the caller is an actual string constant, which will cause the call to be inlined
-                // as a constant value.
-                return WriteValueFromStack(str, out token);
-            }
-#endif
-
             // PERF: This is the unoptimized version.
             return WriteValueFromHeap(str, out token, mode);
         }

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Text;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -28,15 +28,9 @@ namespace Sparrow.Json.Parsing
         private int _prevEscapePosition;
         private byte _currentQuote;
 
-        private struct TokenInfo(byte[] tokenBuffer, int tokenBufferPosition, string tokenString)
-        {
-            public readonly byte[] Buffer = tokenBuffer;
-            public int BufferPosition = tokenBufferPosition;
-            public readonly string String = tokenString;
-        };
-
-        private TokenInfo _expectedTokenInfo;
-
+        private byte[] _expectedTokenBuffer;
+        private int _expectedTokenBufferPosition;
+        private string _expectedTokenString;
         private bool _zeroPrefix;
         private bool _isNegative;
         private bool _isFractionedDouble;
@@ -54,38 +48,6 @@ namespace Sparrow.Json.Parsing
             ParseUnlikely
         }
 
-        private enum ParseWhitespaceAction
-        {
-            NonWhitespace = 0,
-            Char,
-            Line
-        }
-
-
-        // PERF: The following enumerator has to be in sync with the JsonParserToken, because we want to
-        //       use the actual byte value stripped from the structural marker to retrieve the token
-        [Flags]
-        internal enum JsonParserReadActionToken : byte
-        {
-            None = 0,
-            Null = 1,
-            False = 2,
-            True = 3,
-            String = 4,
-            Float = 5,
-            Integer = 6,
-            Separator = 7 | GroupMarker,
-            StartObject = 8 | GroupMarker,
-            StartArray = 9 | GroupMarker,
-            EndArray = 10 | GroupMarker,
-            EndObject = 11 | GroupMarker,
-            Blob = 12,
-            NegativeSign = 13,
-
-            StructuralMask = 0b1111,
-            GroupMarker = 1 << 4  // 16
-        }
-
         private static readonly ParseNumberAction[] ParseNumberTable;
 
         public OnStringReadDelegate OnStringRead
@@ -93,48 +55,8 @@ namespace Sparrow.Json.Parsing
             set => _onStringRead = value;
         }
 
-        private static readonly ParseWhitespaceAction[] ParseWhitespaceTable;
-
-        private static readonly JsonParserReadActionToken[] ByteToActionMap;
-
-        private static readonly (TokenInfo Token, JsonParserTokenContinuation Continuation)[] TokenInfoCache;
-
         static UnmanagedJsonParser()
         {
-            TokenInfoCache = new (TokenInfo, JsonParserTokenContinuation)[(int)JsonParserReadActionToken.Integer];
-            TokenInfoCache[(int)JsonParserReadActionToken.Null] = (new TokenInfo(AbstractBlittableJsonTextWriter.NullBuffer, 1, "null"), JsonParserTokenContinuation.PartialNull);
-            TokenInfoCache[(int)JsonParserReadActionToken.True] = (new TokenInfo(AbstractBlittableJsonTextWriter.TrueBuffer, 1, "true"), JsonParserTokenContinuation.PartialTrue);
-            TokenInfoCache[(int)JsonParserReadActionToken.False] = (new TokenInfo(AbstractBlittableJsonTextWriter.FalseBuffer, 1, "false"), JsonParserTokenContinuation.PartialFalse);
-
-
-            ByteToActionMap = new JsonParserReadActionToken[255];
-
-            // Structural characters
-            ByteToActionMap['{'] = JsonParserReadActionToken.StartObject;
-            ByteToActionMap['}'] = JsonParserReadActionToken.EndObject;
-            ByteToActionMap['['] = JsonParserReadActionToken.StartArray;
-            ByteToActionMap[']'] = JsonParserReadActionToken.EndArray;
-            ByteToActionMap[':'] = JsonParserReadActionToken.Separator;
-            ByteToActionMap[','] = JsonParserReadActionToken.Separator;
-
-            // String quotes
-            ByteToActionMap['"'] = JsonParserReadActionToken.String;
-            ByteToActionMap['\''] = JsonParserReadActionToken.String;
-
-            // Digits
-            for (char c = '0'; c <= '9'; c++)
-                ByteToActionMap[c] = JsonParserReadActionToken.Integer;
-
-            // Negative sign
-            ByteToActionMap['-'] = JsonParserReadActionToken.NegativeSign;
-
-            // Keyword initials
-            ByteToActionMap['n'] = JsonParserReadActionToken.Null;
-            ByteToActionMap['t'] = JsonParserReadActionToken.True;
-            ByteToActionMap['f'] = JsonParserReadActionToken.False;
-            ByteToActionMap['N'] = JsonParserReadActionToken.Float; // NaN
-            ByteToActionMap['I'] = JsonParserReadActionToken.Float; // Infinity
-
             ParseStringTable = new byte[255];
             ParseStringTable['r'] = (byte)'\r';
             ParseStringTable['n'] = (byte)'\n';
@@ -147,14 +69,6 @@ namespace Sparrow.Json.Parsing
             ParseStringTable['\n'] = Unlikely;
             ParseStringTable['\r'] = Unlikely;
             ParseStringTable['u'] = Unlikely;
-
-            ParseWhitespaceTable = new ParseWhitespaceAction[255];
-            ParseWhitespaceTable[' '] = ParseWhitespaceAction.Char;
-            ParseWhitespaceTable['\t'] = ParseWhitespaceAction.Char;
-            ParseWhitespaceTable['\v'] = ParseWhitespaceAction.Char;
-            ParseWhitespaceTable['\f'] = ParseWhitespaceAction.Char;
-            ParseWhitespaceTable['\r'] = ParseWhitespaceAction.Line;
-            ParseWhitespaceTable['\n'] = ParseWhitespaceAction.Line;
 
             ParseNumberTable = new ParseNumberAction[255];
 
@@ -259,27 +173,6 @@ namespace Sparrow.Json.Parsing
             uint pos = _pos;
             while (true)
             {
-                // Skip whitespace characters
-                var whitespaceTable = ParseWhitespaceTable;
-                while (pos < bufferSize)
-                {
-                    b = currentBuffer[pos];
-
-                    ParseWhitespaceAction action = whitespaceTable[b];
-                    if (action == ParseWhitespaceAction.NonWhitespace)
-                        break;
-
-                    pos++;
-                    _charPos += (action == ParseWhitespaceAction.Char).ToUInt32();
-                    _line += (action == ParseWhitespaceAction.Line).ToInt32();
-
-                    if (b != (byte)'\r' || pos >= bufferSize)
-                        continue;
-
-                    pos += (currentBuffer[pos] == (byte)'\n').ToUInt32();
-                }
-
-                // Check if we've reached the end of the buffer
                 if (pos >= bufferSize)
                 {
                     _pos = pos;
@@ -288,66 +181,87 @@ namespace Sparrow.Json.Parsing
 
                 b = currentBuffer[pos];
                 pos++;
-                _charPos++;
 
-                JsonParserReadActionToken actionToken = ByteToActionMap[b];
-                switch (actionToken)
+                // Handle whitespace first (most common)
+                if (b == ' ' || b == '\t' || b == '\v' || b == '\f')
                 {
-                    case JsonParserReadActionToken.StartObject:
-                    case JsonParserReadActionToken.EndObject:
-                    case JsonParserReadActionToken.StartArray:
-                    case JsonParserReadActionToken.EndArray:
-                        state.CurrentTokenType = (JsonParserToken)(1 << (int)(actionToken & JsonParserReadActionToken.StructuralMask));
-                        _pos = pos;
-                        return true;
-                    case JsonParserReadActionToken.Integer:
-                        goto ParseNumber;
-                    case JsonParserReadActionToken.String:
-                        goto ParseString;
-                    case JsonParserReadActionToken.Separator:
-                        if (state.CurrentTokenType == JsonParserToken.Separator || state.CurrentTokenType == JsonParserToken.StartObject || state.CurrentTokenType == JsonParserToken.StartArray)
-                            goto Error;
-                        state.CurrentTokenType = JsonParserToken.Separator;
-                        continue;
-                    case JsonParserReadActionToken.True:
-                    case JsonParserReadActionToken.Null:
-                    case JsonParserReadActionToken.False:
-                        {
-                            _state.CurrentTokenType = (JsonParserToken)(1 << (int)actionToken);
-
-                            ref var item = ref TokenInfoCache[(int)actionToken];
-
-                            _expectedTokenInfo = item.Token;
-                            if (EnsureRestOfToken(ref pos))
-                            {
-                                _pos = pos;
-                                return true;
-                            }
-
-                            _state.Continuation = item.Continuation;
-                            _pos = pos;
-                            return false;
-                        }
+                    _charPos++;
+                    continue;
+                }
+                if (b == '\n')
+                {
+                    _line++;
+                    _charPos = 1;
+                    continue;
+                }
+                if (b == '\r')
+                {
+                    _line++;
+                    _charPos = 1;
+                    if (pos < bufferSize && currentBuffer[pos] == '\n')
+                        pos++;
+                    continue;
                 }
 
-                if (IsPossibleNegativeNumber(b, bufferSize, pos, currentBuffer))
+                // Now handle non-whitespace characters
+                _charPos++;
+
+                if (b == ':' || b == ',')
+                {
+                    if (state.CurrentTokenType == JsonParserToken.Separator || state.CurrentTokenType == JsonParserToken.StartObject || state.CurrentTokenType == JsonParserToken.StartArray)
+                        goto Error;
+
+                    state.CurrentTokenType = JsonParserToken.Separator;
+                    continue;
+                }
+
+                if (b == '\'' || b == '"')
+                    goto ParseString; // PERF: Avoid very lengthy method here; as we are going to return anyways.
+
+                if ((b >= '0' && b <= '9') || IsPossibleNegativeNumber(b, bufferSize, pos, currentBuffer))
                     goto ParseNumber; // PERF: Avoid very lengthy method here; as we are going to return anyways.
 
-                if (ReadUnlikely(b, ref pos, out bool couldRead) == false)
+                if (b == '{')
+                {
+                    state.CurrentTokenType = JsonParserToken.StartObject;
+                    _pos = pos;
+                    return true;
+                }
+
+                if (b == '}')
+                {
+                    state.CurrentTokenType = JsonParserToken.EndObject;
+                    _pos = pos;
+                    return true;
+                }
+                if (b == '[')
+                {
+                    state.CurrentTokenType = JsonParserToken.StartArray;
+                    _pos = pos;
+                    return true;
+                }
+                if (b == ']')
+                {
+                    state.CurrentTokenType = JsonParserToken.EndArray;
+                    _pos = pos;
+                    return true;
+                }
+
+                bool couldRead;
+                if (!ReadUnlikely(b, ref pos, out couldRead))
                     continue; // We can only continue here, if there is a failure to parse, we will throw inside ReadUnlikely.
 
                 _pos = pos;
                 return couldRead;
             }
 
-            ParseString:
+        ParseString:
             {
                 state.EscapePositions.Clear();
                 _unmanagedWriteBuffer.Clear();
                 _prevEscapePosition = 0;
                 _currentQuote = b;
                 state.CurrentTokenType = JsonParserToken.String;
-
                 if (ParseString(ref pos) == false)
                 {
                     state.Continuation = JsonParserTokenContinuation.PartialString;
@@ -359,12 +273,8 @@ namespace Sparrow.Json.Parsing
                 return true;
             }
 
-            ParseNumber:
+        ParseNumber:
             {
-                // ParseNumber need to call _charPos++ & _pos++, so we'll reset them for the first char and fall-through to ParseNumber
-                pos--;
-                _charPos--;
-
                 _unmanagedWriteBuffer.Clear();
                 state.EscapePositions.Clear();
                 state.Long = 0;
@@ -373,6 +283,10 @@ namespace Sparrow.Json.Parsing
                 _isFractionedDouble = false;
                 _isExponent = false;
                 _isOverflow = false;
+
+                // ParseNumber need to call _charPos++ & _pos++, so we'll reset them for the first char
+                pos--;
+                _charPos--;
 
                 if (ParseNumber(ref state.Long, ref pos) == false)
                 {
@@ -383,15 +297,14 @@ namespace Sparrow.Json.Parsing
 
                 if (state.CurrentTokenType == JsonParserToken.Float)
                     _unmanagedWriteBuffer.EnsureSingleChunk(state);
-
                 _pos = pos;
                 return true;
             }
-            
-            Error:
+
+        Error:
             ThrowCannotHaveCharInThisPosition(b);
 
-            ReadContinuation: // PERF: This is a "manual procedure"
+        ReadContinuation: // PERF: This is a "manual procedure"
             if (state.Continuation != JsonParserTokenContinuation.None) // parse normally
             {
                 return ContinueParsingValue();
@@ -426,6 +339,7 @@ namespace Sparrow.Json.Parsing
             couldRead = false;
             switch (b)
             {
+
                 case (byte)'N':
                     {
                         ReadToken(ref pos, ref couldRead, NaN, "NaN", JsonParserTokenContinuation.PartialNaN);
@@ -444,6 +358,53 @@ namespace Sparrow.Json.Parsing
                         ReadToken(ref pos, ref couldRead, NegativeInfinity, "-Infinity", JsonParserTokenContinuation.PartialNegativeInfinity);
                         return true;
                     }
+
+                case (byte)'n':
+                case (byte)'t':
+                case (byte)'f':
+                    {
+                        // Set values based on the specific byte
+                        byte[] buffer;
+                        string str;
+                        JsonParserToken token;
+                        JsonParserTokenContinuation cont;
+                        
+                        if (b == (byte)'n')
+                        {
+                            token = JsonParserToken.Null;
+                            buffer = AbstractBlittableJsonTextWriter.NullBuffer;
+                            str = "null";
+                            cont = JsonParserTokenContinuation.PartialNull;
+                        }
+                        else if (b == (byte)'t')
+                        {
+                            token = JsonParserToken.True;
+                            buffer = AbstractBlittableJsonTextWriter.TrueBuffer;
+                            str = "true";
+                            cont = JsonParserTokenContinuation.PartialTrue;
+                        }
+                        else // (byte)'f'
+                        {
+                            token = JsonParserToken.False;
+                            buffer = AbstractBlittableJsonTextWriter.FalseBuffer;
+                            str = "false";
+                            cont = JsonParserTokenContinuation.PartialFalse;
+                        }
+                        
+                        _state.CurrentTokenType = token;
+                        _expectedTokenBuffer = buffer;
+                        _expectedTokenBufferPosition = 1;
+                        _expectedTokenString = str;
+                        
+                        if (EnsureRestOfToken(ref pos) == false)
+                        {
+                            _state.Continuation = cont;
+                            return false;
+                        }
+                        
+                        couldRead = true;
+                        return true;
+                    }
             }
 
             ThrowCannotHaveCharInThisPosition(b);
@@ -455,8 +416,9 @@ namespace Sparrow.Json.Parsing
         {
             _unmanagedWriteBuffer.Clear();
             _state.CurrentTokenType = JsonParserToken.Float;
-
-            _expectedTokenInfo = new (tokenBuffer, 1, tokenString);
+            _expectedTokenBuffer = tokenBuffer;
+            _expectedTokenBufferPosition = 1;
+            _expectedTokenString = tokenString;
             if (EnsureRestOfToken(ref pos) == false)
             {
                 _state.Continuation = jsonParserTokenContinuation;
@@ -483,7 +445,9 @@ namespace Sparrow.Json.Parsing
             if (_inputBuffer[_pos] == Utf8Preamble[0])
             {
                 _pos++;
-                _expectedTokenInfo = new(Utf8Preamble, 1, "UTF8 Preamble");
+                _expectedTokenBuffer = Utf8Preamble;
+                _expectedTokenBufferPosition = 1;
+                _expectedTokenString = "UTF8 Preamble";
                 if (EnsureRestOfToken(ref _pos) == false)
                 {
                     _state.Continuation = JsonParserTokenContinuation.PartialPreamble;
@@ -504,7 +468,7 @@ namespace Sparrow.Json.Parsing
                 case JsonParserTokenContinuation.PartialNegativeInfinity:
                     // here we need to check if we have a negative number or negative
                     // infinity
-                    if (_expectedTokenInfo.BufferPosition == 1 &&
+                    if (_expectedTokenBufferPosition == 1 &&
                         _inputBuffer[_pos] != (byte)'I')
                     {
                         _zeroPrefix = false;
@@ -528,7 +492,7 @@ namespace Sparrow.Json.Parsing
 
                         _state.Continuation = JsonParserTokenContinuation.None;
                         _state.CurrentTokenType = JsonParserToken.Float;
-                        _unmanagedWriteBuffer.Write(_expectedTokenInfo.Buffer, 0, _expectedTokenInfo.Buffer.Length);
+                        _unmanagedWriteBuffer.Write(_expectedTokenBuffer, 0, _expectedTokenBuffer.Length);
                         _unmanagedWriteBuffer.EnsureSingleChunk(_state);
 
                         return true;
@@ -747,17 +711,16 @@ namespace Sparrow.Json.Parsing
         {
             uint bufferSize = _bufSize;
             byte* inputBuffer = _inputBuffer;
-
-            byte[] expectedTokenBuffer = _expectedTokenInfo.Buffer;
-            for (int i = _expectedTokenInfo.BufferPosition; i < expectedTokenBuffer.Length; i++)
+            byte[] expectedTokenBuffer = _expectedTokenBuffer;
+            for (int i = _expectedTokenBufferPosition; i < expectedTokenBuffer.Length; i++)
             {
                 if (pos >= bufferSize)
                     return false;
 
                 if (inputBuffer[pos++] != expectedTokenBuffer[i])
-                    ThrowException("Invalid token found, expected: " + _expectedTokenInfo.String);
+                    ThrowException("Invalid token found, expected: " + _expectedTokenString);
 
-                _expectedTokenInfo.BufferPosition++;
+                _expectedTokenBufferPosition++;
                 _charPos++;
             }
             return true;
@@ -793,8 +756,9 @@ namespace Sparrow.Json.Parsing
                         if (ParseUnicodeValue(ref currentPos) == false)
                         {
                             _onStringRead?.Invoke(_unmanagedWriteBuffer, true);
-                            return false;
+                            goto ReturnFalse;
                         }
+                            
 
                         continue;
                     }
@@ -814,8 +778,9 @@ namespace Sparrow.Json.Parsing
                         if (b == _currentQuote)
                         {
                             _onStringRead?.Invoke(_unmanagedWriteBuffer, false);
-                            return true;
+                            goto ReturnTrue;
                         }
+
 
                         // Then it is '\\'
                         _escapeMode = true;
@@ -848,7 +813,7 @@ namespace Sparrow.Json.Parsing
                             if (currentPos >= bufferSize)
                             {
                                 _onStringRead?.Invoke(_unmanagedWriteBuffer, true);
-                                return false;
+                                goto ReturnFalse;
                             }
 
                             _line++;
@@ -856,7 +821,7 @@ namespace Sparrow.Json.Parsing
                             if (currentPos >= bufferSize)
                             {
                                 _onStringRead?.Invoke(_unmanagedWriteBuffer, true);
-                                return false;
+                                goto ReturnFalse;
                             }
 
                             if (currentBuffer[currentPos] == (byte)'\n')
@@ -867,7 +832,7 @@ namespace Sparrow.Json.Parsing
                             if (ParseUnicodeValue(ref currentPos) == false)
                             {
                                 _onStringRead?.Invoke(_unmanagedWriteBuffer, true);
-                                return false;
+                                goto ReturnFalse;
                             }
                         }
                         else
@@ -883,9 +848,15 @@ namespace Sparrow.Json.Parsing
                 if (currentPos >= bufferSize)
                 {
                     _onStringRead?.Invoke(_unmanagedWriteBuffer, true);
-                    return false;
+                    goto ReturnFalse;
                 }
             }
+
+        ReturnTrue:
+            return true;
+
+        ReturnFalse:
+            return false;
         }
 
         private static void ThrowInvalidEscapeChar(byte b)

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -966,18 +966,18 @@ namespace Sparrow.Json.Parsing
 
         public void ValidateFloat()
         {
-            _unmanagedWriteBuffer.EnsureSingleChunk(out var buffer, out var size);
-            if (Utf8Parser.TryParse(new ReadOnlySpan<byte>(buffer, size), out double value, out var consumed) && size == consumed)
+            _unmanagedWriteBuffer.EnsureSingleChunk(out var buffer, out var used);
+            if (Utf8Parser.TryParse(new ReadOnlySpan<byte>(buffer, used), out double value, out var consumed) && used == consumed)
             {
                 if (double.IsInfinity(value) == false)
                     return;
-                else if (size == "Infinity".Length && IsInfinity(buffer, 0))
+                else if (used == "Infinity".Length && IsInfinity(buffer, 0))
                     return;
-                else if (size == "-Infinity".Length && buffer[0] == '-' && IsInfinity(buffer, 1))
+                else if (used == "-Infinity".Length && buffer[0] == '-' && IsInfinity(buffer, 1))
                     return;
             }
 
-            ThrowException("Could not parse double: " + Encoding.UTF8.GetString(buffer, size));
+            ThrowException("Could not parse double: " + Encoding.UTF8.GetString(buffer, used));
 
             static bool IsInfinity(byte* buffer, int offset)
             {

--- a/src/Sparrow/Json/UnmanagedWriteBuffer.cs
+++ b/src/Sparrow/Json/UnmanagedWriteBuffer.cs
@@ -20,7 +20,10 @@ namespace Sparrow.Json
         void Write<T>(in Span<T> buffer) where T : unmanaged;
         void Write<T>(in ReadOnlySpan<T> buffer) where T : unmanaged;
         void EnsureSingleChunk(JsonParserState state);
-        void EnsureSingleChunk(out byte* ptr, out int size);
+        void EnsureSingleChunk(out byte* ptr, out int used);
+        
+        Span<byte> ReserveSpace(int maxSize);
+        void CommitSpace(int written);
     }
 
     internal unsafe struct UnmanagedStreamBuffer : IUnmanagedWriteBuffer
@@ -28,8 +31,9 @@ namespace Sparrow.Json
         private readonly Stream _stream;
         private int _sizeInBytes;
         public int Used;
-        private readonly JsonOperationContext.MemoryBuffer _buffer;
-        private readonly JsonOperationContext.MemoryBuffer.ReturnBuffer _returnBuffer;
+        private readonly JsonOperationContext _context;
+        private JsonOperationContext.MemoryBuffer _buffer;
+        private JsonOperationContext.MemoryBuffer.ReturnBuffer _returnBuffer;
         private bool _isDisposed;
 
         public int SizeInBytes => _sizeInBytes;
@@ -39,6 +43,7 @@ namespace Sparrow.Json
             _stream = stream;
             _sizeInBytes = 0;
             Used = 0;
+            _context = context;
             _returnBuffer = context.GetMemoryBuffer(out _buffer);
             _isDisposed = false;
         }
@@ -240,9 +245,38 @@ namespace Sparrow.Json
         {
             throw new NotSupportedException();
         }
-        public void EnsureSingleChunk(out byte* ptr, out int size)
+        public void EnsureSingleChunk(out byte* ptr, out int used)
         {
             throw new NotSupportedException();
+        }
+
+        public Span<byte> ReserveSpace(int maxSize)
+        {
+            // For stream buffer, ensure we have enough space in the current buffer
+            if (_buffer.Size - Used < maxSize)
+            {
+                // Flush the current buffer and start fresh
+                _stream.Write(_buffer.Memory.Memory.Span.Slice(0, Used));
+                Used = 0;
+            }
+
+            // IF even after flushing the size is not big enough. Then we need to get a new memory buffer.            
+            if (_buffer.Size < maxSize)
+            {
+                _returnBuffer.Dispose();
+                _returnBuffer = _context.GetMemoryBuffer(maxSize, out _buffer);
+            }
+            
+            return new Span<byte>(_buffer.Address, maxSize);
+        }
+
+        public void CommitSpace(int actualSize)
+        {
+            if (actualSize < 0)
+                throw new ArgumentOutOfRangeException(nameof(actualSize), "Must be non-negative");
+
+            _sizeInBytes += actualSize;
+            Used += actualSize;
         }
 
         public bool IsDisposed => _isDisposed;
@@ -692,13 +726,13 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EnsureSingleChunk(JsonParserState state)
         {
-            EnsureSingleChunk(out var buffer, out var size);
+            EnsureSingleChunk(out var buffer, out var used);
             state.StringBuffer = buffer;
-            state.StringSize = size;
+            state.StringSize = used;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void EnsureSingleChunk(out byte* ptr, out int size)
+        public void EnsureSingleChunk(out byte* ptr, out int used)
         {
             ThrowOnDisposed();
 
@@ -707,14 +741,14 @@ namespace Sparrow.Json
                 // Common case is we have a single chunk already, so no need 
                 // to do anything
                 ptr = _head.Address;
-                size = SizeInBytes;
+                used = SizeInBytes;
                 return;
             }
 
-            UnlikelyEnsureSingleChunk(out ptr, out size);
+            UnlikelyEnsureSingleChunk(out ptr, out used);
         }
 
-        private void UnlikelyEnsureSingleChunk(out byte* ptr, out int size)
+        private void UnlikelyEnsureSingleChunk(out byte* ptr, out int used)
         {
             // we are using multiple segments, but the current one can fit all
             // the required memory
@@ -725,7 +759,7 @@ namespace Sparrow.Json
                 Memory.Move(_head.Address, _head.Address + _head.Used, SizeInBytes);
 
                 ptr = _head.Address;
-                size = SizeInBytes;
+                used = SizeInBytes;
                 _head.Used = SizeInBytes;
                 // Ensure we are thought of as a single chunk
                 _head.Previous = null;
@@ -760,7 +794,34 @@ namespace Sparrow.Json
             _head.Previous = null;
 
             ptr = _head.Address;
-            size = _head.Used;
+            used = _head.Used;
+        }
+        
+        public Span<byte> ReserveSpace(int maxSize)
+        {
+            ThrowOnDisposed();
+
+            if (maxSize <= 0)
+                return Span<byte>.Empty;
+
+            // Ensure we have enough contiguous space
+            var head = _head;
+            if (head.Allocation.SizeInBytes - head.Used < maxSize)
+            {
+                AllocateNextSegment(maxSize, true);
+            }
+
+            return new Span<byte>(_head.Address + _head.Used, maxSize);
+        }
+
+        public void CommitSpace(int written)
+        {
+            if (written < 0)
+                throw new ArgumentOutOfRangeException(nameof(written), "Must be non-negative");
+
+            var head = _head;
+            head.AccumulatedSizeInBytes += written;
+            head.Used += written;
         }
     }
 }

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -1130,6 +1130,49 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                 }
             }
         }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(511)]  // Test stackalloc path (<512 properties)
+        [InlineData(512)]  // Test boundary: stackalloc path (=512 properties)
+        [InlineData(513)]  // Test boundary: WriteDirect path (>512 properties)
+        [InlineData(600)]  // Test WriteDirect path (>512 properties)
+        [InlineData(1000)] // Test larger case
+        public void LargeObjectWithManyPropertiesTest(int propertiesCount)
+        {
+            using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))
+            {
+                using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
+                {
+                    builder.Reset(BlittableJsonDocumentBuilder.UsageMode.None);
+
+                    builder.StartWriteObjectDocument();
+                    builder.StartWriteObject();
+
+                    // Create a single object with many properties to trigger WriteDirect path
+                    for (int i = 0; i < propertiesCount; i++)
+                    {
+                        builder.WritePropertyName($"Property{i}");
+                        builder.WriteValue(i * 2); // Simple values
+                    }
+
+                    builder.WriteObjectEnd();
+                    builder.FinalizeDocument();
+
+                    using (var reader = builder.CreateReader())
+                    {
+                        Assert.Equal(propertiesCount, reader.Count);
+                        
+                        // Verify a few random properties to ensure data integrity
+                        for (int i = 0; i < Math.Min(10, propertiesCount); i++)
+                        {
+                            var propertyName = $"Property{i}";
+                            Assert.True(reader.TryGet(propertyName, out object value));
+                            Assert.Equal(i * 2, Convert.ToInt32(value));
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-24875

### Additional description

This PR removes optimizations that worked on .Net 8.0 but are counterproductive in .Net 9.0+ 

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
