### PR TITLE
RavenDB-25024 session.Advanced.HasChanges does not reflect metadata c…

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1258,6 +1258,7 @@ more responsive application.
             {
                 foreach (var entity in DocumentsByEntity)
                 {
+                    UpdateMetadataModifications(entity.Value.MetadataInstance, entity.Value.Metadata);
                     using (var document = JsonConverter.ToBlittable(entity.Key, entity.Value))
                     {
                         if (EntityChanged(document, entity.Value, null))
@@ -1283,6 +1284,8 @@ more responsive application.
             DocumentInfo documentInfo;
             if (DocumentsByEntity.TryGetValue(entity, out documentInfo) == false)
                 return false;
+
+            UpdateMetadataModifications(documentInfo.MetadataInstance, documentInfo.Metadata);
             using (var document = JsonConverter.ToBlittable(entity, documentInfo))
                 return EntityChanged(document, documentInfo, null);
         }

--- a/test/SlowTests/Issues/RavenDB-25024.cs
+++ b/test/SlowTests/Issues/RavenDB-25024.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using FastTests;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25024 : RavenTestBase
+    {
+        public RavenDB_25024(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ChangeMetadataDoesNotShowChanges()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = "users/1";
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "user1" }, id);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>(id);
+                    session.Advanced.GetMetadataFor(user)["@refresh"] = DateTime.UtcNow.AddDays(1);
+
+                    var whatChanged = session.Advanced.WhatChanged();
+                    var sessionHasChanges = session.Advanced.HasChanges;
+                    var entityHasChanges = session.Advanced.HasChanged(user);
+
+                    Assert.NotEmpty(whatChanged);
+                    Assert.True(entityHasChanges);
+                    Assert.True(sessionHasChanges);
+                   
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…hanges

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25024

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
