### PR TITLE
RavenDB-24863 Meet escape behavior of only-ascii Id with not-only-ascii Id and allow cleaning documents with corrupted Ids

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.Documents
             // Attachment etag should be generated before updating the document
             var attachmentEtag = _documentsStorage.GenerateNextEtag();
 
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerDocumentId))
             {
                 TableValueReader tvr = default;
                 if (fromSmuggler == false)
@@ -407,7 +407,7 @@ namespace Raven.Server.Documents
 
         public string UpdateDocumentAfterAttachmentChange(DocumentsOperationContext context, string documentId)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerDocumentId))
             {
                 var exists = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: true, tvr: out TableValueReader tvr);
                 if (exists == false)
@@ -457,7 +457,7 @@ namespace Raven.Server.Documents
                 var cv = Slices.Empty;
                 var type = AttachmentType.Document;
 
-                using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerDocumentId))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerDocumentId))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, name, out Slice lowerName, out Slice nameSlice))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypeSlice))
                 using (Slice.External(context.Allocator, hash, out Slice base64Hash))
@@ -700,8 +700,8 @@ namespace Raven.Server.Documents
         private Attachment GetAttachmentDirect(DocumentsOperationContext context, string documentId, string name, AttachmentType type, string changeVector,
             string hash = null, string contentType = null, bool usePartialKey = true)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerId))
-            using (DocumentIdWorker.GetSliceFromId(context, name, out Slice lowerName))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, name, out Slice lowerName))
             {
                 Slice keySlice;
                 ByteStringContext<ByteStringMemoryCache>.InternalScope scope;
@@ -895,7 +895,7 @@ namespace Raven.Server.Documents
                 throw new ArgumentException("Context must be set with a valid transaction before calling Get", nameof(context));
 
             collectionName = null;
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerDocumentId))
             {
                 var hasDoc = TryGetDocumentTableValueReaderForAttachment(context, documentId, name, lowerDocumentId, out TableValueReader docTvr);
                 if (hasDoc == false)
@@ -917,7 +917,7 @@ namespace Raven.Server.Documents
                 var changeVector = _documentsStorage.GetNewChangeVector(context, tombstoneEtag);
                 context.LastDatabaseChangeVector = changeVector;
 
-                using (DocumentIdWorker.GetSliceFromId(context, name, out Slice lowerName))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, name, out Slice lowerName))
                 {
                     Slice keySlice;
                     ByteStringContext<ByteStringMemoryCache>.InternalScope scope;
@@ -1005,8 +1005,8 @@ namespace Raven.Server.Documents
         private void DeleteAttachmentDirect(DocumentsOperationContext context, Slice lowerId, LazyStringValue conflictName,
             LazyStringValue conflictContentType, LazyStringValue conflictHash, string changeVector)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, conflictName, out Slice lowerName))
-            using (DocumentIdWorker.GetSliceFromId(context, conflictContentType, out Slice lowerContentType))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, conflictName, out Slice lowerName))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, conflictContentType, out Slice lowerContentType))
             using (Slice.External(context.Allocator, conflictHash, out Slice base64Hash))
             using (AttachmentKey.GetKey(context, lowerId.Content.Ptr, lowerId.Size,
                        lowerName.Content.Ptr, lowerName.Size,

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -357,7 +357,7 @@ namespace Raven.Server.Documents
             if (ConflictsCount == 0)
                 return false;
 
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetConflictsIdPrefix(context, lowerId, out Slice prefixSlice))
             {
                 var conflictsTable = context.Transaction.InnerTransaction.OpenTable(ConflictsSchema, ConflictsSlice);
@@ -374,7 +374,7 @@ namespace Raven.Server.Documents
             if (ConflictsCount == 0)
                 return ImmutableAppendOnlyList<DocumentConflict>.Empty;
 
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetConflictsIdPrefix(context, lowerId, out Slice prefixSlice))
             {
                 return GetConflictsFor(context, prefixSlice);
@@ -724,7 +724,7 @@ namespace Raven.Server.Documents
         public string GetCollection(DocumentsOperationContext context, string id)
         {
             LazyStringValue collection = null;
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetConflictsIdPrefix(context, lowerId, out Slice prefixSlice))
             {
                 foreach (var conflict in GetConflictsFor(context, prefixSlice))
@@ -745,7 +745,7 @@ namespace Raven.Server.Documents
 
         public string GetFirstOrNullCollection(DocumentsOperationContext context, string id)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetConflictsIdPrefix(context, lowerId, out Slice prefixSlice))
             {
                 foreach (var conflict in GetConflictsFor(context, prefixSlice))

--- a/src/Raven.Server/Documents/CountersRepairTask.cs
+++ b/src/Raven.Server/Documents/CountersRepairTask.cs
@@ -229,7 +229,7 @@ public class CountersRepairTask
         {
             var table = new Table(_database.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
 
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice key, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice key, separator: SpecialChars.RecordSeparator))
             {
                 foreach (var result in table.SeekByPrimaryKeyPrefix(key, Slices.Empty, 0))
                 {
@@ -404,7 +404,7 @@ public class CountersRepairTask
 
         public unsafe Slice GetStartAfterSlice(DocumentsOperationContext context)
         {
-            _toDispose.Add(DocumentIdWorker.GetSliceFromId(context, _docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator));
+            _toDispose.Add(DocumentIdWorker.GetLoweredIdSliceFromId(context, _docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator));
             _toDispose.Add(context.Allocator.Allocate(documentKeyPrefix.Size + sizeof(long), out var startAfterBuffer));
             _toDispose.Add(Slice.External(context.Allocator, startAfterBuffer.Ptr, startAfterBuffer.Length, out var startAfter));
 

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -320,7 +320,7 @@ namespace Raven.Server.Documents
                 var table = GetCountersTable(context.Transaction.InnerTransaction, collectionName);
 
                 ByteStringContext.InternalScope countersGroupKeyScope = default;
-                using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                 using (DocumentIdWorker.GetLower(context.Allocator, name, out Slice counterName))
                 using (context.Allocator.Allocate(documentKeyPrefix.Size + counterName.Size, out var counterKeyBuffer))
                 using (CreateCounterKeySlice(context, counterKeyBuffer, documentKeyPrefix, counterName, out var counterKeySlice))
@@ -852,7 +852,7 @@ namespace Raven.Server.Documents
                 var collectionName = _documentsStorage.ExtractCollectionName(context, collection);
                 var table = GetCountersTable(context.Transaction.InnerTransaction, collectionName);
 
-                using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                 {
                     if (sourceData.TryGet(Values, out BlittableJsonReaderObject sourceCounters) == false)
                     {
@@ -989,7 +989,7 @@ namespace Raven.Server.Documents
 
                                 if (changeType == CounterChangeTypes.Delete)
                                 {
-                                    using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice documentKeyPrefixSlice, separator: SpecialChars.RecordSeparator))
+                                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice documentKeyPrefixSlice, separator: SpecialChars.RecordSeparator))
                                     using (DocumentIdWorker.GetLower(context.Allocator, prop.Name, out Slice deletedCounterNameSlice))
                                     {
                                         CreateCounterTombstone(context, documentKeyPrefixSlice, deletedCounterNameSlice, collectionName, changeVector);
@@ -1510,7 +1510,7 @@ namespace Raven.Server.Documents
             var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
 
             var countersCount = 0L;
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
             {
                 foreach (var counterGroup in table.SeekByPrimaryKeyPrefix(key, Slices.Empty, 0))
                 {
@@ -1532,7 +1532,7 @@ namespace Raven.Server.Documents
 
         internal static IEnumerable<string> GetCountersForDocumentInternal(DocumentsOperationContext context, string docId, Table table)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
             {
                 var names = GetCountersOriginalCasing(context, table, key);
                 if (names == null)
@@ -1600,7 +1600,7 @@ namespace Raven.Server.Documents
             etag = -1;
             var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
 
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice documentIdPrefix, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice documentIdPrefix, separator: SpecialChars.RecordSeparator))
             using (DocumentIdWorker.GetLower(context.Allocator, counterName, out Slice counterNameSlice))
             using (context.Allocator.Allocate(counterNameSlice.Size + documentIdPrefix.Size, out var buffer))
             using (CreateCounterKeySlice(context, buffer, documentIdPrefix, counterNameSlice, out var counterKeySlice))
@@ -1637,7 +1637,7 @@ namespace Raven.Server.Documents
 
             var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
 
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice documentIdPrefix, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice documentIdPrefix, separator: SpecialChars.RecordSeparator))
             using (DocumentIdWorker.GetLower(context.Allocator, counterName, out Slice counterNameSlice))
             using (context.Allocator.Allocate(counterNameSlice.Size + documentIdPrefix.Size, out var buffer))
             using (CreateCounterKeySlice(context, buffer, documentIdPrefix, counterNameSlice, out var counterKeySlice))
@@ -1712,7 +1712,7 @@ namespace Raven.Server.Documents
         {
             var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
 
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
             {
                 foreach (var result in table.SeekByPrimaryKeyPrefix(key, Slices.Empty, 0))
                 {
@@ -1732,7 +1732,7 @@ namespace Raven.Server.Documents
             if (table.NumberOfEntries == 0)
                 return;
 
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerIdPrefix, separator: 30))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerIdPrefix, separator: 30))
             {
                 table.DeleteByPrimaryKeyPrefix(lowerIdPrefix);
             }
@@ -1746,7 +1746,7 @@ namespace Raven.Server.Documents
                 Debug.Assert(false); // never hit
             }
 
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
             using (DocumentIdWorker.GetLower(context.Allocator, counterName, out Slice counterNameSlice))
             using (context.Allocator.Allocate(documentKeyPrefix.Size + counterNameSlice.Size, out var counterKeyBuffer))
             using (CreateCounterKeySlice(context, counterKeyBuffer, documentKeyPrefix, counterNameSlice, out var counterKeySlice))
@@ -2009,7 +2009,7 @@ namespace Raven.Server.Documents
 
                 foreach (var name in counterNames)
                 {
-                    using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     using (DocumentIdWorker.GetLower(context.Allocator, context.GetLazyString(name), out Slice counterNameSlice))
                     using (context.Allocator.Allocate(documentKeyPrefix.Size + counterNameSlice.Size, out var counterKeyBuffer))
                     using (CreateCounterKeySlice(context, counterKeyBuffer, documentKeyPrefix, counterNameSlice, out var counterKeySlice))

--- a/src/Raven.Server/Documents/DocumentIdWorker.cs
+++ b/src/Raven.Server/Documents/DocumentIdWorker.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
-using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
@@ -30,34 +29,8 @@ namespace Raven.Server.Documents
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetSliceFromId(
-            ByteStringContext allocator, string id, out Slice idSlice,
-            byte? separator = null)
-        {
-            return GetSliceFromId(allocator, id.AsSpan(), out idSlice, separator);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetSliceFromId<TTransaction>(
-            TransactionOperationContext<TTransaction> context, string id, out Slice idSlice,
-            byte? separator = null)
-            where TTransaction : RavenTransaction
-        {
-            return GetSliceFromId(context.Allocator, id.AsSpan(), out idSlice, separator);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetSliceFromId<TTransaction>(
-            TransactionOperationContext<TTransaction> context, ReadOnlyMemory<char> id, out Slice idSlice,
-            byte? separator = null)
-            where TTransaction : RavenTransaction
-        {
-            return GetSliceFromId(context.Allocator, id.Span, out idSlice, separator);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetSliceFromId<TTransaction>(
-            TransactionOperationContext<TTransaction> context, LazyStringValue id, out Slice idSlice,
+        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLoweredIdSliceFromId<TTransaction>(
+            TransactionOperationContext<TTransaction> context, LazyStringValue id, out Slice lowerIdSlice,
             byte? separator = null)
             where TTransaction : RavenTransaction
         {
@@ -68,11 +41,24 @@ namespace Raven.Server.Documents
             {
                 if(id.Size > 0)
                     charCount = Encodings.Utf8.GetChars(id.Buffer, id.Size, pChars, tempBuffer.Length);
-                return GetSliceFromId(context.Allocator, new Span<char>(pChars, charCount), out idSlice, separator);
+                return GetLoweredIdSliceFromId(context.Allocator, new Span<char>(pChars, charCount), out lowerIdSlice, separator);
             }
         }
 
-        private static ByteStringContext<ByteStringMemoryCache>.InternalScope GetSliceFromId(ByteStringContext allocator, ReadOnlySpan<char> id, out Slice idSlice, byte? separator = null)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLoweredIdSliceFromId<TTransaction>(TransactionOperationContext<TTransaction> context,
+            ReadOnlySpan<char> id, out Slice lowerIdSlice, byte? separator = null)
+            where TTransaction : RavenTransaction
+        {
+            return GetLoweredIdSliceFromId(context.Allocator, id, out lowerIdSlice, separator);
+        }
+
+        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLoweredIdSliceFromId(ByteStringContext allocator, string id, out Slice lowerIdSlice, byte? separator = null)
+        {
+            return GetLoweredIdSliceFromId(allocator, id.AsSpan(), out lowerIdSlice, separator);
+        }
+        
+        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLoweredIdSliceFromId(ByteStringContext allocator, ReadOnlySpan<char> id, out Slice lowerIdSlice, byte? separator = null)
         {
             if (_jsonParserState == null)
                 _jsonParserState = new JsonParserState();
@@ -85,7 +71,7 @@ namespace Raven.Server.Documents
             var escapeAndControlSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(id, out _);
 
             if (strLength > MaxIdSize)
-                ThrowDocumentIdTooBig(id.ToString());
+                ThrowDocumentIdTooBig(id);
 
             var internalScope = allocator.Allocate(
                 maxStrSize // this buffer is allocated to also serve the ReadFromUnicodeKey
@@ -94,15 +80,15 @@ namespace Raven.Server.Documents
                 + (separator != null ? 1 : 0),
                 out var buffer);
 
-            idSlice = new Slice(buffer);
+            lowerIdSlice = new Slice(buffer);
 
             for (var i = 0; i < id.Length; i++)
             {
                 var ch = id[i];
                 if (ch > 127) // not ASCII, use slower mode
                 {
-                    strLength = ReadFromUnicodeKey(id, buffer, maxStrSize, separator);
-                    goto Finish;
+                    strLength = ReadFromUnicodeKey(id, buffer, maxStrSize);
+                    break;
                 }
 
                 if ((ch >= 65) && (ch <= 90))
@@ -118,28 +104,16 @@ namespace Raven.Server.Documents
                 strLength++;
             }
 
-            Finish:
             buffer.Truncate(strLength);
             return internalScope;
         }
 
-        private static int ReadFromUnicodeKey(
-            ReadOnlySpan<char> key,
-            ByteString buffer,
-            int maxByteCount,
-            byte? separator)
+        private static int ReadFromUnicodeKey(ReadOnlySpan<char> key, ByteString buffer, int maxByteCount)
         {
             var destChars = (char*)(buffer.Ptr + maxByteCount);
             for (var i = 0; i < key.Length; i++)
                 destChars[i] = char.ToLowerInvariant(key[i]);
-            var size = Encoding.GetBytes(destChars, key.Length, buffer.Ptr, maxByteCount);
-
-            if (separator != null)
-            {
-                buffer.Ptr[size] = separator.Value;
-                size++;
-            }
-            return size;
+            return Encoding.GetBytes(destChars, key.Length, buffer.Ptr, maxByteCount);
         }
 
         
@@ -260,7 +234,7 @@ namespace Raven.Server.Documents
             return GetLowerIdSliceAndStorageKey(context.Allocator, str, out lowerIdSlice, out idSlice);
         }
 
-        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLowerIdSliceAndStorageKey(ByteStringContext allocator, string str, out Slice lowerIdSlice,
+        public static ByteStringContext<ByteStringMemoryCache>.InternalScope GetLowerIdSliceAndStorageKey(ByteStringContext allocator, ReadOnlySpan<char> str, out Slice lowerIdSlice,
             out Slice idSlice)
         {
             // Because we need to also store escape positions for the key when we store it
@@ -282,9 +256,7 @@ namespace Raven.Server.Documents
             _jsonParserState.Reset();
 
             int originalStrLength = str.Length;
-            int strLength = originalStrLength;
-
-            if (strLength > MaxIdSize)
+            if (originalStrLength > MaxIdSize)
                 ThrowDocumentIdTooBig(str);
 
             int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(str, out var controlCount);
@@ -296,7 +268,7 @@ namespace Raven.Server.Documents
              *  For example: string with two control characters such as '\0\0' will be converted to '\u0000\u0000' (another example: '\b\b' => '\u000b\u000b')
              *  string size = 2, GetMaxByteCount = 9, converted string size = 12, maxStrSize = 19
              */
-            var maxIdSize = Encoding.GetMaxByteCount(strLength) + JsonParserState.ControlCharacterItemSize * controlCount;
+            var maxIdSize = Encoding.GetMaxByteCount(originalStrLength) + JsonParserState.ControlCharacterItemSize * controlCount;
             var originalMaxStrSize = maxIdSize;
 
             int maxIdLenSize = JsonParserState.VariableSizeIntSize(maxIdSize);
@@ -308,10 +280,9 @@ namespace Raven.Server.Documents
             
             byte* ptr = buffer.Ptr;
 
-            ReadOnlySpan<char> pChars = str.AsSpan();
-            for (var i = 0; i < pChars.Length; i++)
+            for (var i = 0; i < str.Length; i++)
             {
-                uint ch = pChars[i];
+                uint ch = str[i];
 
                 // PERF: Trick to avoid multiple compare instructions on hot loops. 
                 //       This is the same as (ch >= 65 && ch <= 90)
@@ -330,33 +301,34 @@ namespace Raven.Server.Documents
                 ptr[i + maxIdLenSize + maxIdSize] = (byte)ch;
             }
 
-            _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr, ref strLength, escapePositionsSize);
-            if (strLength != originalStrLength)
+            int lowerIdLength = originalStrLength;
+            _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr, ref lowerIdLength, escapePositionsSize);
+            if (lowerIdLength != originalStrLength)
             {
-                var anotherStrLength = originalStrLength;
-                _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr + maxIdLenSize + maxIdSize, ref anotherStrLength, escapePositionsSize);
+                var idLength = originalStrLength;
+                _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr + maxIdLenSize + maxIdSize, ref idLength, escapePositionsSize);
 
 #if DEBUG
-                if (strLength != anotherStrLength)
-                    throw new InvalidOperationException($"String length mismatch between Id ({str}) and it's lowercased counterpart after finding escape positions. Original: {anotherStrLength}. Lowercased: {strLength}");
+                if (lowerIdLength != idLength)
+                    throw new InvalidOperationException($"String length mismatch between Id ({str}) and it's lowercased counterpart after finding escape positions. Original: {idLength}. Lowercased: {lowerIdLength}");
 #endif
             }
 
             var writePos = ptr + maxIdSize;
 
-            Debug.Assert(strLength <= originalMaxStrSize, $"Calculated {nameof(originalMaxStrSize)} value {originalMaxStrSize}, was smaller than actually {nameof(strLength)} value {strLength}");
+            Debug.Assert(lowerIdLength <= originalMaxStrSize, $"Calculated {nameof(originalMaxStrSize)} value {originalMaxStrSize}, was smaller than actually {nameof(lowerIdLength)} value {lowerIdLength}");
 
             // in case there were no control characters the idSize could be smaller
-            var sizeDifference = maxIdLenSize - JsonParserState.VariableSizeIntSize(strLength);
+            var sizeDifference = maxIdLenSize - JsonParserState.VariableSizeIntSize(lowerIdLength);
             writePos += sizeDifference;
             maxIdLenSize -= sizeDifference;
 
-            JsonParserState.WriteVariableSizeInt(ref writePos, strLength);
-            escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + strLength);
-            maxIdLenSize = escapePositionsSize + strLength + maxIdLenSize;
+            JsonParserState.WriteVariableSizeInt(ref writePos, lowerIdLength);
+            escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + lowerIdLength);
+            maxIdLenSize = escapePositionsSize + lowerIdLength + maxIdLenSize;
 
             Slice.External(allocator, ptr + maxIdSize + sizeDifference, maxIdLenSize, out idSlice);
-            Slice.External(allocator, ptr, strLength, out lowerIdSlice);
+            Slice.External(allocator, ptr, lowerIdLength, out lowerIdSlice);
 
             Debug.Assert(ptr + maxIdSize + sizeDifference + maxIdLenSize <= buffer.Ptr + buffer.Size, "Exceed buffer size");
             return scope;
@@ -367,7 +339,7 @@ namespace Raven.Server.Documents
         }
 
         private static ByteStringContext.InternalScope UnicodeGetLowerIdAndStorageKey(
-            ByteStringContext allocator, string str,
+            ByteStringContext allocator, ReadOnlySpan<char> str,
             out Slice lowerIdSlice, out Slice idSlice, int maxStrSize, int maxIdLenSize, int escapePositionsSize)
         {
             // See comment in GetLowerIdSliceAndStorageKey for the format
@@ -385,41 +357,44 @@ namespace Raven.Server.Documents
             {
                 var destChars = (char*)buffer.Ptr;
                 for (var i = 0; i < strLength; i++)
-                    destChars[i] = char.ToLowerInvariant(pChars[i]);
+                    destChars[i] = char.ToLowerInvariant(str[i]);
 
                 byte* lowerId = buffer.Ptr + strLength * sizeof(char);
 
-                int lowerSize = Encoding.GetBytes(destChars, strLength, lowerId, maxStrSize);
-
-                if (lowerSize > MaxIdSize)
+                int lowerIdSize = Encoding.GetBytes(destChars, strLength, lowerId, maxStrSize);
+                if (lowerIdSize > MaxIdSize)
                     ThrowDocumentIdTooBig(str);
-
-                byte* id = buffer.Ptr + strLength * sizeof(char) + maxStrSize;
-                int idSize = Encoding.GetBytes(pChars, strLength, id + maxIdLenSize, maxStrSize);
-
-                var actualIdLenSize = JsonParserState.VariableSizeIntSize(idSize);
-                if (actualIdLenSize < maxIdLenSize)
-                {
-                    var movePtr = maxIdLenSize - actualIdLenSize;
-                    id += movePtr;
-                }
-
-                byte* writePos = id;
-                _jsonParserState.FindEscapedPositionsAndEscapeControls(id + maxIdLenSize, ref idSize, escapePositionsSize);
-                JsonParserState.WriteVariableSizeInt(ref writePos, idSize);
-                escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + idSize);
-                idSize += escapePositionsSize + actualIdLenSize;
-
-                Slice.External(allocator, id, idSize, out idSlice);
-                Slice.External(allocator, lowerId, lowerSize, out lowerIdSlice);
                 
-                Debug.Assert(id + idSize <= buffer.Ptr + buffer.Size, "Exceed buffer size");
+                var originalLowerSize = lowerIdSize;
+                _jsonParserState.FindEscapedPositionsAndEscapeControls(lowerId, ref lowerIdSize, escapePositionsSize);
+                
+                byte* actualIdPtr = buffer.Ptr + strLength * sizeof(char) + maxStrSize;
+                int actualIdSize = Encoding.GetBytes(pChars, strLength, actualIdPtr + maxIdLenSize, maxStrSize);
+                
+                var actualIdLenSize = JsonParserState.VariableSizeIntSize(actualIdSize);
+                if (actualIdLenSize < maxIdLenSize)
+                    actualIdPtr += maxIdLenSize - actualIdLenSize;
+
+                byte* writePos = actualIdPtr;
+                
+                //We already checked if there are control characters to escape
+                if (originalLowerSize != lowerIdSize)
+                    _jsonParserState.FindEscapedPositionsAndEscapeControls(actualIdPtr + maxIdLenSize, ref actualIdSize, escapePositionsSize);
+
+                JsonParserState.WriteVariableSizeInt(ref writePos, actualIdSize);
+                escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + actualIdSize);
+                actualIdSize += escapePositionsSize + actualIdLenSize;
+
+                Slice.External(allocator, actualIdPtr, actualIdSize, out idSlice);
+                Slice.External(allocator, lowerId, lowerIdSize, out lowerIdSlice);
+                
+                Debug.Assert(actualIdPtr + actualIdSize <= buffer.Ptr + buffer.Size, "Exceed buffer size");
                 return scope;
             }
         }
 
         [DoesNotReturn]
-        public static void ThrowDocumentIdTooBig(string str)
+        public static void ThrowDocumentIdTooBig(ReadOnlySpan<char> str)
         {
             throw new ArgumentException(
                 $"Document ID cannot exceed {MaxIdSize} bytes, but the ID was {Encoding.GetByteCount(str)} bytes. The invalid ID is '{str}'.",

--- a/src/Raven.Server/Documents/DocumentsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.Debug.cs
@@ -1,4 +1,5 @@
 ﻿using Raven.Server.ServerWide.Context;
+using Voron;
 using Voron.Data.Tables;
 using static Raven.Server.Documents.Schemas.Documents;
 
@@ -17,7 +18,7 @@ namespace Raven.Server.Documents
                 _storage = storage;
             }
             // Used to delete corrupted document from the JS admin console
-            public void DeleteDocumentByEtag(long etag)
+            public bool DeleteDocumentByEtag(long etag)
             {
                 using (_storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (var tx = context.OpenWriteTransaction())
@@ -25,12 +26,18 @@ namespace Raven.Server.Documents
                     var table = new Table(_storage.DocsSchema, context.Transaction.InnerTransaction);
                     var index = _storage.DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice];
 
-                    if (table.FindByIndex(index, etag, out var reader))
+                    if (table.FindByIndex(index, etag, out var reader) == false) 
+                        return false;
+                    
+                    var doc = _storage.TableValueToDocument(context, ref reader, DocumentFields.LowerId | DocumentFields.Id);
+                    bool isDelete;
+                    using (Slice.From(context.Allocator, doc.LowerId.AsReadOnlySpan(), out var lowerId))
                     {
-                        var doc = _storage.TableValueToDocument(context, ref reader, DocumentFields.Id);
-                        _storage.Delete(context, doc.Id, DocumentFlags.None);
-                        tx.Commit();
+                        var result = _storage.Delete(context, lowerId, doc.Id, null);
+                        isDelete = result.HasValue;
                     }
+                    tx.Commit();
+                    return isDelete;
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -756,8 +756,8 @@ namespace Raven.Server.Documents
             var needsWildcardMatch = string.IsNullOrEmpty(matches) == false || string.IsNullOrEmpty(exclude) == false;
 
             var startAfterSlice = Slices.Empty;
-            using (DocumentIdWorker.GetSliceFromId(context, idPrefix, out Slice prefixSlice))
-            using (isStartAfter ? (IDisposable)DocumentIdWorker.GetSliceFromId(context, startAfterId, out startAfterSlice) : null)
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, idPrefix, out Slice prefixSlice))
+            using (isStartAfter ? (IDisposable)DocumentIdWorker.GetLoweredIdSliceFromId(context, startAfterId, out startAfterSlice) : null)
             {
                 foreach (var result in table.SeekByPrimaryKeyPrefix(prefixSlice, startAfterSlice, skip?.Value ?? 0))
                 {
@@ -1024,7 +1024,7 @@ namespace Raven.Server.Documents
             if (context.Transaction == null)
                 throw new ArgumentException("Context must be set with a valid transaction before calling Put", nameof(context));
 
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             {
                 return GetDocumentOrTombstone(context, lowerId, fields, throwOnConflict);
             }
@@ -1084,27 +1084,28 @@ namespace Raven.Server.Documents
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Document Get(DocumentsOperationContext context, ReadOnlyMemory<char> id, DocumentFields fields = DocumentFields.All, bool throwOnConflict = true)
-        {
-            if (id.IsEmpty)
-                throw new ArgumentException("Argument is null", nameof(id));
-            if (context.Transaction == null)
-                throw new ArgumentException("Context must be set with a valid transaction before calling Get", nameof(context));
-
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
-            {
-                return Get(context, lowerId, fields, throwOnConflict);
-            }
-        }
-
         public Document Get(DocumentsOperationContext context, string id, DocumentFields fields = DocumentFields.All, bool throwOnConflict = true)
         {
             if (string.IsNullOrWhiteSpace(id))
                 throw new ArgumentException("Argument is null or whitespace", nameof(id));
+            return Get(context, id.AsSpan(), fields, throwOnConflict);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Document Get(DocumentsOperationContext context, ReadOnlyMemory<char> id, DocumentFields fields = DocumentFields.All, bool throwOnConflict = true)
+        {
+            if (id.IsEmpty)
+                throw new ArgumentException("Argument is null", nameof(id));
+            return Get(context, id.Span, fields, throwOnConflict);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Document Get(DocumentsOperationContext context, ReadOnlySpan<char> id, DocumentFields fields = DocumentFields.All, bool throwOnConflict = true)
+        {
             if (context.Transaction == null)
                 throw new ArgumentException("Context must be set with a valid transaction before calling Get", nameof(context));
 
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             {
                 return Get(context, lowerId, fields, throwOnConflict);
             }
@@ -1164,7 +1165,7 @@ namespace Raven.Server.Documents
 
         public (int ActualSize, int AllocatedSize, bool IsCompressed)? GetDocumentMetrics(DocumentsOperationContext context, string id)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             {
                 var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -1620,7 +1621,7 @@ namespace Raven.Server.Documents
 
         public DeleteOperationResult? Delete(DocumentsOperationContext context, string id, DocumentFlags flags)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             {
                 return Delete(context, lowerId, id, expectedChangeVector: null, newFlags: flags);
             }
@@ -1628,7 +1629,7 @@ namespace Raven.Server.Documents
 
         public DeleteOperationResult? Delete(DocumentsOperationContext context, string id, string expectedChangeVector, DocumentFlags newFlags = DocumentFlags.None)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (var cv = context.GetLazyString(expectedChangeVector))
             {
                 return Delete(context, lowerId, id, expectedChangeVector: cv, newFlags: newFlags);
@@ -1932,7 +1933,7 @@ namespace Raven.Server.Documents
 
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
-            using (DocumentIdWorker.GetSliceFromId(context, prefix, out Slice prefixSlice))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, prefix, out Slice prefixSlice))
             {
                 while (true)
                 {

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
@@ -67,7 +67,7 @@ public sealed class ClusterTransactionMergedCommand : TransactionMergedCommand
                                 if (cmd.FromBackup is not BackupKind.Full)
                                 {
                                     // delete the document to avoid exception if we put new document in a different collection.
-                                    using (DocumentIdWorker.GetSliceFromId(context, cmd.Id, out Slice lowerId))
+                                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, cmd.Id, out Slice lowerId))
                                     {
                                         Database.DocumentsStorage.Delete(context, lowerId, cmd.Id, expectedChangeVector: null,
                                             nonPersistentFlags: NonPersistentDocumentFlags.SkipRevisionCreation);
@@ -121,7 +121,7 @@ public sealed class ClusterTransactionMergedCommand : TransactionMergedCommand
                         case CommandType.DELETE:
                             if (current < count)
                             {
-                                using (DocumentIdWorker.GetSliceFromId(context, cmd.Id, out Slice lowerId))
+                                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, cmd.Id, out Slice lowerId))
                                 {
                                     var deleteResult = Database.DocumentsStorage.Delete(context, lowerId, cmd.Id, null, changeVector: context.GetChangeVector(changeVector),
                                         newFlags: DocumentFlags.FromClusterTransaction);

--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -1,9 +1,16 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Threading.Tasks;
+using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
@@ -52,6 +59,133 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                 writer.WriteEndObject();
             }
+        }
+
+        [RavenAction("/databases/*/debug/documents/scan-corrupted-ids", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task ScanCorruptedIds()
+        {
+            var startEtag = GetIntValueQueryString("startEtag", required: false) ?? 0;
+            var resultCount = GetIntValueQueryString("resultCount", required: false) ?? 1024;
+            var maxBatchTimeInSec = GetIntValueQueryString("maxBatchTimeInSec", required: false) ?? 60;
+
+            var wrongEscapedPositionsIds = new List<string>();
+            var unescapedControlCharacterIds = new List<string>();
+            long lastEtag = startEtag;
+            var scannedDocuments = 0;
+            var maxBatchTime = TimeSpan.FromSeconds(maxBatchTimeInSec);
+
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, Stream.Null))
+                {
+                    var timeout = Stopwatch.StartNew();
+                    while (resultCount > 0)
+                    {
+                        timeout.Restart();
+                        using (context.OpenReadTransaction())
+                        {
+                            foreach (var doc in IterateDocumentsAndRevisionsByEtag(context, lastEtag))
+                            {
+                                HttpContext.RequestAborted.ThrowIfCancellationRequested();
+
+                                ++scannedDocuments;
+                                using (doc)
+                                {
+                                    unsafe
+                                    {
+                                        using var cloned = context.GetLazyString(doc.LowerId.Buffer, doc.LowerId.Size, longLived: false);
+                                        if (cloned.Length > doc.LowerId.Length)
+                                        {
+                                            AddToResult(unescapedControlCharacterIds, doc);
+                                            resultCount--;
+                                        }
+                                    }
+
+                                    try
+                                    {
+                                        writer.WriteString(doc.Id);
+                                    }
+                                    catch (Exception)
+                                    {
+                                        AddToResult(wrongEscapedPositionsIds, doc);
+                                        resultCount--;
+                                    }
+
+                                    if (resultCount <= 0 || timeout.Elapsed > maxBatchTime)
+                                    {
+                                        lastEtag = doc.Etag;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                {
+                    writer.WriteStartObject();
+                    writer.WriteArray("WrongEscapedPositionsIds", wrongEscapedPositionsIds);
+                    writer.WriteComma();
+                    writer.WriteArray("UnescapedControlCharacterIds", unescapedControlCharacterIds);
+                    writer.WriteComma();
+                    if (lastEtag > 0)
+                    {
+                        writer.WritePropertyName("LastEtag");
+                        writer.WriteInteger(lastEtag);
+                    }
+                    else
+                    {
+                        writer.WritePropertyName("AllScanned");
+                        writer.WriteBool(true);
+                    }
+
+                    writer.WriteComma();
+                    writer.WritePropertyName("ScannedDocuments");
+                    writer.WriteInteger(scannedDocuments);
+                    writer.WriteEndObject();
+                }
+            }
+
+            return;
+
+            void AddToResult(List<string> list, Document doc)
+            {
+                list.Add(
+                    $"Id: '{doc.Id}', LowerId: '{doc.LowerId}', ChangeVector: '{doc.ChangeVector}', Etag: '{doc.Etag}', Flags: '{doc.Flags}'");
+            }
+        }
+
+        private IEnumerable<Document> IterateDocumentsAndRevisionsByEtag(DocumentsOperationContext context, long startEtag)
+        {
+            const DocumentFields documentFields = DocumentFields.Id | DocumentFields.LowerId | DocumentFields.ChangeVector;
+            var documents = Database.DocumentsStorage.GetDocumentsFrom(context, startEtag, 0, long.MaxValue, documentFields);
+            var revisions = Database.DocumentsStorage.RevisionsStorage.GetRevisionsFrom(context, startEtag, long.MaxValue, documentFields);
+
+            using var documentsEnumerator = documents.GetEnumerator();
+            using var revisionsEnumerator = revisions.GetEnumerator();
+
+            var mergedEnumerator = new MergedEnumerator<Document>(DocumentsEtagComparer.Instance);
+            mergedEnumerator.AddEnumerator(documentsEnumerator);
+            mergedEnumerator.AddEnumerator(revisionsEnumerator);
+            
+            while (mergedEnumerator.MoveNext())
+            {
+                yield return mergedEnumerator.Current;
+            }
+        }
+
+        private class DocumentsEtagComparer : IComparer<Document>
+        {
+            public static readonly DocumentsEtagComparer Instance = new();
+
+            private DocumentsEtagComparer()
+            {
+            }
+
+            public int Compare(Document x, Document y) => x.Etag.CompareTo(y.Etag);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -276,7 +276,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 // making sure that we normalize the case of the id so we'll be able to find
                 // it in case-insensitive manner
                 // in addition, special characters need to be escaped
-                DocumentIdWorker.GetSliceFromId(QueryContext.Documents, id, out idSlice);
+                DocumentIdWorker.GetLoweredIdSliceFromId(QueryContext.Documents, id, out idSlice);
             }
             else
             {
@@ -350,14 +350,14 @@ namespace Raven.Server.Documents.Indexes.Static
                 if (keyLazy.Length == 0)
                     return false;
 
-                DocumentIdWorker.GetSliceFromId(QueryContext.Documents, keyLazy, out keySlice);
+                DocumentIdWorker.GetLoweredIdSliceFromId(QueryContext.Documents, keyLazy, out keySlice);
             }
             else
             {
                 if (keyString.Length == 0)
                     return false;
 
-                DocumentIdWorker.GetSliceFromId(QueryContext.Documents, keyString, out keySlice);
+                DocumentIdWorker.GetLoweredIdSliceFromId(QueryContext.Documents, keyString, out keySlice);
             }
 
             return true;

--- a/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCompareExchangeCountersReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCompareExchangeCountersReferences.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Counters
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            using (DocumentIdWorker.GetSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithCounterKeySeparator, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithCounterKeySeparator, SpecialChars.RecordSeparator))
             using (stats.For(IndexingOperation.Storage.UpdateReferences))
                 _referencesStorage.RemoveReferencesByPrefix(documentIdPrefixWithCounterKeySeparator, collection, null, indexContext.Transaction);
         }

--- a/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCountersReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCountersReferences.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Counters
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            using (DocumentIdWorker.GetSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithTsKeySeparator, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithTsKeySeparator, SpecialChars.RecordSeparator))
             using (stats.For(IndexingOperation.Storage.UpdateReferences))
                 _referencesStorage.RemoveReferencesByPrefix(documentIdPrefixWithTsKeySeparator, collection, null, indexContext.Transaction);
         }

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleCompareExchangeTimeSeriesReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleCompareExchangeTimeSeriesReferences.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            using (DocumentIdWorker.GetSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithTsKeySeparator, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithTsKeySeparator, SpecialChars.RecordSeparator))
             using (stats.For(IndexingOperation.Storage.UpdateReferences))
                 _referencesStorage.RemoveReferencesByPrefix(documentIdPrefixWithTsKeySeparator, collection, null, indexContext.Transaction);
         }

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleTimeSeriesReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleTimeSeriesReferences.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            using (DocumentIdWorker.GetSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithTsKeySeparator, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(indexContext, tombstone.LowerId, out Slice documentIdPrefixWithTsKeySeparator, SpecialChars.RecordSeparator))
             using (stats.For(IndexingOperation.Storage.UpdateReferences))
                 _referencesStorage.RemoveReferencesByPrefix(documentIdPrefixWithTsKeySeparator, collection, null, indexContext.Transaction);
         }

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -67,7 +67,7 @@ namespace Raven.Server.Documents.Patch
             if (runIfMissing != null)
                 runIfMissing.DebugMode = _debugMode;
 
-            using (DocumentIdWorker.GetSliceFromId(context.Allocator, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context.Allocator, id, out Slice lowerId))
             {
                 _database.DocumentsStorage.ValidateId(context, lowerId, type: DocumentChangeTypes.Put);
             }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -614,7 +614,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                         }
                                         else
                                         {
-                                            using (DocumentIdWorker.GetSliceFromId(context, doc.Id, out Slice keySlice))
+                                            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, doc.Id, out Slice keySlice))
                                             {
                                                 database.DocumentsStorage.Delete(
                                                     context, keySlice, doc.Id, null,

--- a/src/Raven.Server/Documents/Revisions/DeleteRevisionsByChangeVectorMergedCommand.cs
+++ b/src/Raven.Server/Documents/Revisions/DeleteRevisionsByChangeVectorMergedCommand.cs
@@ -36,7 +36,7 @@ public partial class RevisionsStorage
             var revisionsStorage = context.DocumentDatabase.DocumentsStorage.RevisionsStorage;
             var deleted = 0L;
 
-            using (DocumentIdWorker.GetSliceFromId(context, _id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, _id, out Slice lowerId))
             using (revisionsStorage.GetKeyPrefix(context, lowerId, out Slice prefixSlice))
             {
                 var collectionName = revisionsStorage.GetCollectionFor(context, prefixSlice);

--- a/src/Raven.Server/Documents/Revisions/DeleteRevisionsByDocumentIdMergedCommand.cs
+++ b/src/Raven.Server/Documents/Revisions/DeleteRevisionsByDocumentIdMergedCommand.cs
@@ -43,7 +43,7 @@ public partial class RevisionsStorage
             for (int i = _ids.Count - 1; i >= 0; i--)
             {
                 var id = _ids[i];
-                using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
                 using (revisionsStorage.GetKeyPrefix(context, lowerId, out Slice prefixSlice))
                 {
                     var collectionName = revisionsStorage.GetCollectionFor(context, prefixSlice);
@@ -60,7 +60,7 @@ public partial class RevisionsStorage
                         maxDeletes = maxTotalDeletes - deleted;
                     }
 
-					var result = revisionsStorage.ForceDeleteAllRevisionsFor(context, lowerId, prefixSlice, collectionName, maxDeletes, ShouldSkipRevision);
+                    var result = revisionsStorage.ForceDeleteAllRevisionsFor(context, lowerId, prefixSlice, collectionName, maxDeletes, ShouldSkipRevision);
                     if (result.MoreWork == false)
                     {
                         _ids.RemoveAt(i);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
@@ -1,11 +1,53 @@
 ﻿using System.Collections.Generic;
+using Raven.Client;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Voron;
 using Voron.Data.Tables;
 
 namespace Raven.Server.Documents.Revisions
 {
     public partial class RevisionsStorage
     {
+        public Debugging ForDebug => new Debugging(this);
+
+        public class Debugging
+        {
+            private readonly RevisionsStorage _storage;
+            public Debugging(RevisionsStorage storage)
+            {
+                _storage = storage;
+            }
+            // Used to delete corrupted document from the JS admin console
+            public bool DeleteRevisionByEtag(long etag)
+            {
+                using (_storage._documentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var index = _storage.RevisionsSchema.FixedSizeIndexes[Schemas.Revisions.AllRevisionsEtagsSlice];
+                    var table = new Table(_storage.RevisionsSchema, context.Transaction.InnerTransaction);
+                    if (table.FindByIndex(index, etag, out var tvr) == false)
+                        return false;
+                        
+                    using var doc = TableValueToRevision(context, ref tvr, DocumentFields.Data | DocumentFields.ChangeVector | DocumentFields.LowerId);
+                    if (doc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false
+                        || metadata.TryGet(Constants.Documents.Metadata.Collection, out string collection) == false)
+                        return false;
+                    
+                    var collectionName = new CollectionName(collection);
+                    var collectionTable = _storage.EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
+
+                    using (_storage.GetKeyPrefix(context, doc.LowerId, out Slice prefixSlice))
+                    {
+                        _storage.DeleteRevisionFromTable(context, collectionTable, new Dictionary<string, Table>(), doc, collectionName, context.GetChangeVector(doc.ChangeVector), _storage._database.Time.GetUtcNow().Ticks, doc.Flags);
+                        IncrementCountOfRevisions(context, prefixSlice, -1);
+                    }
+                    
+                    tx.Commit();
+                    return true;
+                }
+            }
+        }
         internal class TestingStuff
         {
             private RevisionsStorage _parent;
@@ -18,7 +60,7 @@ namespace Raven.Server.Documents.Revisions
             internal void DeleteLastRevisionFor(DocumentsOperationContext context, string id, string collection)
             {
                 var collectionName = new CollectionName(collection);
-                using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var lowerId))
                 using (_parent.GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
                 using (GetKeyWithEtag(context, lowerId, etag: long.MaxValue, out var compoundPrefix))
                 {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.RevisionsBinCleanMergedCommand.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.RevisionsBinCleanMergedCommand.cs
@@ -42,7 +42,7 @@ public partial class RevisionsStorage
 
             foreach (var (id, etag) in _idsAndEtags)
             {
-                using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
                 using (revisionsStorage.GetKeyPrefix(context, lowerId, out Slice prefixSlice))
                 {
                     var collectionName = revisionsStorage.GetCollectionFor(context, prefixSlice);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -305,7 +305,7 @@ namespace Raven.Server.Documents.Revisions
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation)) // creation of the ForceCreated revision after deletion of old revision with the same cv 
                 return false;
 
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out var revisionIdSlice))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out var revisionIdSlice))
             using (CreateRevisionTombstoneKeySlice(context, revisionIdSlice, revisionChangeVector.Version.ToString(), out _, out var tombstoneKeySlice))
             {
                 var tombstoneTable = context.Transaction.InnerTransaction.OpenTable(_documentsStorage.TombstonesSchema, RevisionsTombstonesSlice);
@@ -655,7 +655,7 @@ namespace Raven.Server.Documents.Revisions
 
         public long DeleteRevisionsFor(DocumentsOperationContext context, string id, bool fromDelete = false)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice lowerIdPrefix))
             {
                 var collectionName = GetCollectionFor(context, lowerIdPrefix);
@@ -930,7 +930,7 @@ namespace Raven.Server.Documents.Revisions
             Document revision, CollectionName collectionName,
             ChangeVector changeVector, long lastModifiedTicks, DocumentFlags flags)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, revision.LowerId, out var prefixSlice))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, revision.LowerId, out var prefixSlice))
             using (CreateRevisionTombstoneKeySlice(context, prefixSlice, revision.ChangeVector, out var changeVectorSlice, out var keySlice))
             {
                 CreateTombstone(context, keySlice, revision.Etag, collectionName, changeVector, lastModifiedTicks, fromReplication: flags.Contain(DocumentFlags.FromReplication), flags);
@@ -1243,7 +1243,7 @@ namespace Raven.Server.Documents.Revisions
 
         internal static void CreateRevisionTombstoneKeySlice(DocumentsOperationContext context, string documentId, string changeVector, out Slice changeVectorSlice, out Slice keySlice, List<IDisposable> toDispose)
         {
-            toDispose.Add(DocumentIdWorker.GetSliceFromId(context, documentId, out var documentIdSlice));
+            toDispose.Add(DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out var documentIdSlice));
             toDispose.Add(CreateRevisionTombstoneKeySlice(context, documentIdSlice, changeVector, out changeVectorSlice, out keySlice));
         }
 
@@ -1501,6 +1501,12 @@ namespace Raven.Server.Documents.Revisions
                 table.Set(tvb);
             }
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, LazyStringValue lowerId, out Slice prefixSlice)
+        {
+            return GetKeyPrefix(context.Allocator, lowerId.Buffer, lowerId.Size, out prefixSlice);
+        }
 
         private void EnsureValidRevisionTable(DocumentsOperationContext context, Slice changeVectorSlice, ref Table table, ref TableValueReader tvr)
         {
@@ -1580,7 +1586,7 @@ namespace Raven.Server.Documents.Revisions
 
         public Document GetRevisionBefore(DocumentsOperationContext context, string id, DateTime max)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
             using (GetLastKey(context, lowerId, out Slice lastKey))
             {
@@ -1612,7 +1618,7 @@ namespace Raven.Server.Documents.Revisions
         {
             var foundAfter = false;
 
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
             using (GetLastKey(context, lowerId, out Slice lastKey))
             {
@@ -1936,7 +1942,7 @@ namespace Raven.Server.Documents.Revisions
 
         public void ForceDeleteAllRevisionsFor(DocumentsOperationContext context, string id, DocumentFlags tombstoneFlags = DocumentFlags.None)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
             {
                 var collectionName = GetCollectionFor(context, prefixSlice);
@@ -2029,7 +2035,7 @@ namespace Raven.Server.Documents.Revisions
         {
             moreWork = false;
 
-            using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var lowerId))
             using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
             {
                 var collectionName = GetCollectionFor(context, lowerIdPrefix);
@@ -2078,7 +2084,7 @@ namespace Raven.Server.Documents.Revisions
 
         internal bool AdoptOrphanedFor(DocumentsOperationContext context, string id, DocumentFlags additionalFlags = DocumentFlags.None)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var lowerId))
             using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
             {
                 var collectionName = GetCollectionFor(context, lowerIdPrefix);
@@ -2421,7 +2427,7 @@ namespace Raven.Server.Documents.Revisions
                     }
                     else
                     {
-                        using (DocumentIdWorker.GetSliceFromId(context, document.Id, out Slice lowerId))
+                        using (DocumentIdWorker.GetLoweredIdSliceFromId(context, document.Id, out Slice lowerId))
                         {
                             documentsStorage.Delete(context, lowerId, document.Id, null, changeVector: documentsStorage.GetNewChangeVector(context).ChangeVector, newFlags: flags);
                         }
@@ -2511,7 +2517,7 @@ namespace Raven.Server.Documents.Revisions
 
         public long GetRevisionsCount(DocumentsOperationContext context, string id)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
             {
                 return GetRevisionsCount(context, prefixSlice);
@@ -2526,7 +2532,7 @@ namespace Raven.Server.Documents.Revisions
 
         public (Document[] Revisions, long Count) GetRevisions(DocumentsOperationContext context, string id, long start, long take)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
             using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
             using (GetLastKey(context, lowerId, out Slice lastKey))
             {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesSliceHolder.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesSliceHolder.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public void Initialize()
         {
-            _internalScopesToDispose.Add(DocumentIdWorker.GetSliceFromId(_context, DocId, out DocumentKeyPrefix, SpecialChars.RecordSeparator)); // documentId/
+            _internalScopesToDispose.Add(DocumentIdWorker.GetLoweredIdSliceFromId(_context, DocId, out DocumentKeyPrefix, SpecialChars.RecordSeparator)); // documentId/
             _internalScopesToDispose.Add(DocumentIdWorker.GetLower(_context.Allocator, Name, out LowerTimeSeriesName));
 
             var keyBufferSize = DocumentKeyPrefix.Size + LowerTimeSeriesName.Size + 1 /* separator */ + sizeof(long) /*  segment start */;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -325,7 +325,7 @@ namespace Raven.Server.Documents.TimeSeries
         public IEnumerable<string> GetTimeSeriesNamesForDocumentOriginalCasing(DocumentsOperationContext context, string docId)
         {
             var table = new Table(TimeSeriesStatsSchema, context.Transaction.InnerTransaction);
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out var documentKeyPrefix, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out var documentKeyPrefix, SpecialChars.RecordSeparator))
             {
                 foreach (var result in table.SeekByPrimaryKeyPrefix(documentKeyPrefix, Slices.Empty, 0))
                 {
@@ -430,7 +430,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope CombinePolicyNameAndTicks(DocumentsOperationContext context, string policy, long ticks, out Slice key, out Slice policyNameSlice)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, policy, out policyNameSlice, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, policy, out policyNameSlice, SpecialChars.RecordSeparator))
             {
                 var size = policyNameSlice.Size + sizeof(long);
                 var scope = context.Allocator.Allocate(size, out var str);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -603,7 +603,7 @@ namespace Raven.Server.Documents.TimeSeries
 
             // delete segments, stats and roll-ups
             var table = GetOrCreateTimeSeriesTable(context.Transaction.InnerTransaction, collection);
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice documentKeyPrefix, SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice documentKeyPrefix, SpecialChars.RecordSeparator))
             {
                 table.DeleteByPrimaryKeyPrefix(documentKeyPrefix);
                 Stats.DeleteByPrimaryKeyPrefix(context, collection, documentKeyPrefix);
@@ -2420,7 +2420,7 @@ namespace Raven.Server.Documents.TimeSeries
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesForDoc(DocumentsOperationContext context, string docId)
         {
             var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
-            using var dispose = DocumentIdWorker.GetSliceFromId(context, docId, out var documentKeyPrefix, SpecialChars.RecordSeparator);
+            using var dispose = DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out var documentKeyPrefix, SpecialChars.RecordSeparator);
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach ((_, Table.TableValueHolder tvh) in table.SeekByPrimaryKeyPrefix(documentKeyPrefix, Slices.Empty, 0))
             {

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -21,7 +21,6 @@ using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
 using Raven.Client;
 using Raven.Client.Util;
-using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Config.Categories;
 using Raven.Server.Utils;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -856,7 +856,7 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
-                    using (DocumentIdWorker.GetSliceFromId(_context, document.Id, out Slice lowerDocumentId))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(_context, document.Id, out Slice lowerDocumentId))
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(_context, name, out Slice lowerName, out Slice nameSlice))
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(_context, contentType, out Slice lowerContentType, out Slice contentTypeSlice))
                     using (Slice.External(_context.Allocator, hash, out Slice base64Hash))
@@ -1014,7 +1014,7 @@ namespace Raven.Server.Smuggler.Documents
                 var count = 0;
                 foreach (var id in Ids)
                 {
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var lowerId))
                     {
                         var document = _database.DocumentsStorage.Get(context, lowerId, throwOnConflict: false, skipValidationInDebug: true);
                         if (document == null)
@@ -1164,7 +1164,7 @@ namespace Raven.Server.Smuggler.Documents
 
                 foreach (var id in Ids)
                 {
-                    using (DocumentIdWorker.GetSliceFromId(context, id.Key, out var lowerId))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id.Key, out var lowerId))
                     {
                         _database.DocumentsStorage.RevisionsStorage.Delete(context,
                             id.Key,

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -27,6 +27,7 @@ using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.Util;
@@ -1435,8 +1436,8 @@ namespace Raven.Server.Smuggler.Documents
 
             public async ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<ValueTask> beforeFlush)
             {
-                var document = item.Document;
-                using (document)
+                using var document = item.Document;
+                try
                 {
                     if (_options.OperateOnTypes.HasFlag(DatabaseItemType.Attachments))
                     {
@@ -1461,6 +1462,11 @@ namespace Raven.Server.Smuggler.Documents
                     Writer.WriteDocument(_context, document, metadataOnly: false, _filterMetadataProperty);
 
                     await Writer.MaybeFlushAsync();
+                }
+                catch (Exception e)
+                {
+                    throw new RavenException(
+                        $"Failed to write document {document.Id}. LowerId: {document.LowerId}, Etag: {document.Etag}, ChangeVector: {document.ChangeVector}", e);
                 }
             }
 

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -411,7 +411,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
         {
             string collection = null;
 
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice lowerId))
             {
                 var docsTable = new Table(DocsSchemaBase, step.ReadTx);
                 if (docsTable.ReadByKey(lowerId, out var tvr))
@@ -430,7 +430,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
             var collectionName = new CollectionName(collection);
 
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
             {
                 var maxNumberOfCountersPerGroup = Math.Max(32, 2048 / (dbIds.Count * 32 + 1)); // rough estimate
                 var orderedKeys = allCountersBatch.OrderBy(x => x.Key).ToList();

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
@@ -167,7 +167,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
         private static unsafe void UpdateDocumentCounters(UpdateStep step, DocumentsOperationContext context, string docId, CollectionName collection)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice lowerDocId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out Slice lowerDocId))
             {
                 var table = step.WriteTx.OpenTable(DocsSchemaBase, collection.GetTableName(CollectionTableType.Documents));
                 if (table.ReadByKey(lowerDocId, out var tvr) == false)
@@ -274,7 +274,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                 yield break;
             }
 
-            using (DocumentIdWorker.GetSliceFromId(ctx, prefix, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, prefix, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
             {
                 if (table.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out var reader))
                 {
@@ -295,7 +295,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
         private unsafe void PutCounters(DocumentsOperationContext context, UpdateStep step, string documentId, string changeVector, BlittableJsonReaderObject sourceData, CollectionName collection)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerId))
             {
                 var docsTable = new Table(DocsSchemaBase, step.ReadTx);
                 if (docsTable.ReadByKey(lowerId, out _) == false)
@@ -310,7 +310,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             {
                 var table = step.DocumentsStorage.CountersStorage.GetOrCreateTable(step.WriteTx, CountersSchemaBase, collection, CollectionTableType.CounterGroups);
 
-                using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                 {
                     if (sourceData.TryGet(Values, out BlittableJsonReaderObject sourceCounters) == false)
                     {

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Utils
         /// </summary>
         public static int GetBucketFor(ShardingConfiguration configuration, ByteStringContext context, string id)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var lowerId))
             {
                 return GetBucketFor(configuration, lowerId);
             }
@@ -128,7 +128,7 @@ namespace Raven.Server.Utils
 
         public static (int ShardNumber, int Bucket) GetShardNumberAndBucketFor(ShardingConfiguration configuration, ByteStringContext allocator, string id)
         {
-            using (DocumentIdWorker.GetSliceFromId(allocator, id, out var lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(allocator, id, out var lowerId))
             {
                 return GetShardNumberAndBucketFor(configuration, lowerId);
             }
@@ -137,7 +137,7 @@ namespace Raven.Server.Utils
         public static (int ShardNumber, int Bucket) GetShardNumberAndBucketFor(ShardingConfiguration configuration, ByteStringContext allocator, LazyStringValue id)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "Avoid the allocation of the LazyStringValue below");
-            using (DocumentIdWorker.GetSliceFromId(allocator, id, out var lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(allocator, id, out var lowerId))
             {
                 return GetShardNumberAndBucketFor(configuration, lowerId);
             }

--- a/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
+++ b/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -54,7 +52,7 @@ namespace FastTests.Server.Documents
                 {
                     const string str = "Person@1";
 
-                    using (DocumentIdWorker.GetSliceFromId(ctx, str, out var lowerId))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, str, out var lowerId))
                     {
                         Assert.Equal(str.ToLower(), lowerId.ToString());
                     }
@@ -68,7 +66,7 @@ namespace FastTests.Server.Documents
             using var ctx = DocumentsOperationContext.ShortTermSingleUse(null);
             const string str = "";
             var lazyString = ctx.GetLazyString(str);
-            using (DocumentIdWorker.GetSliceFromId(ctx, lazyString, out var lowerId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, lazyString, out var lowerId))
             {
                 Assert.Equal(str.ToLower(), lowerId.ToString());
             }
@@ -84,7 +82,7 @@ namespace FastTests.Server.Documents
                 {
                     const string str = "Person@יפתח";
 
-                    using (DocumentIdWorker.GetSliceFromId(ctx, str, out var lowerId))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, str, out var lowerId))
                     {
                         Assert.Equal(str.ToLower(), lowerId.ToString());
                     }
@@ -101,7 +99,7 @@ namespace FastTests.Server.Documents
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
                 {
                     var before = ctx.AllocatedMemory;
-                    using (DocumentIdWorker.GetSliceFromId(ctx, "Person@יפתח", out var lowerId))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(ctx, "Person@יפתח", out var lowerId))
                     {
                     }
                     var after = ctx.AllocatedMemory;
@@ -120,45 +118,61 @@ namespace FastTests.Server.Documents
             new object[][]
             {
                 ["\0{\r\n>"], 
-                [new string('\0', AbstractPager.MaxKeySize / (JsonParserState.ControlCharacterItemSize + 1) - 2)], 
-                ['a' + new string('\r', AbstractPager.MaxKeySize / (JsonParserState.EscapePositionItemSize + 1) - 4)]
+                [new string('\0', AbstractPager.MaxKeySize / (JsonParserState.ControlCharacterItemSize + 1) - 2) + '\n'], 
+                ['a' + new string('\r', AbstractPager.MaxKeySize / (JsonParserState.EscapePositionItemSize + 1) - 4) + '\n']
             };
 
         [RavenTheory(RavenTestCategory.Memory)]
         [MemberData(nameof(Ids))]
         public async Task DocumentId_WhenWrite_ShouldBeAbleToRead(string id)
         {
-            const char nonAscii = (char)(DocumentIdWorker.MaxAsciiCodePoint + 1);
+            const char nonAscii = 'Ć';
 
+            var idWithNonAscii = id + nonAscii;
+            
+            using var context = JsonOperationContext.ShortTermSingleUse();
             using var memoryStream = new MemoryStream();
 
             using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
-            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(allocator, id, out _, out Slice withoutAsciiSlice))
-            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(allocator, id + nonAscii, out _, out Slice withAsciiSlice))
-            using (var context = JsonOperationContext.ShortTermSingleUse())
-            await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(allocator, id, out var withoutAsciiSliceLower, out var withoutAsciiSlice))
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(allocator, idWithNonAscii, out var withAsciiSliceLower, out var withAsciiSlice))
             {
                 var withoutAsciiLazyString = GetLazyStringValue(context, withoutAsciiSlice);
                 var withAsciiLazyString = GetLazyStringValue(context, withAsciiSlice);
+            
+            
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+                {
+                    Assert.True(withAsciiLazyString.StartsWith(withoutAsciiLazyString));
 
-                Assert.True(withAsciiLazyString.StartsWith(withoutAsciiLazyString));
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("withoutAsciiSlice");
+                    writer.WriteString(withoutAsciiLazyString);
+                    writer.WriteComma();
+                    writer.WritePropertyName("withAsciiSlice");
+                    writer.WriteString(withAsciiLazyString);
+                    writer.WriteEndObject();
+                }
 
-                writer.WriteString(withoutAsciiLazyString);
-                writer.WriteString(withAsciiLazyString);
-            }
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                using (var reader = await context.ReadForMemoryAsync(memoryStream, "result"))
+                {
+                    Assert.True(reader["withoutAsciiSlice"].Equals(id));
+                    Assert.True(reader["withAsciiSlice"].Equals(idWithNonAscii));
+                }
 
-            memoryStream.Seek(0, SeekOrigin.Begin);
-            using (var reader = new StreamReader(memoryStream, Encoding.UTF8))
-            {
-                var result = await reader.ReadToEndAsync();
-                string expected = JsonConvert.DeserializeObject<string>(JsonConvert.SerializeObject(result));
-                Assert.Equal(expected, result);
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(allocator, id, out Slice withoutAsciiSlice2))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(allocator, idWithNonAscii, out Slice withAsciiSlice2))
+                {
+                    Assert.Equal(withoutAsciiSliceLower, withoutAsciiSlice2, new SliceComparer());
+                    Assert.Equal(withAsciiSliceLower, withAsciiSlice2, new SliceComparer());
+                }
             }
         }
 
         [RavenTheory(RavenTestCategory.Memory)]
         [MemberData(nameof(Ids))]
-        public async Task DocumentId_WhenStore_ShouldBeAbleToLoad(string id)
+        public async Task DocumentId_WhenStore_ShouldBeAbleToLoadAndDelete(string id)
         {
             var idWithNonAscii = (char)(DocumentIdWorker.MaxAsciiCodePoint + 1) + id;
             
@@ -174,6 +188,19 @@ namespace FastTests.Server.Documents
             {
                 Assert.NotNull(await session.LoadAsync<TestObj>(id));
                 Assert.NotNull(await session.LoadAsync<TestObj>(idWithNonAscii));
+            }
+            
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(id);
+                session.Delete(idWithNonAscii);
+                await session.SaveChangesAsync();
+            }
+            
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.Null(await session.LoadAsync<TestObj>(id));
+                Assert.Null(await session.LoadAsync<TestObj>(idWithNonAscii));
             }
         }
 

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -2678,7 +2678,7 @@ namespace SlowTests.Client.Attachments
             using (context2.OpenReadTransaction())
             using (context3.OpenReadTransaction())
             {
-                using (DocumentIdWorker.GetSliceFromId(context1, "users/1", out Slice docIdSlice))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context1, "users/1", out Slice docIdSlice))
                 {
                     var attachments1 = db1.DocumentsStorage.AttachmentsStorage.GetAttachmentDetailsForDocument(context1, docIdSlice).ToList();
                     var attachments2 = db2.DocumentsStorage.AttachmentsStorage.GetAttachmentDetailsForDocument(context2, docIdSlice).ToList();
@@ -3088,7 +3088,7 @@ namespace SlowTests.Client.Attachments
             using (context2.OpenReadTransaction())
             using (context3.OpenReadTransaction())
             {
-                using (DocumentIdWorker.GetSliceFromId(context1, "users/1", out Slice docIdSlice))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context1, "users/1", out Slice docIdSlice))
                 {
                     var attachments1 = db1.DocumentsStorage.AttachmentsStorage.GetAttachmentDetailsForDocument(context1, docIdSlice).ToList();
                     var attachments2 = db2.DocumentsStorage.AttachmentsStorage.GetAttachmentDetailsForDocument(context2, docIdSlice).ToList();

--- a/test/SlowTests/Issues/RavenDB-24797.cs
+++ b/test/SlowTests/Issues/RavenDB-24797.cs
@@ -446,7 +446,7 @@ namespace SlowTests.Issues
                 {
                     var readTable = new Table(db.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -551,7 +551,7 @@ namespace SlowTests.Issues
                 {
                     var readTable = new Table(db.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -625,7 +625,7 @@ namespace SlowTests.Issues
             {
                 var readTable = new Table(database.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                 TableValueReader tvr;
-                using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                 {
                     Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                 }

--- a/test/SlowTests/Issues/RavenDB_15240.cs
+++ b/test/SlowTests/Issues/RavenDB_15240.cs
@@ -74,10 +74,12 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store);
 
-                state = tombstoneCleaner.GetState().Tombstones;
-
-                Assert.Equal(9, state["Companies"].Documents.Etag);
-                Assert.Equal(2, state["Companies"].TimeSeries.Etag);
+                WaitForValue(() =>
+                {
+                    state = tombstoneCleaner.GetState().Tombstones;
+                    var companyState = state["Companies"];
+                    return companyState.Documents.Etag == 9 && companyState.TimeSeries.Etag == 2;
+                }, true);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_19529.cs
+++ b/test/SlowTests/Issues/RavenDB_19529.cs
@@ -112,7 +112,7 @@ public class RavenDB_19529 : ReplicationTestBase
             var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
             {
                 Assert.True(database.DocumentsStorage.ForTestingPurposesOnly().IsDocumentCompressed(context, lowerDocumentId, out var isLargeValue));
                 Assert.True(isLargeValue);
@@ -158,7 +158,7 @@ public class RavenDB_19529 : ReplicationTestBase
             var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
             {
                 Assert.True(database.DocumentsStorage.ForTestingPurposesOnly().IsDocumentCompressed(context, lowerDocumentId, out var isLargeValue));
                 Assert.True(isLargeValue);
@@ -222,7 +222,7 @@ public class RavenDB_19529 : ReplicationTestBase
             var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(storeDst.Database);
             using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
             {
                 Assert.True(database.DocumentsStorage.ForTestingPurposesOnly().IsDocumentCompressed(context, lowerDocumentId, out var isLargeValue));
                 Assert.True(isLargeValue);
@@ -278,7 +278,7 @@ public class RavenDB_19529 : ReplicationTestBase
 
             using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
             {
                 Assert.False(database.DocumentsStorage.ForTestingPurposesOnly().IsDocumentCompressed(context, lowerDocumentId, out var isLargeValue));
                 Assert.True(isLargeValue);
@@ -346,7 +346,7 @@ public class RavenDB_19529 : ReplicationTestBase
 
             using (var context = DocumentsOperationContext.ShortTermSingleUse(databaseDst))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
             {
                 Assert.False(databaseDst.DocumentsStorage.ForTestingPurposesOnly().IsDocumentCompressed(context, lowerDocumentId, out var isLargeValue));
                 Assert.True(isLargeValue);

--- a/test/SlowTests/Issues/RavenDB_20843.cs
+++ b/test/SlowTests/Issues/RavenDB_20843.cs
@@ -93,7 +93,7 @@ namespace SlowTests.Issues
                         using (database3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         using (context.OpenReadTransaction())
                         {
-                            using (DocumentIdWorker.GetSliceFromId(context, "users/1", out Slice docIdSlice))
+                            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, "users/1", out Slice docIdSlice))
                             {
                                 var attachments = database3.DocumentsStorage.AttachmentsStorage.GetAttachmentsForDocument(context, docIdSlice).ToList();
                                 Assert.NotNull(attachments);

--- a/test/SlowTests/Issues/RavenDB_22835.cs
+++ b/test/SlowTests/Issues/RavenDB_22835.cs
@@ -386,7 +386,7 @@ namespace SlowTests.Issues
                 {
                     var readTable = new Table(db.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -491,7 +491,7 @@ namespace SlowTests.Issues
                 {
                     var readTable = new Table(db.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -626,7 +626,7 @@ namespace SlowTests.Issues
                 {
                     var readTable = new Table(db.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -753,7 +753,7 @@ namespace SlowTests.Issues
                 {
                     var readTable = new Table(db.DocumentsStorage.CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -811,7 +811,7 @@ namespace SlowTests.Issues
                 foreach (var id in docIdsToCorrupt)
                 {
                     TableValueReader tvr;
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }
@@ -894,7 +894,7 @@ namespace SlowTests.Issues
                 }
                 else
                 {
-                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
                     {
                         Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
                     }

--- a/test/SlowTests/Issues/RavenDB_23167.cs
+++ b/test/SlowTests/Issues/RavenDB_23167.cs
@@ -125,7 +125,7 @@ namespace SlowTests.Issues
 
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, id, out var idSlice))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var idSlice))
             using (db.DocumentsStorage.RevisionsStorage.GetKeyPrefix(context, idSlice, out Slice prefixSlice))
             using (RevisionsStorage.GetKeyWithEtag(context, idSlice, endEtag, out var compoundPrefix))
             {
@@ -158,7 +158,7 @@ namespace SlowTests.Issues
 
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())
-            using (DocumentIdWorker.GetSliceFromId(context, id, out var idSlice))
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out var idSlice))
             using (db.DocumentsStorage.RevisionsStorage.GetKeyPrefix(context, idSlice, out Slice prefixSlice))
             {
                 var table = new Table(revisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);

--- a/test/SlowTests/Server/Documents/DocumentIdWorkerTests.cs
+++ b/test/SlowTests/Server/Documents/DocumentIdWorkerTests.cs
@@ -1,0 +1,276 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Server;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents;
+
+public class DocumentIdWorkerTests : ClusterTestBase
+{
+    public DocumentIdWorkerTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+    }
+
+    [RavenTheory(RavenTestCategory.Core)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IdWithEscapedAndControlCharacters_WhenReplicate_CanGet(bool withNonAscii)
+    {
+        var id = "A" + (char)1 + '\n';
+        if (withNonAscii)
+            id += 'Ć';
+        const int replicas = 2;
+
+        var (nodes, leader) = await CreateRaftCluster(replicas, watcherCluster: true);
+
+        using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = replicas, });
+        using var s1 = GetDocumentStoreForNode(store, nodes[0]);
+        using var s2 = GetDocumentStoreForNode(store, nodes[1]);
+
+        using (var session = s1.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = id }, id);
+            await session.SaveChangesAsync();
+        }
+
+        var loaded = await AssertWaitForNotNullAsync(async () =>
+        {
+            using var session = s2.OpenAsyncSession();
+            return await session.Query<TestObj>().SingleOrDefaultAsync();
+        });
+
+        using (var session = s2.OpenAsyncSession())
+        {
+            var load = await session.LoadAsync<TestObj>(loaded.Id);
+            Assert.NotNull(load);
+        }
+
+        using (var session = s1.OpenAsyncSession())
+        {
+            var load = await session.LoadAsync<TestObj>(id);
+            Assert.NotNull(load);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Core, Skip = "RavenDB-24940")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IdWithControlCharacters_WhenReplicate_CanGetAndDeleteByNotEscapedId(bool withNonAscii)
+    {
+        var id = "A" + (char)1;
+        if (withNonAscii)
+            id += 'Ć';
+        const int replicas = 2;
+
+        var (nodes, leader) = await CreateRaftCluster(replicas, watcherCluster: true);
+
+        using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = replicas, });
+        using var s1 = GetDocumentStoreForNode(store, nodes[0]);
+        using var s2 = GetDocumentStoreForNode(store, nodes[1]);
+
+        using (var session = s1.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = id }, id);
+            await session.SaveChangesAsync();
+        }
+
+        await AssertWaitForTrueAsync(async () =>
+        {
+            using var session = s2.OpenAsyncSession();
+            return await session.Query<TestObj>().CountAsync() == 1;
+        });
+
+        using (var session = s2.OpenAsyncSession())
+        {
+            var load = await session.LoadAsync<TestObj>(id);
+            Assert.NotNull(load);
+            session.Delete(id);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = s2.OpenAsyncSession())
+        {
+            var count = await session.Query<TestObj>().CountAsync();
+            Assert.Equal(0, count);
+        }
+
+        await AssertWaitForTrueAsync(async () =>
+        {
+            using var session = s1.OpenAsyncSession();
+            return await session.Query<TestObj>().CountAsync() == 0;
+        });
+    }
+
+    [RavenTheory(RavenTestCategory.Core, Skip = "RavenDB-24940")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IdWithControlCharacters_WhenReplicate_CanGetAndDeleteByEscapedId(bool withNonAscii)
+    {
+        var id = "A" + (char)1;
+        if (withNonAscii)
+            id += 'Ć';
+        const int replicas = 2;
+
+        var (nodes, leader) = await CreateRaftCluster(replicas, watcherCluster: true);
+
+        using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = replicas, });
+        using var s1 = GetDocumentStoreForNode(store, nodes[0]);
+        using var s2 = GetDocumentStoreForNode(store, nodes[1]);
+
+        using (var session = s1.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = id }, id);
+            await session.SaveChangesAsync();
+        }
+
+        await AssertWaitForTrueAsync(async () =>
+        {
+            using var session = s1.OpenAsyncSession();
+            return await session.Query<TestObj>().CountAsync() == 1;
+        });
+
+        using (var session2 = s2.OpenAsyncSession())
+        {
+            var loadFrom2 = await session2.Query<TestObj>().SingleAsync();
+            using var session1 = s1.OpenAsyncSession();
+            var loadFrom1 = await session1.LoadAsync<TestObj>(loadFrom2.Id);
+            Assert.NotNull(loadFrom1);
+            session1.Delete(loadFrom2.Id);
+            await session1.SaveChangesAsync();
+        }
+
+        using (var session = s1.OpenAsyncSession())
+        {
+            var count = await session.Query<TestObj>().CountAsync();
+            Assert.Equal(0, count);
+        }
+
+        await AssertWaitForTrueAsync(async () =>
+        {
+            using var session = s2.OpenAsyncSession();
+            return await session.Query<TestObj>().CountAsync() == 0;
+        });
+    }
+
+    [RavenTheory(RavenTestCategory.Core, Skip = "RavenDB-24940")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IdWithControlCharacters_WhenReplicateModification_CanGetAndDeleteByNotEscapedId(bool withNonAscii)
+    {
+        var id = "A" + (char)1;
+        if (withNonAscii)
+            id += 'Ć';
+        const int replicas = 3;
+
+        var (nodes, leader) = await CreateRaftCluster(replicas, watcherCluster: true);
+
+        using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = replicas, });
+        using var s1 = GetDocumentStoreForNode(store, nodes[0]);
+        using var s2 = GetDocumentStoreForNode(store, nodes[1]);
+
+        using (var session = s2.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = id }, id);
+            await session.SaveChangesAsync();
+        }
+
+        await AssertWaitForTrueAsync(async () =>
+        {
+            using var session = s2.OpenAsyncSession();
+            return await session.Query<TestObj>().CountAsync() == 1;
+        });
+
+        using (var session2 = s2.OpenAsyncSession())
+        {
+            var load = await session2.LoadAsync<TestObj>(id);
+            load.Prop += "changed";
+            await session2.SaveChangesAsync();
+        }
+
+        await AssertWaitForTrueAsync(async () =>
+        {
+            using var session = s1.OpenAsyncSession();
+            var load = await session.Query<TestObj>().SingleAsync();
+            return load.Prop.EndsWith("changed");
+        });
+
+        WaitForUserToContinueTheTest(store);
+        using (var session = s1.OpenAsyncSession())
+        {
+            var load = await session.LoadAsync<TestObj>(id);
+            Assert.NotNull(load);
+            session.Delete(id);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = s1.OpenAsyncSession())
+        {
+            var count = await session.Query<TestObj>().CountAsync();
+            Assert.Equal(0, count);
+        }
+    }
+
+
+    [RavenTheory(RavenTestCategory.Core, Skip = "RavenDB-24940")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task IdWithControlCharacters_WhenGetDocumentIdFromReplicatedDocument_ShouldBeEqualToTheOriginId(bool withNonAscii)
+    {
+        var id = "A" + (char)1 + '\n';
+        if (withNonAscii)
+            id += 'Ć';
+        const int replicas = 2;
+
+        var (nodes, leader) = await CreateRaftCluster(replicas, watcherCluster: true);
+
+        using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = replicas, });
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User { Name = id }, id);
+            await session.SaveChangesAsync();
+        }
+
+        await Task.WhenAll(nodes.Select(async server =>
+        {
+            using var s = new DocumentStore
+            {
+                Database = store.Database,
+                Urls = [server.WebUrl],
+            };
+            s.Conventions.DisableTopologyUpdates = true;
+            s.Initialize();
+
+            await AssertWaitForTrueAsync(async () =>
+            {
+                using var session = s.OpenAsyncSession();
+                return await session.Query<User>().AnyAsync();
+            });
+
+            using var session = s.OpenAsyncSession();
+            var user = await session.Query<User>().SingleAsync();
+            Assert.Equal(id, user.Id);
+        }));
+    }
+
+    private static IDocumentStore GetDocumentStoreForNode(DocumentStore store, RavenServer server)
+    {
+        return new DocumentStore
+        {
+            Database = store.Database,
+            Urls = [server.WebUrl],
+            Conventions = new DocumentConventions { DisableTopologyUpdates = true }
+        }.Initialize();
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24863

### Additional description

#### V6.2 PR for https://github.com/ravendb/ravendb/pull/21188

#### Align escape behavior of ASCII IDs with non-ASCII IDs
In the case of ASCII IDs, both the lower ID and the original ID were being escaped,  
which was not the case with non-ASCII IDs.  
This applied to both `GetLowerIdSliceAndStorageKey` and `GetSliceFromId`.  

#### Allow cleaning documents with corrupted Ids
I tried to add functionality that will also help us later for future issues.

First, I logged the failed document in Smuggler.  
I did it at the `StreamDestination` level since the data is already disposed in the outer scope.  
I logged the information relevant for deleting the data (the ETag) and I also added the change vector since I found it makes querying the data easier if needed.  
The deletion by ETag can be done with the admin console.

I added functionality to delete revisions by ETag since we have a customer with a corrupted ID belonging to a revision.  
`return database.DocumentsStorage.ForDebug.DeleteDocumentByEtag(8623258)`  
`return database.DocumentsStorage.RevisionsStorage.ForDebug.DeleteRevisionByEtag(8623258)`

Also, I added a dedicated endpoint to scan all documents and retrieve the relevant information for those with corrupted IDs.  
It is not an elegant solution since it is only meant to handle this situation and will be irrelevant in the future.  
We can also rely on Smuggler, but if there are multiple documents with issues, we would need to rerun Smuggler after deleting a document to find the next one.  
So far, all the cases I investigated had only a few documents with corrupted IDs.

I also considered “fixing” delete-by-query to use `LowerId`.  
In the current situation, the `Id` and the `LowerId` are different.  
The operation takes the `Id` and tries to find it in the database but gets no results.  
I didn’t do it in this PR because we need a fast solution, and such a modification is riskier.


### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
