### PR TITLE
RavenDB-24856 - Add debug info, and delete garbage from exception message on GetResponseContentAsync

### DIFF
--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI
 {
@@ -30,6 +32,22 @@ namespace Raven.Server.Documents.AI
         }
         public UnexpectedResponseException(string message, Exception e) : base(message, e)
         {
+        }
+
+        public static UnexpectedResponseException Create(string message, HttpResponseMessage response, BlittableJsonReaderObject content, Exception e = null)
+            => Create(message, response, content.ToString(), e);
+
+        public static UnexpectedResponseException Create(string message, HttpResponseMessage response, string content, Exception e = null)
+        {
+            return new UnexpectedResponseException(
+                $"{message}.{Environment.NewLine}" +
+                $"Status Code: {response.StatusCode}{Environment.NewLine}" +
+                $"Response:{Environment.NewLine}{response}{Environment.NewLine}" +
+                $"Content:{Environment.NewLine}{content}",
+                e)
+            {
+                RequestId = ChatCompletionClient.GetRequestId(response.Headers)
+            };
         }
     }
 

--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI
@@ -39,12 +40,13 @@ namespace Raven.Server.Documents.AI
 
         public static UnexpectedResponseException Create(string message, HttpResponseMessage response, string content, Exception e = null)
         {
-            return new UnexpectedResponseException(
-                $"{message}.{Environment.NewLine}" +
-                $"Status Code: {response.StatusCode}{Environment.NewLine}" +
-                $"Response:{Environment.NewLine}{response}{Environment.NewLine}" +
-                $"Content:{Environment.NewLine}{content}",
-                e)
+            var sb = new StringBuilder();
+            sb.Append(message).AppendLine(".")
+                .Append("Status Code: ").Append(response.StatusCode).AppendLine()
+                .AppendLine("Response:").AppendLine(response.ToString())
+                .AppendLine("Content:").AppendLine(content);
+
+            return new UnexpectedResponseException(sb.ToString(), e)
             {
                 RequestId = ChatCompletionClient.GetRequestId(response.Headers)
             };

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -369,7 +369,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         {
             if (responseContent.TryGet(Constants.ResponseFields.Choices, out BlittableJsonReaderArray choices) == false || choices.Length == 0)
             {
-                throw new UnexpectedResponseException("No choices in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+                throw UnexpectedResponseException.Create(message: "No choices in response", response, responseContent);
             }
 
             _choice0 = (BlittableJsonReaderObject)choices[0];
@@ -377,11 +377,11 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             if (_choice0.TryGet(Constants.ResponseFields.Message, out Message) == false ||
                 Message.TryGet(Constants.ResponseFields.Content, out _content) == false)
             {
-                throw new UnexpectedResponseException("No message/content property in choice: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+                throw UnexpectedResponseException.Create(message: "No message/content property in choice", response, responseContent);
             }
 
             if (responseContent.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject usageJson) == false)
-                throw new UnexpectedResponseException("No choices property in response: " + responseContent) { RequestId = GetRequestId(response.Headers) };
+                throw UnexpectedResponseException.Create(message: "No usage in response content", response, responseContent);
 
             usage.UpdateFrom(usageJson);
         }
@@ -401,10 +401,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                     call.TryGet(Constants.ResponseFields.Function, out BlittableJsonReaderObject function) is false ||
                     function.TryGet(Constants.ResponseFields.Name, out string name) is false ||
                     function.TryGet(Constants.ResponseFields.Arguments, out string args) is false)
-                    throw new UnexpectedResponseException("Invalid function call: " + call)
-                    {
-                        RequestId = GetRequestId(response.Headers)
-                    };
+                    throw UnexpectedResponseException.Create(message: "Invalid function call: " + call, response, responseContent);
                 toolCalls.Add(new AiToolCall(callId, name, args));
             }
 
@@ -613,6 +610,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
             await responseStream.CopyToAsync(ms, token);
+            var contentLength = (int)ms.Position;
             ms.Position = 0;
             try
             {
@@ -621,11 +619,8 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
             catch (Exception e)
             {
                 ms.Position = 0;
-                string content = Encoding.UTF8.GetString(ms.GetMemory().Span);
-                throw new UnexpectedResponseException($"Got unrecognized response from the server: {content}. {response.StatusCode}", e)
-                {
-                    RequestId = GetRequestId(response.Headers)
-                };
+                string content = Encoding.UTF8.GetString(ms.GetMemory().Span[..contentLength]);
+                throw UnexpectedResponseException.Create(message: "Received an unrecognized response from the server", response, content, e);
             }
         }
     }
@@ -637,20 +632,14 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         var reqId = GetRequestId(headers);
 
         if (responseContent.TryGet(Constants.ResponseFields.Error, out BlittableJsonReaderObject errBjo) is false || errBjo.TryGet(Constants.ResponseFields.Message, out string message) is false)
-            throw new UnexpectedResponseException("Unexpected response: " + responseContent)
-            {
-                RequestId = reqId
-            };
+            throw UnexpectedResponseException.Create(message: "Unexpected response", response, responseContent);
 
         switch (response.StatusCode)
         {
             case HttpStatusCode.TooManyRequests:
 
                 if (errBjo.TryGet(Constants.ResponseFields.ErrorType, out string type) == false)
-                    throw new UnexpectedResponseException($"No type specified (status {HttpStatusCode.TooManyRequests}): " + responseContent)
-                    {
-                        RequestId = reqId
-                    };
+                    throw UnexpectedResponseException.Create(message: "No type specified", response, responseContent);
 
                 switch (type)
                 {
@@ -711,7 +700,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         }
     }
 
-    private static string GetRequestId(HttpResponseHeaders headers)
+    internal static string GetRequestId(HttpResponseHeaders headers)
     {
         if (headers.TryGetValues(Constants.Headers.RequestId, out var values) == false || values.IsNullOrEmpty())
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Extensions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -284,13 +285,29 @@ public class AiAgentErrors : RavenTestBase
 
     private class QuestionOutputSchema
     {
-        public static QuestionOutputSchema Instance = new();
+        public static QuestionOutputSchema Instance = new()
+        {
+            Answer = "Combined answer of the answers for the questions ",
+            RefusedToAnswer = false,
+            RelevantQuestionsIds = ["The questions ids relevant to the query or response"]
+        };
 
-        public string Answer = "Combined answer of the answers for the questions ";
+        public string Answer;
 
-        public bool RefusedToAnswer = false;
+        public bool RefusedToAnswer;
 
-        public List<string> RelevantQuestionsIds = ["The questions ids relevant to the query or response"];
+        public List<string> RelevantQuestionsIds;
+
+        public override string ToString()
+        {
+            var s = $"Answer: {Answer}, RefusedToAnswer: {RefusedToAnswer}";
+            if (RelevantQuestionsIds.IsNullOrEmpty() == false)
+            {
+                s += $", RelevantQuestionsIds: {string.Join(",", RelevantQuestionsIds)}";
+            }
+            return s;
+        }
+
     }
 
     private class Question
@@ -360,7 +377,7 @@ public class AiAgentErrors : RavenTestBase
         var aviv = r.Answer;
         Assert.Equal(AiConversationResult.Done, r.Status);
         Assert.NotNull(aviv.Answer);
-        Assert.False(aviv.RefusedToAnswer);
+        Assert.False(aviv.RefusedToAnswer, aviv.ToString());
 
         chat.SetUserPrompt("Can you answer Karmel questions?");
         r = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
@@ -368,7 +385,7 @@ public class AiAgentErrors : RavenTestBase
         var karmel = r.Answer;
         Assert.Equal(AiConversationResult.Done, r.Status);
         Assert.NotNull(karmel.Answer);
-        Assert.False(karmel.RefusedToAnswer);
+        Assert.False(karmel.RefusedToAnswer, karmel.ToString());
 
         chat.SetUserPrompt("Can you answer Shahar questions?");
         r = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
@@ -376,7 +393,7 @@ public class AiAgentErrors : RavenTestBase
         var shahar = r.Answer;
         Assert.Equal(AiConversationResult.Done, r.Status);
         Assert.NotNull(shahar.Answer);
-        Assert.True(shahar.RefusedToAnswer);
+        Assert.True(shahar.RefusedToAnswer, shahar.ToString());
     }
 
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -239,7 +239,7 @@ public class AiAgentErrors : RavenTestBase
 
         // Raven.Client.Exceptions.RavenException: Raven.Server.Documents.AI.UnsuccessfulRequestException: The model `gpt-4oxyz` does not exist or you do not have access to it
         var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<CustomerOutputSchema>(CancellationToken.None));
-        Assert.Contains("The model `gpt-4oxyz` does not exist or you do not have access to it", e.Message);
+        Assert.Contains($"The model `{config.Connection.OpenAiSettings.Model}` does not exist or you do not have access to it", e.Message);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]


### PR DESCRIPTION
RavenDB-24856, RavenDB-24857, RavenDB-24879

### Issue links

https://issues.hibernatingrhinos.com/issue/RavenDB-24856/SlowTests.Server.Documents.AI.AiAgent.AiAgentClientApiBasics.ThrowConcurrencyExceptionoptions-DatabaseMode-Single-config

https://issues.hibernatingrhinos.com/issue/RavenDB-24857/SlowTests.Server.Documents.AI.AiAgent.RavenDB24407.CanResumeConversationWithSummarizationoptions-DatabaseMode-Single-config

https://issues.hibernatingrhinos.com/issue/RavenDB-24879/SlowTests.Server.Documents.AI.AiAgent.AiAgentErrors.RefusedChatoptions-DatabaseMode-Single-config-OpenAiAiIntegrationTask

### Additional description

Add debug info (for tests next failures) - issues: RavenDB-24856, RavenDB-24857, RavenDB-24879.
and delete garbage from the exception message on GetResponseContentAsync.
fix failing test 'AiAgentErrors.BadModel'

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
