### PR TITLE
RavenDB-24217 Process posting list and lookup tree separately.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -227,6 +227,9 @@ public partial class IndexWriter
                     _dumper.WriteRemoval(term, oldValue);
                     break;
                 }
+                case (AddEntriesToTermResult.NothingToDo, TreeChanged: _):
+                    break;
+                default: throw new ArgumentOutOfRangeException($"Unknown operation: {job.Operation}");
             }
         }
         

--- a/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.NumericalFieldInserter.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Voron;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Util;
 
@@ -22,7 +24,8 @@ public partial class IndexWriter
 
         private IndexTermDumper _dumper;
 
-        private ContextBoundNativeList<long> _pagesToPrefetch;
+        private ContextBoundNativeList<long> _postingListPagesProcessingBuffer;
+        private ContextBoundNativeList<LookupTreeOperationJob> _jobs;
 
         private int _offsetAdjustment;
         private long _curPage;
@@ -40,8 +43,9 @@ public partial class IndexWriter
             _fieldTree.InitializeCursorState();
 
             _dumper = new IndexTermDumper(_writer._fieldsTree, _fieldName);
-            _pagesToPrefetch = new(_writer._entriesAllocator);
-
+            _postingListPagesProcessingBuffer = new(_writer._entriesAllocator);
+            _jobs = new(_writer._entriesAllocator);
+            
             _writer._entriesToTermsTracker.ClearEntriesForTerm();
             _tmpBuf = tmpBuf;
             _numberOfTermsToProcess = typeof(Int64LookupKey) == typeof(TLookupKey) ? _indexedField.Longs.Count : indexedField.Doubles.Count;
@@ -50,7 +54,8 @@ public partial class IndexWriter
         public void Dispose()
         {
             _dumper.Dispose();
-            _pagesToPrefetch.Dispose();
+            _postingListPagesProcessingBuffer.Dispose();
+            _jobs.Dispose();
         }
 
         public void InsertNumericalField(CancellationToken token)
@@ -75,20 +80,27 @@ public partial class IndexWriter
                     var treeChanged = _fieldTree.CheckTreeStructureChanges();
                     _offsetAdjustment = 0;
                     int read = _fieldTree.BulkUpdateStart(keys, postingListIds, pageOffsets, out _curPage);
-                    FieldInserterHelper.PrefetchContainerPages(_writer, ref _pagesToPrefetch, postingListIds[..read]);
+                    FieldInserterHelper.PrefetchPostingListsPagesAndPrepareOrderedPostingListProcessingList(_writer, ref _postingListPagesProcessingBuffer, postingListIds[..read]);
+                    _jobs.ResetAndEnsureCapacity(read);
+                    _jobs.Count = read;
 
-                    int idX = 0;
-                    for (; idX < read; idX++)
+                    int idX;
+                    for (idX = 0; idX < read; idX++)
                     {
-                        ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[idX]);
-                        ProcessSingleEntry(ref entries, ref keys[idX], sortedTerms[idX], postingListIds[idX], pageOffsets[idX]);
+                        //We will process the containers by page ID, keeping in mind that a page can contain multiple entries.
+                        //The posting lists will be processed in page order; however, the lookup tree will be updated in term order.
+                        //Singles / new items are processed at the end. 
+                        var offset = (int)(_postingListPagesProcessingBuffer[idX] & FieldInserterHelper.OffsetMask);
+                        
+                        
+                        ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[offset]);
+                        _jobs[offset] = ProcessSingleEntry(ref entries, ref keys[offset], sortedTerms[offset], postingListIds[offset], pageOffsets[offset]);
                         entries.Dispose(_writer._entriesAllocator);
-
-                        if (treeChanged.Changed)
-                        {
-                            idX++; // we need to skip the currently processed
-                            break;
-                        }
+                    }
+                    
+                    for (idX = 0; idX < read; idX++)
+                    {
+                        ProcessLookupOperation(_jobs[idX], ref keys[idX], treeChanged, pageOffsets[idX], sortedTerms[idX]);
                     }
 
                     keys = keys[idX..];
@@ -104,12 +116,12 @@ public partial class IndexWriter
             _writer._entriesToTermsTracker.CommitCurrentDataFor(_fieldName);
         }
 
-        private void ProcessSingleEntry(ref EntriesModifications entries, ref TLookupKey key, TKey term, long postingListId, int pageOffset)
+        private LookupTreeOperationJob ProcessSingleEntry(ref EntriesModifications entries, ref TLookupKey key, TKey term, long postingListId, int pageOffset)
         {
             bool termFound = postingListId != Constants.IndexSearcher.InvalidId;
             Debug.Assert(termFound || entries.Removals.Count == 0, "Cannot remove entries from term that isn't already there");
             _writer._entriesToTermsTracker.InsertEntries(entries, key.ToLong());
-
+            LookupTreeOperationJob result;
             if (entries.HasChanges)
             {
                 long termId;
@@ -119,8 +131,7 @@ public partial class IndexWriter
                         throw new InvalidOperationException($"Attempt to remove entries from new term: '{term}' for field {_indexedField.Name}! This is a bug.");
 
                     _writer.CreatePostingListForNewTerm(ref entries, _tmpBuf, out termId);
-                    _dumper.WriteAddition(term, termId);
-                    _fieldTree.BulkUpdateSet(ref key, termId, _curPage, pageOffset, ref _offsetAdjustment);
+                    result = new (AddEntriesToTermResult.UpdateTermId, termId);
                 }
                 else
                 {
@@ -130,26 +141,26 @@ public partial class IndexWriter
                         case AddEntriesToTermResult.UpdateTermId:
                             if (termId != postingListId)
                                 _dumper.WriteRemoval(term, postingListId);
-                            _dumper.WriteAddition(term, termId);
-                            _fieldTree.BulkUpdateSet(ref key, termId, _curPage, pageOffset, ref _offsetAdjustment);
+                            result = new (AddEntriesToTermResult.UpdateTermId, termId);
                             break;
                         case AddEntriesToTermResult.RemoveTermId:
-                            if (_fieldTree.BulkUpdateRemove(ref key, _curPage, pageOffset, ref _offsetAdjustment, out long oldValue) == false)
-                            {
-                                _dumper.WriteRemoval(term, termId);
-                                ThrowTriedToDeleteTermThatDoesNotExists(term, _fieldName);
-                            }
-
-                            _dumper.WriteRemoval(term, oldValue);
+                            result = new LookupTreeOperationJob(AddEntriesToTermResult.RemoveTermId, termId);
                             _writer._numberOfTermModifications--;
                             break;
                         case AddEntriesToTermResult.NothingToDo:
+                            result = new(AddEntriesToTermResult.NothingToDo, -1L);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException(entriesToTermResult.ToString());
                     }
                 }
             }
+            else
+            {
+                result = new LookupTreeOperationJob(AddEntriesToTermResult.NothingToDo, -1L);
+            }
+            
+            return result;
         }
         
         private void PrepareNumericalFieldBatch(
@@ -183,6 +194,42 @@ public partial class IndexWriter
             pageOffsets = _buffers.PageOffsets.AsSpan(start: 0, length: max);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ProcessLookupOperation(in LookupTreeOperationJob job, ref TLookupKey key, in Lookup<TLookupKey>.TreeStructureChanged treeChanged, int pageOffset, TKey term)
+        {
+            switch (job.Operation, TreeChanged: treeChanged.Changed)
+            {
+                case (AddEntriesToTermResult.UpdateTermId, TreeChanged: false):
+                    _fieldTree.BulkUpdateSet(ref key, job.TermId, _curPage, pageOffset, ref _offsetAdjustment);
+                    _dumper.WriteAddition(term, job.TermId);
+                    break;
+                case (AddEntriesToTermResult.UpdateTermId, TreeChanged: true):
+                    _fieldTree.Add(key, job.TermId);
+                    _dumper.WriteAddition(term, job.TermId);
+                    break;
+                case (AddEntriesToTermResult.RemoveTermId, TreeChanged: false):
+                {
+                    if (_fieldTree.BulkUpdateRemove(ref key, _curPage, pageOffset, ref _offsetAdjustment, out long oldValue) == false)
+                    {
+                        _dumper.WriteRemoval(term, job.TermId);
+                        ThrowTriedToDeleteTermThatDoesNotExists(term, _indexedField.Name);
+                    }
+                    _dumper.WriteRemoval(term, oldValue);
+                    break;
+                }
+                case (AddEntriesToTermResult.RemoveTermId, TreeChanged: true):
+                {
+                    if (_fieldTree.TryRemove(key, out long oldValue) == false)
+                    {
+                        _dumper.WriteRemoval(term, job.TermId);
+                        ThrowTriedToDeleteTermThatDoesNotExists(term, _indexedField.Name);
+                    }
+                    _dumper.WriteRemoval(term, oldValue);
+                    break;
+                }
+            }
+        }
+        
         private FieldBuffers<TKey, TLookupKey> GetBuffers()
         {
             if (typeof(TLookupKey) == typeof(Int64LookupKey))

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -208,6 +208,9 @@ public unsafe partial class IndexWriter
                     _dumper.WriteRemoval(term, oldValue);
                     break;
                 }
+                case (AddEntriesToTermResult.NothingToDo, TreeChanged: _):
+                    break;
+                default: throw new ArgumentOutOfRangeException($"Unknown operation: {job.Operation}");
             }
         }
         

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Corax.Utils;
@@ -11,6 +12,7 @@ using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
+using Voron.Data.Lookups;
 using Voron.Data.PostingLists;
 using Voron.Util;
 
@@ -28,7 +30,8 @@ public unsafe partial class IndexWriter
 
         private IndexTermDumper _dumper;
         private NativeList<TermInEntryModification> _entriesForTerm;
-        private ContextBoundNativeList<long> _pagesToPrefetch;
+        private ContextBoundNativeList<long> _postingListPagesProcessingBuffer;
+        private ContextBoundNativeList<LookupTreeOperationJob> _jobs;
 
         /// <summary>
         /// Terms are lazily initialized on disk, and we obtain the real address after processing EntriesModification.
@@ -50,7 +53,8 @@ public unsafe partial class IndexWriter
             _fieldTree.InitializeStateForTryGetNextValue();
             _entriesForTerm = new NativeList<TermInEntryModification>();
             _entriesForTerm.Initialize(_writer._entriesAllocator);
-            _pagesToPrefetch = new ContextBoundNativeList<long>(_writer._entriesAllocator);
+            _postingListPagesProcessingBuffer = new (_writer._entriesAllocator);
+            _jobs = new(writer._entriesAllocator);
             _buffers = _writer._textualFieldBuffers ??= new FieldBuffers<Slice, CompactTree.CompactKeyLookup>(_writer);
 
             if (indexedField.FieldSupportsPhraseQuery)
@@ -66,7 +70,7 @@ public unsafe partial class IndexWriter
         {
             _dumper.Dispose();
             _entriesForTerm.Dispose(_writer._entriesAllocator);
-            _pagesToPrefetch.Dispose();
+            _postingListPagesProcessingBuffer.Dispose();
         }
 
         public void InsertTextualField(in CancellationToken token)
@@ -106,7 +110,7 @@ public unsafe partial class IndexWriter
                     sortedTerms,
                     termsOffsets,
                     out var keys,
-                    out var postListIds,
+                    out var postingListIds,
                     out var pageOffsets);
 
                 var entriesOffsets = termsOffsets; // a copy that we trim internally in the loop belows
@@ -115,41 +119,37 @@ public unsafe partial class IndexWriter
                     var treeChanged = _fieldTree.CheckTreeStructureChanges();
 
                     _offsetAdjustment = 0;
-                    int read = _fieldTree.BulkUpdateStart(keys, postListIds, pageOffsets, out _curPage);
-
-                    FieldInserterHelper.PrefetchContainerPages(_writer, ref _pagesToPrefetch, postListIds[..read]);
+                    int read = _fieldTree.BulkUpdateStart(keys, postingListIds, pageOffsets, out _curPage);
+                    _jobs.ResetAndEnsureCapacity(read);
+                    _jobs.Count = read;
+                    _postingListPagesProcessingBuffer.ResetAndEnsureCapacity(read);
+                    FieldInserterHelper.PrefetchPostingListsPagesAndPrepareOrderedPostingListProcessingList(_writer, ref _postingListPagesProcessingBuffer, postingListIds[..read]);
 
                     int idx = 0;
                     for (; idx < read; idx++)
                     {
-                        ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[idx]);
-                        totalLengthOfTerm += ProcessSingleEntry(ref entries, ref keys[idx], isNullTerm: false,
-                            sortedTerms[idx], postListIds[idx],
-                            keys[idx].ContainerId, pageOffsets[idx], entriesOffsets[idx]);
-
-                        // if the tree structure changed, the bulk insert details are wrong
-                        // and will need to restart the operation with a new BulkUpdateStart
-                        if (treeChanged.Changed)
-                        {
-                            // next time, we start from the _next_ key, not the current one
-                            idx++;
-                            for (int j = idx; j < read; j++)
-                            {
-                                // Reset the known container id, since we modified the tree structure.
-                                // The issue is that we may have a term id that was remembered by a separator key
-                                // and we'll lose that after a page merge, so we'll have a reference to a deleted key
-                                // see: RavenDB-21272
-                                keys[j].ContainerId = Container.InvalidId;
-                            }
-
-                            break;
-                        }
-
+                        //We will process the containers by page ID, keeping in mind that a page can contain multiple entries.
+                        //The posting lists will be processed in page order; however, the lookup tree will be updated in term order.
+                        //Singles / new items are processed at the end. 
+                        var offset = (int)(_postingListPagesProcessingBuffer[idx] & FieldInserterHelper.OffsetMask);
+                        
+                        ref var entries = ref _indexedField.Storage.GetAsRef(entriesOffsets[offset]);
+                        var job = ProcessSingleEntry(ref entries, isNullTerm: false,
+                            sortedTerms[offset], postingListIds[offset],
+                            keys[offset].ContainerId, entriesOffsets[offset], out var totalLengthOfTermDelta);
+                        totalLengthOfTerm += totalLengthOfTermDelta;
                         entries.Dispose(_writer._entriesAllocator);
+                        _jobs[offset] = job;
                     }
 
+                    for (idx = 0; idx < read; idx++)
+                    {
+                        ProcessCompactTreeOperation(_jobs[idx], ref keys[idx], treeChanged, pageOffsets[idx], sortedTerms[idx]);
+                    }
+                    
+
                     keys = keys[idx..];
-                    postListIds = postListIds[idx..];
+                    postingListIds = postingListIds[idx..];
                     pageOffsets = pageOffsets[idx..];
                     entriesOffsets = entriesOffsets[idx..];
                     sortedTerms = sortedTerms[idx..];
@@ -169,12 +169,49 @@ public unsafe partial class IndexWriter
             (long postingListId, long termContainerId) = GetOrCreateSpecialPostingList(tree);
             ref var entries = ref _indexedField.Storage.GetAsRef(termsOffsets[termIndex]);
             var nullLookup = new CompactTree.CompactKeyLookup(CompactKey.NullInstance);
-            totalLengthOfTerm += ProcessSingleEntry(ref entries, ref nullLookup, isNullTerm: true,
-                sortedTerms[termIndex], postingListId, termContainerId, -1, termsOffsets[termIndex]);
+            var job = ProcessSingleEntry(ref entries, isNullTerm: true,
+                sortedTerms[termIndex], postingListId, termContainerId, termsOffsets[termIndex], out var totalLengthOfTermDelta);
+            totalLengthOfTerm += totalLengthOfTermDelta;
+            ProcessCompactTreeOperation(job, ref nullLookup, _fieldTree.CheckTreeStructureChanges(), pageOffset: -1, sortedTerms[termIndex]);
         }
 
-        private long ProcessSingleEntry(ref EntriesModifications entries, ref CompactTree.CompactKeyLookup key,
-            bool isNullTerm, Slice term, long postListId, long termContainerId, int pageOffset, int storageLocation)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ProcessCompactTreeOperation(in LookupTreeOperationJob job, ref CompactTree.CompactKeyLookup key, in Lookup<CompactTree.CompactKeyLookup>.TreeStructureChanged treeChanged, int pageOffset, Slice term)
+        {
+            switch (job.Operation, TreeChanged: treeChanged.Changed)
+            {
+                case (AddEntriesToTermResult.UpdateTermId, TreeChanged: false):
+                    _fieldTree.BulkUpdateSet(ref key, job.TermId, _curPage, pageOffset, ref _offsetAdjustment);
+                    _dumper.WriteAddition(term, job.TermId);
+                    break;
+                case (AddEntriesToTermResult.UpdateTermId, TreeChanged: true):
+                    _fieldTree.Add(key, job.TermId);
+                    _dumper.WriteAddition(term, job.TermId);
+                    break;
+                case (AddEntriesToTermResult.RemoveTermId, TreeChanged: false):
+                {
+                    if (_fieldTree.BulkUpdateRemove(ref key, _curPage, pageOffset, ref _offsetAdjustment, out long oldValue) == false)
+                    {
+                        _dumper.WriteRemoval(term, job.TermId);
+                        ThrowTriedToDeleteTermThatDoesNotExists(term, _indexedField.Name);
+                    }
+                    _dumper.WriteRemoval(term, oldValue);
+                    break;
+                }
+                case (AddEntriesToTermResult.RemoveTermId, TreeChanged: true):
+                {
+                    if (_fieldTree.TryRemove(key, out long oldValue) == false)
+                    {
+                        _dumper.WriteRemoval(term, job.TermId);
+                        ThrowTriedToDeleteTermThatDoesNotExists(term, _indexedField.Name);
+                    }
+                    _dumper.WriteRemoval(term, oldValue);
+                    break;
+                }
+            }
+        }
+        
+        private LookupTreeOperationJob ProcessSingleEntry(ref EntriesModifications entries, bool isNullTerm, Slice term, long postListId, long termContainerId, int storageLocation, out int totalLengthOfTermDelta)
         {
             UpdateEntriesForTerm(ref _entriesForTerm, in entries);
             if (_indexedField.Spatial == null) // For spatial, we handle this in InsertSpatialField, so we skip it here
@@ -182,8 +219,8 @@ public unsafe partial class IndexWriter
 
             bool found = postListId != Constants.IndexSearcher.InvalidId;
             Debug.Assert(found || entries.Removals.Count == 0, "Cannot remove entries from term that isn't already there");
-
-            int totalLengthOfTerm = 0;
+            LookupTreeOperationJob lookupTreeOperationJob;
+            totalLengthOfTermDelta = 0;
             if (entries.HasChanges)
             {
                 long termId;
@@ -193,10 +230,8 @@ public unsafe partial class IndexWriter
                         throw new InvalidOperationException($"Attempt to remove entries from new term: '{term}' for field {_indexedField.Name}! This is a bug.");
 
                     _writer.CreatePostingListForNewTerm(ref entries, _tmpBuf, out termId);
-                    totalLengthOfTerm = entries.TermSize;
-
-                    _dumper.WriteAddition(term, termId);
-                    _fieldTree.BulkUpdateSet(ref key, termId, _curPage, pageOffset, ref _offsetAdjustment);
+                    totalLengthOfTermDelta = entries.TermSize;
+                    lookupTreeOperationJob = new LookupTreeOperationJob(AddEntriesToTermResult.UpdateTermId, termId);
                 }
                 else
                 {
@@ -211,27 +246,25 @@ public unsafe partial class IndexWriter
 
                             Debug.Assert(isNullTerm == false, "isNullTerm == false - we pre-generate the ids, after all");
 
-                            _dumper.WriteAddition(term, termId);
-                            _fieldTree.BulkUpdateSet(ref key, termId, _curPage, pageOffset, ref _offsetAdjustment);
+                            lookupTreeOperationJob = new LookupTreeOperationJob(AddEntriesToTermResult.UpdateTermId, termId);
                             break;
                         case AddEntriesToTermResult.RemoveTermId:
                             Debug.Assert(isNullTerm == false, "isNullTerm == false, checked inside AddEntriesToTerm");
-                            if (_fieldTree.BulkUpdateRemove(ref key, _curPage, pageOffset, ref _offsetAdjustment, out long oldValue) == false)
-                            {
-                                _dumper.WriteRemoval(term, termId);
-                                ThrowTriedToDeleteTermThatDoesNotExists(term, _indexedField.Name);
-                            }
-
-                            totalLengthOfTerm = -entries.TermSize;
-                            _dumper.WriteRemoval(term, oldValue);
+                            totalLengthOfTermDelta = -entries.TermSize;
                             _writer._numberOfTermModifications--;
+                            lookupTreeOperationJob = new LookupTreeOperationJob(AddEntriesToTermResult.RemoveTermId, termId);
                             break;
                         case AddEntriesToTermResult.NothingToDo:
+                            lookupTreeOperationJob = new LookupTreeOperationJob(AddEntriesToTermResult.NothingToDo, -1L);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException(entriesToTermResult.ToString());
                     }
                 }
+            }
+            else
+            {
+                lookupTreeOperationJob = new LookupTreeOperationJob(AddEntriesToTermResult.NothingToDo, -1L);
             }
 
             RecordTermsForEntries(entries, termContainerId);
@@ -244,10 +277,10 @@ public unsafe partial class IndexWriter
                 _virtualTermIdToTermContainerId[storageLocation] = termContainerId;
             }
 
-            return totalLengthOfTerm;
+            return lookupTreeOperationJob;
         }
 
-        void ProcessTermsVector()
+        private void ProcessTermsVector()
         {
             if (_indexedField.FieldSupportsPhraseQuery == false)
                 return;
@@ -497,10 +530,12 @@ public unsafe partial class IndexWriter
 
     private static class FieldInserterHelper
     {
-        public static void PrefetchContainerPages(IndexWriter writer, ref ContextBoundNativeList<long> pagesToPrefetch, Span<long> postListIds)
+        public const int OffsetMask = 0x3FF;
+        
+        public static void PrefetchPostingListsPagesAndPrepareOrderedPostingListProcessingList(IndexWriter writer, ref ContextBoundNativeList<long> postingListPagesProcessingBuffer, Span<long> postListIds)
         {
-            pagesToPrefetch.Clear();
-            pagesToPrefetch.EnsureCapacityFor(postListIds.Length);
+            postingListPagesProcessingBuffer.Clear();
+            postingListPagesProcessingBuffer.EnsureCapacityFor(postListIds.Length);
 
             foreach (var cur in postListIds)
             {
@@ -510,12 +545,29 @@ public unsafe partial class IndexWriter
                     continue;
 
                 long containerId = EntryIdEncodings.GetContainerId(cur);
-                pagesToPrefetch.Add(containerId / Voron.Global.Constants.Storage.PageSize);
+                postingListPagesProcessingBuffer.Add(containerId / Voron.Global.Constants.Storage.PageSize);
             }
 
-            pagesToPrefetch.Count = Sorting.SortAndRemoveDuplicates(pagesToPrefetch.RawItems, pagesToPrefetch.Count);
+            postingListPagesProcessingBuffer.Count = Sorting.SortAndRemoveDuplicates(postingListPagesProcessingBuffer.RawItems, postingListPagesProcessingBuffer.Count);
 
-            writer._transaction.LowLevelTransaction.DataPager.MaybePrefetchMemory(pagesToPrefetch.GetEnumerator());
+            writer._transaction.LowLevelTransaction.DataPager.MaybePrefetchMemory(postingListPagesProcessingBuffer.GetEnumerator());
+            postingListPagesProcessingBuffer.Clear();
+
+            Debug.Assert(postListIds.Length <= 1024);
+            //ContainerId has 10 lowest bits in use to encode the metadata. We can use them to store the offset of the item in the original order.
+            for (int i = 0; i < postListIds.Length; i++)
+            {
+                if (postListIds[i] == Constants.IndexSearcher.InvalidId || (postListIds[i] & (long)TermIdMask.EnsureIsSingleMask) == 0)
+                {
+                    // new and single term will be allocating new containers or will be deleted. So let's put them at the end of the list.
+                    postingListPagesProcessingBuffer.AddByRefUnsafe() = (long.MaxValue & ~OffsetMask) | (long)i;
+                    continue;
+                }
+                
+                postingListPagesProcessingBuffer.AddByRefUnsafe() = (postListIds[i] & ~OffsetMask) | (long)i;
+            }
+            
+            postingListPagesProcessingBuffer.Sort();
         }
     }
 }

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1137,13 +1137,12 @@ namespace Corax.Indexing
             return AddEntriesToTermResultSingleValue(tmpBuf, idInTree, ref entries, out termId);
         }
 
-        private AddEntriesToTermResult AddEntriesToTermResultViaSmallPostingList(Span<byte> tmpBuf, ref EntriesModifications entries, out long termIdInTree,
-            long idInTree)
+        private AddEntriesToTermResult AddEntriesToTermResultViaSmallPostingList(Span<byte> tmpBuf, ref EntriesModifications entries, out long termIdInTree, long idInTree)
         {
             var containerId = EntryIdEncodings.GetContainerId(idInTree);
 
             var llt = _transaction.LowLevelTransaction;
-            Container.Get(llt, containerId, out var item);
+            Container.GetMutable(llt, containerId, out var item);
 
             Debug.Assert(entries.Removals.ToSpan().ToArray().Distinct().Count() == entries.Removals.Count, $"Removals list is not distinct.");
 
@@ -1194,7 +1193,7 @@ namespace Corax.Indexing
 
             if (encoded.Length == item.Length)
             {
-                var mutableSpace = Container.GetMutable(llt, containerId);
+                var mutableSpace = item.ToSpan();
                 encoded.CopyTo(mutableSpace);
 
                 // can update in place
@@ -1286,6 +1285,13 @@ namespace Corax.Indexing
             return AddEntriesToTermResult.UpdateTermId;
         }
 
+        /// <summary>
+        /// Operation to perform on a lookup tree after processing a term.
+        /// </summary>
+        /// <param name="Operation">Operation to perform.</param>
+        /// <param name="TermId">Encoded location of the posting list / single document.</param>
+        private record struct LookupTreeOperationJob(AddEntriesToTermResult Operation, long TermId);
+        
         private AddEntriesToTermResult AddEntriesToTermResultViaLargePostingList(ref EntriesModifications entries, out long termId, bool isNullTerm, long id)
         {
             var containerId = EntryIdEncodings.GetContainerId(id);

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -343,6 +343,16 @@ public sealed partial class CompactTree : IPrepareForCommit
 
         return lookup.ContainerId;
     }
+    
+    public long Add(CompactKeyLookup key, long value)
+    {
+        Debug.Assert(key.Key.Dictionary == _inner.State.DictionaryId);
+        AssertValueAndKeySize(key.Key, value);
+        
+        CompactTreeDumper.WriteAddition(this, ref key, value);
+        _inner.Add(ref key, value);
+        return key.ContainerId;
+    }
 
     public void PrepareForCommit()
     {

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Sparrow;
 using Sparrow.Server;
 using Sparrow.Server.Binary;
+using Sparrow.Server.Platform.Posix;
 using Voron.Data.Lookups;
 using Voron.Exceptions;
 using Voron.Global;
@@ -1280,6 +1281,8 @@ namespace Voron.Data.Containers
             return *(long*)pagePointer;
         }
 
+        
+        
         public static Span<byte> GetMutable(LowLevelTransaction llt, long id)
         {
             if (id <= 0)
@@ -1301,6 +1304,29 @@ namespace Voron.Data.Containers
             var pagePointer= page.Pointer;
             int size = metadata.Get(ref pagePointer);
             return new Span<byte>(pagePointer, size);
+        }
+        
+        public static void GetMutable(LowLevelTransaction llt, long id, out Item item)
+        {
+            if (id <= 0)
+                throw new InvalidOperationException("Got an invalid container id: " + id);
+
+            var (pageNum, offset) = Math.DivRem(id, Constants.Storage.PageSize);
+            var page = llt.ModifyPage(pageNum);
+
+            if (page.IsOverflow)
+            {
+                Debug.Assert(page.IsOverflow);
+                item = new Item(page, page.DataPointer, page.OverflowSize);
+                return;
+            }
+
+            var container = new Container(page);
+            var itemMetadata = container.MetadataFor(OffsetToIndex(offset));
+            Debug.Assert(itemMetadata.IsFree == false);
+            byte* pagePointer = page.Pointer;
+            var size = itemMetadata.Get(ref pagePointer);
+            item = new Item(page, pagePointer, size);
         }
 
         public static void Get(LowLevelTransaction llt, long id, out Item item)
@@ -1393,6 +1419,9 @@ namespace Voron.Data.Containers
 
         public readonly struct Item
         {
+            public static readonly Item Invalid = new Item(default, null, 0);
+            public bool IsInvalid => _ptr == null;
+            
             private readonly Page _page;
             private readonly byte* _ptr;
             public readonly int Length;

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -1280,8 +1280,6 @@ namespace Voron.Data.Containers
             Debug.Assert(size == sizeof(long));
             return *(long*)pagePointer;
         }
-
-        
         
         public static Span<byte> GetMutable(LowLevelTransaction llt, long id)
         {
@@ -1316,7 +1314,6 @@ namespace Voron.Data.Containers
 
             if (page.IsOverflow)
             {
-                Debug.Assert(page.IsOverflow);
                 item = new Item(page, page.DataPointer, page.OverflowSize);
                 return;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24217

### Additional description

This PR changes the flow of batch processing of terms during field indexing. It separates processing posting lists for each term and then updates the lookup tree with the already processed data.
Preparing posting lists happens in a page-ordered manner, which could lead to better disk access than processing them in a "zip" manner (posting list - lookup tree - posting list - [...]).


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
