### PR TITLE
RavenDB-20854 - Fix for `SlowTests.Issues.RavenDB_20150.CompareExchangeTombstoneWillBeCleanedOnlyWhenAllNodesHaveBackedUpPreviousOnes`

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20150.cs
+++ b/test/SlowTests/Issues/RavenDB_20150.cs
@@ -63,6 +63,7 @@ public class RavenDB_20150 : ClusterTestBase
             //run periodic backup on other database server
             var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 * *");
             var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+            await Cluster.WaitForRaftIndexToBeAppliedOnClusterNodesAsync(result.TaskId, databaseServers, timeout: TimeSpan.FromSeconds(10));
 
             foreach (var dbServer in databaseServers)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20854

### Additional description

We need to wait until the backup configuration is present on all the cluster nodes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed