### PR TITLE
RavenDB-24621 - Change AiAttachmentSource names

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/AiAttachment.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/AiAttachment.cs
@@ -43,4 +43,4 @@ public class AiAttachment
     }
 }
 
-public enum AiAttachmentSource { FromDatabase, FromUser, NotFound }
+public enum AiAttachmentSource { FromAttachments, FromScript, NotFound }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/AiAttachment.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/AiAttachment.cs
@@ -43,4 +43,9 @@ public class AiAttachment
     }
 }
 
-public enum AiAttachmentSource { FromAttachments, FromScript, NotFound }
+public enum AiAttachmentSource
+{
+    FromAttachment, 
+    FromScript, 
+    NotFound
+}

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -209,7 +209,7 @@ var ai = new AI();
                         var data = string.Empty;
                         string type = attachmentObj.GetOwnProperty(AttachmentsRequestConstants.Type).Value.AsString();
                         string filename = "unknown.name";
-                        var source = AiAttachmentSource.FromDatabase;
+                        var source = AiAttachmentSource.FromAttachments;
 
                         // TODO: we aren't being really efficient here in terms of allocations / memory
                         // but the problem is that the API itself may require large BASE64 strings, annoying 
@@ -228,7 +228,7 @@ var ai = new AI();
                         else
                         {
                             //if we arrive here we probably didn't pass through loadAttachment() function
-                            source = AiAttachmentSource.FromUser;
+                            source = AiAttachmentSource.FromScript;
                             data = reference.ToString();
                             if (type != AttachmentsRequestConstants.MediaTypeTextPlain && IsBase64(data) == false)
                                 throw new InvalidOperationException($"Attachment must be loaded or base64 string (on type {type})");

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -209,7 +209,7 @@ var ai = new AI();
                         var data = string.Empty;
                         string type = attachmentObj.GetOwnProperty(AttachmentsRequestConstants.Type).Value.AsString();
                         string filename = "unknown.name";
-                        var source = AiAttachmentSource.FromAttachments;
+                        var source = AiAttachmentSource.FromAttachment;
 
                         // TODO: we aren't being really efficient here in terms of allocations / memory
                         // but the problem is that the API itself may require large BASE64 strings, annoying 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -497,7 +497,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             if (item.ContextOutput.Attachments.IsNullOrEmpty())
                 continue;
 
-            foreach (var genAtt in item.ContextOutput.Attachments.Where(a => a.Source == AiAttachmentSource.FromDatabase))
+            foreach (var genAtt in item.ContextOutput.Attachments.Where(a => a.Source == AiAttachmentSource.FromAttachments))
             {
                 // try to reload again every loaded/not-found attachment
                 var attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(context, item.DocumentId, genAtt.Name, AttachmentType.Document, changeVector: null);

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -497,7 +497,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             if (item.ContextOutput.Attachments.IsNullOrEmpty())
                 continue;
 
-            foreach (var genAtt in item.ContextOutput.Attachments.Where(a => a.Source == AiAttachmentSource.FromAttachments))
+            foreach (var genAtt in item.ContextOutput.Attachments.Where(a => a.Source == AiAttachmentSource.FromAttachment))
             {
                 // try to reload again every loaded/not-found attachment
                 var attachment = Database.DocumentsStorage.AttachmentsStorage.GetAttachment(context, item.DocumentId, genAtt.Name, AttachmentType.Document, changeVector: null);

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -822,13 +822,13 @@ namespace Orders
                             {
                                 Name: "heart.png",
                                 Type: "image/png",
-                                Source: "FromDatabase",
+                                Source: "FromAttachment",
                                 Data: "[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']",
                             },
                             {
                                 Name: "transactions.csv",
                                 Type: "text/plain",
-                                Source: "FromDatabase",
+                                Source: "FromAttachment",
                                 Data: "Date,Description,Category,Amount\r\n2025-01-01,Grocery Store,food,45.32\r\n2025-01-02,Utility Bill,Ut...",
                             },
                         ],
@@ -849,13 +849,13 @@ namespace Orders
                             {
                                 Name: "heart.png",
                                 Type: "image/png",
-                                Source: "FromDatabase",
+                                Source: "FromAttachment",
                                 Data: "[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']",
                             },
                             {
                                 Name: "transactions.csv",
                                 Type: "text/plain",
-                                Source: "FromDatabase",
+                                Source: "FromAttachment",
                                 Data: "Date,Description,Category,Amount\r\n2025-01-01,Grocery Store,food,45.32\r\n2025-01-02,Utility Bill,Ut...",
                             },
                         ],

--- a/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
@@ -451,8 +451,8 @@ for(const comment of this.Comments)
         Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
         Assert.Equal("[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.Equal("[Hash:'94IlaZrchKnAQBD3vQQ7sE0Yt6f0CJeu69Ljfb66bxo=']", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
-        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachment, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachment, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
         Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
 
@@ -592,8 +592,8 @@ for(const comment of this.Comments)
         Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
         Assert.Equal("[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.Equal("[Hash:'94IlaZrchKnAQBD3vQQ7sE0Yt6f0CJeu69Ljfb66bxo=']", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
-        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachment, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachment, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
         Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
         
@@ -727,8 +727,8 @@ for(const comment of this.Comments)
             Assert.Equal("text.csv", aiAttachments[5].Name);
             Assert.Equal("short_text.txt", aiAttachments[6].Name);
 
-            Assert.Equal(AiAttachmentSource.FromAttachments, aiAttachments[0].Source);
-            Assert.Equal(AiAttachmentSource.FromAttachments, aiAttachments[1].Source);
+            Assert.Equal(AiAttachmentSource.FromAttachment, aiAttachments[0].Source);
+            Assert.Equal(AiAttachmentSource.FromAttachment, aiAttachments[1].Source);
             Assert.Equal(AiAttachmentSource.NotFound, aiAttachments[2].Source);
             Assert.Equal(AiAttachmentSource.FromScript, aiAttachments[3].Source);
             Assert.Equal("[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']", aiAttachments[0].Data);

--- a/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/RavenDB-24648.cs
@@ -451,8 +451,8 @@ for(const comment of this.Comments)
         Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
         Assert.Equal("[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.Equal("[Hash:'94IlaZrchKnAQBD3vQQ7sE0Yt6f0CJeu69Ljfb66bxo=']", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.Equal(AiAttachmentSource.FromDatabase, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
-        Assert.Equal(AiAttachmentSource.FromDatabase, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
         Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
 
@@ -573,7 +573,7 @@ for(const comment of this.Comments)
             Assert.Equal(1, genAiContexts2[i].ContextOutput.Attachments.Count);
             var att = genAiContexts2[0].ContextOutput.Attachments.First();
             Assert.Equal("unknown.name", att.Name);
-            Assert.Equal(AiAttachmentSource.FromUser, att.Source);
+            Assert.Equal(AiAttachmentSource.FromScript, att.Source);
             Assert.Equal("image/png", att.Type);
             Assert.Equal(BananaPngBase64, att.Data);
         }
@@ -592,15 +592,15 @@ for(const comment of this.Comments)
         Assert.Equal("image/png", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Type);
         Assert.Equal("[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']", genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.Equal("[Hash:'94IlaZrchKnAQBD3vQQ7sE0Yt6f0CJeu69Ljfb66bxo=']", genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.Equal(AiAttachmentSource.FromDatabase, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
-        Assert.Equal(AiAttachmentSource.FromDatabase, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromAttachments, genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Source);
         Assert.NotNull(genAiContexts[0].ContextOutput.Attachments.FirstOrDefault()?.Data);
         Assert.NotNull(genAiContexts[1].ContextOutput.Attachments.FirstOrDefault()?.Data);
         
         Assert.Equal(1, genAiContexts[2].ContextOutput.Attachments.Count);
         Assert.Equal("unknown.name", genAiContexts[2].ContextOutput.Attachments.FirstOrDefault()?.Name);
         Assert.Equal(BananaPngBase64, genAiContexts[2].ContextOutput.Attachments.FirstOrDefault()?.Data);
-        Assert.Equal(AiAttachmentSource.FromUser, genAiContexts[2].ContextOutput.Attachments.FirstOrDefault()?.Source);
+        Assert.Equal(AiAttachmentSource.FromScript, genAiContexts[2].ContextOutput.Attachments.FirstOrDefault()?.Source);
         Assert.Equal("image/png", genAiContexts[2].ContextOutput.Attachments.FirstOrDefault()?.Type);
         
         
@@ -727,10 +727,10 @@ for(const comment of this.Comments)
             Assert.Equal("text.csv", aiAttachments[5].Name);
             Assert.Equal("short_text.txt", aiAttachments[6].Name);
 
-            Assert.Equal(AiAttachmentSource.FromDatabase, aiAttachments[0].Source);
-            Assert.Equal(AiAttachmentSource.FromDatabase, aiAttachments[1].Source);
+            Assert.Equal(AiAttachmentSource.FromAttachments, aiAttachments[0].Source);
+            Assert.Equal(AiAttachmentSource.FromAttachments, aiAttachments[1].Source);
             Assert.Equal(AiAttachmentSource.NotFound, aiAttachments[2].Source);
-            Assert.Equal(AiAttachmentSource.FromUser, aiAttachments[3].Source);
+            Assert.Equal(AiAttachmentSource.FromScript, aiAttachments[3].Source);
             Assert.Equal("[Hash:'FLNK25A3VOpVPIiusBEZMwUU5mWqSZR7T2OqYF4nBfA=']", aiAttachments[0].Data);
             Assert.Equal("[Hash:'94IlaZrchKnAQBD3vQQ7sE0Yt6f0CJeu69Ljfb66bxo=']", aiAttachments[1].Data);
             Assert.Equal(string.Empty, aiAttachments[2].Data);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24621/GenAI-support-for-images-documents

### Additional description

Change AiAttachmentSource names: 
FromDatabase => FromAttachments, 
FromUser => FromScript

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
