### PR TITLE
RavenDB-24812

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
@@ -20,7 +20,7 @@ public class AiUsage : IDynamicJsonValueConvertible
         CompletionTokens += completionTokens;
         TotalTokens += totalTokens;
 
-        if (json.TryGet("prompt_tokens_details", out BlittableJsonReaderObject promptDetails))
+        if (json.TryGet("prompt_tokens_details", out BlittableJsonReaderObject promptDetails) && promptDetails != null)
         {
             if (promptDetails.TryGet("cached_tokens", out int cachedTokens))
                 CachedTokens += cachedTokens;

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -981,7 +981,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string OpenAiProject = "OpenAI-Project";
             public const string MediaTypeApplicationJson = "application/json";
 
-            public const string DefaultRelativeUri = "/v1/chat/completions";
+            public const string DefaultRelativeUri = "v1/chat/completions";
             public const string ModelsUri = "/v1/models";
             public const string AuthorizationApiKeyProperty = "Bearer";
             

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -81,6 +81,11 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
         conventions ??= ConventionsToUse;
 
+        if (baseUri.EndsWith("/") == false)
+        {
+            baseUri += "/";
+        }
+
         _httpClientCacheKey = HttpClientCacheKey.Create(conventions.UseHttpDecompression,
             conventions.HasExplicitlySetDecompressionUsage, conventions.HttpPooledConnectionLifetime,
             conventions.HttpPooledConnectionIdleTimeout, conventions.GlobalHttpClientTimeout,
@@ -982,7 +987,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             public const string MediaTypeApplicationJson = "application/json";
 
             public const string DefaultRelativeUri = "v1/chat/completions";
-            public const string ModelsUri = "/v1/models";
+            public const string ModelsUri = "v1/models";
             public const string AuthorizationApiKeyProperty = "Bearer";
             
             public const string Stream = "stream";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24812/Validate-if-OpenRouter-can-be-used-via-OpenAI-compatible-API

### Additional description

OpenRouter can be used via OpenAI compatible API.
but, because of the free tier I could not check action/query tools for AI Agent.

Some AI providers (like OpenRouter) send back a response where the prompt_tokens_details key exists, but its value is null for some models - Added a null check when parsing the prompt_tokens_details from the AI provider's response.

The relative URL for chat completions was missing the required /v1/ prefix. Due to a feature in .NET's HttpClient that treats paths starting with / as absolute from the domain root, the base path was being discarded, leading to an incorrect final URL.
https://openrouter.ai/api -> https://openrouter.ai/v1/chat/completions (api removed)
tested that it changed nothing for Openai and Ollama connection.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works - **could not test tools**
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
