### PR TITLE
RavenDB-24542 - block replication of retired attachment to sharded database

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/IncomingExternalReplicationHandlerForShard.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.Incoming;
@@ -42,6 +42,18 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
             protected override ChangeVector PreProcessItemInternal(DocumentsOperationContext context, ReplicationBatchItem item)
             {
+                switch (item)
+                {
+                    case AttachmentReplicationItem attachmentReplicationItem:
+
+                        if (attachmentReplicationItem.Flags == RetiredAttachmentFlags.Retired)
+                        {
+                            throw new NotSupportedException("Replicating retired attachments to sharded database is not supported.");
+                        }
+
+                        break;
+                }
+
                 var changeVector = context.GetChangeVector(item.ChangeVector);
                 var result = _database.DocumentsStorage.GetNewChangeVector(context);
 

--- a/test/InterversionTests/AttachmentsTests.cs
+++ b/test/InterversionTests/AttachmentsTests.cs
@@ -42,12 +42,17 @@ namespace InterversionTests
         [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Attachments | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux, AwsRequired = true)]
         public async Task CannotReplicateRetiredAttachmentsToOld()
         {
+            await CannotReplicateRetiredAttachmentsToOldInternal(InterversionTestOptions.Default);
+        }
+
+        private async Task CannotReplicateRetiredAttachmentsToOldInternal(InterversionTestOptions ops)
+        {
             var version = Server62Version;
 
             var settings = Etl.GetS3Settings(nameof(AttachmentsTests), $"{Guid.NewGuid()}");
 
             await using (DeleteObjects(settings))
-            using (var oldStore = await GetDocumentStoreAsync(version))
+            using (var oldStore = await GetDocumentStoreAsync(version, ops))
             using (var store = GetDocumentStore())
             {
                 await CannotRetiredAttachmentsToOldInternal(settings, store);
@@ -67,6 +72,12 @@ namespace InterversionTests
                 Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException))), "replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Any(x => x.GetType() == typeof(LegacyReplicationViolationException)))");
                 Assert.True(replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains("found an item of type 'AttachmentReplicationItem' to replicate"))), "replicationLoader.OutgoingFailureInfo.Any(ofi => ofi.Value.Errors.Select(x => x.Message).Any(x => x.Contains('found an item of type 'AttachmentReplicationItem' to replicate')))");
             }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Attachments | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux, AwsRequired = true)]
+        public async Task CannotReplicateRetiredAttachmentsToOldSharded()
+        {
+            await CannotReplicateRetiredAttachmentsToOldInternal(InterversionTestOptions.Sharded);
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Attachments | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux, AwsRequired = true)]

--- a/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsSlowTests.cs
@@ -19,6 +19,8 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using SlowTests.Client.Attachments;
+using Sparrow.Server;
+using Sparrow.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,8 +29,6 @@ namespace SlowTests.Server.Documents.Attachments
 {
     public class S3RetiredAttachmentsSlowTests : RetiredAttachmentsS3Base
     {
-        //TODO: egor add retired attachment => delete config => replication should throw
-
         public S3RetiredAttachmentsSlowTests(ITestOutputHelper output) : base(output)
         {
         }
@@ -1278,6 +1278,74 @@ namespace SlowTests.Server.Documents.Attachments
                     var stats22 = store2.Maintenance.Send(new GetDetailedStatisticsOperation());
                     Assert.Equal(0, stats22.CountOfRetiredAttachments);
                     Assert.Equal(0, stats22.CountOfAttachments);
+                }
+            }
+        }
+
+        [AmazonS3RetryTheory]
+        [InlineData(1, 3)]
+        public async Task ExternalReplicateRetiredAttachmentFromRegularToShrdDatabase_ShouldThrow(int attachmentsCount, int size)
+        {
+            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Egor, DevelopmentHelper.Severity.Minor, "Change/Remove this test when RavenDB-24148 is implemented");
+            using (var regularStore = GetDocumentStore())
+            using (var shardedStore = Sharding.GetDocumentStore())
+            {
+                await using (var holder = CreateCloudSettings())
+                {
+                    // Setup retired attachments configuration for regular store
+                    var identifier = await PutRetireAttachmentsConfiguration(regularStore, Settings);
+
+                    // Create documents and attachments in regular store
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+                    await CreateDocs(regularStore, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(regularStore, identifier, size, ids, attachmentsPerDoc);
+
+                    // Get database instance and retire attachments
+                    var regularDatabase = await GetDocumentDatabaseInstanceFor(regularStore);
+
+                    // Move time forward and retire attachments
+                    regularDatabase.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    await regularDatabase.RetireAttachmentsSender.RetireAttachments(int.MaxValue, int.MaxValue);
+
+                    // Verify attachments are retired in cloud
+                    var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
+                    GetStorageAttachmentsMetadataFromAllAttachments(regularDatabase, Settings);
+                    await AssertAllRetiredAttachments(regularStore, cloudObjects, size, identifier);
+
+                    var mre = new AsyncManualResetEvent();
+                    Exception ex = null;
+                    await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(shardedStore))
+                    {
+                        db.ReplicationLoader.ForTestingPurposesOnly().OnIncomingReplicationHandlerFailure += (exception) =>
+                        {
+                            if (exception is AggregateException ae)
+                            {
+                                exception = ae.InnerException;
+                            }
+
+                            if (exception == null)
+                                return;
+
+                            if (exception is NotSupportedException nse)
+                            {
+                                if (nse.Message.Contains("Replicating retired attachments to sharded database is not supported"))
+                                {
+                                    // yes
+                                    ex = nse;
+                                    mre.Set();
+                                }
+                            }
+                        };
+                    }
+
+                    // Setup external replication from regular to sharded store
+                    await SetupReplicationAsync(regularStore, shardedStore);
+
+                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)));
+                    Assert.NotNull(ex);
+                    Assert.Equal(typeof(NotSupportedException), ex.GetType());
+                    Assert.Equal("Replicating retired attachments to sharded database is not supported.", ex.Message);
                 }
             }
         }

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -8,13 +8,13 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Util;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Utils;
@@ -374,6 +374,17 @@ namespace Tests.Infrastructure
             private Dictionary<string, string> _environmentVariables = new();
 
             public static readonly InterversionTestOptions Default = new InterversionTestOptions(true);
+
+            public static readonly InterversionTestOptions Sharded = new InterversionTestOptions(false)
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Sharding = new ShardingConfiguration()
+                    {
+                        Shards = new Dictionary<int, DatabaseTopology>() { { 0, new DatabaseTopology() }, { 1, new DatabaseTopology() }, { 2, new DatabaseTopology() }, }
+                    };
+                }
+            };
 
             public InterversionTestOptions() : this(false)
             {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24542

### Additional description

This pull request introduces validation and tests to ensure that retired attachments cannot be replicated to sharded databases. The main changes include throwing a `NotSupportedException` when such replication is attempted, adding interversion and slow tests to verify this behavior, and updating test infrastructure to support sharded configuration.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
