### PR TITLE
RavenDB-24445 Certificate for cluster communication must not be edited, regenerated or deleted

### DIFF
--- a/src/Raven.Studio/typescript/commands/auth/getCertificatesCommand.ts
+++ b/src/Raven.Studio/typescript/commands/auth/getCertificatesCommand.ts
@@ -12,17 +12,20 @@ interface Result {
 }
 
 class getCertificatesCommand extends commandBase {
-    constructor(private includeSecondary: boolean = false, private metadataOnly: boolean = true) {
+    constructor(
+        private includeSecondary: boolean = false,
+        private metadataOnly: boolean = true
+    ) {
         super();
     }
-    
-    execute(): JQueryPromise<CertificatesResponseDto> {
+
+    execute(): JQueryPromise<Result> {
         const args = {
             secondary: this.includeSecondary,
             metadataOnly: this.metadataOnly,
         };
         const url = endpoints.global.adminCertificates.adminCertificates + this.urlEncodeArgs(args);
-        
+
         return this.query(url, null, null, (x) => ({
             Certificates: x.Results,
             LoadedServerCert: x.LoadedServerCert,

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesClientList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesClientList.tsx
@@ -7,13 +7,20 @@ import { useAppSelector } from "components/store";
 
 export default function CertificatesClientList() {
     const serverCertificateThumbprint = useAppSelector(certificatesSelectors.serverCertificateThumbprint);
+    const serverCertificateForCommunicationThumbprint = useAppSelector(
+        certificatesSelectors.serverCertificateForCommunicationThumbprint
+    );
 
     const allClientCertsCount = useAppSelector(certificatesSelectors.certificates).filter(
-        (cert) => !cert.Thumbprints.includes(serverCertificateThumbprint)
+        (cert) =>
+            !cert.Thumbprints.includes(serverCertificateThumbprint) &&
+            !cert.Thumbprints.includes(serverCertificateForCommunicationThumbprint)
     ).length;
 
     const filteredCertificates = useAppSelector(certificatesSelectors.filteredCertificates).filter(
-        (cert) => !cert.Thumbprints.includes(serverCertificateThumbprint)
+        (cert) =>
+            !cert.Thumbprints.includes(serverCertificateThumbprint) &&
+            !cert.Thumbprints.includes(serverCertificateForCommunicationThumbprint)
     );
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
@@ -40,6 +40,9 @@ export default function CertificatesListItem({ certificate }: CertificatesListIt
     const { reportEvent } = useEventsCollector();
 
     const serverCertificateThumbprint = useAppSelector(certificatesSelectors.serverCertificateThumbprint);
+    const serverCertificateForCommunicationThumbprint = useAppSelector(
+        certificatesSelectors.serverCertificateForCommunicationThumbprint
+    );
     const serverCertificateSetupMode = useAppSelector(certificatesSelectors.serverCertificateSetupMode);
     const serverCertificateRenewalDate = useAppSelector(certificatesSelectors.serverCertificateRenewalDate);
     const clientCertificateThumbprint = useAppSelector(accessManagerSelectors.clientCertificateThumbprint);
@@ -48,14 +51,15 @@ export default function CertificatesListItem({ certificate }: CertificatesListIt
     const state = certificatesUtils.getState(certificate.NotAfter);
     const clearance = certificatesUtils.getClearance(certificate.SecurityClearance);
     const isServerCert = certificate.Thumbprints.includes(serverCertificateThumbprint);
+    const isServerCertForCommunication = certificate.Thumbprints.includes(serverCertificateForCommunicationThumbprint);
     const isCurrentBrowserCert = certificate.Thumbprints.includes(clientCertificateThumbprint);
     const has2fa = certificate.HasTwoFactor ?? false;
 
     const canBeAutomaticallyRenewed = isServerCert && serverCertificateSetupMode === "LetsEncrypt";
-    const canEdit = !isServerCert && state !== "Expired";
-    const canClone = !isServerCert;
+    const canEdit = !isServerCert && !isServerCertForCommunication && state !== "Expired";
+    const canClone = !isServerCert && !isServerCertForCommunication;
     const canDelete = (() => {
-        if (isServerCert) {
+        if (isServerCert || isServerCertForCommunication) {
             return false;
         }
         if (!isClusterAdminOrClusterNode && clearance === "Admin") {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesServerList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesServerList.tsx
@@ -7,8 +7,14 @@ import { useAppSelector } from "components/store";
 
 export default function CertificatesServerList() {
     const serverCertificateThumbprint = useAppSelector(certificatesSelectors.serverCertificateThumbprint);
-    const filteredCertificates = useAppSelector(certificatesSelectors.filteredCertificates).filter((cert) =>
-        cert.Thumbprints.includes(serverCertificateThumbprint)
+    const serverCertificateForCommunicationThumbprint = useAppSelector(
+        certificatesSelectors.serverCertificateForCommunicationThumbprint
+    );
+
+    const filteredCertificates = useAppSelector(certificatesSelectors.filteredCertificates).filter(
+        (cert) =>
+            cert.Thumbprints.includes(serverCertificateThumbprint) ||
+            cert.Thumbprints.includes(serverCertificateForCommunicationThumbprint)
     );
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSlice.ts
@@ -14,6 +14,7 @@ interface InitialState {
     isInitialLoad: boolean;
     loadStatus: loadStatus;
     serverCertificateThumbprint: string;
+    serverCertificateForCommunicationThumbprint: string;
     serverCertificateRenewalDate: string;
     serverCertificateSetupMode: Raven.Server.Commercial.SetupMode;
     wellKnownAdminCerts: string[];
@@ -35,6 +36,7 @@ const initialState: InitialState = {
     loadStatus: "idle",
     isInitialLoad: true,
     serverCertificateThumbprint: null,
+    serverCertificateForCommunicationThumbprint: null,
     serverCertificateRenewalDate: null,
     serverCertificateSetupMode: null,
     wellKnownAdminCerts: [],
@@ -116,6 +118,7 @@ export const certificatesSlice = createSlice({
             state.serverCertificateRenewalDate = serverCertificateRenewalDate;
             state.serverCertificateSetupMode = serverCertificateSetupMode;
             state.serverCertificateThumbprint = certificatesDto.LoadedServerCert;
+            state.serverCertificateForCommunicationThumbprint = certificatesDto.LoadedServerCertForCommunication;
             state.wellKnownAdminCerts = certificatesDto.WellKnownAdminCerts ?? [];
             state.wellKnownIssuers = certificatesDto.WellKnownIssuers ?? [];
 

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
@@ -137,6 +137,8 @@ export const certificatesSelectors = {
     wellKnownAdminCerts: (state: RootState) => state.certificates.wellKnownAdminCerts,
     wellKnownIssuers: (state: RootState) => state.certificates.wellKnownIssuers,
     serverCertificateThumbprint: (state: RootState) => state.certificates.serverCertificateThumbprint,
+    serverCertificateForCommunicationThumbprint: (state: RootState) =>
+        state.certificates.serverCertificateForCommunicationThumbprint,
     serverCertificateSetupMode: (state: RootState) => state.certificates.serverCertificateSetupMode,
     serverCertificateRenewalDate: (state: RootState) => state.certificates.serverCertificateRenewalDate,
     nameOrThumbprintFilter: (state: RootState) => state.certificates.nameOrThumbprintFilter,

--- a/src/Raven.Studio/typescript/test/stubs/ManageServerStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/ManageServerStubs.ts
@@ -480,8 +480,25 @@ export class ManageServerStubs {
                     PublicKeyPinningHash: "tYDktnF7XEos5gOGMC4t4eBi5MDSAHDpFqX1rV9oLCE=",
                     HasTwoFactor: false,
                 },
+                {
+                    Name: "Server Certificate for communication A",
+                    Thumbprint: "JF61904E1926ED2EDD5BB4BA8BC34742960B7100",
+                    SecurityClearance: "ClusterNode",
+                    Permissions: {},
+                    NotAfter: moment()
+                        .add(2 as const, "years")
+                        .format(),
+                    NotBefore: moment()
+                        .add(-10 as const, "days")
+                        .format(),
+                    CollectionSecondaryKeys: [],
+                    CollectionPrimaryKey: "",
+                    PublicKeyPinningHash: "zyaqn9MDYitTWCf+oGwvu+GG9xqyxzZoZLANt5F/BL4=",
+                    HasTwoFactor: false,
+                },
             ],
             LoadedServerCert: "BCD2B71A3021A644E94768CCEFF7BE56E2006144",
+            LoadedServerCertForCommunication: "JF61904E1926ED2EDD5BB4BA8BC34742960B7100",
             WellKnownAdminCerts: ["AdminCerts1", "AdminCerts2"],
             WellKnownIssuers: ["Issuers1", "Issuers2"],
         };

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1076,8 +1076,9 @@ type CertificateDto = Partial<Raven.Client.ServerWide.Operations.Certificates.Ce
 type CertificatesResponseDto = {
     Certificates: CertificateDto[],
     LoadedServerCert: string,
+    LoadedServerCertForCommunication?: string,
     WellKnownAdminCerts: string[],
-    WellKnownIssuers: string[]
+    WellKnownIssuers: string[],
 }
 
 interface TrafficWatchPostgresChange extends Raven.Client.Documents.Changes.TrafficWatchChangeBase {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24908/Certificate-for-cluster-communication-must-not-be-edited-regenerated-or-deleted

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
