### PR TITLE
RavenDB-25006 Renew server certificate on 30% of it's lifespan

### DIFF
--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -84,7 +84,12 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(null)]
         [ConfigurationEntry("LetsEncrypt.AcmeProfile", ConfigurationEntryScope.ServerWideOnly)]
         public string AcmeProfile { get; set; }
-        
+
+        [Description("The percentage of certificate lifetime remaining that triggers automatic renewal. For example, with the default 30%, a certificate valid for 90 days will be renewed when 27 days remain.")]
+        [DefaultValue(30)]
+        [ConfigurationEntry("AcmeRenewalThresholdPercentage", ConfigurationEntryScope.ServerWideOnly)]
+        public int AcmeRenewalThresholdPercentage { get; set; }
+
         [Description("Indicates if we should throw an exception if any index could not be opened")]
         [DefaultValue(false)]
         [ConfigurationEntry("ThrowIfAnyIndexCannotBeOpened", ConfigurationEntryScope.ServerWideOrPerDatabase)]

--- a/src/Raven.Server/Config/Categories/CoreConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/CoreConfiguration.cs
@@ -85,11 +85,6 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("LetsEncrypt.AcmeProfile", ConfigurationEntryScope.ServerWideOnly)]
         public string AcmeProfile { get; set; }
         
-        [Description("Number of days before expiration when the server should automatically renew server certificates.")]
-        [DefaultValue(20)]
-        [ConfigurationEntry("LetsEncrypt.DaysToRenewCertBeforeExpiration", ConfigurationEntryScope.ServerWideOnly)]
-        public int AcmeDaysToRenewBeforeExpiration { get; set; }
-        
         [Description("Indicates if we should throw an exception if any index could not be opened")]
         [DefaultValue(false)]
         [ConfigurationEntry("ThrowIfAnyIndexCannotBeOpened", ConfigurationEntryScope.ServerWideOrPerDatabase)]

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -409,6 +409,7 @@ namespace Raven.Server
         private void UpdateCertificateExpirationAlert()
         {
             var remainingDays = (Certificate.ServerCertificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
+            var daysToRenewBeforeExpiration = CalculateDaysToRenewBeforeExpiration(Certificate.ServerCertificate);
             if (remainingDays <= 0)
             {
                 string msg = $"The server certificate has expired on {Certificate.ServerCertificate.NotAfter.ToShortDateString()}.";
@@ -423,7 +424,7 @@ namespace Raven.Server
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations(msg);
             }
-            else if (remainingDays <= Configuration.Core.AcmeDaysToRenewBeforeExpiration)
+            else if (remainingDays <= daysToRenewBeforeExpiration)
             {
                 string msg = $"The server certificate will expire on {Certificate.ServerCertificate.NotAfter.ToShortDateString()}. There are only {(int)remainingDays} days left for renewal.";
 
@@ -450,6 +451,12 @@ namespace Raven.Server
             {
                 ServerStore.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.Certificates_Expiration, null));
             }
+        }
+
+        private double CalculateDaysToRenewBeforeExpiration(X509Certificate2 serverCertificate)
+        {
+            // 30% of the certificate lifetime
+            return Math.Floor((serverCertificate.NotAfter - serverCertificate.NotBefore).TotalDays * 0.3);
         }
 
         private void OnServerCertificateChanged(object sender, EventArgs e)
@@ -1267,12 +1274,14 @@ namespace Raven.Server
                 return (true, DateTime.UtcNow.Date);
 
             var remainingDays = (currentCertificate.ServerCertificate.NotAfter - Time.GetUtcNow().ToLocalTime()).TotalDays;
-            if (remainingDays <= ServerStore.Configuration.Core.AcmeDaysToRenewBeforeExpiration)
+            var daysToRenewBeforeExpiration = CalculateDaysToRenewBeforeExpiration(Certificate.ServerCertificate);
+            
+            if (remainingDays <= daysToRenewBeforeExpiration)
             {
                 return (true, DateTime.UtcNow.Date);
             }
 
-            var firstPossibleDate = currentCertificate.ServerCertificate.NotAfter.ToUniversalTime().AddDays(-30);
+            var firstPossibleDate = currentCertificate.ServerCertificate.NotAfter.ToUniversalTime().AddDays(-daysToRenewBeforeExpiration);
 
             // We can do this because saturday is last in the DayOfWeek enum
             var daysUntilSaturday = DayOfWeek.Saturday - firstPossibleDate.DayOfWeek;

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -455,8 +455,8 @@ namespace Raven.Server
 
         private double CalculateDaysToRenewBeforeExpiration(X509Certificate2 serverCertificate)
         {
-            // 30% of the certificate lifetime
-            return Math.Floor((serverCertificate.NotAfter - serverCertificate.NotBefore).TotalDays * 0.3);
+            // % of the certificate lifetime
+            return Math.Floor((serverCertificate.NotAfter - serverCertificate.NotBefore).TotalDays * ServerStore.Configuration.Core.AcmeRenewalThresholdPercentage / 100.0);
         }
 
         private void OnServerCertificateChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25006 

### Additional description

Base server certificate renewal date on percentage of it's lifespan instead of manual configuration.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
