### PR TITLE
RavenDB-24960 added temperature to OpenAiSettings and AzureOpenAiSettings and set that to 0 in tests

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiConnectionString.cs
@@ -213,7 +213,7 @@ public sealed class AiConnectionString : ConnectionString
                (AbstractAiSettings)MistralAiSettings;
     }
 
-    internal bool TryGetParametersForGenAiTesting(out string uri, out string apiKey, out string model, out string organizationId, out string projectId, out bool? think, out double? temperature)
+    internal bool TryGetParameters(out string uri, out string apiKey, out string model, out string organizationId, out string projectId, out bool? think, out double? temperature)
     {
         uri = null;
         apiKey = null;
@@ -242,6 +242,13 @@ public sealed class AiConnectionString : ConnectionString
                 model = OpenAiSettings.Model;
                 organizationId = OpenAiSettings.OrganizationId;
                 projectId = OpenAiSettings.ProjectId;
+                temperature = OpenAiSettings.Temperature;
+                return true;
+            case AiConnectorType.AzureOpenAi:
+                uri = AzureOpenAiSettings.Endpoint;
+                apiKey = AzureOpenAiSettings.ApiKey;
+                model = AzureOpenAiSettings.Model;
+                temperature = AzureOpenAiSettings.Temperature;
                 return true;
             case AiConnectorType.Ollama:
                 uri = OllamaSettings.Uri; 

--- a/src/Raven.Client/Documents/Operations/AI/AzureOpenAiSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AzureOpenAiSettings.cs
@@ -5,7 +5,7 @@ namespace Raven.Client.Documents.Operations.AI;
 
 public sealed class AzureOpenAiSettings : OpenAiBaseSettings
 {
-    public AzureOpenAiSettings(string apiKey, string endpoint, string model, string deploymentName, int? dimensions = null) : base(apiKey, endpoint, model, dimensions)
+    public AzureOpenAiSettings(string apiKey, string endpoint, string model, string deploymentName, int? dimensions = null, double? temperature = null) : base(apiKey, endpoint, model, dimensions, temperature)
     {
         DeploymentName = deploymentName;
     }

--- a/src/Raven.Client/Documents/Operations/AI/OllamaSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OllamaSettings.cs
@@ -54,6 +54,9 @@ public sealed class OllamaSettings : AbstractAiSettings
 
         if (string.IsNullOrWhiteSpace(Model))
             errors.Add($"Value of `{nameof(Model)}` field cannot be empty.");
+        
+        if (Temperature is < 0d)
+            errors.Add($"Value of `{nameof(Temperature)}` field must be non-negative.");
     }
 
     public override AiSettingsCompareDifferences Compare(AbstractAiSettings other)

--- a/src/Raven.Client/Documents/Operations/AI/OpenAiBaseSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OpenAiBaseSettings.cs
@@ -1,17 +1,19 @@
 ﻿using System.Collections.Generic;
+using Sparrow.Extensions;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.AI;
 
 public abstract class OpenAiBaseSettings : AbstractAiSettings
 {
-    protected OpenAiBaseSettings(string apiKey, string endpoint, string model, int? dimensions = null)
+    protected OpenAiBaseSettings(string apiKey, string endpoint, string model, int? dimensions = null, double? temperature = null)
 
     {
         ApiKey = apiKey;
         Endpoint = endpoint;
         Model = model;
         Dimensions = dimensions;
+        Temperature = temperature;
     }
 
     protected OpenAiBaseSettings()
@@ -39,6 +41,13 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings
     /// </summary>
     public int? Dimensions { get; set; }
 
+    /// <summary>
+    /// Controls randomness of the model output. Range typically [0.0, 2.0].
+    /// Higher values (e.g., 1.0+) make output more creative and diverse; lower values (e.g., 0.2) make it more deterministic.
+    /// When null, the parameter is not sent.
+    /// </summary>
+    public double? Temperature { get; set; } = null;
+
     public override void ValidateFields(List<string> errors)
     {
         if (string.IsNullOrWhiteSpace(ApiKey))
@@ -52,6 +61,9 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings
 
         if (Dimensions is <= 0)
             errors.Add($"Value of `{nameof(Dimensions)}` field must be positive.");
+
+        if (Temperature is < 0d)
+            errors.Add($"Value of `{nameof(Temperature)}` field must be non-negative.");
     }
 
     public override AiSettingsCompareDifferences Compare(AbstractAiSettings other)
@@ -73,6 +85,10 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings
         if (Dimensions != openAiSettings.Dimensions)
             differences |= AiSettingsCompareDifferences.EmbeddingDimensions;
 
+        if (Temperature.HasValue != openAiSettings.Temperature.HasValue ||
+            (Temperature.HasValue && openAiSettings.Temperature.HasValue && Temperature.Value.AlmostEquals(openAiSettings.Temperature.Value) == false))
+            differences |= AiSettingsCompareDifferences.EndpointConfiguration;
+
         return differences;
     }
 
@@ -87,6 +103,8 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings
 
         if (Dimensions.HasValue)
             json[nameof(Dimensions)] = Dimensions.Value;
+
+        json[nameof(Temperature)] = Temperature;
 
         return json;
     }

--- a/src/Raven.Client/Documents/Operations/AI/OpenAiBaseSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OpenAiBaseSettings.cs
@@ -104,7 +104,8 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings
         if (Dimensions.HasValue)
             json[nameof(Dimensions)] = Dimensions.Value;
 
-        json[nameof(Temperature)] = Temperature;
+        if (Temperature.HasValue)
+            json[nameof(Temperature)] = Temperature;
 
         return json;
     }

--- a/src/Raven.Client/Documents/Operations/AI/OpenAiSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OpenAiSettings.cs
@@ -7,7 +7,7 @@ namespace Raven.Client.Documents.Operations.AI;
 /// </summary>
 public sealed class OpenAiSettings : OpenAiBaseSettings
 {
-    public OpenAiSettings(string apiKey, string endpoint, string model, string organizationId = null, string projectId = null, int? dimensions = null) : base(apiKey, endpoint, model, dimensions)
+    public OpenAiSettings(string apiKey, string endpoint, string model, string organizationId = null, string projectId = null, int? dimensions = null, double? temperature = null) : base(apiKey, endpoint, model, dimensions, temperature)
     {
         OrganizationId = organizationId;
         ProjectId = projectId;

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -69,7 +69,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
 
     public static ChatCompletionClient CreateChatCompletionClient(IMemoryContextPool contextPool, AiConnectionString connection)
     {
-        if (connection.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model, out var organizationId, out var projectId, out var think, out var temperature) == false)
+        if (connection.TryGetParameters(out var uri, out var apiKey, out var model, out var organizationId, out var projectId, out var think, out var temperature) == false)
         {
             var connectorType = connection.GetActiveProvider();
             throw new NotSupportedException($"The specified provider (\"{connectorType.ToString()}\") is not supported.");

--- a/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
@@ -352,10 +352,12 @@ namespace Raven.Server.Web.Studio
                         apiKey = request.OpenAiSettings.ApiKey;
                         organization = request.OpenAiSettings.OrganizationId;
                         project = request.OpenAiSettings.ProjectId;
+                        temperature = request.OpenAiSettings.Temperature;
                         break;
                     case AiConnectorType.AzureOpenAi:
                         uri = request.AzureOpenAiSettings.Endpoint;
                         apiKey = request.AzureOpenAiSettings.ApiKey;
+                        temperature = request.AzureOpenAiSettings.Temperature;
                         break;
                     case AiConnectorType.Ollama:
                         uri = request.OllamaSettings.Uri;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
@@ -110,7 +110,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             protected override ChatCompletionClient CreateClient(AiConnectionString connection)
             {
-                if (connection.TryGetParametersForGenAiTesting(out var uri, out var apiKey, out var model, out var organizationId, out var projectId, out var think, out var temperature) ==
+                if (connection.TryGetParameters(out var uri, out var apiKey, out var model, out var organizationId, out var projectId, out var think, out var temperature) ==
                     false)
                 {
                     var connectorType = connection.GetActiveProvider();

--- a/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
@@ -14,7 +14,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
     {
         RequiredEnvironmentVariables = [EnvironmentVariableApiKey, EnvironmentVariableDeploymentEndpoint, EnvironmentVariableDeploymentName];
     }
-    
+
     public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.AzureOpenAi);
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
@@ -26,7 +26,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
         return new AiConnectionString
         {
             ModelType = AiModelType.TextEmbeddings,
-            AzureOpenAiSettings = new AzureOpenAiSettings(apiKey, endpoint, Model, deploymentName)
+            AzureOpenAiSettings = new AzureOpenAiSettings(apiKey, endpoint, Model, deploymentName) { Temperature = 0 }
         };
     }
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -41,7 +41,7 @@ internal static class OpenAiConnectorHelper
         return new AiConnectionString
         {
             ModelType = modelType,
-            OpenAiSettings = new OpenAiSettings(apiKey, Endpoint, model)
+            OpenAiSettings = new OpenAiSettings(apiKey, Endpoint, model) { Temperature = 0 }
         };
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24960

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
