### PR TITLE
RavenDB-25014 Lock free ring padded more

### DIFF
--- a/src/Sparrow/Collections/LockFreeRingBuffer.cs
+++ b/src/Sparrow/Collections/LockFreeRingBuffer.cs
@@ -26,8 +26,7 @@ namespace Sparrow.Collections
         private readonly int _bufferMask;
         private readonly Cell[] _buffer;
 
-        private long _enqueuePos;
-        private long _dequeuePos;
+        private PaddedPositions _positions;
 
         static LockFreeRingBuffer()
         {
@@ -65,7 +64,7 @@ namespace Sparrow.Collections
         /// </summary>
         public bool TryEnqueue(in T item)
         {
-            long pos = Volatile.Read(ref _enqueuePos);
+            long pos = Volatile.Read(ref _positions.Enqueue);
             ref Cell cell = ref _buffer[pos & _bufferMask];
 
             while (true)
@@ -75,7 +74,7 @@ namespace Sparrow.Collections
 
                 if (dif == 0)
                 {
-                    if (Interlocked.CompareExchange(ref _enqueuePos, pos + 1, pos) == pos)
+                    if (Interlocked.CompareExchange(ref _positions.Enqueue, pos + 1, pos) == pos)
                         break;
                 }
                 else if (dif < 0)
@@ -84,7 +83,7 @@ namespace Sparrow.Collections
                     return false;
                 }
 
-                pos = Volatile.Read(ref _enqueuePos);
+                pos = Volatile.Read(ref _positions.Enqueue);
                 cell = ref _buffer[pos & _bufferMask];
             }
 
@@ -99,7 +98,7 @@ namespace Sparrow.Collections
         /// </summary>
         public bool TryDequeue(out T item)
         {
-            long pos = Volatile.Read(ref _dequeuePos);
+            long pos = Volatile.Read(ref _positions.Dequeue);
             ref Cell cell = ref _buffer[pos & _bufferMask];
 
             while (true)
@@ -109,7 +108,7 @@ namespace Sparrow.Collections
 
                 if (dif == 0)
                 {
-                    if (Interlocked.CompareExchange(ref _dequeuePos, pos + 1, pos) == pos)
+                    if (Interlocked.CompareExchange(ref _positions.Dequeue, pos + 1, pos) == pos)
                         break;
                 }
                 else if (dif < 0)
@@ -119,7 +118,7 @@ namespace Sparrow.Collections
                     return false;
                 }
 
-                pos = Volatile.Read(ref _dequeuePos);
+                pos = Volatile.Read(ref _positions.Dequeue);
                 cell = ref _buffer[pos & _bufferMask];
             }
 
@@ -135,10 +134,10 @@ namespace Sparrow.Collections
         {
             get
             {
-                long currentEnqueuePos = Volatile.Read(ref _enqueuePos);
+                long currentEnqueuePos = Volatile.Read(ref _positions.Enqueue);
                 Cell enqueueCell = _buffer[currentEnqueuePos & _bufferMask];
 
-                long currentDequeuePos = Volatile.Read(ref _dequeuePos);
+                long currentDequeuePos = Volatile.Read(ref _positions.Dequeue);
                 Cell dequeueCell = _buffer[currentDequeuePos & _bufferMask];
 
                 return (int) (Volatile.Read(ref enqueueCell.Sequence) - Volatile.Read(ref dequeueCell.Sequence));
@@ -152,7 +151,7 @@ namespace Sparrow.Collections
         {
             get
             {
-                long currentDequeuePos = Volatile.Read(ref _dequeuePos);
+                long currentDequeuePos = Volatile.Read(ref _positions.Dequeue);
                 Cell cell = _buffer[currentDequeuePos & _bufferMask];
                 return (Volatile.Read(ref cell.Sequence) - (currentDequeuePos + 1)) < 0;
             }
@@ -165,10 +164,26 @@ namespace Sparrow.Collections
         {
             get
             {
-                long currentEnqueuePos = Volatile.Read(ref _enqueuePos);
+                long currentEnqueuePos = Volatile.Read(ref _positions.Enqueue);
                 Cell cell = _buffer[currentEnqueuePos & _bufferMask];
                 return (Volatile.Read(ref cell.Sequence) - currentEnqueuePos) < 0;
             }
         }
+    }
+    
+    /// <summary>
+    /// Keep queue and dequeue positions padded along the cache lines.
+    /// When padded, the enqueuer does not trash the dequeuer and vice versa.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 3 * CacheLine)]
+    internal struct PaddedPositions
+    {
+        private const int CacheLine = 64;
+        
+        [FieldOffset(CacheLine)]
+        public long Enqueue;
+        
+        [FieldOffset(CacheLine * 2)]
+        public long Dequeue;
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25014/Make-LockFreeRingBuffer-padded-more

### Additional description

A minor. `LockFreeRingBuffer<T>` uses padding for cells but does not use it for dequeue/enqueue positions. Enhance it with it so that Enqueue/Dequeue can touch different cache lines.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
