### PR TITLE
RavenDB-24494 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/FailoverTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/FailoverTests.cs
@@ -133,7 +133,8 @@ loadToOrders(partitionBy(key),
 
             var store2 = stores.First(s => s != store);
 
-            var newResponsible = WaitForNewResponsibleNode(store2, task.TaskId, OngoingTaskType.OlapEtl, mentorTag);
+            var newResponsible = WaitForNewResponsibleNode(store2, task.TaskId, OngoingTaskType.OlapEtl, mentorTag, timeout : (int)timeout.TotalMilliseconds);
+            Assert.True(newResponsible != null, $"new responsible node was not selected in time (waited for {timeout}). cluster debug info :" + await AddClusterDebugLogsToErrorMessage());
             var newResponsibleNode = cluster.Nodes.Single(s => s.ServerStore.NodeTag == newResponsible);
             etlDone = await WaitForEtlAsync(newResponsibleNode, dbName, (n, statistics) => statistics.LoadSuccesses != 0);
 
@@ -206,6 +207,13 @@ loadToOrders(partitionBy(key),
                 .AppendLine("Debug info from the new responsible node:")
                 .AppendLine(newStats);
 
+            return sb.ToString();
+        }
+
+        private async Task<string> AddClusterDebugLogsToErrorMessage()
+        {
+            var sb = new StringBuilder();
+            await GetClusterDebugLogsAsync(sb);
             return sb.ToString();
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24494/SlowTests.Server.Documents.ETL.Olap.FailoverTests.OlapTaskShouldBeHighlyAvailable

### Additional description

increase timeout when waiting for a new responsible node, add debug info to error message

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
