### PR TITLE
RavenDB-25008 Fix index name replacement in TestIndex query to avoid substring conflicts

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminIndexHandlerProcessorForTestIndex<DatabaseRequestHandler, DocumentsOperationContext>
 {
     private static readonly Regex FromIndexClauseRegex = new Regex(
-        @"from index\s+(['""])(.*?)\1",
+        @"from\sindex\s+(['""])(.*?)\1",
         RegexOptions.IgnoreCase | RegexOptions.Compiled
     );
     public AdminIndexHandlerProcessorForTestIndex([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
@@ -44,8 +44,6 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
             const int documentsPerIndexUpperLimit = 10_000;
             const int documentsPerIndexLowerLimit = 1;
             
-            const string defaultTestIndexName = "<TestIndexName>";
-
             if (testIndexParameters.IndexDefinition is null)
                 throw new BadRequestException($"Index must have an {nameof(TestIndexParameters.IndexDefinition)} field");
 

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http.Features.Authentication;
@@ -18,6 +19,10 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 
 internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminIndexHandlerProcessorForTestIndex<DatabaseRequestHandler, DocumentsOperationContext>
 {
+    private static readonly Regex FromIndexClauseRegex = new Regex(
+        @"from index\s+(['""])(.*?)\1",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
     public AdminIndexHandlerProcessorForTestIndex([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
     {
     }
@@ -54,16 +59,12 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
                     throw new UnauthorizedAccessException("Testing C# indexes requires admin privileges.");
             }
 
-            var providedIndexName = testIndexDefinition.Name;
-
-            if (string.IsNullOrEmpty(providedIndexName))
-                providedIndexName = defaultTestIndexName;
-            
-            query ??= $"from index \"{providedIndexName}\"";
-            
             var testIndexName = Guid.NewGuid().ToString("N");
-            
-            query = query.Replace(providedIndexName, testIndexName);
+
+            var fromClause = $"from index '{testIndexName}'";
+            query = query == null 
+                ? fromClause 
+                : FromIndexClauseRegex.Replace(query, m => fromClause);
             
             testIndexDefinition.Name = testIndexName;
 
@@ -77,9 +78,6 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
                 
             var indexQueryServerSide = IndexQueryServerSide.Create(HttpContext, queryAsBlittable, RequestHandler.Database.QueryMetadataCache, tracker);
 
-            if (indexQueryServerSide.Metadata.IndexName != testIndexName)
-                throw new BadRequestException($"Expected {providedIndexName} as index name in query, but could not find it.");
-                
             using (var index = RequestHandler.Database.IndexStore.CreateTestIndexFromDefinition(testIndexDefinition, context.DocumentDatabase, context, maxDocumentsPerIndex))
             {
                 index.Start();

--- a/test/SlowTests/Issues/RavenDB-23380.cs
+++ b/test/SlowTests/Issues/RavenDB-23380.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
@@ -7,6 +10,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Http;
 using Raven.Client.Json;
+using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
 using Raven.Server.Documents.Indexes.Test;
 using Sparrow.Json;
 using Tests.Infrastructure;
@@ -151,7 +155,41 @@ public class RavenDB_23380 : RavenTestBase
             }
         }
     }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task TestIndex_WhenIndexNameIsSubstringOfQuery_ShouldTranslateTestIndexParametersCorrectly()
+    {
+        const int expectedValue = 9;
+        
+        var payload = new TestIndexParameters
+        {
+            IndexDefinition = new IndexDefinition { Name = "i", Maps = new HashSet<string> { "from obj in docs.Dtos select new { IndexProp = obj.Value }" } },
+            Query = "from index 'i'"
+        };
+
+        using var store = GetDocumentStore();
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Dto{Value = expectedValue});
+            await session.SaveChangesAsync();
+        }
+        
+        using var commands = store.Commands();
+
+        var command = new PutTestIndexCommand(payload);
+        await commands.ExecuteAsync(command);
+        
+        var result = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<ClientTestIndexResult>((BlittableJsonReaderObject)command.Result);
+        Assert.Single(result.QueryResults);
+        Assert.Equal(expectedValue, result.QueryResults.First().Value);
+    }
+
+    private class ClientTestIndexResult
+    {
+        public Dto[] QueryResults { get; set; }
+    }
     
+
     private class Dto
     {
         public string Id { get; set; }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25008

### Additional description
When running TestIndex, we generate a unique temporary index name and replace the provided index name inside the query to avoid collisions.
The replacement is a simple string substitution that is not token-aware.
If the original index name is short and appears as a substring of other tokens, the query is corrupted and the request fails.

Since this code is not performance-critical, I think the most straightforward approach here is to use a regex.  

Previously, the implementation rejected requests if there was a mismatch between the index name in the definition and the index name in the query.  
I believe this is unnecessary, because it doesn’t make sense to run a TestIndex request with a query targeting a different index.  
We can safely adjust the definition and query to match each other instead.  

The important part is to ensure that the index is created with a name that is not already in use.  


### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
