### PR TITLE
RavenDB-24640 Subscription sessions are not respecting the PreserveDo…

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -24,7 +24,7 @@ namespace Raven.Client.Documents.Subscriptions
         internal override ValueTask InitializeAsync(BatchFromServer batch)
         {
             _sessionOpened = false;
-
+            _converter = _requestExecutor.Conventions.Serialization.CreateConverter(this);
             return base.InitializeAsync(batch);
         }
 
@@ -133,6 +133,11 @@ namespace Raven.Client.Documents.Subscriptions
             {
                 foreach (var item in _timeSeriesIncludes)
                     s.RegisterTimeSeries(item);
+            }
+
+            if (_requestExecutor.Conventions.PreserveDocumentPropertiesNotFoundOnModel)
+            {
+                s.JsonConverter.MissingProperties = _converter.MissingProperties;
             }
 
             foreach (var item in Items)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatchBase.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatchBase.cs
@@ -7,6 +7,7 @@ using Raven.Client.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
 using Sparrow.Logging;
+using Raven.Client.Json.Serialization;
 
 namespace Raven.Client.Documents.Subscriptions;
 
@@ -59,6 +60,7 @@ public abstract class SubscriptionBatchBase<T>
     protected List<BlittableJsonReaderObject> _includes;
     protected List<(BlittableJsonReaderObject Includes, Dictionary<string, string[]> IncludedCounterNames)> _counterIncludes;
     protected List<BlittableJsonReaderObject> _timeSeriesIncludes;
+    internal ISubscriptionsBlittableJsonConverter _converter;
 
     protected SubscriptionBatchBase(RequestExecutor requestExecutor, string dbName, Logger logger)
     {
@@ -104,7 +106,7 @@ public abstract class SubscriptionBatchBase<T>
                 {
                     try
                     {
-                        instance = _requestExecutor.Conventions.Serialization.DefaultConverter.FromBlittable<T>(curDoc, id);
+                        instance = _converter.FromBlittable<T>(curDoc, id);
                     }
                     catch (InvalidOperationException e)
                     {

--- a/src/Raven.Client/Json/Serialization/IBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/IBlittableJsonConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Raven.Client.Documents.Session;
 using Sparrow.Json;
 
@@ -19,6 +20,13 @@ namespace Raven.Client.Json.Serialization
         T FromBlittable<T>(BlittableJsonReaderObject json, string id = null);
     }
 
+    public interface ISubscriptionsBlittableJsonConverter : IBlittableJsonConverterBase
+    {
+        T FromBlittable<T>(BlittableJsonReaderObject json, string id = null);
+
+        internal Dictionary<object, Dictionary<object, object>> MissingProperties { get; set; }
+    }
+
     public interface ISessionBlittableJsonConverter : IBlittableJsonConverterBase
     {
         BlittableJsonReaderObject ToBlittable(object entity, DocumentInfo documentInfo);
@@ -34,6 +42,8 @@ namespace Raven.Client.Json.Serialization
         void RemoveFromMissing<T>(T entity);
 
         void Clear();
+
+        internal Dictionary<object, Dictionary<object, object>> MissingProperties { get; set; }
     }
 
     public interface IBlittableJsonConverterBase

--- a/src/Raven.Client/Json/Serialization/ISerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/ISerializationConventions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Subscriptions;
 using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization
@@ -16,6 +17,8 @@ namespace Raven.Client.Json.Serialization
         IJsonSerializer CreateDeserializer(CreateDeserializerOptions options = null);
 
         IBlittableJsonConverter DefaultConverter { get; }
+
+        ISubscriptionsBlittableJsonConverter CreateConverter<T>(SubscriptionBatch<T> batch);
 
         ISessionBlittableJsonConverter CreateConverter(InMemoryDocumentSessionOperations session);
 

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterWithMissingProperties.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterWithMissingProperties.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Util;
+
+namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
+
+internal abstract class BlittableJsonConverterWithMissingProperties : BlittableJsonConverterBase
+{
+    public Dictionary<object, Dictionary<object, object>> MissingProperties { get; set; }
+
+    protected BlittableJsonConverterWithMissingProperties(ISerializationConventions conventions) : base(conventions)
+    {
+    }
+
+    protected void RegisterMissingProperties(object o, string id, object value)
+    {
+        if (Conventions.Conventions.PreserveDocumentPropertiesNotFoundOnModel == false ||
+            id == Constants.Documents.Metadata.Key)
+            return;
+
+        MissingProperties ??= new Dictionary<object, Dictionary<object, object>>(ObjectReferenceEqualityComparer<object>.Default);
+
+        if (MissingProperties.TryGetValue(o, out var dictionary) == false)
+        {
+            MissingProperties[o] = dictionary = new Dictionary<object, object>();
+        }
+
+        dictionary[id] = value;
+    }
+}

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
@@ -3,27 +3,20 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json.Serialization;
 using Raven.Client.Documents.Session;
-using Raven.Client.Util;
 using Sparrow;
 using Sparrow.Json;
+using System.Linq;
 
 namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
 {
-    internal sealed class SessionBlittableJsonConverter : BlittableJsonConverterBase, ISessionBlittableJsonConverter
+    internal sealed class SessionBlittableJsonConverter : BlittableJsonConverterWithMissingProperties, ISessionBlittableJsonConverter
     {
         private readonly InMemoryDocumentSessionOperations _session;
 
-        private readonly Dictionary<object, Dictionary<object, object>> _missingDictionary = new Dictionary<object, Dictionary<object, object>>(ObjectReferenceEqualityComparer<object>.Default);
-
-        public SessionBlittableJsonConverter(InMemoryDocumentSessionOperations session)
+       public SessionBlittableJsonConverter(InMemoryDocumentSessionOperations session)
             : base(session.Conventions.Serialization)
         {
             _session = session ?? throw new ArgumentNullException(nameof(session));
-        }
-
-        public void Clear()
-        {
-            _missingDictionary.Clear();
         }
 
         public object FromBlittable(Type type, ref BlittableJsonReaderObject json, string id, bool trackEntity)
@@ -132,11 +125,6 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             _session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, id);
         }
 
-        public void RemoveFromMissing<T>(T entity)
-        {
-            _missingDictionary.Remove(entity);
-        }
-
         public BlittableJsonReaderObject ToBlittable(object entity, DocumentInfo documentInfo)
         {
             //maybe we don't need to do anything..
@@ -157,25 +145,22 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 return document;
             }
         }
+        public void Clear()
+        {
+            MissingProperties?.Clear();
+        }
 
         private IEnumerable<KeyValuePair<object, object>> FillMissingProperties(object o)
         {
-            _missingDictionary.TryGetValue(o, out var props);
-            return props;
+            if (MissingProperties != null && MissingProperties.TryGetValue(o, out var props))
+                return props;
+
+            return Enumerable.Empty<KeyValuePair<object, object>>();
         }
 
-        private void RegisterMissingProperties(object o, string id, object value)
+        public void RemoveFromMissing<T>(T entity)
         {
-            if (_session.Conventions.PreserveDocumentPropertiesNotFoundOnModel == false ||
-                id == Constants.Documents.Metadata.Key)
-                return;
-
-            if (_missingDictionary.TryGetValue(o, out var dictionary) == false)
-            {
-                _missingDictionary[o] = dictionary = new Dictionary<object, object>();
-            }
-
-            dictionary[id] = value;
+            MissingProperties?.Remove(entity);
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SubscriptionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SubscriptionBlittableJsonConverter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Newtonsoft.Json.Serialization;
+using Raven.Client.Documents.Session;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
+{
+    internal class SubscriptionBlittableJsonConverter : BlittableJsonConverterWithMissingProperties, ISubscriptionsBlittableJsonConverter
+    {
+        public SubscriptionBlittableJsonConverter(ISerializationConventions conventions) : base(conventions)
+        {
+
+        }
+
+        public T FromBlittable<T>(BlittableJsonReaderObject json, string id)
+        {
+            return (T)FromBlittable(typeof(T), json, id);
+        }
+
+        public object FromBlittable(Type type, BlittableJsonReaderObject json, string id)
+        {
+            try
+            {
+                ExtensionDataSetter dataSetter = null;
+                if (Conventions.Conventions.PreserveDocumentPropertiesNotFoundOnModel)
+                {
+                    dataSetter = RegisterMissingProperties;
+                }
+
+                using (DefaultRavenContractResolver.RegisterExtensionDataSetter(dataSetter))
+                {
+                    var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
+                    var entity = defaultValue;
+
+                    var documentTypeAsString = Conventions.Conventions.GetClrType(id, json);
+                    if (documentTypeAsString != null)
+                    {
+                        var documentType = Conventions.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
+                        if (documentType != null && type.IsAssignableFrom(documentType))
+                        {
+                            entity = Conventions.DeserializeEntityFromBlittable(documentType, json);
+                        }
+                    }
+
+                    if (Equals(entity, defaultValue))
+                    {
+                        entity = Conventions.DeserializeEntityFromBlittable(type, json);
+                    }
+
+                    return entity;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Could not convert document {id} to entity of type {type}",
+                    ex);
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/NewtonsoftJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/NewtonsoftJsonSerializationConventions.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
 using Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters;
 using Sparrow.Json;
+using Raven.Client.Documents.Subscriptions;
 
 namespace Raven.Client.Json.Serialization.NewtonsoftJson
 {
@@ -115,6 +116,11 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson
                 Conventions?.AssertNotFrozen();
                 _ignoreUnsafeMembers = value;
             }
+        }
+
+        public ISubscriptionsBlittableJsonConverter CreateConverter<T>(SubscriptionBatch<T> batch)
+        {
+            return new SubscriptionBlittableJsonConverter(this);
         }
 
         ISessionBlittableJsonConverter ISerializationConventions.CreateConverter(InMemoryDocumentSessionOperations session)

--- a/test/SlowTests/Issues/RavenDB-24640.cs
+++ b/test/SlowTests/Issues/RavenDB-24640.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client;
+using Raven.Client.Documents.Subscriptions;
+using Sparrow.Collections;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24640 : RavenTestBase
+    {
+        public RavenDB_24640(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class TestDocument
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task ShouldWork()
+        {
+            using (var store = GetDocumentStore(new Options()
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.PreserveDocumentPropertiesNotFoundOnModel = true;
+                    s.Conventions.IdentityPartsSeparator = '-';
+                    s.Conventions.MaxNumberOfRequestsPerSession = int.MaxValue;
+                    s.Conventions.UseOptimisticConcurrency = true;
+                }
+            }))
+            {
+                var mre = new AsyncManualResetEvent();
+                var testDoc = new TestDocument { Name = "Foo", Id = "TestDocuments-1-A" };
+
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(testDoc);
+                    await session.SaveChangesAsync();
+                }
+
+                var options = new SubscriptionCreationOptions<TestDocument> { Name = "Test" };
+                await store.Subscriptions.CreateAsync(options, store.Database);
+                var worker = store.Subscriptions.GetSubscriptionWorker<TestDocument>(
+                    new SubscriptionWorkerOptions(options.Name) { Strategy = SubscriptionOpeningStrategy.TakeOver }, store.Database);
+
+                var s = new ConcurrentSet<string>();
+
+                worker.AfterAcknowledgment += batch =>
+                {
+                    foreach (var i in batch.Items)
+                    {
+                        s.Add(i.Result.Name);
+                    }
+
+                    return Task.CompletedTask;
+                };
+                _ = worker
+                    .Run(async batch =>
+                    {
+                        using (var session = batch.OpenAsyncSession())
+                        {
+                            await session.SaveChangesAsync();
+                        }
+
+                        if (mre.IsSet == false)
+                        {
+                            mre.Set();
+                        }
+
+                    });
+                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)));
+
+
+                using (var commands = store.Commands())
+                {
+                    testDoc.Name = "Documents";
+                    var str = JsonSerializer.Serialize<TestDocument>(testDoc);
+                    dynamic json = JObject.Parse(str);
+                    json.Foo = "EGOR";
+                    await commands.PutAsync("TestDocuments-1-A", null, json,
+                        new Dictionary<string, object> { { Constants.Documents.Metadata.Collection, "TestDocuments" } });
+                }
+
+                await WaitForValueAsync(() => s.Count, 2, 60_000);
+
+                using (var commands = store.Commands())
+                {
+                    dynamic doc = await commands.GetAsync("TestDocuments-1-A");
+                    Assert.Equal("Documents", doc.Name);
+                    Assert.Equal("EGOR", doc.Foo); // This is failing because Foo is missing
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…cumentPropertiesNotFoundOnModel

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24640

### Additional description
Previously, when serializing documents from a BlittableJsonReaderObject in a subscription batch, we did not persist the Missing Properties even if the PreserveDocumentPropertiesNotFoundOnModel flag was set to true.
As a result, when the document was later loaded into the session, this information was lost.

I updated the code so that when PreserveDocumentPropertiesNotFoundOnModel is enabled, the Missing Properties are now saved during subscription batch serialization and passed along to the session when needed, ensuring this data is preserved.

V5.4 PR- https://github.com/ravendb/ravendb/pull/21160
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
