### PR TITLE
RavenDB-24705 - GenAi: Chat `Messages` format refactoring

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -423,10 +423,21 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         var msg2 = new DynamicJsonValue
         {
             [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
-            [Constants.RequestFields.Content] = CreateContentWithAttachments(userPrompt, attachments)
+            [Constants.RequestFields.Content] = userPrompt
         };
 
-        var messages = new List<BlittableJsonReaderObject>() { ctx.ReadObject(msg1, "system/msg"), ctx.ReadObject(msg2, "user/msg") };
+        var messages = new List<BlittableJsonReaderObject>() { ctx.ReadObject(msg1, "system/msg"), ctx.ReadObject(msg2, "user/msg")};
+
+        if (attachments?.Count > 0)
+        {
+            var msg3 = new DynamicJsonValue
+            {
+                [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
+                [Constants.RequestFields.Content] = CreateContentWithAttachments(attachments)
+            };
+            messages.Add(ctx.ReadObject(msg3, "user/msg"));
+        }
+
         using var request = CreateCompletionRequest(ctx, messages, schema);
         var usage = new AiUsage();
         var results = await CompleteAsync(ctx, request, usage, token);
@@ -435,19 +446,9 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
     }
 
 
-    private DynamicJsonArray CreateContentWithAttachments(string context, List<AiAttachment> attachments)
+    private DynamicJsonArray CreateContentWithAttachments(List<AiAttachment> attachments)
     {
-        var content = new DynamicJsonArray
-        {
-            new DynamicJsonValue
-            {
-                [Constants.AttachmentsRequestFields.Type] = Constants.AttachmentsRequestFields.TypeText,
-                [Constants.AttachmentsRequestFields.TypeText] = context
-            }
-        };
-
-        if (attachments?.Count > 0 == false)
-            return content;
+        var content = new DynamicJsonArray();
 
         foreach (var attachment in attachments)
         {

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -423,11 +423,7 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
         var msg2 = new DynamicJsonValue
         {
             [Constants.RequestFields.Role] = Constants.RequestFields.RoleUserValue,
-            [Constants.RequestFields.Content] = attachments switch
-            {
-                null => userPrompt,
-                _ => CreateContentWithAttachments(userPrompt, attachments)
-            }
+            [Constants.RequestFields.Content] = CreateContentWithAttachments(userPrompt, attachments)
         };
 
         var messages = new List<BlittableJsonReaderObject>() { ctx.ReadObject(msg1, "system/msg"), ctx.ReadObject(msg2, "user/msg") };
@@ -449,6 +445,9 @@ internal class ChatCompletionClient : IChatCompletionClient, IChatCompletionClie
                 [Constants.AttachmentsRequestFields.TypeText] = context
             }
         };
+
+        if (attachments?.Count > 0 == false)
+            return content;
 
         foreach (var attachment in attachments)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24705/GenAi-Chat-Messages-format-refactoring

### Additional description

We now always use CreateContentWithAttachments (contextOutputAttachments switch was removed from CompleteAsync).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
