### PR TITLE
RavenDB-24962 - Add StreamBufferAllocator to use shared buffer pool for stream operations instead of per-context allocation

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2357,6 +2357,10 @@ namespace Raven.Server.Documents.Indexes
                                     entriesCount = writeOperation.Value.EntriesCount();
                                 }
 
+                                // at this point, we have completed storing all Lucene segment files,
+                                // so we can safely release the stream buffer.
+                                indexContext.Transaction.InnerTransaction.DisposeStreamBuffer();
+
                                 UpdateThreadAllocations(indexContext, null, null, IndexingWorkType.None);
                             }
 

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -4,17 +4,12 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Sparrow;
-using Sparrow.Json;
-using Sparrow.LowMemory;
-using Sparrow.Platform;
 using Sparrow.Server.Utils;
-using Sparrow.Threading;
 using Voron.Data.Fixed;
 using Voron.Exceptions;
 using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.Paging;
-using NativeMemory = Sparrow.Utils.NativeMemory;
 
 namespace Voron.Data.BTrees
 {
@@ -82,12 +77,12 @@ namespace Voron.Data.BTrees
 
             public void Write(Stream stream)
             {
-                using (var buffer = stream != Stream.Null ? StreamBufferAllocator.Instance.Rent() : StreamBufferAllocator.Buffer.Null)
                 {
                     AllocateNextPage();
 
                     ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
 
+                    var buffer = stream != Stream.Null ? _parent.Llt.Transaction.StreamBuffer : StreamBufferAllocator.Buffer.Null;
                     var localBuffer = buffer.AsSpan();
 
                     {
@@ -516,81 +511,6 @@ namespace Voron.Data.BTrees
         {
             VoronUnrecoverableErrorException.Raise(_tx.LowLevelTransaction.Environment,
                 $"Stream size mismatch of '{name}' stream. Sum of chunks size is {totalChunksSize} while stream info has {info->TotalSize}");
-        }
-
-        private class StreamBufferAllocator : ILowMemoryHandler
-        {
-            public static StreamBufferAllocator Instance = new StreamBufferAllocator();
-
-            private readonly PerCoreContainer<Buffer> _buffers = new PerCoreContainer<Buffer>(8);
-            private readonly MultipleUseFlag _isExtremelyLowMemory = new MultipleUseFlag();
-
-            private static readonly int BufferSize = PlatformDetails.Is32Bits == false
-                ? 512 * Constants.Size.Kilobyte
-                : 16 * Constants.Size.Kilobyte;
-
-            private StreamBufferAllocator()
-            {
-                LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
-            }
-
-            public Buffer Rent()
-            {
-                if (_buffers.TryPull(out var buffer))
-                    return buffer;
-
-                var ptr = NativeMemory.AllocateMemory(BufferSize);
-                return new Buffer(ptr, BufferSize);
-            }
-
-            public void LowMemory(LowMemorySeverity lowMemorySeverity)
-            {
-                if (lowMemorySeverity != LowMemorySeverity.ExtremelyLow)
-                    return;
-
-                if (_isExtremelyLowMemory.Raise() == false)
-                    return;
-
-                foreach (var buffer in _buffers.EnumerateAndClear())
-                {
-                    buffer.Free();
-                }
-            }
-
-            public void LowMemoryOver()
-            {
-                _isExtremelyLowMemory.Lower();
-            }
-
-            public class Buffer : IDisposable
-            {
-                private readonly byte* _ptr;
-                private readonly long _size;
-
-                public byte* Pointer => _ptr;
-
-                public static readonly Buffer Null = new Buffer(null, 0);
-
-                public Span<byte> AsSpan() => new Span<byte>(_ptr, (int)_size);
-
-                public Buffer(byte* ptr, long size)
-                {
-                    _ptr = ptr;
-                    _size = size;
-                }
-
-                public void Free()
-                {
-                    NativeMemory.Free(_ptr, _size);
-                }
-
-                public void Dispose()
-                {
-                    if (_ptr != null && Instance._buffers.TryPush(this) == false)
-                        Free();
-
-                }
-            }
         }
     }
 

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -82,7 +82,7 @@ namespace Voron.Data.BTrees
 
             public void Write(Stream stream)
             {
-                using (var buffer = StreamBufferAllocator.Instance.Rent())
+                using (var buffer = stream != Stream.Null ? StreamBufferAllocator.Instance.Rent() : StreamBufferAllocator.Buffer.Null)
                 {
                     AllocateNextPage();
 
@@ -552,7 +552,7 @@ namespace Voron.Data.BTrees
 
                 foreach (var buffer in _buffers.EnumerateAndClear())
                 {
-                    buffer.Dispose();
+                    buffer.Free();
                 }
             }
 
@@ -568,6 +568,8 @@ namespace Voron.Data.BTrees
 
                 public byte* Pointer => _ptr;
 
+                public static readonly Buffer Null = new Buffer(null, 0);
+
                 public Span<byte> AsSpan() => new Span<byte>(_ptr, (int)_size);
 
                 public Buffer(byte* ptr, long size)
@@ -576,10 +578,16 @@ namespace Voron.Data.BTrees
                     _size = size;
                 }
 
+                public void Free()
+                {
+                    NativeMemory.Free(_ptr, _size);
+                }
+
                 public void Dispose()
                 {
-                    if (Instance._buffers.TryPush(this) == false)
-                        NativeMemory.Free(_ptr, _size);
+                    if (_ptr != null && Instance._buffers.TryPush(this) == false)
+                        Free();
+
                 }
             }
         }

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -4,13 +4,17 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Sparrow;
+using Sparrow.Json;
+using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Server.Utils;
+using Sparrow.Threading;
 using Voron.Data.Fixed;
 using Voron.Exceptions;
 using Voron.Global;
 using Voron.Impl;
 using Voron.Impl.Paging;
+using NativeMemory = Sparrow.Utils.NativeMemory;
 
 namespace Voron.Data.BTrees
 {
@@ -52,10 +56,6 @@ namespace Voron.Data.BTrees
         
         private struct StreamToPageWriter
         {
-            private static readonly int BufferSize = PlatformDetails.Is32Bits == false
-                ? 512 * Constants.Size.Kilobyte
-                : 16 * Constants.Size.Kilobyte;
-            
             private int _chunkNumber;
 
             private byte* _writePos;
@@ -82,13 +82,14 @@ namespace Voron.Data.BTrees
 
             public void Write(Stream stream)
             {
-                using (_parent._tx.Allocator.Allocate(BufferSize, out Span<byte> localBuffer))
+                using (var buffer = StreamBufferAllocator.Instance.Rent())
                 {
                     AllocateNextPage();
 
                     ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
 
-                    fixed (byte* pBuffer = localBuffer)
+                    var localBuffer = buffer.AsSpan();
+
                     {
                         while (true)
                         {
@@ -99,7 +100,7 @@ namespace Voron.Data.BTrees
                             var toWrite = 0L;
                             while (true)
                             {
-                                toWrite += WriteBufferToPage(pBuffer + toWrite, read - toWrite);
+                                toWrite += WriteBufferToPage(buffer.Pointer + toWrite, read - toWrite);
                                 if (toWrite == read)
                                     break;
 
@@ -515,6 +516,72 @@ namespace Voron.Data.BTrees
         {
             VoronUnrecoverableErrorException.Raise(_tx.LowLevelTransaction.Environment,
                 $"Stream size mismatch of '{name}' stream. Sum of chunks size is {totalChunksSize} while stream info has {info->TotalSize}");
+        }
+
+        private class StreamBufferAllocator : ILowMemoryHandler
+        {
+            public static StreamBufferAllocator Instance = new StreamBufferAllocator();
+
+            private readonly PerCoreContainer<Buffer> _buffers = new PerCoreContainer<Buffer>(8);
+            private readonly MultipleUseFlag _isExtremelyLowMemory = new MultipleUseFlag();
+
+            private static readonly int BufferSize = PlatformDetails.Is32Bits == false
+                ? 512 * Constants.Size.Kilobyte
+                : 16 * Constants.Size.Kilobyte;
+
+            private StreamBufferAllocator()
+            {
+            }
+
+            public Buffer Rent()
+            {
+                if (_buffers.TryPull(out var buffer))
+                    return buffer;
+
+                var ptr = NativeMemory.AllocateMemory(BufferSize);
+                return new Buffer(ptr, BufferSize);
+            }
+
+            public void LowMemory(LowMemorySeverity lowMemorySeverity)
+            {
+                if (lowMemorySeverity != LowMemorySeverity.ExtremelyLow)
+                    return;
+
+                if (_isExtremelyLowMemory.Raise() == false)
+                    return;
+
+                foreach (var buffer in _buffers.EnumerateAndClear())
+                {
+                    buffer.Dispose();
+                }
+            }
+
+            public void LowMemoryOver()
+            {
+                _isExtremelyLowMemory.Lower();
+            }
+
+            public class Buffer : IDisposable
+            {
+                private readonly byte* _ptr;
+                private readonly long _size;
+
+                public byte* Pointer => _ptr;
+
+                public Span<byte> AsSpan() => new Span<byte>(_ptr, (int)_size);
+
+                public Buffer(byte* ptr, long size)
+                {
+                    _ptr = ptr;
+                    _size = size;
+                }
+
+                public void Dispose()
+                {
+                    if (Instance._buffers.TryPush(this) == false)
+                        NativeMemory.Free(_ptr, _size);
+                }
+            }
         }
     }
 

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -531,6 +531,7 @@ namespace Voron.Data.BTrees
 
             private StreamBufferAllocator()
             {
+                LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
             }
 
             public Buffer Rent()

--- a/src/Voron/Impl/StreamBufferAllocator.cs
+++ b/src/Voron/Impl/StreamBufferAllocator.cs
@@ -1,0 +1,83 @@
+using System;
+using Sparrow.Global;
+using Sparrow.Json;
+using Sparrow.LowMemory;
+using Sparrow.Platform;
+using Sparrow.Threading;
+using Sparrow.Utils;
+
+namespace Voron.Impl;
+
+public unsafe class StreamBufferAllocator : ILowMemoryHandler
+{
+    public static readonly StreamBufferAllocator Instance = new StreamBufferAllocator();
+
+    private readonly PerCoreContainer<Buffer> _buffers = new PerCoreContainer<Buffer>(8);
+    private readonly MultipleUseFlag _isExtremelyLowMemory = new MultipleUseFlag();
+
+    private static readonly int BufferSize = PlatformDetails.Is32Bits == false
+        ? 512 * Constants.Size.Kilobyte
+        : 16 * Constants.Size.Kilobyte;
+
+    private StreamBufferAllocator()
+    {
+        LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
+    }
+
+    public Buffer Rent()
+    {
+        if (_buffers.TryPull(out var buffer))
+            return buffer;
+
+        var ptr = NativeMemory.AllocateMemory(BufferSize);
+        return new Buffer(ptr, BufferSize);
+    }
+
+    public void LowMemory(LowMemorySeverity lowMemorySeverity)
+    {
+        if (lowMemorySeverity != LowMemorySeverity.ExtremelyLow)
+            return;
+
+        if (_isExtremelyLowMemory.Raise() == false)
+            return;
+
+        foreach (var buffer in _buffers.EnumerateAndClear())
+        {
+            buffer.Free();
+        }
+    }
+
+    public void LowMemoryOver()
+    {
+        _isExtremelyLowMemory.Lower();
+    }
+
+    public class Buffer : IDisposable
+    {
+        private readonly byte* _ptr;
+        private readonly long _size;
+
+        public byte* Pointer => _ptr;
+
+        public static readonly Buffer Null = new Buffer(null, 0);
+
+        public Span<byte> AsSpan() => new Span<byte>(_ptr, (int)_size);
+
+        public Buffer(byte* ptr, long size)
+        {
+            _ptr = ptr;
+            _size = size;
+        }
+
+        public void Free()
+        {
+            NativeMemory.Free(_ptr, _size);
+        }
+
+        public void Dispose()
+        {
+            if (_ptr != null && Instance._buffers.TryPush(this) == false)
+                Free();
+        }
+    }
+}

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -24,6 +24,19 @@ namespace Voron.Impl
         private Dictionary<Tuple<Tree, Slice>, Tree> _multiValueTrees;
         private Dictionary<long, ByteString> _cachedDecompressedBuffersByStorageId;
 
+        private StreamBufferAllocator.Buffer _streamBuffer;
+
+        public StreamBufferAllocator.Buffer StreamBuffer
+        {
+            get
+            {
+                if (_streamBuffer != null)
+                    return _streamBuffer;
+
+                return _streamBuffer = StreamBufferAllocator.Instance.Rent();
+            }
+        }
+
         internal Dictionary<long, ByteString> CachedDecompressedBuffersByStorageId =>
             _cachedDecompressedBuffersByStorageId ??= new Dictionary<long, ByteString>();
 
@@ -534,8 +547,10 @@ namespace Voron.Impl
                 }
             }
 
-            _lowLevelTransaction?.Dispose();
+            _streamBuffer?.Dispose();
+            _streamBuffer = null;
 
+            _lowLevelTransaction?.Dispose();
             _lowLevelTransaction = null;
         }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -511,7 +511,13 @@ namespace Voron.Impl
 
             return tree;
         }
-        
+
+        public void DisposeStreamBuffer()
+        {
+            _streamBuffer?.Dispose();
+            _streamBuffer = null;
+        }
+
         public void Dispose()
         {
             if (_trees != null)
@@ -547,8 +553,7 @@ namespace Voron.Impl
                 }
             }
 
-            _streamBuffer?.Dispose();
-            _streamBuffer = null;
+            DisposeStreamBuffer();
 
             _lowLevelTransaction?.Dispose();
             _lowLevelTransaction = null;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24962/Higher-unmanaged-mem-usage-on-PROD-since-July-30th

### Additional description

Implement shared stream buffer allocator to reduce memory allocations.
This change introduces a centralized `StreamBufferAllocator` that provides reusable `512KB` buffers (`16KB` on `32-bit` platforms) for all stream operations, replacing the previous approach where each stream write would allocate buffers from the current context.
Instead of allocating a new buffer for every stream write operation, buffers are now pooled and reused across all streams.
`Before`: Each stream write → context allocation → potential new buffer allocation (especially when contexts aren't reused, and there's no guarantee that we use a context that has already allocated the buffer).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
