### PR TITLE
RavenDB-24559 - add ETL & Replication interversion tests

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -79,6 +79,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int ReplicationWithTimeSeries = 50_000;
         public static readonly int ReplicationWithDeduplicatedAttachments = 53_001;
         public static readonly int ReplicationWithRevisionTombstones = 60_000;
+        public static readonly int ReplicationWithRetireAttachments = 72_000;
 
         public static readonly int TcpConnectionsWithCompression = 53_000;
         public static readonly int SubscriptionBaseLine = 40;
@@ -89,7 +90,7 @@ namespace Raven.Client.ServerWide.Tcp
 
         public static readonly int ClusterTcpVersion = ClusterWithTcpCompression;
         public static readonly int HeartbeatsTcpVersion = HeartbeatsWithTcpCompression;
-        public static readonly int ReplicationTcpVersion = ReplicationWithRevisionTombstones;
+        public static readonly int ReplicationTcpVersion = ReplicationWithRetireAttachments;
         public static readonly int SubscriptionTcpVersion = TcpConnectionsWithCompression; 
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
 
@@ -264,6 +265,7 @@ namespace Raven.Client.ServerWide.Tcp
                 public bool IncrementalTimeSeries;
                 public bool DeduplicatedAttachments;
                 public bool RevisionTombstonesWithId;
+                public bool RetiredAttachments;
             }
         }
 
@@ -292,6 +294,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Replication] = new List<int>
                 {
+                    ReplicationWithRetireAttachments,
                     ReplicationWithRevisionTombstones,
                     ReplicationWithDeduplicatedAttachments,
                     TcpConnectionsWithCompression,
@@ -387,6 +390,23 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Replication] = new Dictionary<int, SupportedFeatures>
                 {
+                    [ReplicationWithRetireAttachments] = new SupportedFeatures(ReplicationWithRetireAttachments)
+                    {
+                        DataCompression = true,
+                        Replication = new SupportedFeatures.ReplicationFeatures
+                        {
+                            RetiredAttachments = true,
+                            RevisionTombstonesWithId = true,
+                            DeduplicatedAttachments = true,
+                            MissingAttachments = true,
+                            CountersBatch = true,
+                            PullReplication = true,
+                            TimeSeries = true,
+                            CaseInsensitiveCounters = true,
+                            ClusterTransaction = true,
+                            IncrementalTimeSeries = true
+                        }
+                    },
                     [ReplicationWithRevisionTombstones] = new SupportedFeatures(ReplicationWithRevisionTombstones)
                     {
                         DataCompression = true,

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -324,6 +324,11 @@ namespace Raven.Server.Documents.Replication.Senders
             {
                 AssertNotIncrementalTimeSeriesForLegacyReplication(item);
             }
+
+            if (_parent.SupportedFeatures.Replication.RetiredAttachments == false)
+            {
+                AssertNotRetiredAttachmentsForLegacyReplication(item);
+            }
         }
 
         private void AssertNotTimeSeriesForLegacyReplication(ReplicationBatchItem item)
@@ -417,6 +422,31 @@ namespace Raven.Server.Documents.Replication.Senders
                     Log.Info(message);
 
                 throw new LegacyReplicationViolationException(message);
+            }
+        }
+
+        private void AssertNotRetiredAttachmentsForLegacyReplication(ReplicationBatchItem item)
+        {
+            if (item.Type != ReplicationBatchItem.ReplicationItemType.Attachment)
+                return;
+            switch (item)
+            {
+                case AttachmentReplicationItem attachment:
+                    if (attachment.Flags == RetiredAttachmentFlags.Retired)
+                    {
+                        var message = $"Replication '{_parent.FromToString}' found an item of type 'AttachmentReplicationItem' to replicate to {_parent.Destination.FromString()}, " +
+                                      $"while we are in legacy mode (downgraded our replication version to match the destination). " +
+                                      $"Can't send Retired-Attachments in legacy mode, destination {_parent.Destination.FromString()} does not support Retired-Attachments feature. Stopping replication.";
+
+                        if (Log.IsInfoEnabled)
+                            Log.Info(message);
+
+                        throw new LegacyReplicationViolationException(message);
+                    }
+
+                    break;
+                default:
+                    return;
             }
         }
 

--- a/test/InterversionTests/AttachmentsTests.cs
+++ b/test/InterversionTests/AttachmentsTests.cs
@@ -1,0 +1,329 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Retired;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Exceptions;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Raven.Server.Documents.PeriodicBackup.Restore;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using SlowTests.Server.Documents.Attachments;
+using SlowTests.Server.Documents.ETL.Olap;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace InterversionTests
+{
+    public class AttachmentsTests : InterversionTestBase
+    {
+        public AttachmentsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Attachments | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task CannotReplicateRetiredAttachmentsToOld()
+        {
+            var version = Server62Version;
+
+            var settings = Etl.GetS3Settings(nameof(AttachmentsTests), $"{Guid.NewGuid()}");
+
+            await using (DeleteObjects(settings))
+            using (var oldStore = await GetDocumentStoreAsync(version))
+            using (var store = GetDocumentStore())
+            {
+                await CannotRetiredAttachmentsToOldInternal(settings, store);
+
+                await SetupReplicationAsync(store, oldStore);
+
+                var replicationLoader = (await Databases.GetDocumentDatabaseInstanceFor(store)).ReplicationLoader;
+                Assert.NotEmpty(replicationLoader.OutgoingFailureInfo);
+                Assert.True(WaitForValue(() => replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.RetriesCount > 2), true), "WaitForValue(() => replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.RetriesCount > 2), true)");
+                Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException))), "replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException)))");
+                Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("found an item of type 'AttachmentReplicationItem' to replicate"))), "replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains('found an item of type 'AttachmentReplicationItem' to replicate')))");
+            }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Attachments | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task CannotEtlRetiredAttachmentsToOld()
+        {
+            var version = Server62Version;
+
+            var settings = Etl.GetS3Settings(nameof(AttachmentsTests), $"{Guid.NewGuid()}");
+
+            await using (DeleteObjects(settings))
+            using (var oldStore = await GetDocumentStoreAsync(version))
+            using (var store = GetDocumentStore())
+            {
+                await CannotRetiredAttachmentsToOldInternal(settings, store);
+
+                var taskName = "etl-test";
+                var csName = "cs-test";
+                var configuration = new RavenEtlConfiguration
+                {
+                    ConnectionStringName = csName,
+                    Name = taskName,
+                    Transforms = { new Transformation { Name = "S1", Collections = { "Orders" } } }
+                };
+
+                var connectionString = new RavenConnectionString { Name = csName, TopologyDiscoveryUrls = oldStore.Urls, Database = oldStore.Database, };
+
+                Etl.AddEtl(store, configuration, connectionString);
+
+                AlertRaised alert = null;
+                Assert.True(await WaitForValueAsync(async () =>
+                {
+                    var operation = new GetEtlDebugStatsOperation();
+                    string statsJson = await store.Maintenance.SendAsync(operation);
+
+                    alert = await GetAlertWithDetailsFromEtlFailure(statsJson);
+
+                    if (alert == null)
+                        return false;
+
+                    return true;
+                }, true, 60_000, interval: 322));
+
+                Assert.NotNull(alert);
+
+                Assert.Equal(AlertType.Etl_LoadError, alert.AlertType);
+                Assert.NotNull(alert.Details);
+                EtlErrorsDetails details = (EtlErrorsDetails)alert.Details;
+
+                Assert.NotEmpty(details.Errors);
+                var error = details.Errors.Dequeue();
+                Assert.NotNull(error.Date);
+                Assert.NotNull(error.Error);
+                Assert.Contains("System.NullReferenceException: System.NullReferenceException: Object reference not set to an instance of an object.", error.Error);
+            }
+        }
+
+        private static async Task<AlertRaised> GetAlertWithDetailsFromEtlFailure(string statsJson)
+        {
+            // Parse the JSON string to BlittableJsonReaderObject
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(statsJson)))
+            using (context.GetMemoryBuffer(out var bytes))
+            {
+                var statsBlittable = await context.ParseToMemoryAsync(stream, "etl-stats", BlittableJsonDocumentBuilder.UsageMode.None, bytes);
+
+                if (statsBlittable.TryGet("Results", out BlittableJsonReaderArray results))
+                {
+                    for (int resultIndex = 0; resultIndex < results.Length; resultIndex++)
+                    {
+                        var result = (BlittableJsonReaderObject)results[resultIndex];
+
+                        if (result.TryGet("Stats", out BlittableJsonReaderArray statsArray))
+                        {
+                            for (int statsIndex = 0; statsIndex < statsArray.Length; statsIndex++)
+                            {
+                                var stat = (BlittableJsonReaderObject)statsArray[statsIndex];
+
+                                if (stat.TryGet("Statistics", out BlittableJsonReaderObject statistics))
+                                {
+                                    // Parse LastAlert using AlertRaised.FromJson()
+                                    if (statistics.TryGet("LastAlert", out BlittableJsonReaderObject lastAlert) &&
+                                        lastAlert != null)
+                                    {
+                                        EtlErrorsDetails details = null;
+                                        if (lastAlert.TryGet("Details", out BlittableJsonReaderObject detailsb) && detailsb != null)
+                                        {
+                                            details = DocumentConventions.DefaultForServer.Serialization.DefaultConverter
+                                                .FromBlittable<EtlErrorsDetails>(detailsb);
+                                        }
+
+                                        AlertRaised alertRaised = AlertRaised.FromJson("lastAlert", lastAlert, details);
+                                        return alertRaised;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Operation to get debug statistics for ETL processes.
+        /// </summary>
+        internal sealed class GetEtlDebugStatsOperation : IMaintenanceOperation<string>
+        {
+            private readonly string[] _etlTaskNames;
+
+            /// <summary>
+            /// Initialize operation to get debug stats for all ETL tasks.
+            /// </summary>
+            public GetEtlDebugStatsOperation()
+            {
+                _etlTaskNames = null;
+            }
+
+            /// <summary>
+            /// Initialize operation to get debug stats for specific ETL tasks.
+            /// </summary>
+            /// <param name="etlTaskNames">Names of the ETL tasks to get debug stats for. If null or empty, gets stats for all ETL tasks.</param>
+            public GetEtlDebugStatsOperation(params string[] etlTaskNames)
+            {
+                _etlTaskNames = etlTaskNames;
+            }
+
+            public RavenCommand<string> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetEtlDebugStatsCommand(_etlTaskNames);
+            }
+
+            private sealed class GetEtlDebugStatsCommand : RavenCommand<string>
+            {
+                private readonly string[] _etlTaskNames;
+
+                public GetEtlDebugStatsCommand(string[] etlTaskNames)
+                {
+                    _etlTaskNames = etlTaskNames;
+                }
+
+                public override bool IsReadRequest => true;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/etl/debug/stats";
+
+                    if (_etlTaskNames is { Length: > 0 })
+                    {
+                        for (var i = 0; i < _etlTaskNames.Length; i++)
+                            url += $"{(i == 0 ? "?" : "&")}name={Uri.EscapeDataString(_etlTaskNames[i])}";
+                    }
+
+                    return new HttpRequestMessage { Method = HttpMethod.Get };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    if (response == null)
+                        return;
+
+                    Result = response.ToString();
+                }
+            }
+        }
+        private async Task CannotRetiredAttachmentsToOldInternal(S3Settings settings, DocumentStore store)
+        {
+            string identifier = await CreateRetiredAttachmentsConfigurationAndGetIdentifier(settings, store);
+
+            var id = "Orders/1";
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Order { Id = id, OrderedAt = new DateTime(2024, 1, 1), ShipVia = $"Shippers/1", Company = $"Companies/1" });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                using var profileStream = new MemoryStream(new byte[] { 1, 2, 3 });
+                session.Advanced.Attachments.Store(id, new StoreAttachmentParameters("test.png", profileStream)
+                {
+                    RetireParameters = new RetireAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3)),
+                    ContentType = "image/png"
+                });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var exists = session.Advanced.Attachments.Exists(id, "test.png");
+                Assert.True(exists);
+            }
+
+            await RetireAndAssertCount(store, settings, 1);
+
+            using (var session = store.OpenSession())
+            {
+                var retiredExists = session.Advanced.Attachments.Exists(id, "test.png");
+                Assert.True(retiredExists);
+            }
+        }
+
+        private IAsyncDisposable DeleteObjects(S3Settings settings)
+        {
+            return new AsyncDisposableAction(async () =>
+            {
+
+                if (settings == null)
+                    return;
+
+                await S3Tests.DeleteObjects(settings, prefix: $"{settings.RemoteFolderName}", delimiter: string.Empty);
+            });
+        }
+
+        private static async Task<string> CreateRetiredAttachmentsConfigurationAndGetIdentifier(S3Settings settings, DocumentStore store)
+        {
+            var identifier = "conf-identifier-s3";
+            var config = new RetiredAttachmentsConfiguration()
+            {
+                Destinations = new Dictionary<string, RetiredAttachmentsDestinationConfiguration>()
+                {
+                    {
+                        identifier, new RetiredAttachmentsDestinationConfiguration()
+                        {
+                            S3Settings = settings,
+                            Disabled = false,
+                            Identifier = identifier
+                        }
+                    }
+                },
+                RetireFrequencyInSec = 1000
+            };
+
+            await store.Maintenance.SendAsync(new ConfigureRetiredAttachmentsOperation(config));
+            return identifier;
+        }
+
+        private async Task RetireAndAssertCount(DocumentStore store, S3Settings settings, int expected)
+        {
+            var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+            database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+            await database.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+
+
+            List<S3FileInfoDetails> cloudObjects = null;
+            var val3 = await WaitForValueAsync(async () =>
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+                using (var s3Client = new RavenAwsS3Client(settings, RavenTestBase.EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
+                {
+                    var prefix = $"{settings.RemoteFolderName}";
+                    cloudObjects = await s3Client.ListAllObjectsAsync(prefix, string.Empty, false);
+                    return cloudObjects.Count;
+                }
+            }, expected);
+            Assert.Equal(expected, val3);
+
+            var x123 = cloudObjects.Select(x => new RetiredAttachmentsHolderBase.FileInfoDetails()
+            {
+                FullPath = x.FullPath,
+                LastModified = x.LastModified
+            }).ToList();
+
+            Assert.Equal(expected, x123.Count);
+        }
+
+    }
+}

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -56,6 +56,7 @@ namespace Tests.Infrastructure
         protected const string Server52Version = "5.2.100";
         protected const string Server53Version = "5.3.100";
         protected const string Server54Version = "5.4.201-nightly-20240706-0301";
+        protected const string Server62Version = "6.2.9"; 
 
         protected DocumentStore GetDocumentStore(
             string serverVersion,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24559/

### Additional description

This pull request introduces support for the "Retired Attachments" replication feature, ensuring that retired attachments are not replicated or ETL'd to older RavenDB server versions that do not support this feature. It updates the TCP protocol versioning, enhances replication compatibility checks, and adds comprehensive interversion tests to validate the new behavior.

**Replication protocol and feature negotiation:**

* Added a new protocol version constant `ReplicationWithRetireAttachments` and set it as the latest `ReplicationTcpVersion` to indicate support for retired attachments in replication handshakes. [[1]](diffhunk://#diff-a713dfb80970130bc932c417864c9e14304e53e25d9861432db31af7ad46659cR82) [[2]](diffhunk://#diff-a713dfb80970130bc932c417864c9e14304e53e25d9861432db31af7ad46659cL92-R93)
* Updated feature negotiation dictionaries to include `ReplicationWithRetireAttachments` and mark the `RetiredAttachments` feature as supported in the appropriate version. [[1]](diffhunk://#diff-a713dfb80970130bc932c417864c9e14304e53e25d9861432db31af7ad46659cR297) [[2]](diffhunk://#diff-a713dfb80970130bc932c417864c9e14304e53e25d9861432db31af7ad46659cR393-R409)
* Extended the `ReplicationFeatures` structure to include a `RetiredAttachments` boolean flag.

**Replication sender enforcement:**

* Added logic in `ReplicationDocumentSenderBase` to assert that retired attachments are not sent to legacy servers, throwing a `LegacyReplicationViolationException` if attempted. [[1]](diffhunk://#diff-12173e270f1c68d022782988e634d62c4ca49071feb4da0b353c15a4fed66a06R327-R331) [[2]](diffhunk://#diff-12173e270f1c68d022782988e634d62c4ca49071feb4da0b353c15a4fed66a06R428-R452)

**Testing and validation:**

* Introduced interversion tests in `AttachmentsTests.cs` to verify that retired attachments cannot be replicated or ETL'd to older server versions, and that appropriate errors and alerts are raised.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
