### PR TITLE
RavenDB-14341 - Add XML documentation to core public classes and methods

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -3,22 +3,38 @@ using Raven.Client.Documents.Indexes.Vector;
 
 namespace Raven.Client
 {
+    /// <summary>
+    /// Contains constants used throughout the RavenDB client library.
+    /// This static class provides categorized collections of constants for various RavenDB operations.
+    /// </summary>
     public static class Constants
     {
+        /// <summary>
+        /// Contains constants related to JSON processing and serialization.
+        /// </summary>
         public sealed class Json
         {
             private Json()
             {
             }
 
+            /// <summary>
+            /// Contains field names used in JSON serialization.
+            /// </summary>
             public sealed class Fields
             {
                 private Fields()
                 {
                 }
 
+                /// <summary>
+                /// The JSON field name used to specify the type information for polymorphic serialization.
+                /// </summary>
                 public const string Type = "$type";
 
+                /// <summary>
+                /// The JSON field name used to specify values in JSON collections.
+                /// </summary>
                 public const string Values = "$values";
             }
         }
@@ -34,62 +50,140 @@ namespace Raven.Client
             public const string ShardNumber = "shardNumber";
         }
 
+        /// <summary>
+        /// Contains HTTP header names used in RavenDB client-server communication.
+        /// </summary>
         public sealed class Headers
         {
             private Headers()
             {
             }
 
+            /// <summary>
+            /// HTTP header name for request timestamp.
+            /// </summary>
             public const string RequestTime = "Request-Time";
 
+            /// <summary>
+            /// HTTP header name for server startup timestamp.
+            /// </summary>
             public const string ServerStartupTime = "Server-Startup-Time";
 
+            /// <summary>
+            /// HTTP header name for triggering topology refresh.
+            /// </summary>
             public const string RefreshTopology = "Refresh-Topology";
 
+            /// <summary>
+            /// HTTP header name for topology etag.
+            /// </summary>
             public const string TopologyEtag = "Topology-Etag";
 
+            /// <summary>
+            /// HTTP header name for cluster topology etag.
+            /// </summary>
             public const string ClusterTopologyEtag = "Cluster-Topology-Etag";
 
+            /// <summary>
+            /// HTTP header name for client configuration etag.
+            /// </summary>
             public const string ClientConfigurationEtag = "Client-Configuration-Etag";
 
+            /// <summary>
+            /// HTTP header name for the last known cluster transaction index.
+            /// </summary>
             public const string LastKnownClusterTransactionIndex = "Known-Raft-Index";
 
+            /// <summary>
+            /// HTTP header name for database cluster transaction identifier.
+            /// </summary>
             public const string DatabaseClusterTransactionId = "Database-Cluster-Tx-Id";
 
+            /// <summary>
+            /// HTTP header name for triggering client configuration refresh.
+            /// </summary>
             public const string RefreshClientConfiguration = "Refresh-Client-Configuration";
 
+            /// <summary>
+            /// HTTP header name for entity tag (ETag).
+            /// </summary>
             public const string Etag = "ETag";
 
+            /// <summary>
+            /// HTTP header name for RavenDB client version.
+            /// </summary>
             public const string ClientVersion = "Raven-Client-Version";
 
+            /// <summary>
+            /// HTTP header name for RavenDB server version.
+            /// </summary>
             public const string ServerVersion = "Raven-Server-Version";
 
+            /// <summary>
+            /// HTTP header name for RavenDB Studio version.
+            /// </summary>
             public const string StudioVersion = "Raven-Studio-Version";
 
+            /// <summary>
+            /// HTTP header name for conditional request matching.
+            /// </summary>
             public const string IfMatch = "If-Match";
 
+            /// <summary>
+            /// HTTP header name for conditional request non-matching.
+            /// </summary>
             public const string IfNoneMatch = "If-None-Match";
 
+            /// <summary>
+            /// HTTP header name for transfer encoding.
+            /// </summary>
             public const string TransferEncoding = "Transfer-Encoding";
 
+            /// <summary>
+            /// HTTP header name for content encoding.
+            /// </summary>
             public const string ContentEncoding = "Content-Encoding";
 
+            /// <summary>
+            /// HTTP header name for accept encoding.
+            /// </summary>
             public const string AcceptEncoding = "Accept-Encoding";
 
+            /// <summary>
+            /// HTTP header name for content disposition.
+            /// </summary>
             public const string ContentDisposition = "Content-Disposition";
 
+            /// <summary>
+            /// HTTP header name for content type.
+            /// </summary>
             public const string ContentType = "Content-Type";
 
+            /// <summary>
+            /// HTTP header name for content length.
+            /// </summary>
             public const string ContentLength = "Content-Length";
 
+            /// <summary>
+            /// HTTP header name for request origin.
+            /// </summary>
             public const string Origin = "Origin";
 
+            /// <summary>
+            /// Prefix used for incremental time series headers.
+            /// </summary>
             public const string IncrementalTimeSeriesPrefix = "INC:";
 
             internal const string Sharded = "Sharded";
 
+            /// <summary>
+            /// HTTP header name for attachment hash.
+            /// </summary>
             public const string AttachmentHash = "Attachment-Hash";
 
+            /// <summary>
+            /// HTTP header name for attachment size.
+            /// </summary>
             public const string AttachmentSize = "Attachment-Size";
 
             internal const string DatabaseMissing = "Database-Missing";
@@ -114,20 +208,32 @@ namespace Raven.Client
             }
         }
 
+        /// <summary>
+        /// Contains platform-specific constants for different operating systems.
+        /// </summary>
         public sealed class Platform
         {
             private Platform()
             {
             }
 
+            /// <summary>
+            /// Contains Windows-specific constants and limitations.
+            /// </summary>
             public sealed class Windows
             {
                 private Windows()
                 {
                 }
 
+                /// <summary>
+                /// Maximum path length supported on Windows.
+                /// </summary>
                 public static readonly int MaxPath = short.MaxValue;
 
+                /// <summary>
+                /// Reserved file names that cannot be used on Windows.
+                /// </summary>
                 internal static readonly string[] ReservedFileNames = {
                     "con",
                     "prn",
@@ -155,25 +261,44 @@ namespace Raven.Client
                 };
             }
 
+            /// <summary>
+            /// Contains Linux-specific constants and limitations.
+            /// </summary>
             public sealed class Linux
             {
                 private Linux()
                 {
                 }
 
+                /// <summary>
+                /// Maximum path length supported on Linux.
+                /// </summary>
                 public const int MaxPath = 4096;
 
+                /// <summary>
+                /// Maximum file name length supported on Linux.
+                /// </summary>
                 public const int MaxFileNameLength = 230;
             }
         }
 
+        /// <summary>
+        /// Contains constants related to certificate management.
+        /// </summary>
         public sealed class Certificates
         {
             private Certificates()
             {
             }
 
+            /// <summary>
+            /// The prefix used for certificate identifiers.
+            /// </summary>
             public const string Prefix = "certificates/";
+            
+            /// <summary>
+            /// Maximum number of certificates allowed with the same hash.
+            /// </summary>
             public const int MaxNumberOfCertsWithSameHash = 5;
         }
 
@@ -194,6 +319,9 @@ namespace Raven.Client
             public const string StudioId = "DatabaseSettings/Studio";
         }
 
+        /// <summary>
+        /// Contains constants related to RavenDB configuration.
+        /// </summary>
         public sealed class Configuration
         {
             private Configuration()
@@ -205,85 +333,187 @@ namespace Raven.Client
                 internal const string IndexingStaticSearchEngineType = "Indexing.Static.SearchEngineType";
             }
 
+            /// <summary>
+            /// Configuration identifier for client settings.
+            /// </summary>
             public const string ClientId = "Configuration/Client";
 
+            /// <summary>
+            /// Configuration identifier for studio settings.
+            /// </summary>
             public const string StudioId = "Configuration/Studio";
         }
 
+        /// <summary>
+        /// Contains constants related to RavenDB counters.
+        /// </summary>
         public static class Counters
         {
+            /// <summary>
+            /// Special identifier for all counters in a document.
+            /// </summary>
             public const string All = "@all_counters";
         }
 
+        /// <summary>
+        /// Contains constants related to RavenDB time series.
+        /// </summary>
         public static class TimeSeries
         {
             internal const string SelectFieldName = "timeseries";
             internal const string QueryFunction = "__timeSeriesQueryFunction";
 
+            /// <summary>
+            /// Special identifier for all time series in a document.
+            /// </summary>
             public const string All = "@all_timeseries";
         }
 
+        /// <summary>
+        /// Contains constants related to RavenDB documents, collections, and metadata.
+        /// </summary>
         public sealed class Documents
         {
             private Documents()
             {
             }
 
+            /// <summary>
+            /// The prefix used for database names in RavenDB.
+            /// </summary>
             public const string Prefix = "db/";
 
+            /// <summary>
+            /// The maximum allowed length for a database name.
+            /// </summary>
             public const int MaxDatabaseNameLength = 128;
 
+            /// <summary>
+            /// Defines special states for subscription change vectors.
+            /// </summary>
             public enum SubscriptionChangeVectorSpecialStates
             {
+                /// <summary>
+                /// Indicates that the change vector should not be changed.
+                /// </summary>
                 DoNotChange,
+                /// <summary>
+                /// Indicates that the subscription should start from the last document.
+                /// </summary>
                 LastDocument,
+                /// <summary>
+                /// Indicates that the subscription should start from the beginning of time.
+                /// </summary>
                 BeginningOfTime
             }
 
+            /// <summary>
+            /// Contains constants for document metadata field names.
+            /// </summary>
             public sealed class Metadata
             {
                 private Metadata()
                 {
                 }
 
+                /// <summary>
+                /// Metadata field name for graph edges.
+                /// </summary>
                 public const string Edges = "@edges";
 
+                /// <summary>
+                /// Metadata field name for document collection.
+                /// </summary>
                 public const string Collection = "@collection";
 
+                /// <summary>
+                /// Metadata field name for query projections.
+                /// </summary>
                 public const string Projection = "@projection";
 
+                /// <summary>
+                /// Metadata field name for the metadata key.
+                /// </summary>
                 public const string Key = "@metadata";
 
+                /// <summary>
+                /// Metadata field name for document identifier.
+                /// </summary>
                 public const string Id = "@id";
 
+                /// <summary>
+                /// Metadata field name for conflict information.
+                /// </summary>
                 public const string Conflict = "@conflict";
 
+                /// <summary>
+                /// Property name for document identifier in objects.
+                /// </summary>
                 public const string IdProperty = "Id";
 
+                /// <summary>
+                /// Metadata field name for document flags.
+                /// </summary>
                 public const string Flags = "@flags";
 
+                /// <summary>
+                /// Metadata field name for document attachments.
+                /// </summary>
                 public const string Attachments = "@attachments";
 
+                /// <summary>
+                /// Metadata field name for document counters.
+                /// </summary>
                 public const string Counters = "@counters";
 
+                /// <summary>
+                /// Metadata field name for document time series.
+                /// </summary>
                 public const string TimeSeries = "@timeseries";
 
+                /// <summary>
+                /// Metadata field name for time series with named values.
+                /// </summary>
                 public const string TimeSeriesNamedValues = "@timeseries-named-values";
 
+                /// <summary>
+                /// Metadata field name for revision counters snapshot.
+                /// </summary>
                 public const string RevisionCounters = "@counters-snapshot";
 
+                /// <summary>
+                /// Metadata field name for revision time series snapshot.
+                /// </summary>
                 public const string RevisionTimeSeries = "@timeseries-snapshot";
 
+                /// <summary>
+                /// Metadata field name for legacy attachment metadata.
+                /// </summary>
                 public const string LegacyAttachmentsMetadata = "@legacy-attachment-metadata";
 
+                /// <summary>
+                /// Metadata field name for index score.
+                /// </summary>
                 public const string IndexScore = "@index-score";
 
+                /// <summary>
+                /// Metadata field name for spatial query results.
+                /// </summary>
                 public const string SpatialResult = "@spatial";
 
+                /// <summary>
+                /// Metadata field name for last modified timestamp.
+                /// </summary>
                 public const string LastModified = "@last-modified";
 
+                /// <summary>
+                /// Metadata field name for the .NET CLR type information.
+                /// </summary>
                 public const string RavenClrType = "Raven-Clr-Type";
 
+                /// <summary>
+                /// Metadata field name for document change vector.
+                /// </summary>
                 public const string ChangeVector = "@change-vector";
 
                 public const string Expires = "@expires";

--- a/src/Raven.Client/Conventions.cs
+++ b/src/Raven.Client/Conventions.cs
@@ -1,5 +1,9 @@
 namespace Raven.Client
 {
+    /// <summary>
+    /// Abstract base class that defines conventions used by the RavenDB client.
+    /// This class serves as a foundation for configuring various client behaviors and settings.
+    /// </summary>
     public abstract class Conventions
     {
     }

--- a/src/Raven.Client/Documents/Indexes/IJsonObject.cs
+++ b/src/Raven.Client/Documents/Indexes/IJsonObject.cs
@@ -2,20 +2,59 @@
 
 namespace Raven.Client.Documents.Indexes
 {
+    /// <summary>
+    /// Represents a JSON object that can be used in indexing operations.
+    /// Provides access to properties and values in a JSON document structure.
+    /// </summary>
     public interface IJsonObject : IEnumerable<KeyValuePair<string, object>>
     {
+        /// <summary>
+        /// Gets the value of the specified property.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The value of the property, or null if the property does not exist.</returns>
         object this[string propertyName] { get; }
 
+        /// <summary>
+        /// Gets the value of the specified property cast to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to cast the value to.</typeparam>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The value of the property cast to the specified type.</returns>
         T Value<T>(string propertyName);
 
+        /// <summary>
+        /// Gets all values in the JSON object cast to the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to cast the values to.</typeparam>
+        /// <returns>An enumerable of all values cast to the specified type.</returns>
         IEnumerable<T> Values<T>();
 
+        /// <summary>
+        /// Represents metadata associated with a JSON object.
+        /// </summary>
         public interface IMetadata
         {
+            /// <summary>
+            /// Gets the value of the specified metadata property.
+            /// </summary>
+            /// <param name="propertyName">The name of the metadata property to retrieve.</param>
+            /// <returns>The value of the metadata property, or null if the property does not exist.</returns>
             object this[string propertyName] { get; }
 
+            /// <summary>
+            /// Gets the value of the specified metadata property cast to the specified type.
+            /// </summary>
+            /// <typeparam name="T">The type to cast the value to.</typeparam>
+            /// <param name="propertyName">The name of the metadata property to retrieve.</param>
+            /// <returns>The value of the metadata property cast to the specified type.</returns>
             T Value<T>(string propertyName);
 
+            /// <summary>
+            /// Gets all metadata values cast to the specified type.
+            /// </summary>
+            /// <typeparam name="T">The type to cast the values to.</typeparam>
+            /// <returns>An enumerable of all metadata values cast to the specified type.</returns>
             IEnumerable<T> Values<T>();
         }
     }

--- a/src/Raven.Client/Documents/Indexes/Vector/VectorEmbeddingType.cs
+++ b/src/Raven.Client/Documents/Indexes/Vector/VectorEmbeddingType.cs
@@ -1,10 +1,28 @@
 ﻿namespace Raven.Client.Documents.Indexes.Vector;
 
+/// <summary>
+/// Specifies the data type used for vector embeddings in RavenDB indexes.
+/// </summary>
 public enum VectorEmbeddingType
 {
+    /// <summary>
+    /// Single-precision floating-point numbers (32-bit).
+    /// </summary>
     Single,
+    
+    /// <summary>
+    /// 8-bit signed integer quantized values.
+    /// </summary>
     Int8,
+    
+    /// <summary>
+    /// Binary representation (1-bit per dimension).
+    /// </summary>
     Binary,
+    
+    /// <summary>
+    /// Text data that will be converted to embeddings using a text embedding model.
+    /// </summary>
     Text
 }
     

--- a/src/Raven.Client/Documents/Indexes/Vector/VectorOptions.cs
+++ b/src/Raven.Client/Documents/Indexes/Vector/VectorOptions.cs
@@ -9,10 +9,17 @@ namespace Raven.Client.Documents.Indexes.Vector;
 /// </summary>
 public class VectorOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorOptions"/> class.
+    /// </summary>
     public VectorOptions()
     {
     }
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorOptions"/> class by copying values from another instance.
+    /// </summary>
+    /// <param name="options">The VectorOptions instance to copy from.</param>
     public VectorOptions(VectorOptions options)
     {
         Dimensions = options.Dimensions;
@@ -51,8 +58,14 @@ public class VectorOptions
     /// </summary>
     public VectorEmbeddingType DestinationEmbeddingType { get; set; }
 
+    /// <summary>
+    /// Gets or sets the number of candidate vectors to consider during indexing for graph construction.
+    /// </summary>
     public int? NumberOfCandidatesForIndexing { get; set; }
     
+    /// <summary>
+    /// Gets or sets the number of edges (connections) each node in the vector graph should have.
+    /// </summary>
     public int? NumberOfEdges { get; set; }
     
     [Conditional("DEBUG")]
@@ -69,6 +82,12 @@ public class VectorOptions
         PortableExceptions.ThrowIf<InvalidOperationException>(NumberOfCandidatesForIndexing <= 0, "Number of candidate nodes has to be positive.");
     }
     
+    /// <summary>
+    /// Compares two VectorOptions instances for equality.
+    /// </summary>
+    /// <param name="left">The first VectorOptions instance to compare.</param>
+    /// <param name="right">The second VectorOptions instance to compare.</param>
+    /// <returns>True if the instances are equal; otherwise, false.</returns>
     public static bool Equals(VectorOptions left, VectorOptions right)
     {
         if (left is null && right is null)
@@ -77,6 +96,11 @@ public class VectorOptions
         return left?.Equals(right) ?? false;
     }
     
+    /// <summary>
+    /// Determines whether the specified object is equal to the current VectorOptions instance.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current instance.</param>
+    /// <returns>True if the specified object is equal to the current instance; otherwise, false.</returns>
     public override bool Equals(object obj)
     {
         if (ReferenceEquals(null, obj))
@@ -96,6 +120,10 @@ public class VectorOptions
                && options.NumberOfCandidatesForIndexing == NumberOfCandidatesForIndexing;
     }
 
+    /// <summary>
+    /// Returns the hash code for this VectorOptions instance.
+    /// </summary>
+    /// <returns>A 32-bit signed integer hash code.</returns>
     public override int GetHashCode()
     {
         unchecked

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -6,93 +6,227 @@ using Raven.Client.Documents.Session;
 
 namespace Raven.Client.Documents.Queries
 {
+    /// <summary>
+    /// Provides static methods for use in LINQ queries that are translated to RavenDB server-side operations.
+    /// These methods are designed for strongly-typed support in LINQ queries and throw exceptions when called directly in client code.
+    /// </summary>
     public sealed class RavenQuery
     {
+        /// <summary>
+        /// Loads a document by its identifier. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the document to load.</typeparam>
+        /// <param name="id">The document identifier.</param>
+        /// <returns>The loaded document.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static T Load<T>(string id)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets the identifier of a document instance. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="documentInstance">The document instance.</param>
+        /// <returns>The document identifier.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static string Id(object documentInstance)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Loads multiple documents by their identifiers. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the documents to load.</typeparam>
+        /// <param name="ids">The collection of document identifiers.</param>
+        /// <returns>The loaded documents.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static IEnumerable<T> Load<T>(IEnumerable<string> ids)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Executes raw JavaScript code in the query. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The return type of the JavaScript execution.</typeparam>
+        /// <param name="js">The JavaScript code to execute.</param>
+        /// <returns>The result of the JavaScript execution.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static T Raw<T>(string js)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Executes raw JavaScript code in the query with a path context. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The return type of the JavaScript execution.</typeparam>
+        /// <param name="path">The path context for the JavaScript execution.</param>
+        /// <param name="js">The JavaScript code to execute.</param>
+        /// <returns>The result of the JavaScript execution.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static T Raw<T>(T path, string js)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets the last modified date of a document instance. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the document instance.</typeparam>
+        /// <param name="instance">The document instance.</param>
+        /// <returns>The last modified date of the document.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static DateTime LastModified<T>(T instance)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets the metadata of a document instance. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the document instance.</typeparam>
+        /// <param name="instance">The document instance.</param>
+        /// <returns>The metadata dictionary of the document.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static IMetadataDictionary Metadata<T>(T instance)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a compare exchange value by key. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the compare exchange value.</typeparam>
+        /// <param name="key">The compare exchange key.</param>
+        /// <returns>The compare exchange value.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static T CmpXchg<T>(string key)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a counter value by name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="name">The counter name.</param>
+        /// <returns>The counter value.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static long? Counter(string name)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a counter value by document identifier and counter name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="docId">The document identifier.</param>
+        /// <param name="name">The counter name.</param>
+        /// <returns>The counter value.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static long? Counter(string docId, string name)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a counter value by document instance and counter name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="documentInstance">The document instance.</param>
+        /// <param name="name">The counter name.</param>
+        /// <returns>The counter value.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static long? Counter(object documentInstance, string name)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a time series by name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="name">The time series name.</param>
+        /// <returns>A queryable time series interface.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static ITimeSeriesQueryable TimeSeries(string name)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a time series by document instance and name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="documentInstance">The document instance.</param>
+        /// <param name="name">The time series name.</param>
+        /// <returns>A queryable time series interface.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static ITimeSeriesQueryable TimeSeries(object documentInstance, string name)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a time series by document instance, name, and time range. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <param name="documentInstance">The document instance.</param>
+        /// <param name="name">The time series name.</param>
+        /// <param name="from">The start time of the range.</param>
+        /// <param name="to">The end time of the range.</param>
+        /// <returns>A queryable time series interface.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static ITimeSeriesQueryable TimeSeries(object documentInstance, string name, DateTime from, DateTime to)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a strongly-typed time series by name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the time series entries.</typeparam>
+        /// <param name="name">The time series name.</param>
+        /// <returns>A strongly-typed queryable time series interface.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static ITimeSeriesQueryable<T> TimeSeries<T>(string name) where T : new()
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a strongly-typed time series by document instance and name. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the time series entries.</typeparam>
+        /// <param name="documentInstance">The document instance.</param>
+        /// <param name="name">The time series name.</param>
+        /// <returns>A strongly-typed queryable time series interface.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static ITimeSeriesQueryable<T> TimeSeries<T>(object documentInstance, string name) where T : new()
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Gets a strongly-typed time series by document instance, name, and time range. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the time series entries.</typeparam>
+        /// <param name="documentInstance">The document instance.</param>
+        /// <param name="name">The time series name.</param>
+        /// <param name="from">The start time of the range.</param>
+        /// <param name="to">The end time of the range.</param>
+        /// <returns>A strongly-typed queryable time series interface.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static ITimeSeriesQueryable<T> TimeSeries<T>(object documentInstance, string name, DateTime from, DateTime to) where T : new()
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
+        /// <summary>
+        /// Includes a related document path in the query for loading. This method is for server-side LINQ query translation only.
+        /// </summary>
+        /// <typeparam name="T">The type of the document.</typeparam>
+        /// <param name="path">Expression specifying the path to include.</param>
+        /// <returns>An object representing the include instruction.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static object Include<T>(Expression<Func<T, string>> path)
         {
             throw new NotSupportedException(

--- a/src/Raven.Client/Exceptions/CompareExchangeInvalidKeyException.cs
+++ b/src/Raven.Client/Exceptions/CompareExchangeInvalidKeyException.cs
@@ -2,12 +2,25 @@
 
 namespace Raven.Client.Exceptions;
 
+/// <summary>
+/// Exception thrown when an invalid key is used in a compare exchange operation.
+/// </summary>
 public sealed class CompareExchangeInvalidKeyException : RavenException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompareExchangeInvalidKeyException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public CompareExchangeInvalidKeyException(string message)
         : base(message)
     {
     }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompareExchangeInvalidKeyException"/> class with a specified error message and a reference to the inner exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public CompareExchangeInvalidKeyException(string message, Exception inner)
         : base(message, inner)
     {

--- a/src/Raven.Client/Exceptions/RavenTimeoutException.cs
+++ b/src/Raven.Client/Exceptions/RavenTimeoutException.cs
@@ -2,21 +2,39 @@
 
 namespace Raven.Client.Exceptions;
 
+/// <summary>
+/// Exception thrown when a RavenDB operation times out.
+/// </summary>
 public sealed class RavenTimeoutException : RavenException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RavenTimeoutException"/> class.
+    /// </summary>
     public RavenTimeoutException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RavenTimeoutException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public RavenTimeoutException(string message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RavenTimeoutException"/> class with a specified error message and a reference to the inner exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public RavenTimeoutException(string message, Exception inner)
         : base(message, inner)
     {
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the operation should fail immediately on timeout.
+    /// </summary>
     public bool FailImmediately;
 }

--- a/src/Raven.Client/Parameters.cs
+++ b/src/Raven.Client/Parameters.cs
@@ -2,13 +2,24 @@
 
 namespace Raven.Client
 {
+    /// <summary>
+    /// Represents a collection of query parameters that can be passed to RavenDB queries.
+    /// This class extends Dictionary&lt;string, object&gt; to provide a strongly-typed way to manage query parameters.
+    /// </summary>
     public sealed class Parameters : Dictionary<string, object>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Parameters"/> class.
+        /// </summary>
         public Parameters()
         {
 
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Parameters"/> class with the parameters from another Parameters instance.
+        /// </summary>
+        /// <param name="other">The Parameters instance to copy from.</param>
         public Parameters(Parameters other) : base(other)
         {
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14341
https://github.com/ravendb/ravendb/pull/21306

### Additional description

This PR adds comprehensive XML documentation comments to key public methods, properties, fields, and classes within the Raven.Client project to improve developer experience and API discoverability.



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
