### PR TITLE
RavenDB-23034 [Studio] Add an Option to Import/Restore a Database in Slow Mode to Minimize Impact on Existing Databases

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
@@ -22,6 +22,8 @@ const defaultValues: FormData = {
         isDisableOngoingTasksAfterRestore: false,
         isSkipIndexes: false,
         isEncrypted: false,
+        isSetMaxReadOpsPerSecond: false,
+        maxReadOpsPerSecond: null,
         sourceType: null,
         sourceData: {
             local: {
@@ -289,6 +291,7 @@ function mapToDto({
         DisableOngoingTasks: sourceStep.isDisableOngoingTasksAfterRestore,
         SkipIndexes: sourceStep.isSkipIndexes,
         DataDirectory: dataDirectoryStep.isDefault ? null : dataDirectoryStep.directory,
+        MaxReadOpsPerSecond: sourceStep.isSetMaxReadOpsPerSecond ? sourceStep.maxReadOpsPerSecond : null,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
@@ -156,6 +156,14 @@ const sourceStepSchema = yup.object({
     isDisableOngoingTasksAfterRestore: yup.boolean(),
     isSkipIndexes: yup.boolean(),
     isEncrypted: yup.boolean(),
+    isSetMaxReadOpsPerSecond: yup.boolean(),
+    maxReadOpsPerSecond: yup
+        .number()
+        .nullable()
+        .when("isSetMaxReadOpsPerSecond", {
+            is: true,
+            then: (schema) => schema.min(1).integer().required(),
+        }),
     sourceType: yup.string<RestoreSource>().nullable().required(),
     sourceData: yup.object({
         local: localSource,

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
@@ -1,4 +1,4 @@
-import { FormLabel, FormSelect, FormSwitch } from "components/common/Form";
+import { FormInput, FormLabel, FormSelect, FormSwitch } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import { OptionWithIcon, SelectOptionWithIcon, SingleValueWithIcon } from "components/common/select/Select";
 import React, { useEffect } from "react";
@@ -19,13 +19,14 @@ import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import AuthenticationOffMessage from "components/pages/resources/databases/partials/create/shared/AuthenticationOffMessage";
 import EncryptionUnavailableMessage from "components/pages/resources/databases/partials/create/shared/EncryptionUnavailableMessage";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 
 const backupSourceImg = require("Content/img/createDatabase/backup-source.svg");
 
 export default function CreateDatabaseFromBackupStepSource() {
     const { control, setValue } = useFormContext<FormData>();
     const {
-        sourceStep: { sourceData, sourceType },
+        sourceStep: { sourceData, sourceType, isSetMaxReadOpsPerSecond },
     } = useWatch({
         control,
     });
@@ -90,6 +91,23 @@ export default function CreateDatabaseFromBackupStepSource() {
                         <Icon icon="index" />
                         Skip indexes
                     </FormSwitch>
+                    <FormSwitch control={control} name="sourceStep.isSetMaxReadOpsPerSecond" color="primary">
+                        <Icon icon="traffic-watch" />
+                        Set max read operations per second
+                        <PopoverWithHoverWrapper message="This setting is used to limit the impact of restore operations on the database performance.">
+                            <Icon icon="info" margin="ms-1" />
+                        </PopoverWithHoverWrapper>
+                    </FormSwitch>
+                    {isSetMaxReadOpsPerSecond && (
+                        <FormInput
+                            type="number"
+                            control={control}
+                            name="sourceStep.maxReadOpsPerSecond"
+                            placeholder="Enter the max read operations per second"
+                            min={1}
+                            className="mb-2"
+                        />
+                    )}
                     <IsEncryptedField
                         isRestorePointSnapshot={isRestorePointSnapshot}
                         isRestorePointEncrypted={isRestorePointEncrypted}

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -44,6 +44,9 @@ class exportDatabaseModel {
     exportDefinitionHasIncludes: KnockoutComputed<boolean>;
     itemsToWarnAbout: KnockoutComputed<string>;
 
+    isSetMaxReadOpsPerSecond = ko.observable<boolean>(false);
+    maxReadOpsPerSecond = ko.observable<number>(null);
+
     constructor() {
         this.initValidation();
         this.initEncryptionValidation();
@@ -190,7 +193,8 @@ class exportDatabaseModel {
             SkipRevisionCreation: undefined,
             AuthorizationStatus: undefined,
             CompressionAlgorithm: this.compressionAlgorithm(),
-            SkipCorruptedData: this.skipCorruptedData()
+            SkipCorruptedData: this.skipCorruptedData(),
+            MaxReadOpsPerSecond: this.isSetMaxReadOpsPerSecond() ? this.maxReadOpsPerSecond() : null
         };
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
@@ -41,6 +41,9 @@ class importDatabaseModel {
     validationGroup: KnockoutValidationGroup;
     importDefinitionHasIncludes: KnockoutComputed<boolean>;
     itemsToWarnAbout: KnockoutComputed<string>;
+
+    isSetMaxReadOpsPerSecond = ko.observable<boolean>(false);
+    maxReadOpsPerSecond = ko.observable<number>(null);
     
     constructor() {
         this.initValidation();
@@ -190,6 +193,7 @@ class importDatabaseModel {
             OperateOnTypes: operateOnTypes.join(",") as Raven.Client.Documents.Smuggler.DatabaseItemType,
             OperateOnDatabaseRecordTypes: recordTypes,
             Collections: this.includeAllCollections() ? null : this.includedCollections(),
+            MaxReadOpsPerSecond: this.isSetMaxReadOpsPerSecond() ? this.maxReadOpsPerSecond() : null
         } as Raven.Client.Documents.Smuggler.DatabaseSmugglerImportOptions;
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -60,6 +60,9 @@ abstract class backupConfiguration {
     locationInfo = ko.observableArray<Raven.Server.Web.Studio.SingleNodeDataDirectoryResult>([]);
     folderPathOptions = ko.observableArray<string>([]);
 
+    isSetMaxReadOpsPerSecond = ko.observable<boolean>(false);
+    maxReadOpsPerSecond = ko.observable<number>(null);
+
     spinners = {
         locationInfoLoading: ko.observable<boolean>(false)
     };

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/manualBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/manualBackupConfiguration.ts
@@ -27,7 +27,9 @@ class manualBackupConfiguration extends backupConfiguration {
             this.backupType,
             this.backupUploadMode,
             this.encryptionSettings().dirtyFlag().isDirty,
-            this.anyBackupTypeIsDirty
+            this.anyBackupTypeIsDirty,
+            this.isSetMaxReadOpsPerSecond,
+            this.maxReadOpsPerSecond
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -61,7 +63,8 @@ class manualBackupConfiguration extends backupConfiguration {
             GlacierSettings: this.glacierSettings().toDto(),
             AzureSettings: this.azureSettings().toDto(),
             GoogleCloudSettings: this.googleCloudSettings().toDto(),
-            FtpSettings: this.ftpSettings().toDto()
+            FtpSettings: this.ftpSettings().toDto(),
+            MaxReadOpsPerSecond: this.isSetMaxReadOpsPerSecond() ? this.maxReadOpsPerSecond() : null
         }
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -48,6 +48,9 @@ class periodicBackupConfiguration extends backupConfiguration {
         this.pinMentorNode(dto.PinToMentorNode);
         
         this.retentionPolicy(!dto.RetentionPolicy ? retentionPolicy.empty() : new retentionPolicy(dto.RetentionPolicy));
+
+        this.isSetMaxReadOpsPerSecond(dto.MaxReadOpsPerSecond != null);
+        this.maxReadOpsPerSecond(dto.MaxReadOpsPerSecond ?? null);
        
         this.initObservables();
         this.initValidation();
@@ -87,7 +90,9 @@ class periodicBackupConfiguration extends backupConfiguration {
             this.snapshot().excludeIndexes,
             this.retentionPolicy().dirtyFlag().isDirty,
             this.encryptionSettings().dirtyFlag().isDirty,
-            this.anyBackupTypeIsDirty
+            this.anyBackupTypeIsDirty,
+            this.isSetMaxReadOpsPerSecond,
+            this.maxReadOpsPerSecond
         ], false, jsonUtil.newLineNormalizingHashFunction);
     }
 
@@ -172,6 +177,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             GoogleCloudSettings: this.googleCloudSettings().toDto(),
             FtpSettings: this.ftpSettings().toDto(),
             CreatedAt: this.createdAt(),
+            MaxReadOpsPerSecond: this.isSetMaxReadOpsPerSecond() ? this.maxReadOpsPerSecond() : null
         };
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -121,7 +121,7 @@
                     </div>
                 </div>
                 <div data-bind="if: backupOperation === 'periodic'">
-                    <div class="row margin-bottom">
+                    <div class="row">
                         <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
                             <div class="toggle">
                                 <div class="toggle" data-placement="right" data-toggle="tooltip" data-bind="attr: { title: $root.db.isSharded() ? 'Not supported in sharded databases' : 'Toggle on to set a responsible node for the task'  }"
@@ -134,6 +134,24 @@
                     </div>
                     <div data-bind="compose: $root.taskResponsibleNodeSectionView"></div>
                     
+                </div>
+                <div class="margin-bottom">
+                    <div class="row">
+                        <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
+                            <div class="toggle">
+                                <div class="toggle" data-placement="right" data-toggle="tooltip" title="This setting is used to limit the impact of backup operations on the database performance.">
+                                    <input id="isSetMaxReadOpsPerSecond" type="checkbox" data-bind="checked: isSetMaxReadOpsPerSecond">
+                                    <label for="isSetMaxReadOpsPerSecond">Set max read operations per second</label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row" data-bind="validationElement: maxReadOpsPerSecond, collapse: isSetMaxReadOpsPerSecond">
+                        <label class="control-label col-sm-4 col-lg-2">Max Read Operations Per Second</label>
+                        <div class="col-sm-4">
+                            <input type="number" data-bind="numericInput: maxReadOpsPerSecond" class="form-control" placeholder="Enter the max read operations per second" min="1" />
+                        </div>
+                    </div>
                 </div>
                 <div data-bind="collapse: isSnapshot, with: snapshot">
                     <div class="row margin-bottom">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
@@ -190,6 +190,15 @@
                         <div data-bind="with: model.databaseModel">
                             <div data-bind="compose: $root.smugglerDatabaseRecordView"></div>
                         </div>
+                        <div class="toggle">
+                            <input id="isSetMaxReadOpsPerSecond" type="checkbox" data-bind="checked: model.isSetMaxReadOpsPerSecond" />
+                            <label for="isSetMaxReadOpsPerSecond" class="margin-right margin-right-sm">Set Max Read Operations Per Second </label>
+                        </div>
+                        <div data-bind="collapse: model.isSetMaxReadOpsPerSecond">
+                            <div class="input-group margin-right">
+                                <input id="maxReadOpsPerSecond" type="number" min="1" class="form-control input-border" data-bind="numericInput: model.maxReadOpsPerSecond" placeholder="Max read operations per second" />
+                            </div>
+                        </div>
                     </div>
                     <div class="form-group">
                         Compression Algorithm: 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
@@ -219,6 +219,15 @@
                         <div data-bind="with: databaseModel">
                             <div data-bind="compose: $root.smugglerDatabaseRecordView"></div>
                         </div>
+                        <div class="toggle">
+                            <input id="isSetMaxReadOpsPerSecond" type="checkbox" data-bind="checked: isSetMaxReadOpsPerSecond" />
+                            <label for="isSetMaxReadOpsPerSecond" class="margin-right margin-right-sm">Set Max Read Operations Per Second </label>
+                        </div>
+                        <div data-bind="collapse: isSetMaxReadOpsPerSecond">
+                            <div class="input-group margin-right">
+                                <input id="maxReadOpsPerSecond" type="number" min="1" class="form-control input-border" data-bind="numericInput: maxReadOpsPerSecond" placeholder="Max read operations per second" />
+                            </div>
+                        </div>
                     </div>
                     <div class="flex-horizontal" data-bind="with: $root">
                         <div class="btn-group">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23034/Add-an-Option-to-Import-Restore-a-Database-in-Slow-Mode-to-Minimize-Impact-on-Existing-Databases

### Additional description

Added to views:
- Restore from backup
- Import data from a .ravendbdump file
- Export database
- Manual backup
- Periodic backup

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
