### PR TITLE
RavenDB-22693 - Handle missing database keys in subscription count calculation

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -658,7 +658,11 @@ public sealed partial class ClusterStateMachine
 
         var clusterSubscriptionsCounts =
             GetDatabaseNames(context)
-                .Sum(databaseName => GetSubscriptionsCountForDatabase(context.Allocator, items, databaseName, subscriptionsNamesPerDatabase[databaseName]));
+                .Sum(databaseName =>
+                {
+                    subscriptionsNamesPerDatabase.TryGetValue(databaseName, out var toExclude);
+                    return GetSubscriptionsCountForDatabase(context.Allocator, items, databaseName, toExclude);
+                });
 
         var subscriptionCommandsCount = subscriptionsNamesPerDatabase.Sum(x => x.Value.Count);
         if (clusterSubscriptionsCounts + subscriptionCommandsCount > maxSubscriptionsPerCluster == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22693/KeyNotFoundException-in-AssertSubscriptionsBatchLicenseLimits

### Additional description

The code was modified to use `TryGetValue()` instead of direct dictionary indexer access when retrieving subscription names for each database. This prevents a `KeyNotFoundException` from being thrown when a database name returned by `GetDatabaseNames(context)` doesn't have a corresponding entry in the `subscriptionsNamesPerDatabase` dictionary. The `TryGetValue()` method safely returns `null` for the `toExclude` parameter when the key is missing, allowing the subscription count calculation to continue without crashing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
