### PR TITLE
RavenDB-24811 Making sure that using Linq we get the _right_ path for…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,9 +24,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
     <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT;FEATURE_ZSTD_SUPPORT</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net8.0'">
-    <DefineConstants>$(DefineConstants);FEATURE_AI_AGENT_STREAMING_SUPPORT</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">
     <IsAnyOS>true</IsAnyOS>
     <IsLinux64>false</IsLinux64>

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿using Raven.Client.Extensions;
+using Sparrow.Json.Sync;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Exceptions;
 using Raven.Client.Util;
 using Sparrow.Json;
-using Sparrow.Json.Sync;
 
 namespace Raven.Client.Documents.AI;
 
@@ -159,10 +159,7 @@ internal class AiConversation : IAiConversationOperations
 #if FEATURE_AI_AGENT_STREAMING_SUPPORT
     public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
-        var pathProvider = new LinqPathProvider(_aiOperations._store.Conventions);
-        var result = pathProvider.GetPath(streamPropertyPath.Body);
-        result.Path = result.Path.Substring(result.Path.IndexOf('.') + 1);
-        return StreamAsync<TAnswer>(result.Path, streamedChunksCallback, token);
+        return StreamAsync<TAnswer>(streamPropertyPath.ToPropertyPath(_aiOperations._store.Conventions), streamedChunksCallback, token);
     }
 
     public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -160,8 +160,9 @@ internal class AiConversation : IAiConversationOperations
     public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         var pathProvider = new LinqPathProvider(_aiOperations._store.Conventions);
-        var pathResult = pathProvider.GetPath(streamPropertyPath.Body);
-        return StreamAsync<TAnswer>(pathResult.Path, streamedChunksCallback, token);
+        var result = pathProvider.GetPath(streamPropertyPath.Body);
+        result.Path = result.Path.Substring(result.Path.IndexOf('.') + 1);
+        return StreamAsync<TAnswer>(result.Path, streamedChunksCallback, token);
     }
 
     public async Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(string streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -156,7 +156,6 @@ internal class AiConversation : IAiConversationOperations
 
     public AiAnswer<TAnswer> Run<TAnswer>() => AsyncHelpers.RunSync(() => RunAsync<TAnswer>());
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
     public Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath, Func<string, Task> streamedChunksCallback, CancellationToken token = default)
     {
         return StreamAsync<TAnswer>(streamPropertyPath.ToPropertyPath(_aiOperations._store.Conventions), streamedChunksCallback, token);
@@ -171,7 +170,6 @@ internal class AiConversation : IAiConversationOperations
                 return r;
         }
     }
-#endif
 
     public async Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default)
     {

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -92,7 +92,6 @@ public interface IAiConversationOperations
     /// </returns>
     Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default);
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
     /// <summary>
     /// Asynchronously executes one “turn” of the conversation, streaming the specified property's value for immediate feedback.
     /// Sends the current prompt, processes any required actions, and awaits the agent’s reply while invoking the callback with streamed values.
@@ -133,7 +132,6 @@ public interface IAiConversationOperations
     /// </returns>
     Task<AiAnswer<TAnswer>> StreamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath, Func<string, Task> streamedChunksCallback,
         CancellationToken token = default);
-#endif
 
     /// <summary>
     /// Synchronously executes one turn of the conversation.

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
-using System.Net.ServerSentEvents;
-#endif
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
@@ -27,10 +25,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     private readonly List<AiAgentActionResponse> _actionResponses;
     private readonly string _changeVector;
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
     private readonly string _streamPropertyPath;
     private readonly Func<string, Task> _streamedChunksCallback;
-#endif
 
     public RunConversationOperation(
         string agentId,
@@ -64,13 +60,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _actionResponses = actionResponses;
         _options = options;
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
         _streamPropertyPath = streamPropertyPath;
         _streamedChunksCallback = streamedChunksCallback;
-#else
-        if (streamPropertyPath != null)
-            throw new InvalidOperationException("AI Agent conversation streaming is not supported in your framework.");
-#endif
     }
 
     public RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
@@ -88,12 +79,10 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             _conventions = conventions;
             _parent = parent;
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
             if (parent._streamPropertyPath is not null)
             {
                 ResponseType = RavenCommandResponseType.Raw;
             }
-#endif
         }
 
         public override bool IsReadRequest => false;
@@ -111,10 +100,8 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             if (_parent._changeVector != null)
                 url += $"&changeVector={Uri.EscapeDataString(_parent._changeVector)}";
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
             if (_parent._streamPropertyPath is not null)
                 url += $"&streaming=true&streamPropertyPath={Uri.EscapeDataString(_parent._streamPropertyPath)}";
-#endif
 
             var body = new ConversionRequestBody
             {
@@ -135,23 +122,25 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             return request;
         }
 
-#if FEATURE_AI_AGENT_STREAMING_SUPPORT
         public override async Task SetResponseRawAsync(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
-            await foreach (var msg in SseParser.Create(stream).EnumerateAsync())
+            using var streamReader = new StreamReader(stream);
+            while (true)
             {
-                if (msg.EventType is "result")
+                var line = await streamReader.ReadLineAsync().ConfigureAwait(false);
+                if (line is null)
+                    break;
+                if (line.StartsWith("{"))
                 {
-                    using var final = context.Sync.ReadForMemory(msg.Data, "final/result");
+                    using var final = context.Sync.ReadForMemory(line, "final/result");
                     Result = ConversationResult<TSchema>.Convert(final, _conventions);
                     break;
                 }
 
-                // streaming the output...
-                await _parent._streamedChunksCallback(msg.Data).ConfigureAwait(false);
+                string unescaped = JToken.Parse(line).Value<string>();
+                await _parent._streamedChunksCallback(unescaped).ConfigureAwait(false);
             }
         }
-#endif
 
         public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
         {

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -179,9 +179,6 @@
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Net.ServerSentEvents" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -36,7 +34,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         }
 
         private async Task<bool> TryHandleActionResponses(JsonOperationContext context, AiAgentConfiguration configuration, string conversationId, ConversationDocument document,
-            RequestBody body)
+            RequestBody body, bool streaming, CancellationToken token)
         {
             var hasActionResponse = body.ActionResponses is { Length: > 0 };
             var hasUserPrompt = string.IsNullOrEmpty(body.UserPrompt) == false;
@@ -69,7 +67,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 // skip reduction - persist the document now without history,
                 // ensuring we can recover if TalkAsync fails.
                 await TryPersistAsync(context, configuration, conversationId, document, history: null);
-                await WriteResponseAsync(context, conversationId, response: null, document);
+                await WriteResponseAsync(context, conversationId, response: null, document, streaming, token);
                 return false;
             }
 
@@ -98,7 +96,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             RequestBody body,
             CancellationToken token)
         {
-            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false)
+            if (await TryHandleActionResponses(context, configuration, conversationId, document, body, streaming: false, token) is false)
                 return;
 
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
@@ -112,7 +110,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
-            await WriteResponseAsync(context, conversationId, r.Response, r.Document);
+            await WriteResponseAsync(context, conversationId, r.Response, r.Document, streaming: false, token);
         }
 
         private static readonly byte[] ResultPrefix = "event: result\ndata: "u8.ToArray();
@@ -128,7 +126,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             RequestBody body,
             CancellationToken token)
         {
-            if (await TryHandleActionResponses(context, configuration, conversationId, document, body) is false)
+            if (await TryHandleActionResponses(context, configuration, conversationId, document, body, streaming: true, token) is false)
                 return;
 
             var streamPropertyPath = RequestHandler.GetStringQueryString("streamPropertyPath");
@@ -176,11 +174,9 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
-            await responseStream.WriteAsync(ResultPrefix, token);
-            await WriteResponseAsync(context, conversationId, r.Response, r.Document); // can have no new lines here
-            await responseStream.WriteAsync(TwoNewLinesEnd, token); // \n\n for end of message
-            await responseStream.FlushAsync(token);
+            await WriteResponseAsync(context, conversationId, r.Response, r.Document, streaming: true, token);
         }
+
 
         public override async ValueTask ExecuteAsync()
         {
@@ -556,7 +552,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             return document.OpenActionCalls.Count > 0;
         }
 
-        public virtual async Task WriteResponseAsync(JsonOperationContext context, string conversationId, BlittableJsonReaderObject response, ConversationDocument document)
+        public virtual async Task WriteResponseAsync(JsonOperationContext context, string conversationId, BlittableJsonReaderObject response, ConversationDocument document, bool streaming, CancellationToken token)
         {
             var output = new DynamicJsonValue
             {
@@ -567,8 +563,16 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 [nameof(ConversationResult<object>.TotalUsage)] = document.TotalUsage.ToJson()
             };
 
-            await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
-            context.Write(writer, output);
+            using var json = context.ReadObject(output, "ai-agent/output");
+
+            var responseStream = RequestHandler.ResponseBodyStream();
+            if(streaming)
+                await responseStream.WriteAsync(ResultPrefix, token);
+            
+            await context.WriteAsync(responseStream, json, token); // single line here
+
+            if (streaming)
+                await responseStream.WriteAsync(TwoNewLinesEnd, token); // \n\n for end of message
         }
 
         public static BlittableJsonReaderObject CreateParameters(JsonOperationContext context, AiToolCall call, BlittableJsonReaderObject parameters)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -67,7 +67,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 // skip reduction - persist the document now without history,
                 // ensuring we can recover if TalkAsync fails.
                 await TryPersistAsync(context, configuration, conversationId, document, history: null);
-                await WriteResponseAsync(context, conversationId, response: null, document, streaming, token);
+                await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
+                WriteResponse(context, writer, conversationId, document, response: null);
                 return false;
             }
 
@@ -110,13 +111,9 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
-            await WriteResponseAsync(context, conversationId, r.Response, r.Document, streaming: false, token);
+            await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
+            WriteResponse(context, writer, conversationId, r.Document, r.Response);
         }
-
-        private static readonly byte[] ResultPrefix = "event: result\ndata: "u8.ToArray();
-        private static readonly byte[] DataPrefix = "data: "u8.ToArray();
-        private static readonly byte[] TwoNewLinesEnd = "\n\n"u8.ToArray();
-        private static readonly byte[] NewLinePostfix = "\n"u8.ToArray();
 
         public async Task HandleStreamingRequest(
             JsonOperationContext context,
@@ -135,37 +132,17 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             var feature = HttpContext.Features.Get<IHttpResponseBodyFeature>();
             feature?.DisableBuffering();
 
-            await using var responseStream = RequestHandler.ResponseBodyStream();
+            await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
+
             (BlittableJsonReaderObject Response, ConversationDocument Document, BlittableJsonReaderObject History) r;
             try
             {
                 r = await StreamingTalkAsync(context, configuration, document, streamPropertyPath, async (data) =>
                 {
-                    while (true)
-                    {
-                        int nextLineBreak = data.Span.IndexOf((byte)'\n');
-                        int length = nextLineBreak >= 0 ? nextLineBreak : data.Length;
-
-                        await responseStream.WriteAsync(DataPrefix, token);
-                        await responseStream.WriteAsync(data[..length], token);
-                        await responseStream.WriteAsync(NewLinePostfix, token);
-
-                        if (nextLineBreak is -1) // wrote the entire thing, no line breaks
-                            break;
-
-                        data = data[(length + 1)..];
-                        if (data.IsEmpty is false)
-                            continue;
-
-                        // means that we had a line break in the end, so let's emit that
-                        await responseStream.WriteAsync(DataPrefix, token);
-                        await responseStream.WriteAsync(NewLinePostfix, token);
-                        break;
-                    }
-
-                    // becomes the blank new line indicating we are done with this message
-                    await responseStream.WriteAsync(NewLinePostfix, token);
-                    await responseStream.FlushAsync(token);
+                    using LazyStringValue s = context.GetLazyString(data.Span, longLived: false);
+                    writer.WriteString(s);
+                    writer.WriteRawString("\r\n"u8);
+                    await writer.FlushAsync(token);
                 }, token: token);
             }
             catch (Exception e)
@@ -174,7 +151,22 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             conversationId = await TryPersistAsync(context, configuration, conversationId, r.Document, r.History);
-            await WriteResponseAsync(context, conversationId, r.Response, r.Document, streaming: true, token);
+            var response = r.Response;
+            WriteResponse(context, writer, conversationId, document, response);
+        }
+
+        public void WriteResponse(JsonOperationContext context, AsyncBlittableJsonTextWriter writer,
+            string conversationId, ConversationDocument document,
+            BlittableJsonReaderObject response)
+        {
+            context.Write(writer, new DynamicJsonValue
+            {
+                [nameof(ConversationResult<object>.ConversationId)] = conversationId,
+                [nameof(ConversationResult<object>.ChangeVector)] = document.ChangeVector,
+                [nameof(ConversationResult<object>.Response)] = response,
+                [nameof(ConversationResult<object>.ActionRequests)] = new DynamicJsonArray(document.OpenActionCalls.Select(t => t.Value.ToJson())),
+                [nameof(ConversationResult<object>.TotalUsage)] = document.TotalUsage.ToJson()
+            });
         }
 
 
@@ -550,29 +542,6 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             return document.OpenActionCalls.Count > 0;
-        }
-
-        public virtual async Task WriteResponseAsync(JsonOperationContext context, string conversationId, BlittableJsonReaderObject response, ConversationDocument document, bool streaming, CancellationToken token)
-        {
-            var output = new DynamicJsonValue
-            {
-                [nameof(ConversationResult<object>.ConversationId)] = conversationId,
-                [nameof(ConversationResult<object>.ChangeVector)] = document.ChangeVector,
-                [nameof(ConversationResult<object>.Response)] = response,
-                [nameof(ConversationResult<object>.ActionRequests)] = new DynamicJsonArray(document.OpenActionCalls.Select(t => t.Value.ToJson())),
-                [nameof(ConversationResult<object>.TotalUsage)] = document.TotalUsage.ToJson()
-            };
-
-            using var json = context.ReadObject(output, "ai-agent/output");
-
-            var responseStream = RequestHandler.ResponseBodyStream();
-            if(streaming)
-                await responseStream.WriteAsync(ResultPrefix, token);
-            
-            await context.WriteAsync(responseStream, json, token); // single line here
-
-            if (streaming)
-                await responseStream.WriteAsync(TwoNewLinesEnd, token); // \n\n for end of message
         }
 
         public static BlittableJsonReaderObject CreateParameters(JsonOperationContext context, AiToolCall call, BlittableJsonReaderObject parameters)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.AI;
@@ -53,8 +54,11 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         return Task.FromResult("test");
     }
 
-    public override async Task WriteResponseAsync(JsonOperationContext context, string conversationId, BlittableJsonReaderObject response, ConversationDocument document)
+    public override async Task WriteResponseAsync(JsonOperationContext context, string conversationId, BlittableJsonReaderObject response, ConversationDocument document, bool streaming, CancellationToken token)
     {
+        if(streaming)
+            throw new NotSupportedException("Streaming is not currently supported for tests");
+        
         var output = new DynamicJsonValue
         {
             [nameof(AiAgentTestResult.Document)] = document.ToJson(),

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -54,23 +54,6 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         return Task.FromResult("test");
     }
 
-    public override async Task WriteResponseAsync(JsonOperationContext context, string conversationId, BlittableJsonReaderObject response, ConversationDocument document, bool streaming, CancellationToken token)
-    {
-        if(streaming)
-            throw new NotSupportedException("Streaming is not currently supported for tests");
-        
-        var output = new DynamicJsonValue
-        {
-            [nameof(AiAgentTestResult.Document)] = document.ToJson(),
-            [nameof(AiAgentTestResult.Response)] = response,
-            [nameof(AiAgentTestResult.ActionRequests)] = new DynamicJsonArray(document.OpenActionCalls.Select(t => t.Value.ToJson())),
-            [nameof(AiAgentTestResult.Usage)] = document.TotalUsage.ToJson()
-        };
-
-        await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
-        context.Write(writer, output);
-    }
-
     public class AiAgentTestResult
     {
         public BlittableJsonReaderObject Document;

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -524,6 +524,14 @@ namespace Sparrow.Json
             }
         }
 
+        public unsafe LazyStringValue GetLazyString(Span<byte> span, bool longLived)
+        {
+            fixed (byte* p = span)
+            {
+                return GetLazyString(p, span.Length, longLived);
+            }
+        }
+
         public unsafe LazyStringValue GetLazyString(byte* ptr, int size, bool longLived = false)
         {
             var state = new JsonParserState();

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24811.cs
@@ -31,7 +31,7 @@ public class RavenDB_24811(ITestOutputHelper output) : RavenTestBase(output)
 
         chat.SetUserPrompt("Give me 15 real cities names, one per line");
         var sb = new StringBuilder();
-        var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>("Answer", s =>
+        var result = await chat.StreamAsync<AiAgentBasics.OutputSchema>( a=>a.Answer, s =>
         {
             sb.Append(s);
             return Task.CompletedTask;


### PR DESCRIPTION
… streaming

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24811 

The `treamAsync<TAnswer>(Expression<Func<TAnswer, string>> streamPropertyPath,..` would generate paths such as: `x.Answer` instead of `Answer`