### PR TITLE
RavenDB-22048 - Fix for `StressTests.Issues.RavenDB_13987.ServerWideBackupShouldNotWakeupIdleDatabases`

### DIFF
--- a/test/StressTests/Issues/RavenDB-13987.cs
+++ b/test/StressTests/Issues/RavenDB-13987.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
@@ -21,10 +22,7 @@ namespace StressTests.Issues
 {
     public class RavenDB_13987 : ReplicationTestBase
     {
-        private long _taskId;
-        private string _databaseName;
         private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromSeconds(60 * 10) : TimeSpan.FromSeconds(60 * 5);
-        private List<RavenServer> _nodes;
 
         public RavenDB_13987(ITestOutputHelper output) : base(output)
         {
@@ -36,84 +34,105 @@ namespace StressTests.Issues
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
             const int clusterSize = 3;
-            _databaseName = GetDatabaseName();
+            var databaseName = GetDatabaseName();
+            Dictionary<string, DocumentStore> documentStores = new();
+            Dictionary<string, PeriodicBackupStatus> perNodeBackupStatuses;
 
-            var cluster = await CreateRaftCluster(numberOfNodes: clusterSize, shouldRunInMemory: false, customSettings: new Dictionary<string, string>()
+            (List<RavenServer> nodes, RavenServer leaderNode) = await CreateRaftCluster(numberOfNodes: clusterSize, shouldRunInMemory: false, customSettings: new Dictionary<string, string>()
             {
-                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "10",
-                [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
-                [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "300",
-                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "20",
                 [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3"
             });
 
-            _nodes = cluster.Nodes;
-            try
+            using var dispose = new DisposableAction(() =>
             {
-                foreach (var server in _nodes)
-                {
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
-                }
-
-                using (var store = GetDocumentStore(new Options
-                {
-                    ModifyDatabaseName = s => _databaseName,
-                    ReplicationFactor = clusterSize,
-                    Server = cluster.Leader,
-                    RunInMemory = false
-                }))
-                {
-                    using (var s = store.OpenAsyncSession())
-                    {
-                        await s.StoreAsync(new User() { Name = "Egor" }, "foo/bar");
-                        await s.SaveChangesAsync();
-                    }
-
-                    var idleCount = WaitForCount(_reasonableWaitTime, 3, GetIdleCount);
-
-                    Assert.Equal(3, idleCount);
-
-                    var putConfiguration = new ServerWideBackupConfiguration
-                    {
-                        FullBackupFrequency = "*/1 * * * *",
-                        IncrementalBackupFrequency = "*/1 * * * *",
-                        LocalSettings = new LocalSettings { FolderPath = backupPath },
-                    };
-                    var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
-                    var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
-                    Assert.NotNull(serverWideConfiguration);
-                    var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-
-                    var backups1 = record1.PeriodicBackups;
-                    _taskId = backups1.First().TaskId;
-                    Assert.Equal(_taskId, serverWideConfiguration.TaskId);
-                    Assert.Equal(1, backups1.Count);
-                    Assert.Equal(3, GetIdleCount());
-
-                    // wait for the backup occurrence
-                    idleCount = WaitForCount(_reasonableWaitTime, 2, GetIdleCount);
-                    Assert.Equal(2, idleCount);
-
-                    var reasons = new Dictionary<string, string>();
-                    // backup status should not wakeup dbs
-                    var count = WaitForCount(_reasonableWaitTime, 3, () => CountOfBackupStatus(out reasons));
-                    
-                    var sb = new StringBuilder();
-                    foreach (var kvp in reasons)
-                    {
-                        sb.AppendLine($"Node {kvp.Key}, backup status:{Environment.NewLine}{kvp.Value}");
-                        sb.AppendLine();
-                    }
-                    Assert.True(3 == count, $"3 == count{Environment.NewLine}{sb.ToString()}");
-                }
-            }
-            finally
-            {
-                foreach (var server in _nodes)
+                foreach (var server in nodes)
                 {
                     server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
+                    documentStores[server.ServerStore.NodeTag].Dispose();
                 }
+            });
+
+            foreach (var server in nodes)
+            {
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
+            }
+
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderNode.WebUrl);
+            var storeCreationOptions = new Options
+            {
+                Server = leaderNode,
+                ModifyDocumentStore = s => s.Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                ModifyDatabaseName = s => databaseName,
+                RunInMemory = false,
+                CreateDatabase = false
+            };
+
+            foreach (var server in nodes)
+            {
+                storeCreationOptions.Server = server;
+                documentStores[server.ServerStore.NodeTag] = GetDocumentStore(storeCreationOptions);
+            }
+
+            while (DateTime.Now.Second > 10)
+                await Task.Delay(1_000);
+
+            using (var session = documentStores[leaderNode.ServerStore.NodeTag].OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Egor" }, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            await WaitAndAssertForValueAsync(IdleCount, expectedVal: 3, timeout: (int)_reasonableWaitTime.TotalMilliseconds, interval: 1_000);
+
+            var putConfiguration = new ServerWideBackupConfiguration
+            {
+                FullBackupFrequency = "* * * * *",
+                LocalSettings = new LocalSettings { FolderPath = backupPath },
+            };
+
+            // Check if put server wide backup configuration will wake up the database
+            var putServerWideBackupConfigurationResponse = await documentStores[leaderNode.ServerStore.NodeTag].Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+            var serverWideConfiguration = await documentStores[leaderNode.ServerStore.NodeTag].Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(putServerWideBackupConfigurationResponse.Name));
+            Assert.NotNull(serverWideConfiguration);
+            var databaseRecord = await documentStores[leaderNode.ServerStore.NodeTag].Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(documentStores[leaderNode.ServerStore.NodeTag].Database));
+
+            var periodicBackups = databaseRecord.PeriodicBackups;
+            long taskId = periodicBackups.First().TaskId;
+            Assert.Equal(taskId, serverWideConfiguration.TaskId);
+            Assert.Equal(1, periodicBackups.Count);
+            Assert.Equal(3, IdleCount());
+
+            // wait for the backup occurrence
+            Assert.True(3 == await WaitForValueAsync(() =>
+            {
+                perNodeBackupStatuses = new Dictionary<string, PeriodicBackupStatus>();
+                foreach ((string nodeTag, DocumentStore store) in documentStores)
+                {
+                    var status = store.Maintenance.Send(new GetPeriodicBackupStatusOperation(taskId)).Status;
+                    perNodeBackupStatuses[nodeTag] = status;
+                }
+
+                return perNodeBackupStatuses.Values.Count(status => status?.LastFullBackup != null);
+            },
+                expectedVal: 3, timeout: 75_000, interval: 1_000), userMessage: CollectDiagnostics());
+
+            Assert.Equal(2, IdleCount());
+
+            return;
+            int IdleCount() => nodes.Sum(server => server.ServerStore.IdleDatabases.Count);
+            string CollectDiagnostics()
+            {
+                var sb = new StringBuilder();
+                foreach ((string nodeTag, DocumentStore store) in documentStores)
+                {
+                    var status = store.Maintenance.Send(new GetPeriodicBackupStatusOperation(taskId)).Status;
+                    sb.AppendLine($"Node `{nodeTag}`, backup status:{Environment.NewLine}{BackupTestBase.PrintBackupStatusAndResult(status, result: null)}");
+                    sb.AppendLine();
+                }
+                return sb.ToString();
             }
         }
 
@@ -194,29 +213,8 @@ namespace StressTests.Issues
             return count;
         }
 
-        private int CountOfBackupStatus(out Dictionary<string, string> reasons)
-        {
-            reasons = new Dictionary<string, string>();
-            var count = 0;
-            Assert.Equal(3, _nodes.Count);
-            foreach (var server in _nodes)
-            {
-                using (var store = new DocumentStore { Urls = new[] { server.WebUrl }, Conventions = { DisableTopologyUpdates = true }, Database = _databaseName }.Initialize())
-                {
-                    var status = store.Maintenance.Send(new GetPeriodicBackupStatusOperation(_taskId)).Status;
-                    reasons.Add(server.ServerStore.NodeTag, BackupTestBase.PrintBackupStatusAndResult(status, result: null));
 
-                    if (status?.LastFullBackup != null)
-                        count++;
-                }
-            }
 
-            return count;
-        }
 
-        private int GetIdleCount()
-        {
-            return _nodes.Sum(server => server.ServerStore.IdleDatabases.Count);
-        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22048

### Additional description

The test failed because, by the time we waited for the database to enter an idle state on all three nodes, we had already made a backup. In that case, no additional database wake-ups could occur.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed