### PR TITLE
RavenDB-24915 Using just a file name for "Security.Certificate.Path" setting during SetupWizard instead of absolute path

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -142,7 +142,7 @@ public static class SettingsZipFileHelper
                     }
                 }
 
-                settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certPath ?? certificateFileName;
+                settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = Path.GetFileName(certPath) ?? certificateFileName;
                 if (string.IsNullOrEmpty(parameters.SetupInfo.Password) == false)
                     settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePassword)] = parameters.SetupInfo.Password;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24915

### Additional description

This change is about changing the value of `Security.Certificate.Path` in `settings.json` files generated for each node during Setup Wizard so instead of using absolute paths like below:

```
"Security.Certificate.Path": "D:\\work\\issues\\24730\\RavenDB-5.4.211-custom-54-windows-x64-A\\Server\\cluster.server.certificate.24742-cluster-same-server-cert.pfx"
```

we'll have just the file name:

```
"Security.Certificate.Path": "cluster.server.certificate.24742-cluster-same-server-cert.pfx"
```

This way the certificate file is copied correctly next to Raven.Server.exe. Then even if we setup multiple nodes on the same machine each node uses it's own cert file.

@TheGoldenPlatypus @poissoncorp @gregolsky please review from the perspective of setup made in ansible / terraform etc

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Usability

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing - when testing https://issues.hibernatingrhinos.com/issue/RavenDB-24754 and https://issues.hibernatingrhinos.com/issue/RavenDB-24755
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
