### PR TITLE
RavenDB-25001  Time kind consistency in tests.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22959.cs
+++ b/test/SlowTests/Issues/RavenDB-22959.cs
@@ -23,7 +23,7 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
         public async Task SessionLoadWithIncludeAllTimeSeriesByRange()
         {
-            var baseTime = new DateTime(year: 2024, month: 1, day: 1, hour: 1, minute: 30, second: 0);
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1, hour: 1, minute: 30, second: 0, kind: DateTimeKind.Utc);
 
             using var store = GetDocumentStore();
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
@@ -147,7 +147,7 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
         public async Task SessionLoadWithIncludeAllTimeSeriesByRangeWithMultipleDocs()
         {
-            var baseTime = new DateTime(year: 2024, month: 1, day: 1, hour: 1, minute: 30, second: 0);
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1, hour: 1, minute: 30, second: 0, kind: DateTimeKind.Utc);
 
             using var store = GetDocumentStore();
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);

--- a/test/SlowTests/Issues/RavenDB-24649.cs
+++ b/test/SlowTests/Issues/RavenDB-24649.cs
@@ -16,6 +16,9 @@ namespace SlowTests.Issues;
 
 public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
 {
+    private static readonly int Timeout = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
+    private const int Interval = 10;
+    
     [RavenFact(RavenTestCategory.Indexes)]
     public async Task ElapsedSinceQueriedTimeIsPersistedAndIncreased()
     {
@@ -43,7 +46,7 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
 
         // Wait that elapsed time will be increased.
         var elapsed1 = index.GetElapsedTimeFromLastQuery();
-        var elapsed2 = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult(index.GetElapsedTimeFromLastQuery()), elapsed1);
+        var elapsed2 = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult(index.GetElapsedTimeFromLastQuery()), elapsed1, timeout: Timeout, interval: Interval);
 
         using (var session = store.OpenAsyncSession())
         {
@@ -53,7 +56,7 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
                 .ToListAsync();
             
             // Wait for changed elapsed time.
-            var currentElapsed = await WaitForNotEqualsAsync(() => Task.FromResult(index.GetElapsedTimeFromLastQuery()), elapsed2);
+            var currentElapsed = await WaitForNotEqualsAsync(() => Task.FromResult(index.GetElapsedTimeFromLastQuery()), elapsed2, timeout: Timeout, interval: Interval);
             Assert.True(currentElapsed != elapsed2, $"{currentElapsed} != {elapsed2}");
         }
 
@@ -73,11 +76,11 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
         var elapsedOnInit = index.GetElapsedTimeFromLastQuery();
         
         //LastQueryingTime on index initialization is InitializationTime - ElapsedSinceQueried. An index on initialization performs indexing batch so that value must be greater than InitializationTime.
-        var lastQueryTime = await WaitAndAssertForLessThanAsync(() => Task.FromResult(index.GetLastQueryingTime()!.Value), index.LastIndexingTime!.Value);
+        var lastQueryTime = await WaitAndAssertForLessThanAsync(() => Task.FromResult(index.GetLastQueryingTime()!.Value), index.LastIndexingTime!.Value, timeout: Timeout, interval: Interval);
         Assert.True(lastQueryTime < index.LastIndexingTime, $"{lastQueryTime} < {index.LastIndexingTime}"); // 
         
         // Wait that elapsed time will be increased.
-        var val = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult((index.LastIndexingTime - index.GetLastQueryingTime())!.Value), elapsedOnInit);
+        var val = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult((index.LastIndexingTime - index.GetLastQueryingTime())!.Value), elapsedOnInit, timeout: Timeout, interval: Interval);
         Assert.True(val > elapsedOnInit, $"{val} > {elapsedOnInit}");
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25001 

### Additional description

We rely on db.Time.UtcDateTime to return the UTC date.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
