### PR TITLE
RavenDB-25023 GenAI: attachments NRE

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/hooks/useEditGenAiTaskTests.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/hooks/useEditGenAiTaskTests.ts
@@ -151,6 +151,10 @@ export function useEditGenAiTaskTests() {
     const getAttachments = (
         attachments: GenAiAiAttachment[]
     ): Raven.Server.Documents.ETL.Providers.AI.AiAttachment[] => {
+        if (!attachments) {
+            return null;
+        }
+
         return attachments.map((x) => ({
             Data: x.Data,
             Name: x.Name,

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskValidation.ts
@@ -9,7 +9,7 @@ const attachmentsSchema = yup.array().of(
         Name: yup.string(),
         Source: yup.string<Raven.Server.Documents.ETL.Providers.AI.AiAttachmentSource>(),
         Type: yup.string(),
-    })
+    }).nullable()
 );
 
 export const editGenAiTaskSchema = yup.object({


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25023

### Additional description

Fix NRE for context without attachments

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
