### PR TITLE
RavenDB-21427 fix test Prevent_Put_Dynamic_Node_Distribution

### DIFF
--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -32,6 +32,7 @@ using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands.Cluster;
+using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
@@ -1069,7 +1070,7 @@ public class MyAnalyzer2 : Analyzer
         public async Task Prevent_Put_Dynamic_Node_Distribution()
         {
             DoNotReuseServer();
-            var (_, leader) = await CreateRaftCluster(3);
+            var (nodes, leader) = await CreateRaftCluster(3);
             var options = Options.ForMode(RavenDatabaseMode.Sharded);
             options.Server = leader;
             options.ModifyDatabaseRecord = record =>
@@ -1084,6 +1085,29 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore(options))
             {
+                await WaitForValueAsync(async () =>
+                {
+                    var sum = 0;
+                    foreach (var node in nodes)
+                    {
+                        using var perNodeStore = new DocumentStore
+                        {
+                            Urls = new[] { node.WebUrl },
+                            Database = store.Database,
+                            Conventions = store.Conventions
+                        }.Initialize();
+
+                        var recored = await perNodeStore.Maintenance.Server.SendAsync(
+                            new GetDatabaseRecordOperation(store.Database));
+
+                        if (recored.Topology.DynamicNodesDistribution)
+                            sum++;
+                    }
+                    return sum;
+                }, 3, timeout: 30_000);
+
+
+
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                 {
                     await PutLicense(leader, RL_COMM);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21427

### Additional description

fix test

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
