### PR TITLE
RavenDB-24997 if no env variables defined, skip try to connect

### DIFF
--- a/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
@@ -22,7 +22,7 @@ where TConfig : EtlConfiguration<AiConnectionString>
     TConfig GetAiConfiguration();
     Lazy<bool> CanConnect { get; }
     Lazy<AiConnectorType> AiConnectorType { get; }
-    bool MissingRequiredApiKey(out string environmentVariableName);
+    bool MissingRequiredEnvVariables(out string environmentVariableName);
 }
 
 public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTesting<TConfig>
@@ -43,7 +43,7 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
 
     protected string[] RequiredEnvironmentVariables = [];
 
-    public virtual bool MissingRequiredApiKey(out string environmentVariableName)
+    public virtual bool MissingRequiredEnvVariables(out string environmentVariableName)
     {
         foreach (var envVar in RequiredEnvironmentVariables)
         {

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -56,8 +56,8 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
             {
                 using (SetSkipValueIfNightlyBuildRequired())
                 using (SetSkipValueIfShardedDbOnX86(databaseMode))
+                using (SetSkipValueIfNoRequiredEnvVariablesDefined(aiConnectionStringForTesting))
                 using (SetSkipValueIfUnableConnectToAi(aiConnectionStringForTesting))
-                using (SetSkipValueIfNoApiKeyDefined(aiConnectionStringForTesting))
                 {
                     var aiIntegrationConfiguration = aiConnectionStringForTesting.GetAiConfiguration();
 
@@ -89,15 +89,15 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
     }
     
     
-    private DisposableAction SetSkipValueIfNoApiKeyDefined(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
+    private DisposableAction SetSkipValueIfNoRequiredEnvVariablesDefined(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
     {
         if (string.IsNullOrEmpty(Skip) == false)
             return null;
 
-        if (aiConnectorForTesting.MissingRequiredApiKey(out var envVar) is false)
+        if (aiConnectorForTesting.MissingRequiredEnvVariables(out var envVar) is false)
             return null;
         
-        Skip = $"API Key is required for {aiConnectorForTesting.AiConnectorType}, but was not specified using: {envVar}";
+        Skip = $"The environment variable {envVar} is required for {aiConnectorForTesting.AiConnectorType}, but was not set.";
         return new DisposableAction(() => Skip = null);
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24997

### Additional description

before trying to connect we should first check whether all required env variables are set.

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
