### PR TITLE
RavenDB-24981 - Fix failing test 'AiAgentBasics.CanRunTest'

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             WriteResponse(context, writer, conversationId, document, response);
         }
 
-        public void WriteResponse(JsonOperationContext context, AsyncBlittableJsonTextWriter writer,
+        public virtual void WriteResponse(JsonOperationContext context, AsyncBlittableJsonTextWriter writer,
             string conversationId, ConversationDocument document,
             BlittableJsonReaderObject response)
         {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -54,6 +54,21 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         return Task.FromResult("test");
     }
 
+    public override void WriteResponse(JsonOperationContext context, AsyncBlittableJsonTextWriter writer,
+        string conversationId, ConversationDocument document,
+        BlittableJsonReaderObject response)
+    {
+        context.Write(writer, new DynamicJsonValue
+        {
+            [nameof(ConversationResult<object>.ConversationId)] = conversationId,
+            [nameof(ConversationResult<object>.ChangeVector)] = document.ChangeVector,
+            [nameof(ConversationResult<object>.Response)] = response,
+            [nameof(ConversationResult<object>.ActionRequests)] = new DynamicJsonArray(document.OpenActionCalls.Select(t => t.Value.ToJson())),
+            [nameof(ConversationResult<object>.TotalUsage)] = document.TotalUsage.ToJson(),
+            ["Document"] = document.ToBlittable(context)
+        });
+    }
+
     public class AiAgentTestResult
     {
         public BlittableJsonReaderObject Document;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -82,7 +82,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             throw new InvalidOperationException("conversation document is not initialized. Call Initialize() first.");
     }
 
-    public BlittableJsonReaderObject ToBlittable(JsonOperationContext context, AiAgentConfiguration configuration)
+    public BlittableJsonReaderObject ToBlittable(JsonOperationContext context)
     {
         var metadata = new DynamicJsonValue
         {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 _conversation.LinkedConversations.Add(putHistoryResult.Id);
             }
 
-            _conversationDoc = _conversation.ToBlittable(context, _configuration);
+            _conversationDoc = _conversation.ToBlittable(context);
             var putResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _conversationDoc);
             PutResult = (putResult, putHistoryResult);
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -346,8 +346,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             internal static TestResult<TSchema> Convert(BlittableJsonReaderObject response, DocumentConventions conventions)
             {
-                response.TryGet(nameof(Usage), out BlittableJsonReaderObject usage);
-                response.TryGet(nameof(Response), out BlittableJsonReaderObject result);
+                response.TryGet(nameof(ConversationResult<object>.TotalUsage), out BlittableJsonReaderObject usage);
+                response.TryGet(nameof(ConversationResult<object>.Response), out BlittableJsonReaderObject result);
                 response.TryGet(nameof(Document), out BlittableJsonReaderObject document);
 
                 List<AiAgentActionRequest> requests = null;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24981/SlowTests.Server.Documents.AI.AiAgent.AiAgentBasics.CanRunTestoptions-DatabaseMode-Single-config-OpenAiAiIntegrationTask

### Additional description

The issue was that in the test-endpoint (ai-agent), we weren’t returning the conversation document. 
This happened because the shared WriteResponse method doesn’t include the document in its response..

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
