### PR TITLE
RavenDB-22224: flaky test adjustments 

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -93,9 +93,12 @@ loadTo(""Orders"", partitionBy(key),
                 }
 
                 // delete task
-                store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
+                var deleteTaskResult = store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
                 var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(result.TaskId, OngoingTaskType.OlapEtl));
                 Assert.Null(ongoingTask);
+
+                // wait for RemoveEtlProcessStateCommand to complete (executed after DeleteOngoingTaskCommand)
+                await Server.ServerStore.Cluster.WaitForIndexNotification(deleteTaskResult.RaftCommandIndex + 1);
 
                 using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22224/SlowTests.Server.Documents.ETL.Olap.RavenDB18465.EtlProcessStateShouldBeDeletedAfterTaskRemovaloptions-DatabaseMode-Sharded

### Additional description

wait for `RemoveEtlProcessStateCommand` to complete (it's executed after the `DeleteOngoingTaskCommand`) before asserting that the process state is deleted from storage 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
