### PR TITLE
RavenDB-24028 Fixed empty lists and arrays handling

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1744,6 +1744,20 @@ namespace Raven.Client.Documents.Indexes
                         return node;
                     }
                     
+                    if (node.Method.DeclaringType == typeof(Enumerable) && node.Method.Name == "Empty")
+                    {
+                        var elementType = node.Type.GetGenericArguments()[0];
+                        
+                        if (CheckIfAnonymousType(elementType) == false && TypeExistsOnServer(elementType))
+                        {
+                            Out($"new {ConvertTypeToCSharpKeyword(elementType, out _)}[0]");
+                        }
+                        else
+                            Out("new DynamicArray(new dynamic[0])");
+
+                        return node;
+                    }
+                    
                     Out(node.Method.DeclaringType.Name);
                     Out(".");
                 }

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -2115,6 +2115,9 @@ namespace Raven.Client.Documents.Indexes
 
             bool IsCollection(Type type)
             {
+                if (type == typeof(string))
+                    return false;
+                
                 if (type.IsArray)
                     return true;
 

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
+using Type = System.Type;
 
 namespace Raven.Client.Documents.Indexes
 {
@@ -1731,6 +1732,18 @@ namespace Raven.Client.Documents.Indexes
                         return node; // we don't do casting on the server
                     }
 
+                    if (node.Method.DeclaringType == typeof(Array) && node.Method.Name == "Empty")
+                    {
+                        if (CheckIfAnonymousType(node.Type.GetElementType()) == false && TypeExistsOnServer(node.Type.GetElementType()))
+                        {
+                            Out($"new {ConvertTypeToCSharpKeyword(node.Type.GetElementType(), out _)}[0]");
+                        }
+                        else
+                            Out("new DynamicArray(new dynamic[0])");
+                        
+                        return node;
+                    }
+                    
                     Out(node.Method.DeclaringType.Name);
                     Out(".");
                 }
@@ -2025,6 +2038,10 @@ namespace Raven.Client.Documents.Indexes
                 VisitType(node.Type);
                 Out("(");
             }
+            else if (IsEmptyCollection(node))
+            {
+                Out("DynamicArray(new dynamic[0]");
+            }
             else
             {
                 Out("{");
@@ -2062,7 +2079,10 @@ namespace Raven.Client.Documents.Indexes
                 Visit(argument);
             }
 
-            Out(TypeExistsOnServer(node.Type) ? ")" : "}");
+            if (TypeExistsOnServer(node.Type) || IsEmptyCollection(node))
+                Out(")");
+            else
+                Out("}");
 
             return node;
 
@@ -2077,6 +2097,22 @@ namespace Raven.Client.Documents.Indexes
                 }
 
                 return isEnum;
+            }
+
+            bool IsCollection(Type type)
+            {
+                if (type.IsArray)
+                    return true;
+
+                if (typeof(System.Collections.IEnumerable).IsAssignableFrom(type))
+                    return true;
+
+                return false;
+            }
+
+            bool IsEmptyCollection(NewExpression node)
+            {
+                return IsCollection(node.Type) && node.Arguments.Count == 0;
             }
         }
 
@@ -2134,6 +2170,13 @@ namespace Raven.Client.Documents.Indexes
             switch (node.NodeType)
             {
                 case ExpressionType.NewArrayInit:
+                    if (node.Expressions.Count == 0 && TypeExistsOnServer(node.Type) == false)
+                    {
+                        Out("new DynamicArray(new dynamic[0])");
+                        
+                        return node;
+                    }
+                    
                     Out("new ");
                     OutputAppropriateArrayType(node);
                     Out("[]");
@@ -2141,6 +2184,17 @@ namespace Raven.Client.Documents.Indexes
                     return node;
 
                 case ExpressionType.NewArrayBounds:
+                    if (TypeExistsOnServer(node.Type) == false && node.Expressions.Any(exp => exp is ConstantExpression constantExpression && constantExpression.Value is int v && v == 0))
+                    {
+                        Out("new DynamicArray(new dynamic");
+                        
+                        VisitExpressions('[', node.Expressions, ']');
+                        
+                        Out(")");
+                        
+                        return node;
+                    }
+
                     if (TypeExistsOnServer(node.Type))
                         Out("new " + node.Type.GetElementType());
                     else

--- a/test/SlowTests/Issues/RavenDB-24028.cs
+++ b/test/SlowTests/Issues/RavenDB-24028.cs
@@ -26,6 +26,7 @@ public class RavenDB_24028 : RavenTestBase
             await store.ExecuteIndexAsync(new MyIndex());
             await store.ExecuteIndexAsync(new MyIndexKnownTypesArrays());
             await store.ExecuteIndexAsync(new MyIndexKnownTypesLists());
+            await store.ExecuteIndexAsync(new MyIndexKnownTypesEnumerables());
             
             using (var session = store.OpenSession())
             {
@@ -66,11 +67,15 @@ public class RavenDB_24028 : RavenTestBase
 
                 let e7 = document.AnyId != null ? AttachmentsFor(document) : new List<AttachmentName>()
                 let e8 = document.AnyId == null ? new List<AttachmentName>() : AttachmentsFor(document)
+                
+                let e9 = document.AnyId != null ? AttachmentsFor(document) : Enumerable.Empty<AttachmentName>()
+                let e10 = document.AnyId == null ? Enumerable.Empty<AttachmentName>() : AttachmentsFor(document)
 
-                let e9 = new AttachmentName[0]
-                let e10 = new AttachmentName[] { }
-                let e11 = Array.Empty<AttachmentName>()
-                let e12 = new List<AttachmentName>()
+                let e11 = new AttachmentName[0]
+                let e12 = new AttachmentName[] { }
+                let e13 = Array.Empty<AttachmentName>()
+                let e14 = new List<AttachmentName>()
+                let e15 = Enumerable.Empty<AttachmentName>()
 
                 select new
                 {
@@ -108,6 +113,15 @@ public class RavenDB_24028 : RavenTestBase
                         .Where(a => a.ContentType == "application/pdf")
                         .ToList(),
                     l12 = e12
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l13 = e13
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l14 = e13
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l15 = e15
                         .Where(a => a.ContentType == "application/pdf")
                         .ToList()
                 };
@@ -237,6 +251,39 @@ public class RavenDB_24028 : RavenTestBase
                 });
             
             StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class MyIndexKnownTypesEnumerables : AbstractMultiMapIndexCreationTask
+    {
+        public MyIndexKnownTypesEnumerables()
+        {
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId != null ? Enumerable.Repeat("abc", 1) : Enumerable.Empty<string>()
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId == null ? Enumerable.Empty<string>() : Enumerable.Repeat("abc", 1)
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = Enumerable.Empty<string>()
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-24028.cs
+++ b/test/SlowTests/Issues/RavenDB-24028.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24028 : RavenTestBase
+{
+    public RavenDB_24028(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task ArrayDoesNotContainDefinitionForWhere()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await store.ExecuteIndexAsync(new MyIndex());
+            await store.ExecuteIndexAsync(new MyIndexKnownTypesArrays());
+            await store.ExecuteIndexAsync(new MyIndexKnownTypesLists());
+            
+            using (var session = store.OpenSession())
+            {
+                session.Store(new TestDocument { Name = "Peter", AnyId = null });
+                session.SaveChanges();
+            }
+
+            await Indexes.WaitForIndexingAsync(store);
+
+            var indexes = await store.Maintenance.SendAsync(new GetIndexErrorsOperation());
+            var erroredIndexes = indexes
+                .Where(i => i.Errors.Any())
+                .ToList();
+
+            Assert.Empty(erroredIndexes);
+        }
+    }
+
+    private class TestDocument
+    {
+        public string Name { get; set; }
+        public string AnyId { get; set; }
+    }
+
+    private class MyIndex : AbstractIndexCreationTask<TestDocument>
+    {
+        public MyIndex()
+        {
+            Map = documents => from document in documents
+                let e1 = document.AnyId != null ? AttachmentsFor(document) : new AttachmentName[0]
+                let e2 = document.AnyId == null ? new AttachmentName[0] : AttachmentsFor(document)
+                
+                let e3 = document.AnyId != null ? AttachmentsFor(document) : new AttachmentName[] { }
+                let e4 = document.AnyId == null ? new AttachmentName[] { } : AttachmentsFor(document)
+                
+                let e5 = document.AnyId != null ? AttachmentsFor(document) : Array.Empty<AttachmentName>()
+                let e6 = document.AnyId == null ? Array.Empty<AttachmentName>() : AttachmentsFor(document)
+
+                let e7 = document.AnyId != null ? AttachmentsFor(document) : new List<AttachmentName>()
+                let e8 = document.AnyId == null ? new List<AttachmentName>() : AttachmentsFor(document)
+
+                let e9 = new AttachmentName[0]
+                let e10 = new AttachmentName[] { }
+                let e11 = Array.Empty<AttachmentName>()
+                let e12 = new List<AttachmentName>()
+
+                select new
+                {
+                    l1 = e1
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l2 = e2
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l3 = e3
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l4 = e4
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l5 = e5
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l6 = e6
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l7 = e7
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l8 = e8
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l9 = e9
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l10 = e10
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l11 = e11
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList(),
+                    l12 = e12
+                        .Where(a => a.ContentType == "application/pdf")
+                        .ToList()
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    private class MyIndexKnownTypesArrays : AbstractMultiMapIndexCreationTask
+    {
+        public MyIndexKnownTypesArrays()
+        {
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId != null ? new []{ "abc" } : new string[0]
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId == null ? new string[0] : new []{ "abc" }
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId != null ? new []{ "abc" } : new string[] { }
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId == null ? new string[] { } : new []{ "abc" }
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId != null ? new []{ "abc" } : Array.Empty<string>()
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId == null ? Array.Empty<string>() : new []{ "abc" }
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = new string[0]
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = new string[] { }
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = Array.Empty<string>()
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    private class MyIndexKnownTypesLists : AbstractMultiMapIndexCreationTask
+    {
+        public MyIndexKnownTypesLists()
+        {
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId != null ? new List<string>{ "abc" } : new List<string>()
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = document.AnyId == null ? new List<string>() : new List<string>{ "abc" }
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            AddMap<TestDocument>(documents => from document in documents
+                let e = new List<string>()
+                select new 
+                {
+                    l = e
+                        .Where(a => a.StartsWith("application/pdf"))
+                        .ToList(),
+                });
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24028/When-array-is-used-in-Index-definition-then-LINQ-extensions-are-not-working

### Additional description

This PR fixes handling of the following expressions for both server known and unknown types
```csharp
new AttachmentName[0]
new AttachmentName[] { }
Array.Empty<AttachmentName>()
new List<AttachmentName>()
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
