### PR TITLE
RavenDB-25006 Expose config option for automatic cert renewal date

### DIFF
--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -85,9 +85,9 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("LetsEncrypt.AcmeProfile", ConfigurationEntryScope.ServerWideOnly)]
         public string AcmeProfile { get; set; }
         
-        [Description("Number of days before expiration when the server should automatically renew server certificates.\n")]
+        [Description("Number of days before expiration when the server should automatically renew server certificates.")]
         [DefaultValue(20)]
-        [ConfigurationEntry("AcmeDaysToRenewBeforeExpiration", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("LetsEncrypt.DaysToRenewCertBeforeExpiration", ConfigurationEntryScope.ServerWideOnly)]
         public int AcmeDaysToRenewBeforeExpiration { get; set; }
         
         [Description("Indicates if we should throw an exception if any index could not be opened")]

--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -85,6 +85,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("LetsEncrypt.AcmeProfile", ConfigurationEntryScope.ServerWideOnly)]
         public string AcmeProfile { get; set; }
         
+        [Description("Number of days before expiration when the server should automatically renew server certificates.\n")]
+        [DefaultValue(20)]
+        [ConfigurationEntry("AcmeDaysToRenewBeforeExpiration", ConfigurationEntryScope.ServerWideOnly)]
+        public int AcmeDaysToRenewBeforeExpiration { get; set; }
+        
         [Description("Indicates if we should throw an exception if any index could not be opened")]
         [DefaultValue(false)]
         [ConfigurationEntry("ThrowIfAnyIndexCannotBeOpened", ConfigurationEntryScope.ServerWideOrPerDatabase)]

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -423,7 +423,7 @@ namespace Raven.Server
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations(msg);
             }
-            else if (remainingDays <= 20)
+            else if (remainingDays <= Configuration.Core.AcmeDaysToRenewBeforeExpiration)
             {
                 string msg = $"The server certificate will expire on {Certificate.ServerCertificate.NotAfter.ToShortDateString()}. There are only {(int)remainingDays} days left for renewal.";
 
@@ -1267,7 +1267,7 @@ namespace Raven.Server
                 return (true, DateTime.UtcNow.Date);
 
             var remainingDays = (currentCertificate.ServerCertificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
-            if (remainingDays <= 20)
+            if (remainingDays <= ServerStore.Configuration.Core.AcmeDaysToRenewBeforeExpiration)
             {
                 return (true, DateTime.UtcNow.Date);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25006 

### Additional description

Currently we assume all certificates are valid for 3 months and renew them 20 days before expiration. This is not true for shortlived certificates - valid for only 7 days.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
