### PR TITLE
RavenDB-24930 : flaky test adjustments 

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
 using Sparrow.Server;
@@ -342,17 +345,13 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
         }
 
         EtlErrorInfo error = null;
-        var value = await WaitForValueAsync(async () =>
+        var gotError = await WaitForValueAsync(async () =>
         {
             error = await Etl.TryGetLoadErrorAsync(store.Database, config);
             return error != null;
         }, true, timeout: 60_000);
 
-
-        Assert.True(value);
-        Assert.NotNull(error);
-
-        Assert.Contains("rate limit", error.Error);
+        Assert.True(gotError && error.Error.Contains("rate limit"), await AddDebugInfo(store, config));
 
         using (var session = store.OpenSession())
         {
@@ -540,4 +539,23 @@ this.Comments[idx].IsSpam = $output.Blocked;";
         Assert.True(lastProcessedEtag > 0);
     }
 
+    private async Task<string> AddDebugInfo(IDocumentStore store, GenAiConfiguration config)
+    {
+        var database = await GetDocumentDatabaseInstanceFor(store);
+        var perfStats = Etl.GetEtlPerformanceStatsForDatabase(database);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("ETL performance stats:").AppendLine(perfStats);
+
+        var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(
+            GenAiTask.GenAiTaskTag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_LoadError);
+
+        if (loadAlert?.Details is EtlErrorsDetails details)
+        {
+            sb.AppendLine("Etl error details:")
+                .AppendLine(string.Join(',', details.Errors.Select(e => e.Error)));
+        }
+
+        return sb.ToString();
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24930/SlowTests.Server.Documents.AI.GenAi.GenAiErrorHandling.GenAiShouldRespectRateLimitErrorAndFallbackoptions-DatabaseMode-Single

### Additional description

added some debug info to error message

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
