### PR TITLE
RavenDB-24929 : fixed failing test for AI Agent

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             var chat = store.AI.Conversation(agentId, "chats/", creationOptions: null);
             chat.OnUnhandledAction += args => Task.CompletedTask;
-            chat.SetUserPrompt("recommend me what to eat for launch, based on my recent orders and tell me where to but it from based on the restaurant I have ordered from");
+            chat.SetUserPrompt("run the tool and tell me where did I ordered pizza margarita from?");
             var result = await chat.RunAsync<ChefOutputSchema>(CancellationToken.None);
 
             if (result.Status == AiConversationResult.ActionRequired)
@@ -82,7 +82,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             }
 
             Assert.Equal(AiConversationResult.Done, result.Status);
-            Assert.NotNull(result.Answer);
+            Assert.Contains("Pizza Hat".ToLower(), result.Answer.Answer.ToString().ToLower());
         }
 
         [RavenTheory(RavenTestCategory.Ai)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24929/SlowTests.Server.Documents.AI.AiAgent.RavenDB24611.CanPassNestedObjectAsActionResponseoptions-DatabaseMode-Single-config

### Additional description

Changed the test to align with the recent changes to the client API.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
