### PR TITLE
RavenDB-22440 : fix flaky test

### DIFF
--- a/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
+++ b/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.OLAP;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.ETL;
@@ -285,15 +286,9 @@ loadToOrders(partitionBy(key), o);
                 {
                     return await Databases.GetDocumentDatabaseInstanceFor(store);
                 }
-                catch (AggregateException e)
+                catch (DatabaseDisabledException)
                 {
-                    if (e.Message.Contains($"The database '{store.Database}' has been unloaded and locked"))
-                    {
-                        await Task.Delay(10);
-                        continue;
-                    }
-
-                    throw;
+                    await Task.Delay(10);
                 }
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22440/StressTests.Server.Documents.ETL.Olap.LocalTestsStress.AfterDatabaseRestartEtlShouldRespectRunFrequency

### Additional description

The bug was in `WaitForDatabaseToUnlockAsync`
It expected to (possibly) get an `AggregateException` from `GetDocumentDatabaseInstanceFor` (with `database has been unloaded and locked` inside the error message), but the actual exception is thrown as a single `DatabaseDisabledException`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
