### PR TITLE
RavenDB-22142 Adress rest of the origin PR comments

### DIFF
--- a/src/Raven.Client/Documents/Operations/SchemaValidation/SchemaDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/SchemaDefinition.cs
@@ -3,11 +3,11 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.SchemaValidation;
 
-public class SchemaValidator
+public class SchemaDefinition
 {
     public bool Disabled { get; set; }
 
-    public string SchemaDefinition { get; set; }
+    public string Schema { get; set; }
 
     public DateTime LastModifiedTime { get; } = DateTime.UtcNow;
 
@@ -16,7 +16,7 @@ public class SchemaValidator
         return new DynamicJsonValue
         {
             [nameof(Disabled)] = Disabled,
-            [nameof(SchemaDefinition)] = SchemaDefinition,
+            [nameof(Schema)] = Schema,
             [nameof(LastModifiedTime)] = LastModifiedTime
         };
     }

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/SchemaValidationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/SchemaValidationConfiguration.cs
@@ -6,14 +6,14 @@ namespace Raven.Client.Documents.Operations.SchemaValidation;
 
 public sealed class SchemaValidationConfiguration
 {
-    private Dictionary<string, SchemaValidator> _validatorsPerCollection;
+    private Dictionary<string, SchemaDefinition> _validatorsPerCollection;
     
     public bool Disabled { get; set; }
 
-    public Dictionary<string, SchemaValidator> ValidatorsPerCollection
+    public Dictionary<string, SchemaDefinition> ValidatorsPerCollection
     {
         get => _validatorsPerCollection;
-        set => _validatorsPerCollection = new Dictionary<string, SchemaValidator>(value, StringComparer.OrdinalIgnoreCase);
+        set => _validatorsPerCollection = new Dictionary<string, SchemaDefinition>(value, StringComparer.OrdinalIgnoreCase);
     }
 
     public DynamicJsonValue ToJson()

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -42,17 +42,17 @@ public class SchemaValidatorCache : IDisposable
 
         Dictionary<string, SchemaValidator> newSchemaValidators = null;
         
-        foreach ((string collection, Client.Documents.Operations.SchemaValidation.SchemaValidator validator) in configuration.ValidatorsPerCollection)
+        foreach ((string collection, Client.Documents.Operations.SchemaValidation.SchemaDefinition validator) in configuration.ValidatorsPerCollection)
         {
             if (_schemaValidatorsPerCollection.TryGetValue(collection, out var existingValidator)
-                && validator.SchemaDefinition.Equals(existingValidator.SchemaDefinition))
+                && validator.Schema.Equals(existingValidator.SchemaDefinition))
                 continue;
 
-            var schemaValidator = new SchemaValidator(validator.Disabled) { SchemaDefinition = validator.SchemaDefinition };
+            var schemaValidator = new SchemaValidator(validator.Disabled) { SchemaDefinition = validator.Schema };
 
             try
             {
-                var blittable = _context.Value.Sync.ReadForMemory(validator.SchemaDefinition, "schema-validation");
+                var blittable = _context.Value.Sync.ReadForMemory(validator.Schema, "schema-validation");
                 EnsureMetadataIsValid(ref blittable);
                 schemaValidator.Init(blittable);
             }

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -66,7 +66,6 @@ namespace Sparrow.Json
             using (var writer = new BlittableJsonTextWriter(_context, stream))
             {
                 writer.WriteObject(this);
-                writer.Flush();
             }
         }
         

--- a/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
@@ -24,11 +24,11 @@ public class SchemaValidationBasicTests : RavenTestBase
         {
             await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(new SchemaValidationConfiguration
             {
-                ValidatorsPerCollection = new Dictionary<string, SchemaValidator>()
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>()
                 {
-                    {"Users", new SchemaValidator
+                    {"Users", new SchemaDefinition
                     {
-                        SchemaDefinition = schemaData
+                        Schema = schemaData
                     }}
                 }
             }));

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -27,7 +27,6 @@ using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
-using SchemaValidator = Raven.Client.Documents.Operations.SchemaValidation.SchemaValidator;
 using SVC = Raven.Server.Documents.SchemaValidation.SchemaValidatorConstants;
 
 namespace SlowTests.SchemaValidation;
@@ -71,10 +70,10 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         Assert.ThrowsAny<ArgumentException>(() => _ = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator() },
-                { "testobjs", new SchemaValidator() },
+                { "TestObjs", new SchemaDefinition() },
+                { "testobjs", new SchemaDefinition() },
             }
         });
 
@@ -123,9 +122,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -158,9 +157,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -192,9 +191,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -234,9 +233,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -271,9 +270,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -317,9 +316,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await source.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -352,9 +351,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -386,9 +385,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await source.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -432,9 +431,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -499,9 +498,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -549,9 +548,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -602,9 +601,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -649,9 +648,9 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
             {
-                { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -264,9 +264,9 @@ namespace SlowTests.Smuggler
                     var configuration = new SchemaValidationConfiguration
                     {
                         Disabled = false,
-                        ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+                        ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
                         {
-                            { "TestObjs", new SchemaValidator { SchemaDefinition = "{\"properties\":{\"Prop\":{\"maxLength\":3}}}" } }
+                            { "TestObjs", new SchemaDefinition { Schema = "{\"properties\":{\"Prop\":{\"maxLength\":3}}}" } }
                         }
                     };
                     await store1.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -354,7 +354,7 @@ namespace SlowTests.Smuggler
                     Assert.NotNull(record.SchemaValidation);
                     Assert.False(record.SchemaValidation.Disabled);
                     Assert.True(record.SchemaValidation.ValidatorsPerCollection.ContainsKey("TestObjs"));
-                    Assert.NotNull(record.SchemaValidation.ValidatorsPerCollection["TestObjs"].SchemaDefinition);                    
+                    Assert.NotNull(record.SchemaValidation.ValidatorsPerCollection["TestObjs"].Schema);                    
                 }
             }
             finally
@@ -1015,17 +1015,17 @@ namespace SlowTests.Smuggler
 
                     await store1.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(new SchemaValidationConfiguration
                     {
-                        ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+                        ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
                         {
-                            { "TestObjs", new SchemaValidator { SchemaDefinition = "{\"properties\":{\"Prop\":{\"maxLength\":3}}}" } }
+                            { "TestObjs", new SchemaDefinition { Schema = "{\"properties\":{\"Prop\":{\"maxLength\":3}}}" } }
                         }
                     }));
                         
                     await store2.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(new SchemaValidationConfiguration
                     {
-                        ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+                        ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
                         {
-                            { "TestObj2s", new SchemaValidator { SchemaDefinition = "{\"properties\":{\"Prop2\":{\"maxLength\":3}}}" } }
+                            { "TestObj2s", new SchemaDefinition { Schema = "{\"properties\":{\"Prop2\":{\"maxLength\":3}}}" } }
                         }
                     }));
                     
@@ -1145,9 +1145,9 @@ namespace SlowTests.Smuggler
                     Assert.NotNull(record.SchemaValidation.ValidatorsPerCollection);
                     Assert.Equal(2, record.SchemaValidation.ValidatorsPerCollection.Count);
                     Assert.True(record.SchemaValidation.ValidatorsPerCollection.ContainsKey("TestObjs"));
-                    Assert.Equal("{\"properties\":{\"Prop\":{\"maxLength\":3}}}", record.SchemaValidation.ValidatorsPerCollection["TestObjs"].SchemaDefinition);
+                    Assert.Equal("{\"properties\":{\"Prop\":{\"maxLength\":3}}}", record.SchemaValidation.ValidatorsPerCollection["TestObjs"].Schema);
                     Assert.True(record.SchemaValidation.ValidatorsPerCollection.ContainsKey("TestObj2s"));
-                    Assert.Equal("{\"properties\":{\"Prop2\":{\"maxLength\":3}}}", record.SchemaValidation.ValidatorsPerCollection["TestObj2s"].SchemaDefinition);
+                    Assert.Equal("{\"properties\":{\"Prop2\":{\"maxLength\":3}}}", record.SchemaValidation.ValidatorsPerCollection["TestObj2s"].Schema);
                 }
             }
             finally
@@ -1372,9 +1372,9 @@ namespace SlowTests.Smuggler
                     var configuration = new SchemaValidationConfiguration
                     {
                         Disabled = false,
-                        ValidatorsPerCollection = new Dictionary<string, SchemaValidator>
+                        ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
                         {
-                            { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition.ToString() } }
+                            { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
                         }
                     };
                     await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -1505,7 +1505,7 @@ namespace SlowTests.Smuggler
                     Assert.NotNull(record.SchemaValidation);
                     Assert.False(record.SchemaValidation.Disabled);
                     Assert.True(record.SchemaValidation.ValidatorsPerCollection.ContainsKey("TestObjs"));
-                    Assert.NotNull(record.SchemaValidation.ValidatorsPerCollection["TestObjs"].SchemaDefinition);
+                    Assert.NotNull(record.SchemaValidation.ValidatorsPerCollection["TestObjs"].Schema);
                 }
             }
         }


### PR DESCRIPTION
https://github.com/ravendb/ravendb/pull/19307#discussion_r2289173603
https://github.com/ravendb/ravendb/pull/19307#discussion_r2289173974
https://github.com/ravendb/ravendb/pull/19307#discussion_r2289212007

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22142

### Additional description
https://github.com/ravendb/ravendb/pull/19307#issue-2534217209

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
