### PR TITLE
RavenDB-24960 [Studio] Add temperature to OpenAiSettings and AzureOpenAiSettings 

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -210,7 +210,7 @@ export function FormSelect<
 
     const valueAccessor = rest.getOptionValue ?? ((option: any) => option.value);
 
-    const selectedOptions = getFormSelectedOptions<Option>(formValues, rest.options, valueAccessor);
+    const selectedOptions = getFormSelectedOptions<Option>(formValues, rest.options, valueAccessor) ?? null;
 
     return (
         <>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
@@ -139,6 +139,8 @@ export interface AiConnection extends ConnectionBase {
         deploymentName?: string;
         dimensions?: number;
         embeddingsMaxConcurrentBatches?: number;
+        isSetTemperature?: boolean;
+        temperature?: number;
     };
     googleSettings?: {
         aiVersion?: Raven.Client.Documents.Operations.AI.GoogleAIVersion;
@@ -172,6 +174,8 @@ export interface AiConnection extends ConnectionBase {
         projectId?: string;
         dimensions?: number;
         embeddingsMaxConcurrentBatches?: number;
+        isSetTemperature?: boolean;
+        temperature?: number;
     };
     mistralAiSettings?: {
         apiKey?: string;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
@@ -4,9 +4,7 @@ import { FormProvider, SubmitHandler, useForm, useWatch } from "react-hook-form"
 import { Icon } from "components/common/Icon";
 import { ConnectionFormData, EditConnectionStringFormProps, AiConnection } from "../connectionStringsTypes";
 import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
 import ConnectionStringUsedByTasks from "./shared/ConnectionStringUsedByTasks";
-import { yupObjectSchema } from "components/utils/yupUtils";
 import { SelectOptionWithIcon, SingleValueWithIcon } from "components/common/select/Select";
 import RichAlert from "components/common/RichAlert";
 import OptionalLabel from "components/common/OptionalLabel";
@@ -22,7 +20,7 @@ import TaskUtils from "components/utils/TaskUtils";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { connectionStringSelectors } from "../store/connectionStringsSlice";
 import { useAppSelector } from "components/store";
-import { ConnectionStringsNameContext, connectionStringsUtils } from "../connectionStringsUtils";
+import { ConnectionStringsNameContext } from "../connectionStringsUtils";
 import { components, OptionProps } from "react-select";
 import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
@@ -31,6 +29,7 @@ import Form from "react-bootstrap/Form";
 import ModelTypeField from "./aiFields/ModelTypeField";
 import { withNestedSubmit } from "components/utils/common";
 import { useEffect } from "react";
+import { aiConnectionStringUtils } from "./aiConnectionStringUtils";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -48,9 +47,9 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
 
     const form = useForm<FormData>({
         mode: "all",
-        defaultValues: getDefaultValues(initialConnection, isForNewConnection),
+        defaultValues: aiConnectionStringUtils.getDefaultValues(initialConnection, isForNewConnection),
         resolver: (data, _, options) =>
-            yupResolver(schema)(
+            yupResolver(aiConnectionStringUtils.schema)(
                 data,
                 {
                     connectorType: data.connectorType,
@@ -76,7 +75,7 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
                 name === "modelType" &&
                 values.modelType === "Chat" &&
                 values.connectorType != null &&
-                !chatConnectorTypes.includes(values.connectorType)
+                !aiConnectionStringUtils.chatConnectorTypes.includes(values.connectorType)
             ) {
                 setValue("connectorType", null);
             }
@@ -157,7 +156,7 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
                         control={control}
                         name="connectorType"
                         placeholder={`Select connector${modelType == null ? " (select model type first)" : ""}`}
-                        options={getConnectorOptions(modelType)}
+                        options={aiConnectionStringUtils.getConnectorOptions(modelType)}
                         isDisabled={isUsedByAnyTask || modelType == null}
                         components={{
                             Option: SettingsOptionComponent,
@@ -206,259 +205,4 @@ export function SettingsOptionComponent(props: OptionProps<SelectOptionWithIcon>
             </components.Option>
         </div>
     );
-}
-
-const chatConnectorTypes: FormData["connectorType"][] = ["ollamaSettings", "openAiSettings", "azureOpenAiSettings"];
-
-function getConnectorOptions(modelType: FormData["modelType"]): SelectOptionWithIcon<FormData["connectorType"]>[] {
-    const allOptions: SelectOptionWithIcon<FormData["connectorType"]>[] = [
-        { label: "Azure OpenAI", value: "azureOpenAiSettings", icon: "openai" },
-        { label: "Google AI", value: "googleSettings", icon: "google-gemini" },
-        { label: "Hugging Face", value: "huggingFaceSettings", icon: "huggingface" },
-        { label: "Ollama", value: "ollamaSettings", icon: "ollama" },
-        { label: "OpenAI", value: "openAiSettings", icon: "openai" },
-        { label: "Mistral AI", value: "mistralAiSettings", icon: "mistralai" },
-        { label: "Embedded (bge-micro-v2)", value: "embeddedSettings", icon: "onnx" },
-    ];
-
-    if (modelType === "Chat") {
-        return [...allOptions.filter((x) => chatConnectorTypes.includes(x.value))].reverse();
-    }
-
-    return allOptions;
-}
-
-const temperatureSchema = yup
-    .number()
-    .nullable()
-    .when(["$modelType", "isSetTemperature"], {
-        is: (modelType: FormData["modelType"], isSetTemperature: boolean) => modelType === "Chat" && isSetTemperature,
-        then: (schema) => schema.min(0).max(2).required(),
-    });
-
-const schema = yupObjectSchema<FormData>({
-    name: connectionStringsUtils.nameSchema,
-    identifier: yup
-        .string()
-        .nullable()
-        .test("is-identifier", "Only lowercase letters (a-z), numbers (0-9) and hyphens (-) are allowed.", (value) => {
-            if (!value) {
-                return true;
-            }
-
-            return /^[a-z0-9-]+$/.test(value);
-        }),
-    connectorType: yup.string<FormData["connectorType"]>().nullable().required(),
-    modelType: yup.string<Raven.Client.Documents.Operations.AI.AiModelType>().nullable().required(),
-    azureOpenAiSettings: yupObjectSchema<FormData["azureOpenAiSettings"]>({
-        apiKey: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "azureOpenAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        endpoint: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "azureOpenAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        model: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "azureOpenAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        deploymentName: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "azureOpenAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        dimensions: yup.number().nullable().integer().positive(),
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-        isSetTemperature: yup.boolean().nullable(),
-        temperature: temperatureSchema,
-    }),
-    googleSettings: yupObjectSchema<FormData["googleSettings"]>({
-        aiVersion: yup.string<Raven.Client.Documents.Operations.AI.GoogleAIVersion>().nullable(),
-        apiKey: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "googleSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        model: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "googleSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        dimensions: yup.number().nullable().integer().positive(),
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-    }),
-    huggingFaceSettings: yupObjectSchema<FormData["huggingFaceSettings"]>({
-        apiKey: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "huggingFaceSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        endpoint: yup.string().nullable(),
-        model: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "huggingFaceSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-    }),
-    ollamaSettings: yupObjectSchema<FormData["ollamaSettings"]>({
-        model: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "ollamaSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        uri: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "ollamaSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-        think: yup.boolean().nullable(),
-        isSetTemperature: yup.boolean().nullable(),
-        temperature: temperatureSchema,
-    }),
-    embeddedSettings: yupObjectSchema<FormData["embeddedSettings"]>({
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-    }),
-    openAiSettings: yupObjectSchema<FormData["openAiSettings"]>({
-        apiKey: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "openAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        endpoint: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "openAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        model: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "openAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        organizationId: yup.string().nullable(),
-        projectId: yup.string().nullable(),
-        dimensions: yup.number().nullable().integer().positive(),
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-        isSetTemperature: yup.boolean().nullable(),
-        temperature: temperatureSchema,
-    }),
-    mistralAiSettings: yupObjectSchema<FormData["mistralAiSettings"]>({
-        apiKey: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "mistralaiAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        endpoint: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "mistralaiAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        model: yup
-            .string()
-            .nullable()
-            .when("$connectorType", {
-                is: "mistralaiAiSettings",
-                then: (schema) => schema.trim().required(),
-            }),
-        embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
-    }),
-});
-
-function getDefaultValues(initialConnection: AiConnection, isForNewConnection: boolean): FormData {
-    if (isForNewConnection) {
-        return {
-            name: null,
-            identifier: null,
-            connectorType: null,
-            modelType: initialConnection?.modelType ?? null,
-            azureOpenAiSettings: {
-                apiKey: null,
-                endpoint: null,
-                model: null,
-                deploymentName: null,
-                dimensions: null,
-                embeddingsMaxConcurrentBatches: null,
-                isSetTemperature: false,
-                temperature: null,
-            } satisfies Required<FormData["azureOpenAiSettings"]>,
-            googleSettings: {
-                aiVersion: null,
-                apiKey: null,
-                model: null,
-                dimensions: null,
-                embeddingsMaxConcurrentBatches: null,
-            } satisfies Required<FormData["googleSettings"]>,
-            huggingFaceSettings: {
-                apiKey: null,
-                endpoint: null,
-                model: null,
-                embeddingsMaxConcurrentBatches: null,
-            } satisfies Required<FormData["huggingFaceSettings"]>,
-            ollamaSettings: {
-                model: null,
-                uri: null,
-                embeddingsMaxConcurrentBatches: null,
-                think: null,
-                isSetTemperature: false,
-                temperature: null,
-            } satisfies Required<FormData["ollamaSettings"]>,
-            embeddedSettings: {
-                embeddingsMaxConcurrentBatches: null,
-            } satisfies Required<FormData["embeddedSettings"]>,
-            openAiSettings: {
-                apiKey: null,
-                endpoint: null,
-                model: null,
-                organizationId: null,
-                projectId: null,
-                dimensions: null,
-                embeddingsMaxConcurrentBatches: null,
-                isSetTemperature: false,
-                temperature: null,
-            } satisfies Required<FormData["openAiSettings"]>,
-            mistralAiSettings: {
-                apiKey: null,
-                endpoint: null,
-                model: null,
-                embeddingsMaxConcurrentBatches: null,
-            } satisfies Required<FormData["mistralAiSettings"]>,
-        };
-    }
-
-    return _.omit(initialConnection, "type", "usedByTasks");
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/AiConnectionString.tsx
@@ -30,8 +30,14 @@ import classNames from "classnames";
 import Form from "react-bootstrap/Form";
 import ModelTypeField from "./aiFields/ModelTypeField";
 import { withNestedSubmit } from "components/utils/common";
+import { useEffect } from "react";
 
 type FormData = ConnectionFormData<AiConnection>;
+
+type FormSchemaContext = ConnectionStringsNameContext & {
+    connectorType: FormData["connectorType"];
+    modelType: FormData["modelType"];
+};
 
 export interface AiConnectionStringProps extends EditConnectionStringFormProps {
     initialConnection: AiConnection;
@@ -50,17 +56,34 @@ export default function AiConnectionString({ initialConnection, isForNewConnecti
                     connectorType: data.connectorType,
                     isForNewConnection,
                     usedNames,
-                } satisfies ConnectionStringsNameContext & { connectorType: FormData["connectorType"] },
+                    modelType: data.modelType,
+                } satisfies FormSchemaContext,
                 options
             ),
     });
 
-    const { control, handleSubmit, setValue } = form;
+    const { control, handleSubmit, setValue, watch } = form;
 
     const { forCurrentDatabase } = useAppUrls();
 
     const formValues = useWatch({ control });
     const { connectorType, modelType } = formValues;
+
+    // Reset connector when model type does not match it
+    useEffect(() => {
+        const { unsubscribe } = watch((values, { name }) => {
+            if (
+                name === "modelType" &&
+                values.modelType === "Chat" &&
+                values.connectorType != null &&
+                !chatConnectorTypes.includes(values.connectorType)
+            ) {
+                setValue("connectorType", null);
+            }
+        });
+
+        return () => unsubscribe();
+    }, [setValue, watch]);
 
     const handleGenerateIdentifier = () => {
         setValue("identifier", TaskUtils.getGeneratedIdentifier(formValues.name));
@@ -185,6 +208,8 @@ export function SettingsOptionComponent(props: OptionProps<SelectOptionWithIcon>
     );
 }
 
+const chatConnectorTypes: FormData["connectorType"][] = ["ollamaSettings", "openAiSettings", "azureOpenAiSettings"];
+
 function getConnectorOptions(modelType: FormData["modelType"]): SelectOptionWithIcon<FormData["connectorType"]>[] {
     const allOptions: SelectOptionWithIcon<FormData["connectorType"]>[] = [
         { label: "Azure OpenAI", value: "azureOpenAiSettings", icon: "openai" },
@@ -197,15 +222,19 @@ function getConnectorOptions(modelType: FormData["modelType"]): SelectOptionWith
     ];
 
     if (modelType === "Chat") {
-        return [
-            ...allOptions.filter(
-                (x) => x.value === "ollamaSettings" || x.value === "openAiSettings" || x.value === "azureOpenAiSettings"
-            ),
-        ].reverse();
+        return [...allOptions.filter((x) => chatConnectorTypes.includes(x.value))].reverse();
     }
 
     return allOptions;
 }
+
+const temperatureSchema = yup
+    .number()
+    .nullable()
+    .when(["$modelType", "isSetTemperature"], {
+        is: (modelType: FormData["modelType"], isSetTemperature: boolean) => modelType === "Chat" && isSetTemperature,
+        then: (schema) => schema.min(0).max(2).required(),
+    });
 
 const schema = yupObjectSchema<FormData>({
     name: connectionStringsUtils.nameSchema,
@@ -252,6 +281,8 @@ const schema = yupObjectSchema<FormData>({
             }),
         dimensions: yup.number().nullable().integer().positive(),
         embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
+        isSetTemperature: yup.boolean().nullable(),
+        temperature: temperatureSchema,
     }),
     googleSettings: yupObjectSchema<FormData["googleSettings"]>({
         aiVersion: yup.string<Raven.Client.Documents.Operations.AI.GoogleAIVersion>().nullable(),
@@ -308,15 +339,7 @@ const schema = yupObjectSchema<FormData>({
         embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
         think: yup.boolean().nullable(),
         isSetTemperature: yup.boolean().nullable(),
-        temperature: yup
-            .number()
-            .nullable()
-            .min(0)
-            .max(2)
-            .when("isSetTemperature", {
-                is: true,
-                then: (schema) => schema.required(),
-            }),
+        temperature: temperatureSchema,
     }),
     embeddedSettings: yupObjectSchema<FormData["embeddedSettings"]>({
         embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
@@ -347,6 +370,8 @@ const schema = yupObjectSchema<FormData>({
         projectId: yup.string().nullable(),
         dimensions: yup.number().nullable().integer().positive(),
         embeddingsMaxConcurrentBatches: yup.number().nullable().integer().positive(),
+        isSetTemperature: yup.boolean().nullable(),
+        temperature: temperatureSchema,
     }),
     mistralAiSettings: yupObjectSchema<FormData["mistralAiSettings"]>({
         apiKey: yup
@@ -388,6 +413,8 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 deploymentName: null,
                 dimensions: null,
                 embeddingsMaxConcurrentBatches: null,
+                isSetTemperature: false,
+                temperature: null,
             } satisfies Required<FormData["azureOpenAiSettings"]>,
             googleSettings: {
                 aiVersion: null,
@@ -421,6 +448,8 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 projectId: null,
                 dimensions: null,
                 embeddingsMaxConcurrentBatches: null,
+                isSetTemperature: false,
+                temperature: null,
             } satisfies Required<FormData["openAiSettings"]>,
             mistralAiSettings: {
                 apiKey: null,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils.ts
@@ -1,4 +1,11 @@
-export const getConnectorType = (
+import { SelectOptionWithIcon } from "components/common/select/Select";
+import { yupObjectSchema } from "components/utils/yupUtils";
+import { AiConnection, ConnectionFormData } from "../connectionStringsTypes";
+import { connectionStringsUtils } from "../connectionStringsUtils";
+import * as yup from "yup";
+import _ from "lodash";
+
+const getConnectorType = (
     connection: Raven.Client.Documents.Operations.AI.AiConnectionString
 ): Raven.Client.Documents.Operations.AI.AiConnectorType => {
     if (connection.AzureOpenAiSettings) {
@@ -26,7 +33,7 @@ export const getConnectorType = (
     throw new Error("No connector type found. Please check the connection string.");
 };
 
-export function mapAiConnectionStringToSettingsDto(
+function mapAiConnectionStringToSettingsDto(
     connection: Raven.Client.Documents.Operations.AI.AiConnectionString
 ): AiConnectionStringsSettings {
     const settings = [
@@ -45,3 +52,294 @@ export function mapAiConnectionStringToSettingsDto(
 
     return settings;
 }
+
+type FormData = ConnectionFormData<AiConnection>;
+
+const chatConnectorTypes: FormData["connectorType"][] = ["ollamaSettings", "openAiSettings", "azureOpenAiSettings"];
+
+function getConnectorOptions(modelType: FormData["modelType"]): SelectOptionWithIcon<FormData["connectorType"]>[] {
+    const allOptions: SelectOptionWithIcon<FormData["connectorType"]>[] = [
+        { label: "Azure OpenAI", value: "azureOpenAiSettings", icon: "openai" },
+        { label: "Google AI", value: "googleSettings", icon: "google-gemini" },
+        { label: "Hugging Face", value: "huggingFaceSettings", icon: "huggingface" },
+        { label: "Ollama", value: "ollamaSettings", icon: "ollama" },
+        { label: "OpenAI", value: "openAiSettings", icon: "openai" },
+        { label: "Mistral AI", value: "mistralAiSettings", icon: "mistralai" },
+        { label: "Embedded (bge-micro-v2)", value: "embeddedSettings", icon: "onnx" },
+    ];
+
+    if (modelType === "Chat") {
+        return [...allOptions.filter((x) => chatConnectorTypes.includes(x.value))].reverse();
+    }
+
+    return allOptions;
+}
+
+const getTemperatureSchema = (connectorType: FormData["connectorType"]) =>
+    yup
+        .number()
+        .nullable()
+        .when(["$connectorType", "$modelType", "isSetTemperature"], {
+            is: (
+                currentConnectorType: FormData["connectorType"],
+                modelType: FormData["modelType"],
+                isSetTemperature: boolean
+            ) => currentConnectorType === connectorType && modelType === "Chat" && isSetTemperature,
+            then: (schema) => schema.min(0).max(2).required(),
+        });
+
+const getDimensionsSchema = (connectorType: FormData["connectorType"]) =>
+    yup
+        .number()
+        .nullable()
+        .when(["$connectorType", "$modelType"], {
+            is: (currentConnectorType: FormData["connectorType"], modelType: FormData["modelType"]) =>
+                currentConnectorType === connectorType && modelType === "TextEmbeddings",
+            then: (schema) => schema.integer().positive(),
+        });
+
+const getEmbeddingsMaxConcurrentBatchesSchema = (connectorType: FormData["connectorType"]) =>
+    yup
+        .number()
+        .nullable()
+        .when(["$connectorType", "$modelType"], {
+            is: (currentConnectorType: FormData["connectorType"], modelType: FormData["modelType"]) =>
+                currentConnectorType === connectorType && modelType === "TextEmbeddings",
+            then: (schema) => schema.integer().positive(),
+        });
+
+const schema = yupObjectSchema<FormData>({
+    name: connectionStringsUtils.nameSchema,
+    identifier: yup
+        .string()
+        .nullable()
+        .test("is-identifier", "Only lowercase letters (a-z), numbers (0-9) and hyphens (-) are allowed.", (value) => {
+            if (!value) {
+                return true;
+            }
+
+            return /^[a-z0-9-]+$/.test(value);
+        }),
+    connectorType: yup.string<FormData["connectorType"]>().nullable().required(),
+    modelType: yup.string<Raven.Client.Documents.Operations.AI.AiModelType>().nullable().required(),
+    azureOpenAiSettings: yupObjectSchema<FormData["azureOpenAiSettings"]>({
+        apiKey: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "azureOpenAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        endpoint: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "azureOpenAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        model: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "azureOpenAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        deploymentName: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "azureOpenAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        dimensions: getDimensionsSchema("azureOpenAiSettings"),
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("azureOpenAiSettings"),
+        isSetTemperature: yup.boolean().nullable(),
+        temperature: getTemperatureSchema("azureOpenAiSettings"),
+    }),
+    googleSettings: yupObjectSchema<FormData["googleSettings"]>({
+        aiVersion: yup.string<Raven.Client.Documents.Operations.AI.GoogleAIVersion>().nullable(),
+        apiKey: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "googleSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        model: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "googleSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        dimensions: getDimensionsSchema("googleSettings"),
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("googleSettings"),
+    }),
+    huggingFaceSettings: yupObjectSchema<FormData["huggingFaceSettings"]>({
+        apiKey: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "huggingFaceSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        endpoint: yup.string().nullable(),
+        model: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "huggingFaceSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("huggingFaceSettings"),
+    }),
+    ollamaSettings: yupObjectSchema<FormData["ollamaSettings"]>({
+        model: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "ollamaSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        uri: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "ollamaSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("ollamaSettings"),
+        think: yup.boolean().nullable(),
+        isSetTemperature: yup.boolean().nullable(),
+        temperature: getTemperatureSchema("ollamaSettings"),
+    }),
+    embeddedSettings: yupObjectSchema<FormData["embeddedSettings"]>({
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("embeddedSettings"),
+    }),
+    openAiSettings: yupObjectSchema<FormData["openAiSettings"]>({
+        apiKey: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "openAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        endpoint: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "openAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        model: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "openAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        organizationId: yup.string().nullable(),
+        projectId: yup.string().nullable(),
+        dimensions: getDimensionsSchema("openAiSettings"),
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("openAiSettings"),
+        isSetTemperature: yup.boolean().nullable(),
+        temperature: getTemperatureSchema("openAiSettings"),
+    }),
+    mistralAiSettings: yupObjectSchema<FormData["mistralAiSettings"]>({
+        apiKey: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "mistralaiAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        endpoint: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "mistralaiAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        model: yup
+            .string()
+            .nullable()
+            .when("$connectorType", {
+                is: "mistralaiAiSettings",
+                then: (schema) => schema.trim().required(),
+            }),
+        embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("mistralAiSettings"),
+    }),
+});
+
+function getDefaultValues(initialConnection: AiConnection, isForNewConnection: boolean): FormData {
+    if (isForNewConnection) {
+        return {
+            name: null,
+            identifier: null,
+            connectorType: null,
+            modelType: initialConnection?.modelType ?? null,
+            azureOpenAiSettings: {
+                apiKey: null,
+                endpoint: null,
+                model: null,
+                deploymentName: null,
+                dimensions: null,
+                embeddingsMaxConcurrentBatches: null,
+                isSetTemperature: false,
+                temperature: null,
+            } satisfies Required<FormData["azureOpenAiSettings"]>,
+            googleSettings: {
+                aiVersion: null,
+                apiKey: null,
+                model: null,
+                dimensions: null,
+                embeddingsMaxConcurrentBatches: null,
+            } satisfies Required<FormData["googleSettings"]>,
+            huggingFaceSettings: {
+                apiKey: null,
+                endpoint: null,
+                model: null,
+                embeddingsMaxConcurrentBatches: null,
+            } satisfies Required<FormData["huggingFaceSettings"]>,
+            ollamaSettings: {
+                model: null,
+                uri: null,
+                embeddingsMaxConcurrentBatches: null,
+                think: null,
+                isSetTemperature: false,
+                temperature: null,
+            } satisfies Required<FormData["ollamaSettings"]>,
+            embeddedSettings: {
+                embeddingsMaxConcurrentBatches: null,
+            } satisfies Required<FormData["embeddedSettings"]>,
+            openAiSettings: {
+                apiKey: null,
+                endpoint: null,
+                model: null,
+                organizationId: null,
+                projectId: null,
+                dimensions: null,
+                embeddingsMaxConcurrentBatches: null,
+                isSetTemperature: false,
+                temperature: null,
+            } satisfies Required<FormData["openAiSettings"]>,
+            mistralAiSettings: {
+                apiKey: null,
+                endpoint: null,
+                model: null,
+                embeddingsMaxConcurrentBatches: null,
+            } satisfies Required<FormData["mistralAiSettings"]>,
+        };
+    }
+
+    return _.omit(initialConnection, "type", "usedByTasks");
+}
+
+export const aiConnectionStringUtils = {
+    getConnectorType,
+    mapAiConnectionStringToSettingsDto,
+    getConnectorOptions,
+    getDefaultValues,
+    schema,
+    chatConnectorTypes,
+};

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
@@ -17,6 +17,7 @@ import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesField";
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
 import { SelectOption } from "components/common/select/Select";
+import TemperatureField from "./TemperatureField";
 
 export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: boolean }) {
     const { control, trigger } = useFormContext<ConnectionFormData<AiConnection>>();
@@ -37,6 +38,9 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
             Model: formValues.azureOpenAiSettings.model,
             DeploymentName: formValues.azureOpenAiSettings.deploymentName,
             Dimensions: formValues.azureOpenAiSettings.dimensions,
+            Temperature: formValues.azureOpenAiSettings.isSetTemperature
+                ? formValues.azureOpenAiSettings.temperature
+                : null,
         });
     });
 
@@ -149,6 +153,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
                     />
                 </div>
             )}
+            <TemperatureField baseName="azureOpenAiSettings" />
             {formValues.modelType === "TextEmbeddings" && (
                 <EmbeddingsMaxConcurrentBatches baseName="azureOpenAiSettings" />
             )}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OllamaSettings.tsx
@@ -1,5 +1,5 @@
 import { FlexGrow } from "components/common/FlexGrow";
-import { FormCheckbox, FormInput, FormLabel, FormSelect, FormSelectAutocomplete } from "components/common/Form";
+import { FormInput, FormLabel, FormSelect, FormSelectAutocomplete } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import {
     ConnectionFormData,
@@ -16,13 +16,12 @@ import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesField";
 import { SelectOption } from "components/common/select/Select";
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
-import InputGroup from "react-bootstrap/InputGroup";
-import { useEffect } from "react";
+import TemperatureField from "./TemperatureField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
 export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: boolean }) {
-    const { control, trigger, watch, setValue } = useFormContext<FormData>();
+    const { control, trigger } = useFormContext<FormData>();
     const { tasksService } = useServices();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
@@ -69,17 +68,6 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         300
     );
 
-    // Reset temperature when isSetTemperature is disabled
-    useEffect(() => {
-        const { unsubscribe } = watch((values, { name }) => {
-            if (name === "ollamaSettings.isSetTemperature" && !values.ollamaSettings.isSetTemperature) {
-                setValue("ollamaSettings.temperature", null, { shouldValidate: true });
-            }
-        });
-
-        return () => unsubscribe();
-    }, [setValue, watch]);
-
     return (
         <>
             <div className="mb-2">
@@ -118,39 +106,7 @@ export default function OllamaSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     <FormSelect control={control} name="ollamaSettings.think" options={thinkOptions} />
                 </div>
             )}
-            {formValues.modelType === "Chat" && (
-                <div className="mb-2">
-                    <FormLabel>
-                        Temperature
-                        <PopoverWithHoverWrapper
-                            message={
-                                <>
-                                    Controls randomness of the model output. Range typically [0.0, 2.0].
-                                    <br />
-                                    <br />
-                                    Higher values (e.g., 1.0+) make output more creative and diverse.
-                                    <br />
-                                    Lower values (e.g., 0.2) make it more deterministic.
-                                </>
-                            }
-                        >
-                            <Icon icon="info" color="info" margin="ms-1" />
-                        </PopoverWithHoverWrapper>
-                    </FormLabel>
-                    <InputGroup>
-                        <div className="toggle-field-checkbox">
-                            <FormCheckbox control={control} name="ollamaSettings.isSetTemperature" color="primary" />
-                        </div>
-                        <FormInput
-                            type="number"
-                            control={control}
-                            name="ollamaSettings.temperature"
-                            placeholder="e.g. 0.4"
-                            disabled={!formValues.ollamaSettings.isSetTemperature}
-                        />
-                    </InputGroup>
-                </div>
-            )}
+            <TemperatureField baseName="ollamaSettings" />
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="ollamaSettings" />}
             <div className="d-flex mb-2">
                 <FlexGrow />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
@@ -17,6 +17,7 @@ import { useFormContext, useWatch } from "react-hook-form";
 import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesField";
 import { SelectOption } from "components/common/select/Select";
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
+import TemperatureField from "./TemperatureField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -39,6 +40,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
             Model: formValues.openAiSettings.model,
             OrganizationId: formValues.openAiSettings.organizationId,
             ProjectId: formValues.openAiSettings.projectId,
+            Temperature: formValues.openAiSettings.isSetTemperature ? formValues.openAiSettings.temperature : null,
         });
     });
 
@@ -189,6 +191,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     />
                 </div>
             )}
+            <TemperatureField baseName="openAiSettings" />
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="openAiSettings" />}
             <div className="d-flex mb-2">
                 <FlexGrow />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/TemperatureField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/TemperatureField.tsx
@@ -1,0 +1,74 @@
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { FieldPath, useFormContext, useWatch } from "react-hook-form";
+import { Icon } from "components/common/Icon";
+import { FormCheckbox, FormInput, FormLabel } from "components/common/Form";
+import {
+    ConnectionFormData,
+    AiConnection,
+} from "components/pages/database/settings/connectionStrings/connectionStringsTypes";
+import { useEffect } from "react";
+import InputGroup from "react-bootstrap/InputGroup";
+
+type FormData = ConnectionFormData<AiConnection>;
+
+interface TemperatureFieldProps {
+    baseName: Extract<FormData["connectorType"], "ollamaSettings" | "azureOpenAiSettings" | "openAiSettings">;
+}
+
+export default function TemperatureField({ baseName }: TemperatureFieldProps) {
+    const { control, setValue, watch } = useFormContext<FormData>();
+
+    const formValues = useWatch({ control });
+
+    const fieldNameIsSetTemperature = `${baseName}.isSetTemperature` satisfies FieldPath<FormData>;
+    const fieldNameTemperature = `${baseName}.temperature` satisfies FieldPath<FormData>;
+
+    // Reset temperature when isSetTemperature is disabled
+    useEffect(() => {
+        const { unsubscribe } = watch((values, { name }) => {
+            if (name === fieldNameIsSetTemperature && !values[baseName].isSetTemperature) {
+                setValue(fieldNameTemperature, null, { shouldValidate: true });
+            }
+        });
+
+        return () => unsubscribe();
+    }, [setValue, watch]);
+
+    if (formValues.modelType !== "Chat") {
+        return null;
+    }
+
+    return (
+        <div className="mb-2">
+            <FormLabel>
+                Temperature
+                <PopoverWithHoverWrapper
+                    message={
+                        <>
+                            Controls randomness of the model output. Range typically [0.0, 2.0].
+                            <br />
+                            <br />
+                            Higher values (e.g., 1.0+) make output more creative and diverse.
+                            <br />
+                            Lower values (e.g., 0.2) make it more deterministic.
+                        </>
+                    }
+                >
+                    <Icon icon="info" color="info" margin="ms-1" />
+                </PopoverWithHoverWrapper>
+            </FormLabel>
+            <InputGroup>
+                <div className="toggle-field-checkbox">
+                    <FormCheckbox control={control} name={fieldNameIsSetTemperature} color="primary" />
+                </div>
+                <FormInput
+                    type="number"
+                    control={control}
+                    name={fieldNameTemperature}
+                    placeholder="e.g. 0.4"
+                    disabled={!formValues[baseName].isSetTemperature}
+                />
+            </InputGroup>
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
@@ -378,6 +378,8 @@ export function mapAiConnectionsFromDto(
                     deploymentName: connection.AzureOpenAiSettings?.DeploymentName,
                     dimensions: connection.AzureOpenAiSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.AzureOpenAiSettings?.EmbeddingsMaxConcurrentBatches,
+                    isSetTemperature: connection.AzureOpenAiSettings?.Temperature != null,
+                    temperature: connection.AzureOpenAiSettings?.Temperature ?? null,
                 },
                 googleSettings: {
                     aiVersion: connection.GoogleSettings?.AiVersion,
@@ -398,7 +400,7 @@ export function mapAiConnectionsFromDto(
                     think: connection.OllamaSettings?.Think,
                     embeddingsMaxConcurrentBatches: connection.OllamaSettings?.EmbeddingsMaxConcurrentBatches,
                     isSetTemperature: connection.OllamaSettings?.Temperature != null,
-                    temperature: connection.OllamaSettings?.Temperature,
+                    temperature: connection.OllamaSettings?.Temperature ?? null,
                 },
                 embeddedSettings: {
                     embeddingsMaxConcurrentBatches: connection.EmbeddedSettings?.EmbeddingsMaxConcurrentBatches,
@@ -411,6 +413,8 @@ export function mapAiConnectionsFromDto(
                     projectId: connection.OpenAiSettings?.ProjectId,
                     dimensions: connection.OpenAiSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.OpenAiSettings?.EmbeddingsMaxConcurrentBatches,
+                    isSetTemperature: connection.OpenAiSettings?.Temperature != null,
+                    temperature: connection.OpenAiSettings?.Temperature ?? null,
                 },
                 mistralAiSettings: {
                     apiKey: connection.MistralAiSettings?.ApiKey,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -216,8 +216,9 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       Endpoint: connection.azureOpenAiSettings.endpoint,
                       Model: connection.azureOpenAiSettings.model,
                       DeploymentName: connection.azureOpenAiSettings.deploymentName,
-                      Dimensions: connection.azureOpenAiSettings.dimensions,
-                      EmbeddingsMaxConcurrentBatches: connection.azureOpenAiSettings.embeddingsMaxConcurrentBatches,
+                      Dimensions: mapDimensionsToDto(connection),
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      Temperature: mapTemperatureToDto(connection),
                   }
                 : null,
         GoogleSettings:
@@ -226,8 +227,8 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       ApiKey: connection.googleSettings.apiKey,
                       Model: connection.googleSettings.model,
                       AiVersion: connection.googleSettings.aiVersion,
-                      Dimensions: connection.googleSettings.dimensions,
-                      EmbeddingsMaxConcurrentBatches: connection.googleSettings.embeddingsMaxConcurrentBatches,
+                      Dimensions: mapDimensionsToDto(connection),
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
                   }
                 : null,
         HuggingFaceSettings:
@@ -236,7 +237,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       ApiKey: connection.huggingFaceSettings.apiKey,
                       Endpoint: connection.huggingFaceSettings.endpoint,
                       Model: connection.huggingFaceSettings.model,
-                      EmbeddingsMaxConcurrentBatches: connection.huggingFaceSettings.embeddingsMaxConcurrentBatches,
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
                   }
                 : null,
         OllamaSettings:
@@ -246,17 +247,15 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       Uri: connection.ollamaSettings.uri,
                       Endpoint: connection.ollamaSettings.uri,
                       ApiKey: null,
-                      Think: connection.ollamaSettings.think,
-                      EmbeddingsMaxConcurrentBatches: connection.ollamaSettings.embeddingsMaxConcurrentBatches,
-                      Temperature: connection.ollamaSettings.isSetTemperature
-                          ? connection.ollamaSettings.temperature
-                          : null,
+                      Think: connection.modelType === "Chat" ? connection.ollamaSettings.think : null,
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      Temperature: mapTemperatureToDto(connection),
                   }
                 : null,
         EmbeddedSettings:
             connection.connectorType === "embeddedSettings"
                 ? {
-                      EmbeddingsMaxConcurrentBatches: connection.embeddedSettings.embeddingsMaxConcurrentBatches,
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
                   }
                 : null,
         OpenAiSettings:
@@ -267,8 +266,9 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       Model: connection.openAiSettings.model,
                       OrganizationId: connection.openAiSettings.organizationId,
                       ProjectId: connection.openAiSettings.projectId,
-                      Dimensions: connection.openAiSettings.dimensions,
-                      EmbeddingsMaxConcurrentBatches: connection.openAiSettings.embeddingsMaxConcurrentBatches,
+                      Dimensions: mapDimensionsToDto(connection),
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      Temperature: mapTemperatureToDto(connection),
                   }
                 : null,
         MistralAiSettings:
@@ -277,10 +277,54 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       ApiKey: connection.mistralAiSettings.apiKey,
                       Endpoint: connection.mistralAiSettings.endpoint,
                       Model: connection.mistralAiSettings.model,
-                      EmbeddingsMaxConcurrentBatches: connection.mistralAiSettings.embeddingsMaxConcurrentBatches,
+                      EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
                   }
                 : null,
     };
+}
+
+function mapEmbeddingsMaxConcurrentBatchesToDto(connection: AiConnection): number {
+    if (connection.modelType !== "TextEmbeddings") {
+        return null;
+    }
+
+    return connection[connection.connectorType].embeddingsMaxConcurrentBatches;
+}
+
+function mapDimensionsToDto(connection: AiConnection): number {
+    const connectorType = connection.connectorType;
+
+    if (
+        connectorType !== "azureOpenAiSettings" &&
+        connectorType !== "openAiSettings" &&
+        connectorType !== "googleSettings"
+    ) {
+        return null;
+    }
+
+    if (connection.modelType !== "TextEmbeddings") {
+        return null;
+    }
+
+    return connection[connectorType].dimensions;
+}
+
+function mapTemperatureToDto(connection: AiConnection): number {
+    const connectorType = connection.connectorType;
+
+    if (
+        connectorType !== "openAiSettings" &&
+        connectorType !== "ollamaSettings" &&
+        connectorType !== "azureOpenAiSettings"
+    ) {
+        return null;
+    }
+
+    if (connection.modelType !== "Chat" || !connection[connectorType].isSetTemperature) {
+        return null;
+    }
+
+    return connection[connectorType].temperature;
 }
 
 export function mapConnectionStringToDto(connection: Connection): ConnectionStringDto {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/steps/EditGenAiTaskStepBasic.tsx
@@ -13,6 +13,7 @@ import EditGenAiTaskInfoHub from "../../EditGenAiTaskInfoHub";
 import EditGenAiTaskCancelButton from "../EditGenAiTaskCancelButton";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { aiConnectionStringUtils } from "components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils";
 
 export function EditGenAiTaskStepBasic() {
     const hasGenAi = useAppSelector(licenseSelectors.statusValue("HasGenAi"));
@@ -62,9 +63,9 @@ export function EditGenAiTaskStepBasicFooter() {
         dispatch(
             editGenAiTaskActions.testConnectionString({
                 databaseName,
-                connectorType: getConnectorType(connectionString),
+                connectorType: aiConnectionStringUtils.getConnectorType(connectionString),
                 modelType: connectionString.ModelType,
-                settings: mapAiConnectionStringToSettingsDto(connectionString),
+                settings: aiConnectionStringUtils.mapAiConnectionStringToSettingsDto(connectionString),
             })
         );
     };
@@ -111,52 +112,4 @@ export function EditGenAiTaskStepBasicFooter() {
             )}
         </div>
     );
-}
-
-const getConnectorType = (
-    connection: Raven.Client.Documents.Operations.AI.AiConnectionString
-): Raven.Client.Documents.Operations.AI.AiConnectorType => {
-    if (connection.AzureOpenAiSettings) {
-        return "AzureOpenAi";
-    }
-    if (connection.GoogleSettings) {
-        return "Google";
-    }
-    if (connection.HuggingFaceSettings) {
-        return "HuggingFace";
-    }
-    if (connection.OllamaSettings) {
-        return "Ollama";
-    }
-    if (connection.EmbeddedSettings) {
-        return "Embedded";
-    }
-    if (connection.OpenAiSettings) {
-        return "OpenAi";
-    }
-    if (connection.MistralAiSettings) {
-        return "MistralAi";
-    }
-
-    throw new Error("No connector type found. Please check the connection string.");
-};
-
-export function mapAiConnectionStringToSettingsDto(
-    connection: Raven.Client.Documents.Operations.AI.AiConnectionString
-): AiConnectionStringsSettings {
-    const settings = [
-        connection.AzureOpenAiSettings,
-        connection.GoogleSettings,
-        connection.HuggingFaceSettings,
-        connection.OllamaSettings,
-        connection.EmbeddedSettings,
-        connection.OpenAiSettings,
-        connection.MistralAiSettings,
-    ].find(Boolean);
-
-    if (!settings) {
-        throw new Error("No settings found. Please check the connection string.");
-    }
-
-    return settings;
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -30,6 +30,10 @@ import generalUtils = require("common/generalUtils");
 
 const minimumCommunityDeleteFrequencyInSec = TimeInSeconds.TimeInSeconds.Day * 36;
 
+const {
+    aiConnectionStringUtils: { getConnectorType, mapAiConnectionStringToSettingsDto },
+} = aiConnectionStringUtils;
+
 class editEmbeddingsGenerationTask extends shardViewModelBase {
     
     view = require("views/database/tasks/editEmbeddingsGenerationTask.html");
@@ -365,7 +369,7 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
             return;
         }
 
-        new testAiConnectionStringCommand(this.db, aiConnectionStringUtils.getConnectorType(connectionString), "TextEmbeddings", aiConnectionStringUtils.mapAiConnectionStringToSettingsDto(connectionString))
+        new testAiConnectionStringCommand(this.db, getConnectorType(connectionString), "TextEmbeddings", mapAiConnectionStringToSettingsDto(connectionString))
             .execute()
             .done((testResult) => this.testConnectionResult(testResult))
             .always(() => this.spinners.testConnection(false));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24960

### Additional description

- add temperature to 'Azure OpenAI' and 'OpenAI'
- fix reseting select to null
- reset connector when it doesn't fit the model type
- code cleanup

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
