### PR TITLE
RavenDB-24150 - add check of the size of attachment when its already exists in the cloud

### DIFF
--- a/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentUploader.cs
@@ -52,6 +52,21 @@ public class AttachmentUploader : MultipleFileUploaderBase<AttachmentUploadToClo
         }
     }
 
+    public long? GetObjectSizeFromMetadata(IDictionary<string, string> metadata)
+    {
+        switch (_destination)
+        {
+            case BackupConfiguration.BackupDestination.AmazonS3:
+                return GetObjectSizeFromMetadataS3(metadata);
+
+            case BackupConfiguration.BackupDestination.Azure:
+                return GetObjectSizeFromMetadataAzure(metadata);
+
+            default:
+                throw new ArgumentOutOfRangeException($"Missing implementation for direct upload destination '{_destination}'");
+        }
+    }
+
     public void CreateUploadTask(DocumentDatabase database, AbstractBackgroundWorkStorage.DocumentExpirationInfo doc, Stream attachmentStream, string objKeyName, long attachmentLength)
     {
         Task task = CreateUploadTaskInternal(database, attachmentStream, objKeyName, attachmentLength);

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -264,8 +264,15 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             try
             {
                 GetObjectMetadataResponse response = await _client.GetObjectMetadataAsync(_bucketName, key, _cancellationToken);
+                var headers = ConvertHeaders(response.Headers);
+                var metadata = ConvertMetadata(response.Metadata);
 
-                return ConvertMetadata(response.Metadata);
+                foreach (var kvp in headers)
+                {
+                    metadata.TryAdd(kvp.Key, kvp.Value);
+                }
+
+                return metadata;
             }
             catch (AmazonS3Exception e)
             {
@@ -405,6 +412,18 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
 
             foreach (var kvp in metadata)
                 collection[Uri.EscapeDataString(kvp.Key)] = Uri.EscapeDataString(kvp.Value);
+        }
+
+        private static IDictionary<string, string> ConvertHeaders(HeadersCollection collection)
+        {
+            var metadata = new Dictionary<string, string>();
+            if (collection == null)
+                return metadata;
+
+            foreach (var key in collection.Keys)
+                metadata[key] = collection[key];
+
+            return metadata;
         }
 
         private static IDictionary<string, string> ConvertMetadata(MetadataCollection collection)

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Core;
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -280,10 +281,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                 var client = _client.GetBlobClient(key);
                 var response = await client.GetPropertiesAsync(cancellationToken: _cancellationToken);
 
-                var metadata = new Dictionary<string, string>();
-                foreach (var kvp in response.Value.Metadata)
+                var headers = ConvertHeaders(response.GetRawResponse().Headers);
+                var metadata = ConvertMetadata(response.Value.Metadata);
+
+                foreach (var kvp in headers)
                 {
-                    metadata[kvp.Key] = kvp.Value;
+                    metadata.TryAdd(kvp.Key, kvp.Value);
                 }
 
                 return metadata;
@@ -295,6 +298,30 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
 
                 throw;
             }
+        }
+
+        private static IDictionary<string, string> ConvertHeaders(ResponseHeaders collection)
+        {
+            var metadata = new Dictionary<string, string>();
+
+            foreach (var header in collection)
+            {
+                metadata[header.Name] = header.Value;
+            }
+
+            return metadata;
+        }
+
+        private static IDictionary<string, string> ConvertMetadata(IDictionary<string, string> collection)
+        {
+            var metadata = new Dictionary<string, string>();
+            if (collection == null)
+                return metadata;
+
+            foreach (var key in collection.Keys)
+                metadata[key] = collection[key];
+
+            return metadata;
         }
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/FileUploaderBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/FileUploaderBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Aws;
@@ -97,6 +98,27 @@ public abstract class FileUploaderBase : FileUploaderDownloaderBase
     protected IDictionary<string, string> GetObjectMetadataFromGoogleCloud(GoogleCloudSettings settings, string folderName, string fileName)
     {
         throw new NotImplementedException();
+    }
+
+    protected long? GetObjectSizeFromMetadataS3(IDictionary<string, string> metadata)
+    {
+        return GetObjectSizeFromMetadataInternal(metadata);
+    }
+
+    protected long? GetObjectSizeFromMetadataAzure(IDictionary<string, string> metadata)
+    {
+        return GetObjectSizeFromMetadataInternal(metadata);
+    }
+
+    private long? GetObjectSizeFromMetadataInternal(IDictionary<string, string> metadata)
+    {
+        if (metadata.TryGetValue(Constants.Headers.ContentLength, out var contentLengthStr) &&
+            long.TryParse(contentLengthStr, out var cloudSize))
+        {
+            return cloudSize;
+        }
+
+        return null;
     }
 
     private string ReportDeletion(string name)

--- a/src/Raven.Server/Documents/RetireAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RetireAttachmentsSender.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -178,18 +179,43 @@ namespace Raven.Server.Documents
 
                                 using var hashSliceDisposable = _database.DocumentsStorage.AttachmentsStorage.RetiredAttachmentsStorage.ExtractHashSliceFromAttachmentId(context, doc.LowerId, out Slice hashSlice);
                                 var hash = hashSlice.ToString();
-                                //TODO: egor add test that will cover this scenario, when the attachment is already in cloud, also cover scenario if we had partial upload
-                                if (directUpload.GetObjectMetadata(string.Empty, hash) != null)
+
+                                var metadata = directUpload.GetObjectMetadata(string.Empty, hash);
+                                bool shouldUpload = true;
+                                long? attachmentLength = null;
+                                if (metadata != null)
+                                {
+                                    // The attachment already exists in the cloud, the file name is the hash so we can check if size matches to detect partial uploads
+                                    var objectSizeFromMetadata = directUpload.GetObjectSizeFromMetadata(metadata);
+                                    if (objectSizeFromMetadata.HasValue)
+                                    {
+                                        attachmentLength = AttachmentsStorage.GetAttachmentStreamLength(context, hashSlice);
+
+                                        // Only skip upload if sizes match exactly
+                                        shouldUpload = objectSizeFromMetadata != attachmentLength;
+                                    }
+                                }
+
+                                _token.ThrowIfCancellationRequested();
+
+                                if (shouldUpload == false)
                                 {
                                     // the attachment already exists in the cloud, no need to upload it again
                                     retired.Enqueue(doc);
                                     continue;
                                 }
 
-                                _token.ThrowIfCancellationRequested();
-
                                 // the attachment stream is disposed by the directUpload
-                                var (attachmentStream, attachmentLength) = _database.DocumentsStorage.AttachmentsStorage.GetAttachmentStreamAndLength(context, hashSlice);
+                                Stream attachmentStream;
+                                if (attachmentLength.HasValue == false)
+                                {
+                                    (attachmentStream, attachmentLength) = _database.DocumentsStorage.AttachmentsStorage.GetAttachmentStreamAndLength(context, hashSlice);
+                                }
+                                else
+                                {
+                                    attachmentStream = _database.DocumentsStorage.AttachmentsStorage.GetAttachmentStream(context, hashSlice);
+                                }
+
                                 if (attachmentStream == null)
                                 {
                                     // attachment was deleted, need to remote it from retired tree
@@ -199,7 +225,7 @@ namespace Raven.Server.Documents
 
                                 if (await directUpload.WaitForFinishedTasksIfNeededAsync(duration, _token))
                                 {
-                                    directUpload.CreateUploadTask(_database, doc, attachmentStream, hash, attachmentLength);
+                                    directUpload.CreateUploadTask(_database, doc, attachmentStream, hash, attachmentLength.Value);
                                 }
                                 else
                                 {

--- a/test/SlowTests/Server/Documents/Attachments/AzureRetiredAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/AzureRetiredAttachmentsSlowTests.cs
@@ -94,7 +94,13 @@ namespace SlowTests.Server.Documents.Attachments
         [AzureRetryFact]
         public async Task CanUploadRetiredAttachmentToAzureIfItAlreadyExists_ShouldNotOverwrite()
         {
-            await CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal();
+            await CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal(overwriteWithDummy: false);
+        }
+
+        [AzureRetryFact]
+        public async Task CanUploadRetiredAttachmentToAzureIfItAlreadyExists_ShouldOverwriteIfBroken()
+        {
+            await CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal(overwriteWithDummy: true);
         }
 
         [AzureRetryFact]

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsAzureBase.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsAzureBase.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -92,6 +94,20 @@ public abstract class RetiredAttachmentsAzureBase : RetiredAttachmentsHolder<Azu
             FullPath = x.Name,
             LastModified = x.LastModified?.DateTime ?? DateTime.MinValue
         }).ToList();
+    }
+
+    protected override Task OverwriteBlobInCloudWithDummyStream(AzureSettings settings, FileInfoDetails file)
+    {
+        using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("EGOR")))
+        using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+        using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
+        {
+            client.PutBlob(file.FullPath, stream, new Dictionary<string, string>
+            {
+                { "Description", "GetBackupDescription" }
+            });
+        }
+        return Task.CompletedTask;
     }
 
     public override async Task DeleteObjects(AzureSettings settings)

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsHolder.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsHolder.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Orders;
@@ -42,6 +43,7 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
 
     public abstract IAsyncDisposable CreateCloudSettings([CallerMemberName] string caller = null);
     protected abstract Task<List<FileInfoDetails>> GetBlobsFromCloudAndAssertForCount(TSettings settings, int expected, int timeout = 120_000);
+    protected abstract Task OverwriteBlobInCloudWithDummyStream(TSettings settings, FileInfoDetails file);
     public abstract Task DeleteObjects(TSettings settings);
     public abstract Task<string> PutRetireAttachmentsConfiguration(IDocumentStore store, TSettings settings, List<string> collections = null, string database = null, string id = null);
     public abstract TSettings GetCloudSetting(string remoteFolderName, [CallerMemberName] string caller = null);
@@ -686,7 +688,7 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
         }
     }
 
-    protected async Task CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal()
+    protected async Task CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal(bool overwriteWithDummy)
     {
         await using (var holder = CreateCloudSettings())
         {
@@ -742,6 +744,19 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
                 await GetAndCompareRetiredAttachment(store, id, "test.png", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "image/png", profileStream, 3, identifier1);
                 await WaitForTaskDelayIfNeeded();
 
+                if (overwriteWithDummy)
+                {
+                    var cloudObject = cloudObjects[0];
+                    await OverwriteBlobInCloudWithDummyStream(Settings, cloudObject);
+                    cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, 1);
+                    using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("EGOR")))
+                    {
+                        // we should have dummy stream in cloud now but the size is same since its saved in attachment metadata
+                        await GetAndCompareRetiredAttachment(store, id, "test.png", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "image/png", stream, 3, identifier1);
+                        await WaitForTaskDelayIfNeeded();
+                    }
+                }
+
                 var database2 = await Databases.GetDocumentDatabaseInstanceFor(server, store2);
                 database2.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                 var expiredDocumentsCleaner2 = database2.RetireAttachmentsSender;
@@ -750,9 +765,17 @@ public abstract class RetiredAttachmentsHolder<TSettings> : RetiredAttachmentsHo
                 List<FileInfoDetails> cloudObjects2 = await GetBlobsFromCloudAndAssertForCount(Settings, 1);
                 Assert.Contains($"{Settings.RemoteFolderName}/EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", cloudObjects2[0].FullPath);
 
-                // should be the same attachment, not a new one
-                Assert.Equal(cloudObjects[0].LastModified, cloudObjects2[0].LastModified);
+                if (overwriteWithDummy)
+                {
+                    Assert.NotEqual(cloudObjects[0].LastModified, cloudObjects2[0].LastModified);
+                }
+                else
+                {
+                    // should be the same attachment, not a new one
+                    Assert.Equal(cloudObjects[0].LastModified, cloudObjects2[0].LastModified);
+                }
 
+                await GetAndCompareRetiredAttachment(store, id, "test.png", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "image/png", profileStream, 3, identifier1);
                 await GetAndCompareRetiredAttachment(store2, id, "test.png", "EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", "image/png", profileStream, 3, identifier2);
             }
 

--- a/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsS3Base.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RetiredAttachmentsS3Base.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
@@ -101,6 +103,19 @@ public abstract class RetiredAttachmentsS3Base : RetiredAttachmentsHolder<S3Sett
             FullPath = x.FullPath,
             LastModified = x.LastModified
         }).ToList();
+    }
+
+    protected override async Task OverwriteBlobInCloudWithDummyStream(S3Settings settings, FileInfoDetails file)
+    {
+        using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("EGOR")))
+        using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+        using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
+        {
+            await s3Client.PutObjectAsync(file.FullPath, stream, new Dictionary<string, string>
+            {
+                { "Description", "GetBackupDescription" }
+            });
+        }
     }
 
     public override async Task DeleteObjects(S3Settings settings)

--- a/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RetiredAttachmentsSlowTests.cs
@@ -712,7 +712,13 @@ namespace SlowTests.Server.Documents.Attachments
         [AmazonS3RetryFact]
         public async Task CanUploadRetiredAttachmentToS3IfItAlreadyExists_ShouldNotOverwrite()
         {
-            await CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal();
+            await CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal(overwriteWithDummy: false);
+        }
+
+        [AmazonS3RetryFact]
+        public async Task CanUploadRetiredAttachmentToS3IfItAlreadyExists_ShouldOverwriteIfBroken()
+        {
+            await CanUploadRetiredAttachmentToCloudIfItAlreadyExists_ShouldNotOverwriteInternal(overwriteWithDummy: true);
         }
 
         [AmazonS3RetryFact]


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24150

### Additional description

This pull request improves the reliability and correctness of retiring (uploading and managing) attachments to cloud storage (S3 and Azure) by ensuring that attachments are only re-uploaded if the cloud copy is missing or incomplete (e.g., partially uploaded/broken). The changes also expand test coverage to verify this behavior, including cases where the cloud copy is intentionally corrupted.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
