### PR TITLE
RavenDB-25031 Optimize DocumentHandler processor method

### DIFF
--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -40,10 +40,13 @@ namespace Raven.Server.Documents.Handlers
         }
 
         [RavenAction("/databases/*/docs", "POST", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
-        public Task PostGet()
+        public async Task PostGet()
         {
             // Disposal of the processor is handled in the `ExecuteAsTaskAsync` method.
-            return new DocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync();
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                await new DocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync(await DocumentHandlerProcessorForGet.GetIdsFromRequestBodyAsync(context, this), context);
+            }
         }
 
         [RavenAction("/databases/*/docs", "DELETE", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/AbstractDocumentHandlerProcessorForGet.cs
@@ -26,6 +26,7 @@ using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.TrafficWatch;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Json;
@@ -58,146 +59,166 @@ internal abstract class
 
     public override ValueTask ExecuteAsync() => throw new NotImplementedException();
     
-    public async Task ExecuteAsTaskAsync()
+    public Task ExecuteAsTaskAsync([CanBeNull] List<ReadOnlyMemory<char>> ids = null, [CanBeNull] TOperationContext context = null)
     {
         // This processor is being disposed here. It means you can execute a command only once per processor instance. 
         // The reason behind this is to avoid awaiting execution in the handler and do it directly in the router code.
         // This reduces AsyncStateMachine size by avoiding creating state in the handler code.
-        using (this)
-        using (ContextPool.AllocateOperationContext(out TOperationContext context))
+        using (var @thisScope = this.AllowBorrow())
+            
+        // For the context, allocate only if it was not previously allocated by the caller.
+        // If not provided by the caller, we create one and wrap it in borrowable to pass down to async path, if needed.
+        // If provided, we don't scope it cause the caller owns it.
         {
-            var sw = Stopwatch.StartNew();
-
-            var parameters = QueryStringParameters.Create(RequestHandler.HttpContext.Request);
-
-            if (_method == HttpMethod.Get)
+            using (DisposableBorrow<IDisposable> ctxScope = context == null ? ContextPool.AllocateOperationContext(out context).AllowBorrow() : default)
             {
-                // no-op - this was parses via QueryStringParameters few lines up
-            }
-            else if (_method == HttpMethod.Post)
-                parameters.Ids = await GetIdsFromRequestBodyAsync(context, RequestHandler);
-            else
-                throw new NotSupportedException($"Unhandled method type: {_method}");
+                var sw = Stopwatch.StartNew();
 
-            if (SupportsShowingRequestInTrafficWatch && TrafficWatchManager.HasRegisteredClients)
-                RequestHandler.AddStringToHttpContext(IdsToString(parameters.Ids), TrafficWatchChangeType.Documents);
+                var parameters = QueryStringParameters.Create(RequestHandler.HttpContext.Request);
 
-            (long NumberOfResults, long TotalDocumentsSizeInBytes) responseWriteStats;
-            int pageSize;
-            string actionName;
-
-            if (parameters.Ids is { Count: > 0 })
-            {
-                pageSize = parameters.Ids.Count;
-                actionName = nameof(GetDocumentsByIdAsync);
-
-                var etag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
-
-                // includes
-                var revisions = GetRevisionsToInclude(parameters);
-                var timeSeries = GetTimeSeriesToInclude(parameters);
-
-                var getDocumentsByIds = GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag);
-                responseWriteStats = getDocumentsByIds.IsCompletedSuccessfully
-                    ? getDocumentsByIds.Result
-                    : await getDocumentsByIds;
-            }
-            else
-            {
-                pageSize = RequestHandler.GetPageSize();
-                actionName = nameof(GetDocumentsAsync);
-
-                var changeVector = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
-                var etag = RequestHandler.GetLongQueryString("etag", false);
-
-                var isStartsWith = HttpContext.Request.Query.ContainsKey("startsWith");
-
-                StartsWithParams startsWithParams = null;
-
-                if (isStartsWith)
+                if (_method == HttpMethod.Get)
                 {
-                    startsWithParams = new StartsWithParams
+                    // no-op - this was parses via QueryStringParameters few lines up
+                }
+                else if (_method == HttpMethod.Post)
+                    parameters.Ids = ids;
+                else
+                    throw new NotSupportedException($"Unhandled method type: {_method}");
+
+                if (SupportsShowingRequestInTrafficWatch && TrafficWatchManager.HasRegisteredClients)
+                    RequestHandler.AddStringToHttpContext(IdsToString(parameters.Ids), TrafficWatchChangeType.Documents);
+
+                int pageSize;
+                string actionName;
+
+                ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> getDocumentsAsync;
+                if (parameters.Ids is { Count: > 0 })
+                {
+                    pageSize = parameters.Ids.Count;
+                    actionName = nameof(GetDocumentsByIdAsync);
+
+                    var etag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+
+                    // includes
+                    var revisions = GetRevisionsToInclude(parameters);
+                    var timeSeries = GetTimeSeriesToInclude(parameters);
+
+                    getDocumentsAsync = GetDocumentsByIdAsync(context, parameters, revisions, timeSeries, etag);
+                }
+                else
+                {
+                    pageSize = RequestHandler.GetPageSize();
+                    actionName = nameof(GetDocumentsAsync);
+
+                    var changeVector = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+                    var etag = RequestHandler.GetLongQueryString("etag", false);
+
+                    var isStartsWith = HttpContext.Request.Query.ContainsKey("startsWith");
+
+                    StartsWithParams startsWithParams = null;
+
+                    if (isStartsWith)
                     {
-                        IdPrefix = HttpContext.Request.Query["startsWith"],
-                        Matches = HttpContext.Request.Query["matches"],
-                        Exclude = HttpContext.Request.Query["exclude"],
-                        StartAfterId = HttpContext.Request.Query["startAfter"],
-                    };
+                        startsWithParams = new StartsWithParams
+                        {
+                            IdPrefix = HttpContext.Request.Query["startsWith"],
+                            Matches = HttpContext.Request.Query["matches"],
+                            Exclude = HttpContext.Request.Query["exclude"],
+                            StartAfterId = HttpContext.Request.Query["startAfter"],
+                        };
+                    }
+
+                    getDocumentsAsync = GetDocumentsAsync(context, etag, startsWithParams, parameters.MetadataOnly, changeVector);
                 }
 
-                var getDocumentsAsync = GetDocumentsAsync(context, etag, startsWithParams, parameters.MetadataOnly, changeVector);
-                
-                
-                responseWriteStats = getDocumentsAsync.IsCompletedSuccessfully 
-                    ? getDocumentsAsync.Result 
-                    : await getDocumentsAsync;
-            }
+                if (getDocumentsAsync.IsCompletedSuccessfully)
+                {
+                    HandleGetDocumentResult(getDocumentsAsync.Result, parameters, actionName, pageSize, sw);
+                    return Task.CompletedTask;
+                }
+            
+                // Slow async path requires careful scope considerations:
+                // 1. @thisScope is always created, and we need to borrow it for the async method
+                // 2. ctxScope leverages the fact that the Borrow on the default returns null so it's a null safe.
+                return HandleGetDocumentResultAsync(@thisScope.Borrow(), ctxScope.Borrow(), getDocumentsAsync, parameters, actionName, pageSize, sw);
+            
+                static string IdsToString(List<ReadOnlyMemory<char>> ids)
+                {
+                    if (ids == null || ids.Count == 0)
+                        return string.Empty;
 
-            if (responseWriteStats != NoResults)
+                    var sb = new StringBuilder();
+                    for (int i = 0; i < ids.Count; i++)
+                    {
+                        if (i != 0)
+                            sb.Append(",");
+
+                        ReadOnlyMemory<char> id = ids[i];
+                        sb.Append(id);
+                    }
+
+                    return sb.ToString();
+                }
+            }
+        }
+    }
+
+    private async Task HandleGetDocumentResultAsync(AbstractDocumentHandlerProcessorForGet<TRequestHandler, TOperationContext, TDocumentType> instance, [CanBeNull] IDisposable contextScope,
+        ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> responseWriteStats,
+        QueryStringParameters parameters, string actionName, int pageSize,
+        Stopwatch sw)
+    {
+        using (instance)
+        using (contextScope)
+        {
+            HandleGetDocumentResult(await responseWriteStats, parameters, actionName, pageSize, sw);    
+        }
+    }
+    
+    private void HandleGetDocumentResult((long NumberOfResults, long TotalDocumentsSizeInBytes) responseWriteStats, QueryStringParameters parameters, string actionName, int pageSize,
+        Stopwatch sw)
+    {
+        if (responseWriteStats != NoResults)
+        {
+            if (RequestHandler.ShouldAddPagingPerformanceHint(responseWriteStats.NumberOfResults))
             {
-                if (RequestHandler.ShouldAddPagingPerformanceHint(responseWriteStats.NumberOfResults))
-                {
-                    string details;
+                string details = parameters.Ids is { Count: > 0 } ? CreatePerformanceHintDetails(parameters) : HttpContext.Request.QueryString.Value;
 
-                    if (parameters.Ids is { Count: > 0 })
-                        details = CreatePerformanceHintDetails();
-                    else
-                        details = HttpContext.Request.QueryString.Value;
-
-                    RequestHandler.AddPagingPerformanceHint(
-                        PagingOperationType.Documents,
-                        actionName,
-                        details,
-                        responseWriteStats.NumberOfResults,
-                        pageSize,
-                        sw.ElapsedMilliseconds,
-                        responseWriteStats.TotalDocumentsSizeInBytes);
-                }
+                RequestHandler.AddPagingPerformanceHint(
+                    PagingOperationType.Documents,
+                    actionName,
+                    details,
+                    responseWriteStats.NumberOfResults,
+                    pageSize,
+                    sw.ElapsedMilliseconds,
+                    responseWriteStats.TotalDocumentsSizeInBytes);
             }
+        }
 
-            string CreatePerformanceHintDetails()
+        static string CreatePerformanceHintDetails(QueryStringParameters parameters)
+        {
+            var sb = new StringBuilder();
+            var addedIdsCount = 0;
+            var first = true;
+
+            while (sb.Length < 1024 && addedIdsCount < parameters.Ids.Count)
             {
-                var sb = new StringBuilder();
-                var addedIdsCount = 0;
-                var first = true;
+                if (first == false)
+                    sb.Append(", ");
+                else
+                    first = false;
 
-                while (sb.Length < 1024 && addedIdsCount < parameters.Ids.Count)
-                {
-                    if (first == false)
-                        sb.Append(", ");
-                    else
-                        first = false;
-
-                    sb.Append($"{parameters.Ids[addedIdsCount++]}");
-                }
-
-                var idsLeftCount = parameters.Ids.Count - addedIdsCount;
-
-                if (idsLeftCount > 0)
-                {
-                    sb.Append($" ... (and {idsLeftCount} more)");
-                }
-
-                return sb.ToString();
+                sb.Append($"{parameters.Ids[addedIdsCount++]}");
             }
 
-            static string IdsToString(List<ReadOnlyMemory<char>> ids)
+            var idsLeftCount = parameters.Ids.Count - addedIdsCount;
+
+            if (idsLeftCount > 0)
             {
-                if (ids == null || ids.Count == 0)
-                    return string.Empty;
-
-                var sb = new StringBuilder();
-                for (int i = 0; i < ids.Count; i++)
-                {
-                    if (i != 0)
-                        sb.Append(",");
-
-                    ReadOnlyMemory<char> id = ids[i];
-                    sb.Append(id.ToString());
-                }
-
-                return sb.ToString();
+                sb.Append($" ... (and {idsLeftCount} more)");
             }
+
+            return sb.ToString();
         }
     }
 
@@ -503,7 +524,7 @@ internal abstract class
         }
     }
 
-    private static async ValueTask<List<ReadOnlyMemory<char>>> GetIdsFromRequestBodyAsync(TOperationContext context, TRequestHandler requestHandler)
+    public static async ValueTask<List<ReadOnlyMemory<char>>> GetIdsFromRequestBodyAsync(TOperationContext context, TRequestHandler requestHandler)
     {
         var docs = await context.ReadForMemoryAsync(requestHandler.RequestBodyStream(), "docs");
         if (docs.TryGet("Ids", out BlittableJsonReaderArray array) == false)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDocumentHandler.cs
@@ -1,7 +1,9 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Processors.Documents;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Documents;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers
 {
@@ -32,9 +34,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
         }
 
         [RavenShardedAction("/databases/*/docs", "POST")]
-        public Task PostGet()
+        public async Task PostGet()
         {
-            return new ShardedDocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync();
+            // Disposal of the processor is handled in the `ExecuteAsTaskAsync` method.
+            using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                await new ShardedDocumentHandlerProcessorForGet(HttpMethod.Post, this).ExecuteAsTaskAsync(await ShardedDocumentHandlerProcessorForGet.GetIdsFromRequestBodyAsync(context, this), context);
+            }
         }
 
         [RavenShardedAction("/databases/*/docs", "DELETE")]

--- a/src/Raven.Server/Utils/DisposableBorrow.cs
+++ b/src/Raven.Server/Utils/DisposableBorrow.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Raven.Server.Utils;
+
+/// <summary>
+/// A disposable allowing to steal the underlying disposable using <see cref="Borrow"/>.
+/// </summary>
+/// <remarks>
+/// It's a ref struct as the scoping with it is meant only for the synchronous execution or async with ValueTask handling.
+/// </remarks>
+public ref struct DisposableBorrow<T> : IDisposable 
+    where T : class, IDisposable
+{
+    private T _actual;
+
+    public DisposableBorrow(T actual)
+    {
+        _actual = actual;
+    }
+
+    public T Borrow()
+    {
+        var value=  _actual;
+        _actual = null;
+        return value;
+    }
+
+    public void Dispose() => _actual?.Dispose();
+}
+
+public static class DisposableBorrowExtensions
+{
+    /// <summary>
+    /// Turns a disposable into a scope allowing borrows with <see cref="DisposableBorrow{T}.Borrow"/>
+    /// </summary>
+    public static DisposableBorrow<T> AllowBorrow<T>(this T @this)
+        where T : class, IDisposable =>
+        new(@this);
+
+    /// <summary>
+    /// Turns a disposable into a scope allowing borrows with <see cref="DisposableBorrow{T}.Borrow"/>
+    /// </summary>
+    public static DisposableBorrow<T> AllowBorrow<T>(this T @this, [MaybeNull] out DisposableBorrow<T> disposableBorrow)
+        where T : class, IDisposable =>
+        disposableBorrow = new(@this);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25031/Optimize-AbstractDocumentHandlerProcessorForGet

### Additional description

This PR optimizes away the heavy state machine in `AbstractDocumentHandlerProcessorForGet` for cases where the retrieval is totally synchronous (non-sharded `GET` case). This allows to remove the async state machine entirely from the method and push it down to the `*Async` fallback for the sharded cases. To address scoping issue a disposable borrowable is instroduced.

The `POST` case, with more than 1024 ids (see below), still requires an await on the body that transmits identifiers. This execution path is quite unlikely though.

https://github.com/ravendb/ravendb/blob/77eed660f636793feed53c04215de283830163c7/src/Raven.Client/Documents/Commands/GetDocumentsCommand.cs#L224

### Benchmarks

A few test scenarios were run, showing the performance improvement in every run, either in `v7.0` or `v6.2`. There were some ridiculous outliers showing really massive gains. In any case, this seems to be much faster. 

<img width="1966" height="1381" alt="v6.2 vs this branch" src="https://github.com/user-attachments/assets/57a5fa17-cda0-4c44-9ea5-0dea45784d9d" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
