### PR TITLE
RavenDB-25029 Fix FormSelectAutocomplete isDisabled state

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Form.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.stories.tsx
@@ -12,6 +12,7 @@ import {
     FormRadio,
     FormRadioToggleWithIcon,
     FormSelect,
+    FormSelectAutocomplete,
     FormSelectCreatable,
     FormSwitch,
 } from "./Form";
@@ -138,8 +139,8 @@ export function Form({ isDefaultValid }: { isDefaultValid: boolean }) {
                     control={control}
                     name="inputSelect"
                     options={[
-                        { label: "Option 1", value: 1 },
-                        { label: "Option 2", value: 2 },
+                        { label: "Option first", value: 1 },
+                        { label: "Option second", value: 2 },
                     ]}
                 />
             </FormGroup>
@@ -149,8 +150,19 @@ export function Form({ isDefaultValid }: { isDefaultValid: boolean }) {
                     control={control}
                     name="inputSelectCreatable"
                     options={[
-                        { label: "Option 1", value: 1 },
-                        { label: "Option 2", value: 2 },
+                        { label: "Option first", value: 1 },
+                        { label: "Option second", value: 2 },
+                    ]}
+                />
+            </FormGroup>
+            <FormGroup>
+                <FormLabel>Select autocomplete</FormLabel>
+                <FormSelectAutocomplete
+                    control={control}
+                    name="inputSelectAutocomplete"
+                    options={[
+                        { label: "Option first", value: 1 },
+                        { label: "Option second", value: 2 },
                     ]}
                 />
             </FormGroup>
@@ -215,6 +227,7 @@ const schema = yup.object().shape({
     inputSelect: yup.number().nullable().required(),
     inputMultiSelect: yup.number().nullable().required(),
     inputSelectCreatable: yup.number().nullable().required(),
+    inputSelectAutocomplete: yup.number().nullable().required(),
     inputDatePicker: yup.date().required(),
     inputDurationPicker: yup.number().required(),
     inputAceEditor: yup.string().required(),
@@ -235,6 +248,7 @@ const validValues: FormData = {
     inputSelect: 1,
     inputMultiSelect: 1,
     inputSelectCreatable: 1,
+    inputSelectAutocomplete: 1,
     inputDatePicker: new Date(),
     inputDurationPicker: 2,
     inputAceEditor: "const x = 1;",
@@ -252,6 +266,7 @@ const invalidValues: FormData = {
     inputSelect: null,
     inputMultiSelect: null,
     inputSelectCreatable: null,
+    inputSelectAutocomplete: null,
     inputDatePicker: null,
     inputDurationPicker: null,
     inputAceEditor: "",

--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -331,13 +331,20 @@ export function FormSelectAutocomplete<
     const { value: isInitialOpen, setValue: setIsInitialOpen } = useBoolean(false);
 
     const valueAccessor = props.getOptionValue ?? ((option: any) => option.value);
+    const labelAccessor = props.getOptionLabel ?? ((option: any) => option.label);
 
     const handleFilterOption = (option: FilterOptionOption<Option>, inputValue: string) => {
         if (isInitialOpen) {
             return true;
         }
 
-        return valueAccessor(option).trim().toLowerCase().includes(inputValue.trim().toLowerCase());
+        return (
+            compareInputValue(valueAccessor(option), inputValue) || compareInputValue(labelAccessor(option), inputValue)
+        );
+    };
+
+    const compareInputValue = (value: unknown, inputValue: string): boolean => {
+        return String(value).trim().toLowerCase().includes(String(inputValue).trim().toLowerCase());
     };
 
     const handleInputChange = (value: string, action: InputActionMeta) => {
@@ -348,17 +355,19 @@ export function FormSelectAutocomplete<
     };
 
     const handleFocus = (e: React.FocusEvent<HTMLInputElement, Element>) => {
-        e.target.selectionStart = value?.length ?? 0;
+        e.target.selectionStart = String(value).length;
         setIsInitialOpen(true);
     };
 
+    const inputValue = props.isDisabled ? "" : (value ?? "");
+
     return (
         <FormSelectCreatable<Option, IsMulti, Group, TFieldValues, TName>
-            inputValue={value ?? ""}
+            inputValue={inputValue}
             onInputChange={handleInputChange}
             components={{ Input: InputNotHidden }}
             tabSelectsValue
-            controlShouldRenderValue={false}
+            controlShouldRenderValue={!!props.isDisabled}
             filterOption={handleFilterOption}
             onFocus={handleFocus}
             blurInputOnSelect


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25029/FormSelectAutocomplete-value-is-hidden-when-isDisabled-true

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
