### PR TITLE
RavenDB-22767 Explicitly dispose read tx and add cancellation tokens to FlushAsync calls. Making the order of disposals in StreamWithTimeout consistent with 5.4 code.

### DIFF
--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -293,8 +293,8 @@ namespace Raven.Client.Util
         {
             GC.SuppressFinalize(this);
 
-            _stream.Dispose();
             base.Dispose(disposing);
+            _stream.Dispose();
 
             _readCts?.Dispose();
             _writeCts?.Dispose();
@@ -312,8 +312,8 @@ namespace Raven.Client.Util
 #else
             GC.SuppressFinalize(this);
 
-            await _stream.DisposeAsync().ConfigureAwait(false);
             await base.DisposeAsync().ConfigureAwait(false);
+            await _stream.DisposeAsync().ConfigureAwait(false);
 
             _readCts?.Dispose();
             _writeCts?.Dispose();

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -212,6 +212,7 @@ internal abstract class
             ? getDocumentsByIdImplAsyncTask.Result 
             : await getDocumentsByIdImplAsyncTask;
 
+        using var _ = result.ReadTransaction;
 
         if (result.StatusCode == HttpStatusCode.NotFound)
         {
@@ -335,8 +336,9 @@ internal abstract class
     {
         var getDocuments = GetDocumentsImplAsync(context, etag, startsWith, changeVector);
         var result = getDocuments.IsCompletedSuccessfully ? getDocuments.Result : await getDocuments;
-        
-        
+
+        using var _ = result.ReadTransaction;
+
         if (changeVector == result.Etag)
         {
             HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
@@ -537,6 +539,8 @@ internal abstract class
         public string Etag { get; set; }
 
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.OK;
+
+        public DocumentsTransaction ReadTransaction;
     }
 
     protected sealed class DocumentsResult
@@ -548,6 +552,8 @@ internal abstract class
         public ShardedPagingContinuation ContinuationToken { get; set; }
 
         public string Etag { get; set; }
+
+        public DocumentsTransaction ReadTransaction;
     }
 
     protected sealed class StartsWithParams

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -15,6 +15,7 @@ using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Queries.Revisions;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -23,13 +24,16 @@ namespace Raven.Server.Documents.Handlers.Processors.Documents;
 
 internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerProcessorForGet<DocumentHandler, DocumentsOperationContext, Document>
 {
+    private readonly OperationCancelToken _cts;
+
     public DocumentHandlerProcessorForGet(HttpMethod method, [NotNull] DocumentHandler requestHandler) : base(method, requestHandler)
     {
+        _cts = RequestHandler.CreateHttpRequestBoundOperationToken();
     }
 
     protected override bool SupportsShowingRequestInTrafficWatch => true;
 
-    protected override CancellationToken CancellationToken => RequestHandler.Database.DatabaseShutdown;
+    protected override CancellationToken CancellationToken => _cts.Token;
 
     protected override ValueTask<DocumentsByIdResult<Document>> GetDocumentsByIdImplAsync(
         DocumentsOperationContext context,
@@ -217,5 +221,12 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             Etag = databaseChangeVector,
             ReadTransaction = readTx
         });
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+
+        _cts?.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -73,7 +73,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         }
 
         long lastModifiedIndex = RequestHandler.Database.ClusterWideTransactionIndexWaiter.LastIndex;
-        context.OpenReadTransaction();
+        var readTx = context.OpenReadTransaction();
 
         foreach (var id in ids)
         {
@@ -156,7 +156,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
             RevisionIncludes = includeRevisions,
             CounterIncludes = includeCounters,
             TimeSeriesIncludes = includeTimeSeries,
-            CompareExchangeIncludes = includeCompareExchangeValues?.Results
+            CompareExchangeIncludes = includeCompareExchangeValues?.Results,
+            ReadTransaction = readTx
         });
     }
 
@@ -180,7 +181,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
     protected override ValueTask<DocumentsResult> GetDocumentsImplAsync(DocumentsOperationContext context, long? etag, StartsWithParams startsWith, string changeVector)
     {
-        context.OpenReadTransaction();
+        var readTx = context.OpenReadTransaction();
 
         var databaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
 
@@ -213,7 +214,8 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
         return new ValueTask<DocumentsResult>(new DocumentsResult
         {
             Documents = documents,
-            Etag = databaseChangeVector
+            Etag = databaseChangeVector,
+            ReadTransaction = readTx
         });
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3371,7 +3371,7 @@ namespace Raven.Server.Documents.Indexes
                     using (var indexTx = indexContext.OpenReadTransaction())
                     {
                         if (queryContext.AreTransactionsOpened() == false)
-                            queryContext.OpenReadTransaction();
+                            resultToFill.ReadTransactionDispose = queryContext.OpenReadTransaction();
 
                         // we have to open read tx for mapResults _after_ we open index tx
 
@@ -3384,6 +3384,8 @@ namespace Raven.Server.Documents.Indexes
                             isStale = IsStale(queryContext, indexContext, cutoffEtag?.DocEtag, cutoffEtag?.ReferenceEtag, cutoffEtag?.CompareExchangeReferenceEtag);
                             if (WillResultBeAcceptable(isStale, query, wait) == false)
                             {
+                                resultToFill.ReadTransactionDispose?.Dispose();
+                                resultToFill.ReadTransactionDispose = null;
                                 queryContext.CloseTransaction();
 
                                 Debug.Assert(query.WaitForNonStaleResultsTimeout != null);

--- a/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/QueryResultServerSide.cs
@@ -107,8 +107,11 @@ namespace Raven.Server.Documents.Queries
        
         public abstract IRevisionIncludes GetRevisionIncludes();
 
+        public IDisposable ReadTransactionDispose;
+
         public virtual void Dispose()
         {
+            ReadTransactionDispose?.Dispose();
         }
     }
 }

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -84,14 +84,14 @@ namespace Sparrow.Json
             DisposeInternal();
 
             // PERF: Check if flush completed synchronously to avoid async state machine
-            var flushTask = FlushAsync();
+            var flushTask = FlushAsync(_cancellationToken);
             if (flushTask.IsCompletedSuccessfully)
             {
                 // Fast synchronous path
                 var bytesWritten = flushTask.Result;
                 if (bytesWritten > 0)
                 {
-                    var outputFlushTask = _outputStream.FlushAsync();
+                    var outputFlushTask = _outputStream.FlushAsync(_cancellationToken);
                     if (outputFlushTask.IsCompleted)
                     {
                         outputFlushTask.GetAwaiter().GetResult();
@@ -115,7 +115,7 @@ namespace Sparrow.Json
         {
             var bytesWritten = await flushTask.ConfigureAwait(false);
             if (bytesWritten > 0)
-                await _outputStream.FlushAsync().ConfigureAwait(false);
+                await _outputStream.FlushAsync(_cancellationToken).ConfigureAwait(false);
 
             await DisposeStreamAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767

### Additional description

More robust way to ensure disposal of read transactions.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
