### PR TITLE
RavenDB-15351 - Fix for `StressTests.Issues.RavenDB_13987.DatabaseWithBackupTaskShouldNotGetIdleBeforeBackupOccurrence`

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -52,8 +52,6 @@ namespace Raven.Server.Documents
         private readonly ServerStore _serverStore;
 
         // used in ServerWideBackupStress
-        internal bool SkipShouldContinueDisposeCheck = false;
-        internal Action<(DocumentDatabase Database, string caller)> AfterDatabaseCreation;
         internal SemaphoreSlim _databaseSemaphore;
         internal TimeSpan _concurrentDatabaseLoadTimeout;
         internal int _dueTimeOnRetry = 60_000;
@@ -99,12 +97,13 @@ namespace Raven.Server.Documents
             internal Action BeforeActualDelete = null;
             internal Action<DocumentDatabase> OnBeforeDocumentDatabaseInitialization;
             internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
-            internal bool ShouldFetchIdleStateImmediately = false;
+            internal bool SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
             internal Action<Exception, string> OnFailedRescheduleNextScheduledActivity;
             internal bool PreventNodePromotion = false;
             internal Func<ServerStore, Task> BeforeHandleClusterTransactionOnDatabaseChanged;
             internal Action DelayNotifyFeaturesAboutStateChange;
             internal ManualResetEventSlim AfterDatabaseRemovedFromIdle = null;
+            internal bool SkipShouldContinueDisposeCheck = false;
         }
 
         private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType, object changeState)
@@ -1218,7 +1217,7 @@ namespace Raven.Server.Documents
 
         public DateTime LastWork(DocumentDatabase resource)
         {
-            if (ForTestingPurposes is { ShouldFetchIdleStateImmediately: true })
+            if (ForTestingPurposes?.SkipIncreasingLastWorkTimeBasedOnDatabaseSize == true )
                 return resource.LastAccessTime;
 
             // This allows us to increase the time large databases will be held in memory
@@ -1512,10 +1511,11 @@ namespace Raven.Server.Documents
             if (idleDatabaseActivity.DateTime.HasValue == false)
                 return true;
 
-            if (SkipShouldContinueDisposeCheck)
+            if (ForTestingPurposes?.SkipShouldContinueDisposeCheck == true)
                 return true;
 
-            // if we have a small value, simply don't dispose the database.
+            // Unloading and then loading a database can use a lot of resources.
+            // Therefore, we don't want to unload the database unless we're sure it will be loaded again soon.
             return idleDatabaseActivity.DueTime > TimeSpan.FromMinutes(5).TotalMilliseconds;
         }
 

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1418,8 +1418,8 @@ namespace SlowTests.Client.Subscriptions
             });
 
             using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
-            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false);
-            server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false);
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             var db = await GetDatabase(server, store.Database);
             var subsId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = "from Users", Name = Guid.NewGuid().ToString() });

--- a/test/SlowTests/Issues/RavenDB-18442.cs
+++ b/test/SlowTests/Issues/RavenDB-18442.cs
@@ -11,6 +11,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Extensions;
 using Tests.Infrastructure;
+using Voron.Util;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -29,6 +30,13 @@ namespace SlowTests.Issues
 
             // Setup Db
             var nodes = await CreateMyCluster();
+
+            using var dispose = new DisposableAction(() =>
+            {
+                foreach (var node in nodes)
+                    node.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+            });
+
             var firstServer = nodes[0]; // leader
             var secondServer = nodes[1]; // no leader
 
@@ -123,7 +131,7 @@ namespace SlowTests.Issues
 
             foreach (var node in nodes)
             {
-                node.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+                node.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
             }
 
             return nodes;

--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -64,8 +64,8 @@ public class RavenDB_20084 : ClusterTestBase
             Assert.True(onGoingTaskBackup is { LastFullBackup: not null });
             var expectedTime = onGoingTaskBackup.NextBackup.DateTime;
 
-            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
-            leaderServer.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
+            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             using (leaderServer.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverStoreContext))
             using (serverStoreContext.OpenReadTransaction())
@@ -78,8 +78,8 @@ public class RavenDB_20084 : ClusterTestBase
                 Assert.Equal(1, leaderServer.ServerStore.IdleDatabases.Count);
 
                 // No longer forcing the idle state for the database
-                leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = false;
-                leaderServer.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+                leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
+                leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
 
                 // Awaiting the next backup event to verify that the '/database' endpoint provides an updated value for the last incremental backup timestamp
                 using var client = new HttpClient().WithConventions(leaderStore.Conventions);

--- a/test/SlowTests/Issues/RavenDB_20915.cs
+++ b/test/SlowTests/Issues/RavenDB_20915.cs
@@ -35,7 +35,7 @@ public class RavenDB_20915 : RavenTestBase
                 await session.SaveChangesAsync(); // update last work time
             }
 
-            Server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
+            Server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
 
             Assert.False(WaitForValue(() => Server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(store.Database, out _), false));
         }

--- a/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
@@ -57,7 +57,7 @@ public class RavenDB_22105 : RabbitMqQueueSinkTestBase
 
         // Try to idle a database
 
-        landlord.SkipShouldContinueDisposeCheck = true;
+        landlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
         var database = await GetDatabase(store.Database);
         database.ResetIdleTime();

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -764,8 +764,8 @@ namespace SlowTests.Server.Replication
 
             }))
             {
-                sinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
-                hubServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
+                sinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
+                hubServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
 
                 await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(name));
                 using (var s2 = hub.OpenSession())
@@ -915,7 +915,7 @@ namespace SlowTests.Server.Replication
 
                 Assert.True(WaitForDocument(hub, "foo/bar/228", timeout * 5), hub.Identifier);
 
-                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().ShouldFetchIdleStateImmediately = true;
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
 
                 var dic = new Dictionary<IdleDatabaseStatistics, int>();
                 Assert.True(WaitForValue( () =>

--- a/test/StressTests/Issues/RavenDB-13987.cs
+++ b/test/StressTests/Issues/RavenDB-13987.cs
@@ -13,6 +13,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Voron.Util;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -52,7 +53,7 @@ namespace StressTests.Issues
             {
                 foreach (var server in _nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
                 }
 
                 using (var store = GetDocumentStore(new Options
@@ -111,7 +112,7 @@ namespace StressTests.Issues
             {
                 foreach (var server in _nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
                 }
             }
         }
@@ -120,6 +121,7 @@ namespace StressTests.Issues
         [NightlyBuildFact]
         public async Task DatabaseWithBackupTaskShouldNotGetIdleBeforeBackupOccurrence()
         {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
             using var server = GetNewServer(new ServerCreationOptions
             {
                 CustomSettings = new Dictionary<string, string>
@@ -129,46 +131,52 @@ namespace StressTests.Issues
                     [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
                 }
             });
-            try
+
+            using var dispose = new DisposableAction(() =>
             {
-                var backupPath = NewDataPath(suffix: "BackupFolder");
-                using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
-                using (var session = store.OpenAsyncSession())
-                {
-                    await session.StoreAsync(new User { Name = "EGOR" }, "su");
-                    await session.SaveChangesAsync();
-                }
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+            });
 
-                var sec = DateTime.Now.Second;
-                while (sec > 10)
-                {
-                    await Task.Delay(1000);
-                    sec = DateTime.Now.Second;
-                }
-                var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(new ServerWideBackupConfiguration
-                {
-                    FullBackupFrequency = "*/1 * * * *",
-                    LocalSettings = new LocalSettings { FolderPath = backupPath }
-                }));
-                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
-                Assert.NotNull(serverWideConfiguration);
-                var backupTaskId = serverWideConfiguration.TaskId;
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
-                var operation = new GetPeriodicBackupStatusOperation(backupTaskId);
-                Assert.Equal(1, WaitForValue(() =>
-                {
-                    Assert.Equal(0, server.ServerStore.IdleDatabases.Count);
-                    var status = store.Maintenance.Send(operation).Status;
-                    return status?.LastEtag;
-                }, 1, timeout: 75000, interval: 300));
+            using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
+            while (DateTime.Now.Second > 10)
+                await Task.Delay(1_000);
 
-                server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
-                Assert.Equal(1, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 300));
-            }
-            finally
+            using (var session = store.OpenAsyncSession())
             {
-                server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+                await session.StoreAsync(new User { Name = "EGOR" }, "su/1");
+                await session.SaveChangesAsync();
             }
+
+            var putServerWideBackupConfigurationResponse = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(new ServerWideBackupConfiguration
+            {
+                FullBackupFrequency = "* * * * *",
+                LocalSettings = new LocalSettings { FolderPath = backupPath }
+            }));
+            var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(putServerWideBackupConfigurationResponse.Name));
+            Assert.NotNull(serverWideConfiguration);
+            var backupTaskId = serverWideConfiguration.TaskId;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "LEV" }, "su/2");
+                await session.SaveChangesAsync();
+            }
+
+            WaitForUserToContinueTheTest(store);
+
+            var getPeriodicBackupStatusOperation = new GetPeriodicBackupStatusOperation(backupTaskId);
+            Assert.True(1 <= await WaitForGreaterThanAsync(async () =>
+            {
+                Assert.Equal(0, server.ServerStore.IdleDatabases.Count);
+                var status = await store.Maintenance.SendAsync(getPeriodicBackupStatusOperation);
+                return status?.Status?.LastEtag ?? 0;
+            }, val: 1, timeout: 75000, interval: 300));
+
+            Assert.Equal(1, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60_000, interval: 3_000));
         }
 
         internal static int WaitForCount(TimeSpan seconds, int excepted, Func<int> func)

--- a/test/StressTests/Issues/RavenDB_14292.cs
+++ b/test/StressTests/Issues/RavenDB_14292.cs
@@ -44,8 +44,8 @@ namespace StressTests.Issues
                     [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
                 }
             });
-            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false);
-            server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false);
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             var dbName = GetDatabaseName();
             var controlgroupDbName = GetDatabaseName() + "controlgroup";

--- a/test/StressTests/Issues/RavenDB_14744.cs
+++ b/test/StressTests/Issues/RavenDB_14744.cs
@@ -40,7 +40,7 @@ namespace StressTests.Issues
             {
                 foreach (var server in nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
                 }
 
                 using (var store = GetDocumentStore(new Options
@@ -86,7 +86,7 @@ namespace StressTests.Issues
             {
                 foreach (var server in nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
                 }
             }
         }

--- a/test/StressTests/Issues/RavenDB_18420.cs
+++ b/test/StressTests/Issues/RavenDB_18420.cs
@@ -31,7 +31,7 @@ public class RavenDB_18420 : RavenTestBase
                 [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false",
             }
         });
-        server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+        server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
         try
         {
             var backupPath = NewDataPath(forceCreateDir: true);
@@ -94,7 +94,7 @@ public class RavenDB_18420 : RavenTestBase
         }
         finally
         {
-            server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
         }
     }
 }

--- a/test/StressTests/Server/Replication/ExternalReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/ExternalReplicationStressTests.cs
@@ -265,7 +265,7 @@ namespace StressTests.Server.Replication
                 foreach (var server in _nodes)
                 {
                     wakeUpReasons.Add(server.ServerStore.NodeTag, new List<string>());
-                    server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
                     server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseCreation = tuple =>
                     {
                         var list = wakeUpReasons[tuple.Database.ServerStore.NodeTag];
@@ -339,7 +339,7 @@ namespace StressTests.Server.Replication
             {
                 foreach (var server in _nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
                     server.ServerStore.DatabasesLandlord.ForTestingPurposes = null;
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15351

### Additional description

The problem arose because the test began after the 10-second mark of the current minute. In this case, we would wait for the next minute to start, and the database would go to sleep during this waiting period since no backup configurations had been created yet.

Additionally, a flag meant only for testing was found outside of the TestingStuff class and has been moved to the correct location.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed