### PR TITLE
RavenDB-24816 Exposed OverlapTokens configuration option for paragraphs chunking

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -8,14 +10,28 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
     public ChunkingMethod ChunkingMethod { get; set; }
 
     public int MaxTokensPerChunk { get; set; } = 512;
-    
+
+    public int OverlapTokens { get; set; } = 0;
+
+    public static readonly List<ChunkingMethod> MethodsSupportingOverlapTokens = [ChunkingMethod.MarkDownSplitParagraphs, ChunkingMethod.PlainTextSplitParagraphs];
+
     public DynamicJsonValue ToJson()
     {
         return new DynamicJsonValue
         {
             [nameof(ChunkingMethod)] = ChunkingMethod, 
-            [nameof(MaxTokensPerChunk)] = MaxTokensPerChunk
+            [nameof(MaxTokensPerChunk)] = MaxTokensPerChunk,
+            [nameof(OverlapTokens)] = OverlapTokens
         };
+    }
+
+    public bool ValidateOptions()
+    {
+        if (OverlapTokens > 0 &&
+            MethodsSupportingOverlapTokens.Contains(ChunkingMethod) == false)
+            return false;
+        
+        return true;
     }
 }
 

--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -13,7 +13,7 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
 
     public int OverlapTokens { get; set; } = 0;
 
-    public static readonly List<ChunkingMethod> MethodsSupportingOverlapTokens = [ChunkingMethod.MarkDownSplitParagraphs, ChunkingMethod.PlainTextSplitParagraphs];
+    internal static readonly HashSet<ChunkingMethod> MethodsSupportingOverlapTokens = [ChunkingMethod.MarkDownSplitParagraphs, ChunkingMethod.PlainTextSplitParagraphs];
 
     public DynamicJsonValue ToJson()
     {
@@ -25,8 +25,11 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
         };
     }
 
-    public bool ValidateOptions()
+    public bool ValidateOverlapTokensProperty()
     {
+        if (OverlapTokens < 0)
+            return false;
+        
         if (OverlapTokens > 0 &&
             MethodsSupportingOverlapTokens.Contains(ChunkingMethod) == false)
             return false;

--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -33,6 +33,9 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
         if (OverlapTokens < 0)
             errors.Add($"Path '{path}': {nameof(OverlapTokens)} value cannot be negative.");
         
+        if (OverlapTokens > MaxTokensPerChunk)
+            errors.Add($"Path '{path}': {nameof(OverlapTokens)} cannot be greater than {nameof(MaxTokensPerChunk)}.");
+        
         if (OverlapTokens > 0 &&
             MethodsSupportingOverlapTokens.Contains(ChunkingMethod) == false)
             errors.Add($"Path '{path}': {nameof(OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", MethodsSupportingOverlapTokens)}.");

--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -25,14 +25,17 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
         };
     }
 
-    public bool ValidateOverlapTokensProperty()
+    public bool Validate(string path, List<string> errors)
     {
+        if (MaxTokensPerChunk <= 0)
+            errors.Add($"Path '{path}': {nameof(MaxTokensPerChunk)} value has to be greater than 0.");
+        
         if (OverlapTokens < 0)
-            return false;
+            errors.Add($"Path '{path}': {nameof(OverlapTokens)} value cannot be negative.");
         
         if (OverlapTokens > 0 &&
             MethodsSupportingOverlapTokens.Contains(ChunkingMethod) == false)
-            return false;
+            errors.Add($"Path '{path}': {nameof(OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", MethodsSupportingOverlapTokens)}.");
         
         return true;
     }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -106,7 +106,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             errors.Add($"Configuration must have either {nameof(EmbeddingsPathConfigurations)} or {nameof(EmbeddingsTransformation)} script specified");
         }
         
-        if (EmbeddingsPathConfigurations is not null && EmbeddingsPathConfigurations.Any(x => x.ChunkingOptions.ValidateOptions() == false))
+        if (EmbeddingsPathConfigurations is not null && EmbeddingsPathConfigurations.Any(x => x.ChunkingOptions.ValidateOverlapTokensProperty() == false))
             errors.Add($"{nameof(ChunkingOptions.OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", ChunkingOptions.MethodsSupportingOverlapTokens)}.");
 
         if (EmbeddingsTransformation?.ValidateScript() == false)

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -105,6 +105,9 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         {
             errors.Add($"Configuration must have either {nameof(EmbeddingsPathConfigurations)} or {nameof(EmbeddingsTransformation)} script specified");
         }
+        
+        if (EmbeddingsPathConfigurations is not null && EmbeddingsPathConfigurations.Any(x => x.ChunkingOptions.ValidateOptions() == false))
+            errors.Add($"{nameof(ChunkingOptions.OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", ChunkingOptions.MethodsSupportingOverlapTokens)}.");
 
         if (EmbeddingsTransformation?.ValidateScript() == false)
             errors.Add($"Transformation script must use {EmbeddingsTransformation.GenerateEmbeddingsFunctionName} method.");
@@ -112,8 +115,18 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         if (Quantization == VectorEmbeddingType.Text)
             errors.Add($"{nameof(Quantization)} cannot be {nameof(VectorEmbeddingType.Text)}");
 
-        if (ChunkingOptionsForQuerying is null || ChunkingOptionsForQuerying.MaxTokensPerChunk <= 0)
-            errors.Add($"{nameof(ChunkingOptionsForQuerying)} must be specified with {nameof(ChunkingOptionsForQuerying.MaxTokensPerChunk)} greater than 0.");
+        if (ChunkingOptionsForQuerying is null)
+        {
+            errors.Add($"{nameof(ChunkingOptionsForQuerying)} must be provided.");
+        }
+        else
+        {
+            if (ChunkingOptionsForQuerying.MaxTokensPerChunk <= 0)
+                errors.Add($"{nameof(ChunkingOptionsForQuerying)} must be specified with {nameof(ChunkingOptionsForQuerying.MaxTokensPerChunk)} greater than 0.");
+        
+            if (ChunkingOptionsForQuerying.OverlapTokens < 0)
+                errors.Add($"{nameof(ChunkingOptionsForQuerying)} must be specified with {nameof(ChunkingOptionsForQuerying.OverlapTokens)} greater than, or equal to 0.");
+        }
 
         return errors.Count == 0;
     }
@@ -137,6 +150,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             {
                 [nameof(ChunkingOptionsForQuerying.ChunkingMethod)] = EmbeddingsTransformation.ChunkingOptions.ChunkingMethod,
                 [nameof(ChunkingOptionsForQuerying.MaxTokensPerChunk)] = EmbeddingsTransformation.ChunkingOptions.MaxTokensPerChunk,
+                [nameof(ChunkingOptionsForQuerying.OverlapTokens)] = EmbeddingsTransformation.ChunkingOptions.OverlapTokens,
             }
         } : null;
         json[nameof(AiConnectorType)] = AiConnectorType;

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -105,10 +105,13 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         {
             errors.Add($"Configuration must have either {nameof(EmbeddingsPathConfigurations)} or {nameof(EmbeddingsTransformation)} script specified");
         }
-        
-        if (EmbeddingsPathConfigurations is not null && EmbeddingsPathConfigurations.Any(x => x.ChunkingOptions.ValidateOverlapTokensProperty() == false))
-            errors.Add($"{nameof(ChunkingOptions.OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", ChunkingOptions.MethodsSupportingOverlapTokens)}.");
 
+        if (EmbeddingsPathConfigurations is not null)
+        {
+            foreach (var pathConfiguration in EmbeddingsPathConfigurations)
+                pathConfiguration.ChunkingOptions.Validate(pathConfiguration.Path, errors);
+        }
+        
         if (EmbeddingsTransformation?.ValidateScript() == false)
             errors.Add($"Transformation script must use {EmbeddingsTransformation.GenerateEmbeddingsFunctionName} method.");
         

--- a/src/Raven.Server/Documents/AI/TextChunker.cs
+++ b/src/Raven.Server/Documents/AI/TextChunker.cs
@@ -25,9 +25,9 @@ public static class TextChunker
                 return Microsoft.SemanticKernel.Text.TextChunker.SplitMarkDownLines(textualValue, chunkingOptions.MaxTokensPerChunk);
 
             case ChunkingMethod.PlainTextSplitParagraphs:
-                return Microsoft.SemanticKernel.Text.TextChunker.SplitPlainTextParagraphs([textualValue], chunkingOptions.MaxTokensPerChunk);
+                return Microsoft.SemanticKernel.Text.TextChunker.SplitPlainTextParagraphs([textualValue], chunkingOptions.MaxTokensPerChunk, chunkingOptions.OverlapTokens);
             case ChunkingMethod.MarkDownSplitParagraphs:
-                return Microsoft.SemanticKernel.Text.TextChunker.SplitMarkdownParagraphs([textualValue], chunkingOptions.MaxTokensPerChunk);
+                return Microsoft.SemanticKernel.Text.TextChunker.SplitMarkdownParagraphs([textualValue], chunkingOptions.MaxTokensPerChunk, chunkingOptions.OverlapTokens);
             default:
                 throw new ArgumentOutOfRangeException(chunkingOptions.ChunkingMethod.ToString());
         }
@@ -38,9 +38,9 @@ public static class TextChunker
         switch (chunkingOptions.ChunkingMethod)
         {
             case ChunkingMethod.PlainTextSplitParagraphs:
-                return Microsoft.SemanticKernel.Text.TextChunker.SplitPlainTextParagraphs(textualValues, chunkingOptions.MaxTokensPerChunk);
+                return Microsoft.SemanticKernel.Text.TextChunker.SplitPlainTextParagraphs(textualValues, chunkingOptions.MaxTokensPerChunk, chunkingOptions.OverlapTokens);
             case ChunkingMethod.MarkDownSplitParagraphs:
-                return Microsoft.SemanticKernel.Text.TextChunker.SplitMarkdownParagraphs(textualValues, chunkingOptions.MaxTokensPerChunk);
+                return Microsoft.SemanticKernel.Text.TextChunker.SplitMarkdownParagraphs(textualValues, chunkingOptions.MaxTokensPerChunk, chunkingOptions.OverlapTokens);
         }
 
         List<string> results = [];

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
@@ -271,10 +271,10 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
     
     private JsValue SplitMarkDownParagraphs(JsValue self, JsValue[] args)
     {
-        const string methodSignature = "markdown.splitParagraphs(line | [line], maxTokensPerLine, overlapTokens)";
+        const string methodSignature = "markdown.splitParagraphs(line | [line], maxTokensPerLine, overlapTokens?)";
         
-        if (args.Length != 3)
-            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 3 arguments");
+        if (args.Length != 2 && args.Length != 3)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with either 2 or 3 arguments");
         
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.MarkDownSplitParagraphs);
     }
@@ -301,10 +301,10 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
     
     private JsValue SplitPlainTextParagraphs(JsValue self, JsValue[] args)
     {
-        const string methodSignature = "text.splitParagraphs(line | [line], maxTokensPerLine, overlapTokens)";
+        const string methodSignature = "text.splitParagraphs(line | [line], maxTokensPerLine, overlapTokens?)";
         
-        if (args.Length != 3)
-            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 3 arguments");
+        if (args.Length != 2 && args.Length != 3)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with either 2 or 3 arguments");
         
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.PlainTextSplitParagraphs);
     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
@@ -262,31 +262,61 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
     private JsValue SplitMarkDownLines(JsValue self, JsValue[] args)
     {
         const string methodSignature = "markdown.splitLines(text | [text], maxTokensPerLine)";
+        
+        if (args.Length != 2)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 2 arguments");
+        
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.MarkDownSplitLines);
     }
     
     private JsValue SplitMarkDownParagraphs(JsValue self, JsValue[] args)
     {
-        const string methodSignature = "markdown.splitParagraphs(line | [line], maxTokensPerLine)";
+        const string methodSignature = "markdown.splitParagraphs(line | [line], maxTokensPerLine, overlapTokens)";
+        
+        if (args.Length != 3)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 3 arguments");
+        
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.MarkDownSplitParagraphs);
     }
     
     private JsValue SplitPlainText(JsValue self, JsValue[] args)
     {
         const string methodSignature = "text.split(text | [text], maxTokensPerLine)";
+        
+        if (args.Length != 2)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 2 arguments");
+        
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.PlainTextSplit);
     }
     
     private JsValue SplitPlainTextLines(JsValue self, JsValue[] args)
     {
         const string methodSignature = "text.splitLines(text | [text], maxTokensPerLine)";
+        
+        if (args.Length != 2)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 2 arguments");
+        
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.PlainTextSplitLines);
     }
     
     private JsValue SplitPlainTextParagraphs(JsValue self, JsValue[] args)
     {
-        const string methodSignature = "text.splitParagraphs(line | [line], maxTokensPerLine)";
+        const string methodSignature = "text.splitParagraphs(line | [line], maxTokensPerLine, overlapTokens)";
+        
+        if (args.Length != 3)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 3 arguments");
+        
         return ChunkFunc(self, args, methodSignature, ChunkingMethod.PlainTextSplitParagraphs);
+    }
+
+    private JsValue StripHtml(JsValue self, JsValue[] args)
+    {
+        const string methodSignature = "html.strip(htmlText | [htmlText], maxTokensPerChunk)";
+        
+        if (args.Length != 2)
+            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 2 arguments");
+        
+        return ChunkFunc(self, args, methodSignature, ChunkingMethod.HtmlStrip);
     }
     
     public class ObjectForChunking([NotNull] Engine engine) : ObjectInstance(engine)
@@ -294,17 +324,8 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
         public readonly List<(string,ChunkingOptions)> Value = [];
     }
 
-    private JsValue StripHtml(JsValue self, JsValue[] args)
-    {
-        const string methodSignature = "html.strip(htmlText | [htmlText], maxTokensPerChunk)";
-        return ChunkFunc(self, args, methodSignature, ChunkingMethod.HtmlStrip);
-    }
-
     private static JsValue ChunkFunc(JsValue self, JsValue[] args, string methodSignature, ChunkingMethod chunkingMethod)
     {
-        if (args.Length != 2)
-            ThrowInvalidScriptMethodCall($"{methodSignature} has to be called with 2 arguments");
-
         if(args[0].IsNull() || args[0].IsUndefined())
             return JsValue.Undefined;
         
@@ -314,9 +335,19 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
         if (args[1].IsNumber() == false)
             ThrowInvalidScriptMethodCall($"{methodSignature} second argument must be a number");
 
+        int overlapTokens = 0;
+        if (args.Length == 3)
+        {
+            if (args[2].IsNumber() == false)
+                ThrowInvalidScriptMethodCall($"{methodSignature} third argument must be a number");
+
+            overlapTokens = (int)args[2].AsNumber();
+        }
+
         ChunkingOptions chunkingOptions = new() { 
             MaxTokensPerChunk = (int)args[1].AsNumber(), 
-            ChunkingMethod = chunkingMethod 
+            ChunkingMethod = chunkingMethod,
+            OverlapTokens = overlapTokens
         };
         
         var result = new ObjectForChunking(((JsObject)self).Engine);

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
@@ -29,6 +29,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
     pathConfigurationPath = ko.observable<string>("");
     pathConfigurationOverlapTokens = ko.observable<number>(null);
 
+    // querying inputs
     overlapTokens = ko.observable<number>(null);
     canUseOverlapTokensForPathConfiguration: KnockoutComputed<boolean>;
     canUseOverlapTokensForTransformation: KnockoutComputed<boolean>;
@@ -97,7 +98,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.initializeValidation();
     }
 
-    private resetOverlapTokensIfNotSupported = (chunkingMethod: Raven.Client.Documents.Operations.AI.ChunkingMethod, type?: "pathConfiguration" | "transformation" | "normal") => {
+    private resetOverlapTokensIfNotSupported = (chunkingMethod: Raven.Client.Documents.Operations.AI.ChunkingMethod, type?: "pathConfiguration" | "transformation") => {
         if (chunkingMethod !== "PlainTextSplitParagraphs" && chunkingMethod !== "MarkDownSplitParagraphs") {
             switch (type) {
                 case "transformation":
@@ -177,6 +178,8 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             this.chunkingMethod,
             this.maxTokensPerChunk,
             this.overlapTokens,
+            this.transformationOverlapTokens,
+            this.pathConfigurationOverlapTokens,
             this.quantizationType,
             this.embeddingsCacheExpiration,
             this.embeddingsCacheForQueryingExpiration,
@@ -275,7 +278,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.embeddingPathConfigurations.push({
             Path: this.pathConfigurationPath(),
             ChunkingOptions: {
-                OverlapTokens: this.pathConfigurationOverlapTokens() ?? 0,
+                OverlapTokens: this.pathConfigurationOverlapTokens(),
                 ChunkingMethod: this.pathConfigurationChunkingMethod(),
                 MaxTokensPerChunk: this.pathConfigurationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue()
             }
@@ -368,13 +371,13 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             Transforms: null,
             Collection: this.collectionInput(),
             ChunkingOptionsForQuerying: {
-                OverlapTokens: this.overlapTokens() ?? 0,
+                OverlapTokens: this.overlapTokens(),
                 ChunkingMethod: this.chunkingMethod(),
                 MaxTokensPerChunk: this.maxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(),
             },
             Quantization: this.quantizationType(),
             EmbeddingsTransformation: this.embeddingsSource() === "script" ? {
-                Script: this.script(), ChunkingOptions: { OverlapTokens: this.transformationOverlapTokens() ?? 0, MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod() }
+                Script: this.script(), ChunkingOptions: { OverlapTokens: this.transformationOverlapTokens(), MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod() }
             } : null,
             EmbeddingsPathConfigurations: this.embeddingsSource() === "paths" ? this.embeddingPathConfigurations() : [],
             EmbeddingsCacheExpiration: genUtils.formatAsTimeSpan(this.embeddingsCacheExpiration() * 1000),

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
@@ -27,6 +27,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
     pathConfigurationChunkingMethod = ko.observable<Raven.Client.Documents.Operations.AI.ChunkingMethod>(defaultChunkingMethod);
     pathConfigurationChunkingMethodLabel: KnockoutComputed<string>;
     pathConfigurationPath = ko.observable<string>("");
+    pathConfigurationOverlapTokens = ko.observable<number>(null);
 
     overlapTokens = ko.observable<number>(null);
     canUseOverlapTokensForPathConfiguration: KnockoutComputed<boolean>;
@@ -43,6 +44,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
     ];
     chunkingMethodLabel: KnockoutComputed<string>;
 
+    transformationOverlapTokens = ko.observable<number>(null);
     transformationChunkingMethod = ko.observable<Raven.Client.Documents.Operations.AI.ChunkingMethod>(defaultChunkingMethod);
     transformationChunkingMethodLabel: KnockoutComputed<string>;
     transformationMaxTokensPerChunk = ko.observable<number>();
@@ -93,21 +95,31 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.initializeObservables();
         this.update(dto);
         this.initializeValidation();
-
-        this.pathConfigurationChunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
-        this.transformationChunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
-        this.chunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
     }
 
-    private resetOverlapTokensIfNotSupported = (chunkingMethod: Raven.Client.Documents.Operations.AI.ChunkingMethod) => {
+    private resetOverlapTokensIfNotSupported = (chunkingMethod: Raven.Client.Documents.Operations.AI.ChunkingMethod, type?: "pathConfiguration" | "transformation" | "normal") => {
         if (chunkingMethod !== "PlainTextSplitParagraphs" && chunkingMethod !== "MarkDownSplitParagraphs") {
-            this.overlapTokens(null);
+            switch (type) {
+                case "transformation":
+                    this.transformationOverlapTokens(null);
+                    break;
+                case "pathConfiguration":
+                    this.pathConfigurationOverlapTokens(null);
+                    break;
+                default:
+                    this.overlapTokens(null);
+                    break;
+            }
         }
     }
     
     protected initializeObservables() {
         super.initializeObservables();
-        
+
+        this.pathConfigurationChunkingMethod.subscribe((newValue) => this.resetOverlapTokensIfNotSupported(newValue, "pathConfiguration"));
+        this.transformationChunkingMethod.subscribe((newValue) => this.resetOverlapTokensIfNotSupported(newValue, "transformation"));
+        this.chunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
+
         this.maxTokensPerChunkDefaultValue = ko.pureComputed(() => {
             const connectionString = this.aiConnectionStrings().find(x => x.Name === this.connectionStringName());
             
@@ -164,6 +176,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             this.allowEtlOnNonEncryptedChannel,
             this.chunkingMethod,
             this.maxTokensPerChunk,
+            this.overlapTokens,
             this.quantizationType,
             this.embeddingsCacheExpiration,
             this.embeddingsCacheForQueryingExpiration,
@@ -262,7 +275,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.embeddingPathConfigurations.push({
             Path: this.pathConfigurationPath(),
             ChunkingOptions: {
-                OverlapTokens: this.overlapTokens() ?? 0,
+                OverlapTokens: this.pathConfigurationOverlapTokens() ?? 0,
                 ChunkingMethod: this.pathConfigurationChunkingMethod(),
                 MaxTokensPerChunk: this.pathConfigurationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue()
             }
@@ -270,6 +283,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.pathConfigurationPath("");
         this.pathConfigurationMaxTokensPerChunk(null);
         this.pathConfigurationChunkingMethod("PlainTextSplitLines");
+        this.pathConfigurationOverlapTokens(null);
     }
 
     removeEmbeddingsPathConfiguration(path: string): void {
@@ -299,6 +313,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             if (configuration.ChunkingOptionsForQuerying) {
                 this.chunkingMethod(configuration.ChunkingOptionsForQuerying.ChunkingMethod);
                 this.maxTokensPerChunk(configuration.ChunkingOptionsForQuerying.MaxTokensPerChunk);
+                this.overlapTokens(configuration.ChunkingOptionsForQuerying.OverlapTokens);
             }
             if (configuration.Quantization) {
                 this.quantizationType(configuration.Quantization);
@@ -322,6 +337,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             if (configuration.EmbeddingsTransformation?.ChunkingOptions) {
                 this.transformationChunkingMethod(configuration.EmbeddingsTransformation.ChunkingOptions.ChunkingMethod);
                 this.transformationMaxTokensPerChunk(configuration.EmbeddingsTransformation.ChunkingOptions.MaxTokensPerChunk);
+                this.transformationOverlapTokens(configuration.EmbeddingsTransformation.ChunkingOptions.OverlapTokens);
             }
 
             // Open the querying section if some value is different from the default
@@ -329,7 +345,8 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
                 configuration.EmbeddingsCacheForQueryingExpiration !== genUtils.formatAsTimeSpan(defaultEmbeddingsCacheForQueryingExpiration * 1000) ||
                 (configuration.ChunkingOptionsForQuerying && (
                     configuration.ChunkingOptionsForQuerying.MaxTokensPerChunk !== this.maxTokensPerChunkDefaultValue() ||
-                    configuration.ChunkingOptionsForQuerying.ChunkingMethod !== defaultChunkingMethod
+                    configuration.ChunkingOptionsForQuerying.ChunkingMethod !== defaultChunkingMethod ||
+                    (configuration.ChunkingOptionsForQuerying.OverlapTokens !== null && configuration.ChunkingOptionsForQuerying.OverlapTokens !== 0)
                 ))
             ) {
                 this.isQueryingOpen(true);
@@ -357,7 +374,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             },
             Quantization: this.quantizationType(),
             EmbeddingsTransformation: this.embeddingsSource() === "script" ? {
-                Script: this.script(), ChunkingOptions: { OverlapTokens: this.overlapTokens() ?? 0, MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod() }
+                Script: this.script(), ChunkingOptions: { OverlapTokens: this.transformationOverlapTokens() ?? 0, MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod() }
             } : null,
             EmbeddingsPathConfigurations: this.embeddingsSource() === "paths" ? this.embeddingPathConfigurations() : [],
             EmbeddingsCacheExpiration: genUtils.formatAsTimeSpan(this.embeddingsCacheExpiration() * 1000),

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
@@ -28,6 +28,10 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
     pathConfigurationChunkingMethodLabel: KnockoutComputed<string>;
     pathConfigurationPath = ko.observable<string>("");
 
+    overlapTokens = ko.observable<number>(null);
+    canUseOverlapTokensForPathConfiguration: KnockoutComputed<boolean>;
+    canUseOverlapTokensForTransformation: KnockoutComputed<boolean>;
+
     chunkingMethod = ko.observable<Raven.Client.Documents.Operations.AI.ChunkingMethod>(defaultChunkingMethod);
     chunkingMethodOptions: valueAndLabelItem<Raven.Client.Documents.Operations.AI.ChunkingMethod, string>[] = [
         { value: "PlainTextSplit", label: "Plain Text: Split" },
@@ -130,6 +134,14 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             }
             return genUtils.assertUnreachable(source);
         });
+
+        this.canUseOverlapTokensForPathConfiguration = ko.pureComputed(() => {
+            return this.pathConfigurationChunkingMethod() === "PlainTextSplitParagraphs" || this.pathConfigurationChunkingMethod() === "MarkDownSplitParagraphs";
+        })
+
+        this.canUseOverlapTokensForTransformation = ko.pureComputed(() => {
+            return this.transformationChunkingMethod() === "PlainTextSplitParagraphs" || this.transformationChunkingMethod() === "MarkDownSplitParagraphs";
+        })
 
         this.dirtyFlag = new ko.DirtyFlag([ 
             this.taskName,
@@ -240,6 +252,7 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.embeddingPathConfigurations.push({
             Path: this.pathConfigurationPath(),
             ChunkingOptions: {
+                OverlapTokens: this.overlapTokens() ?? 0,
                 ChunkingMethod: this.pathConfigurationChunkingMethod(),
                 MaxTokensPerChunk: this.pathConfigurationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue()
             }
@@ -328,12 +341,13 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
             Transforms: null,
             Collection: this.collectionInput(),
             ChunkingOptionsForQuerying: {
+                OverlapTokens: this.overlapTokens() ?? 0,
                 ChunkingMethod: this.chunkingMethod(),
                 MaxTokensPerChunk: this.maxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(),
             },
             Quantization: this.quantizationType(),
             EmbeddingsTransformation: this.embeddingsSource() === "script" ? {
-                Script: this.script(), ChunkingOptions: { MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod() }
+                Script: this.script(), ChunkingOptions: { OverlapTokens: this.overlapTokens() ?? 0, MaxTokensPerChunk: this.transformationMaxTokensPerChunk() ?? this.maxTokensPerChunkDefaultValue(), ChunkingMethod: this.transformationChunkingMethod() }
             } : null,
             EmbeddingsPathConfigurations: this.embeddingsSource() === "paths" ? this.embeddingPathConfigurations() : [],
             EmbeddingsCacheExpiration: genUtils.formatAsTimeSpan(this.embeddingsCacheExpiration() * 1000),

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskEmbeddingsGenerationEditModel.ts
@@ -93,6 +93,16 @@ class ongoingTaskEmbeddingsGenerationEditModel extends ongoingTaskEditModel {
         this.initializeObservables();
         this.update(dto);
         this.initializeValidation();
+
+        this.pathConfigurationChunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
+        this.transformationChunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
+        this.chunkingMethod.subscribe(this.resetOverlapTokensIfNotSupported);
+    }
+
+    private resetOverlapTokensIfNotSupported = (chunkingMethod: Raven.Client.Documents.Operations.AI.ChunkingMethod) => {
+        if (chunkingMethod !== "PlainTextSplitParagraphs" && chunkingMethod !== "MarkDownSplitParagraphs") {
+            this.overlapTokens(null);
+        }
     }
     
     protected initializeObservables() {

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -388,6 +388,7 @@ export class TasksStubs {
                     {
                         Path: "Name",
                         ChunkingOptions: {
+                            OverlapTokens: 0,
                             ChunkingMethod: "PlainTextSplit",
                             MaxTokensPerChunk: 2048,
                         },
@@ -397,6 +398,7 @@ export class TasksStubs {
                 Quantization: "Single",
                 EmbeddingsCacheExpiration: "90.00:00:00",
                 ChunkingOptionsForQuerying: {
+                    OverlapTokens: 0,
                     ChunkingMethod: "PlainTextSplit",
                     MaxTokensPerChunk: 2048,
                 },

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -224,6 +224,13 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
                               The options below apply to the search term used in the query.
                           </small>`
             });
+
+        popoverUtils.longWithHover($(".overlap-tokens"),
+            {
+                content: `<small class="margin-top-xs no-padding-left">
+                              This value will be used as the default when no specific value is set in the script.
+                          </small>`
+            });
     }    
 
     toggleIsNewConnectionStringOpen() {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
@@ -285,7 +285,7 @@ static readonly embeddingsGenerationSampleText =
     Name: this.Name,
     Note: text.split(this.Note, 2048),
     Description: text.splitLines(this.Description, 2048),
-    Paragraphs: text.splitParagraphs(this.Paragraphs, 2048)
+    Paragraphs: text.splitParagraphs(this.Paragraphs, 2048, 128)
 });`;
 
 embeddingsGenerationSampleMarkdownHighlighted = transformationScriptSyntax.highlightJavascript(transformationScriptSyntax.embeddingsGenerationSampleMarkdown);
@@ -293,7 +293,7 @@ embeddingsGenerationSampleMarkdownHighlighted = transformationScriptSyntax.highl
 static readonly embeddingsGenerationSampleMarkdown =
 `embeddings.generate({ 
     MarkdownDescription: markdown.splitLines(this.MarkdownDescription, 2048),
-    MarkdownSections: markdown.splitParagraphs(this.MarkdownSections, 1024)
+    MarkdownSections: markdown.splitParagraphs(this.MarkdownSections, 1024, 64)
 });`
 
 embeddingsGenerationSampleHtmlHighlighted = transformationScriptSyntax.highlightJavascript(transformationScriptSyntax.embeddingsGenerationSampleHtml);

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
@@ -245,7 +245,7 @@
                                                 <td data-bind="text: Path"></td>
                                                 <td data-bind="text: ChunkingOptions.ChunkingMethod"></td>
                                                 <td data-bind="text: ChunkingOptions.MaxTokensPerChunk"></td>
-                                                <td data-bind="text: ChunkingOptions.OverlapTokens"></td>
+                                                <td data-bind="text: ChunkingOptions.OverlapTokens ?? 0"></td>
                                                 <td class="actions">
                                                     <a title="Remove path" href="#" data-bind="click: $parent.removeEmbeddingsPathConfiguration.bind($parent, Path)"><i class="icon-trash"></i></a>
                                                 </td>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
@@ -214,7 +214,7 @@
                                     <div class="form-group flex-grow">
                                         <label class="control-label">Overlap Tokens</label>
                                         <div class="flex-grow">
-                                            <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: overlapTokens, attr: { disabled: !canUseOverlapTokensForPathConfiguration() }"/>
+                                            <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: pathConfigurationOverlapTokens, attr: { disabled: !canUseOverlapTokensForPathConfiguration() }"/>
                                         </div>
                                     </div>
                                 </div>
@@ -297,7 +297,7 @@
                                 <i class="icon-info text-info overlap-tokens"></i>
                             </label>
                             <div class="flex-grow">
-                                <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: overlapTokens, attr: { disabled: !canUseOverlapTokensForTransformation() }"/>
+                                <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: transformationOverlapTokens, attr: { disabled: !canUseOverlapTokensForTransformation() }"/>
                             </div>
                         </div>
                     </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
@@ -294,7 +294,7 @@
                         </div><div class="form-group">
                             <label class="control-label">
                                 Overlap Tokens
-                                <i class="icon-info text-info TODO"></i>
+                                <i class="icon-info text-info overlap-tokens"></i>
                             </label>
                             <div class="flex-grow">
                                 <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: overlapTokens, attr: { disabled: !canUseOverlapTokensForTransformation() }"/>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
@@ -211,10 +211,10 @@
                                             <input type="number" class="form-control" data-bind="value: pathConfigurationMaxTokensPerChunk, attr: { placeholder: `Default: ${maxTokensPerChunkDefaultValue()}` }" min="1"/>
                                         </div>
                                     </div>
-                                    <div class="form-group flex-grow" data-bind="validationElement: TODO">
+                                    <div class="form-group flex-grow">
                                         <label class="control-label">Overlap Tokens</label>
                                         <div class="flex-grow">
-                                            <input type="number" class="form-control" data-bind="value: TODO, attr: { placeholder: `Default: ${TODO()}` }" min="1"/>
+                                            <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: overlapTokens, attr: { disabled: !canUseOverlapTokensForPathConfiguration() }"/>
                                         </div>
                                     </div>
                                 </div>
@@ -291,13 +291,13 @@
                             <div class="flex-grow">
                                 <input type="number" class="form-control" data-bind="value: transformationMaxTokensPerChunk, attr: { placeholder: `Default: ${maxTokensPerChunkDefaultValue()}` }" min="1"/>
                             </div>
-                        </div><div class="form-group" data-bind="validationElement: TODO">
+                        </div><div class="form-group">
                             <label class="control-label">
                                 Overlap Tokens
                                 <i class="icon-info text-info TODO"></i>
                             </label>
                             <div class="flex-grow">
-                                <input type="number" class="form-control" data-bind="value: TODO, attr: { placeholder: `Default: ${TODO()}` }" min="1"/>
+                                <input type="number" class="form-control" placeholder="Default: 0" data-bind="value: overlapTokens, attr: { disabled: !canUseOverlapTokensForTransformation() }"/>
                             </div>
                         </div>
                     </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
@@ -211,6 +211,12 @@
                                             <input type="number" class="form-control" data-bind="value: pathConfigurationMaxTokensPerChunk, attr: { placeholder: `Default: ${maxTokensPerChunkDefaultValue()}` }" min="1"/>
                                         </div>
                                     </div>
+                                    <div class="form-group flex-grow" data-bind="validationElement: TODO">
+                                        <label class="control-label">Overlap Tokens</label>
+                                        <div class="flex-grow">
+                                            <input type="number" class="form-control" data-bind="value: TODO, attr: { placeholder: `Default: ${TODO()}` }" min="1"/>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div data-bind="validationOptions: { errorsAsTitle: false }, validationElement: embeddingPathConfigurations">
                                     <div class="help-block" data-bind="validationMessage: embeddingPathConfigurations"></div>
@@ -230,6 +236,7 @@
                                                 <th>Path</th>
                                                 <th>Chunking Method</th>
                                                 <th>Max Tokens per Chunk</th>
+                                                <th>Overlap Tokens</th>
                                                 <th></th>
                                             </tr>
                                         </thead>
@@ -238,6 +245,7 @@
                                                 <td data-bind="text: Path"></td>
                                                 <td data-bind="text: ChunkingOptions.ChunkingMethod"></td>
                                                 <td data-bind="text: ChunkingOptions.MaxTokensPerChunk"></td>
+                                                <td data-bind="text: ChunkingOptions.OverlapTokens"></td>
                                                 <td class="actions">
                                                     <a title="Remove path" href="#" data-bind="click: $parent.removeEmbeddingsPathConfiguration.bind($parent, Path)"><i class="icon-trash"></i></a>
                                                 </td>
@@ -282,6 +290,14 @@
                             </label>
                             <div class="flex-grow">
                                 <input type="number" class="form-control" data-bind="value: transformationMaxTokensPerChunk, attr: { placeholder: `Default: ${maxTokensPerChunkDefaultValue()}` }" min="1"/>
+                            </div>
+                        </div><div class="form-group" data-bind="validationElement: TODO">
+                            <label class="control-label">
+                                Overlap Tokens
+                                <i class="icon-info text-info TODO"></i>
+                            </label>
+                            <div class="flex-grow">
+                                <input type="number" class="form-control" data-bind="value: TODO, attr: { placeholder: `Default: ${TODO()}` }" min="1"/>
                             </div>
                         </div>
                     </div>

--- a/test/SlowTests/Issues/RavenDB-24816.cs
+++ b/test/SlowTests/Issues/RavenDB-24816.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.ETL.Providers.AI;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using SlowTests.Server.Documents.AI.Embeddings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24816 : EmbeddingsGenerationTestBase
+{
+    public RavenDB_24816(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Ai)]
+    public void OverlapTokensSettingShouldWork()
+    {
+        const string plainTextToChunk = "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
+        var expectedChunks = new List <string>()
+        {
+            "this is a relatively long text",
+            "relatively long text that should",
+            "that should produce multiple",
+            "produce multiple chunks because",
+            "chunks because of the chunking",
+            "of the chunking configuration (max",
+            "configuration (max tokens per chunk)",
+            "tokens per chunk)"
+        };
+
+        var chunkingOptions = new ChunkingOptions()
+        {
+            ChunkingMethod = ChunkingMethod.PlainTextSplitParagraphs,
+            MaxTokensPerChunk = 10,
+            OverlapTokens = 5
+        };
+        
+        var chunks = Raven.Server.Documents.AI.TextChunker.Chunk(plainTextToChunk, chunkingOptions);
+        
+        Assert.Equal(expectedChunks, chunks);
+    }
+    
+    [RavenFact(RavenTestCategory.Ai)]
+    public void OverlapTokensSettingForMarkdownShouldWork()
+    {
+        const string markdownToChunk = """
+                                        ## This is an example markdown content
+                                            - Text text
+                                            - Text text text
+                                        
+                                        ### More content
+                                            this is some text
+                                        """;
+        var expectedChunks = new List <string>()
+        {
+            "## This is an example markdown",
+            "example markdown content\n    -",
+            "content\n    - Text text",
+            "Text text - Text text",
+            "- Text text text\n\n### More",
+            "text\n\n### More content\n    this",
+            "content\n    this is some text",
+            "is some text"
+        };
+
+        var chunkingOptions = new ChunkingOptions()
+        {
+            ChunkingMethod = ChunkingMethod.MarkDownSplitParagraphs,
+            MaxTokensPerChunk = 10,
+            OverlapTokens = 5
+        };
+        
+        var chunks = Raven.Server.Documents.AI.TextChunker.Chunk(markdownToChunk, chunkingOptions);
+        
+        Assert.Equal(expectedChunks, chunks);
+    }
+    
+    [RavenFact(RavenTestCategory.Ai)]
+    public void OverlapTokensSettingInScriptShouldWork()
+    {
+        const string plainTextToChunk =
+            "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
+        string[] expectedChunks = [
+            "this is a relatively long text",
+            "relatively long text that should",
+            "that should produce multiple",
+            "produce multiple chunks because",
+            "chunks because of the chunking",
+            "of the chunking configuration (max",
+            "configuration (max tokens per chunk)",
+            "tokens per chunk)"
+        ];
+
+        var dto = new Dto { Name = plainTextToChunk };
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(dto);
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
+                script: "embeddings.generate({ ChunkedName: text.splitParagraphs(this.Name, 10, 5) });");
+
+            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+
+            AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Ai)]
+    public void OverlapTokensSettingViaPathShouldWork()
+    {
+        const string plainTextToChunk =
+            "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
+        string[] expectedChunks = [
+            "this is a relatively long text",
+            "relatively long text that should",
+            "that should produce multiple",
+            "produce multiple chunks because",
+            "chunks because of the chunking",
+            "of the chunking configuration (max",
+            "configuration (max tokens per chunk)",
+            "tokens per chunk)"
+        ];
+
+        var dto = new Dto { Name = plainTextToChunk };
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(dto);
+                session.SaveChanges();
+            }
+
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
+                embeddingsPaths: 
+                [
+                    new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = new ChunkingOptions()
+                    {
+                        ChunkingMethod = ChunkingMethod.PlainTextSplitParagraphs,
+                        MaxTokensPerChunk = 10,
+                        OverlapTokens = 5
+                    }}
+                ]);
+
+            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+
+            AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", expectedChunks, dto.Id);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public void UnsupportedChunkingMethodsThrowRelevantException()
+    {
+        const string plainTextToChunk =
+            "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
+
+        var dto = new Dto { Name = plainTextToChunk };
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(dto);
+                session.SaveChanges();
+            }
+
+            var exception = Assert.Throws<RavenException>(() => AddEmbeddingsGenerationTask(store,
+                embeddingsPaths:
+                [
+                    new EmbeddingPathConfiguration()
+                    {
+                        Path = "Name", ChunkingOptions = new ChunkingOptions()
+                        {
+                            ChunkingMethod = ChunkingMethod.PlainTextSplit,
+                            MaxTokensPerChunk = 10,
+                            OverlapTokens = 5
+                        }
+                    }
+                ]));
+
+            Assert.Contains("OverlapTokens option is only supported for the following chunking methods: MarkDownSplitParagraphs, PlainTextSplitParagraphs.", exception.Message);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Ai)]
+    public void UnsupportedChunkingSettingsInScriptThrowRelevantException()
+    {
+        const string plainTextToChunk =
+            "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
+
+        var dto = new Dto { Name = plainTextToChunk };
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(dto);
+                session.SaveChanges();
+            }
+            
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+            var (configuration, _) = AddEmbeddingsGenerationTask(store,
+                script: "embeddings.generate({ ChunkedName: text.splitLines(this.Name, 10, 5) });");
+
+            aiTaskDone.Wait(TimeSpan.FromSeconds(5));
+
+            var transformationError = Etl.TryGetTransformationErrorAsync(store.Database, configuration).GetAwaiter().GetResult();
+
+            Assert.Contains("text.splitLines(text | [text], maxTokensPerLine) has to be called with 2 arguments", transformationError.Error);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public List<string> Names { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-24816.cs
+++ b/test/SlowTests/Issues/RavenDB-24816.cs
@@ -198,7 +198,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
                     }
                 ]));
 
-            Assert.Contains("OverlapTokens option is only supported for the following chunking methods: MarkDownSplitParagraphs, PlainTextSplitParagraphs.", exception.Message);
+            Assert.Contains("Path 'Name': OverlapTokens option is only supported for the following chunking methods: MarkDownSplitParagraphs, PlainTextSplitParagraphs.", exception.Message);
         }
     }
     

--- a/test/SlowTests/Issues/RavenDB-24816.cs
+++ b/test/SlowTests/Issues/RavenDB-24816.cs
@@ -230,6 +230,43 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
             Assert.Contains("text.splitLines(text | [text], maxTokensPerLine) has to be called with 2 arguments", transformationError.Error);
         }
     }
+    
+    [RavenFact(RavenTestCategory.Ai)]
+    public void OverlapTokensShouldBeBackwardCompatible()
+    {
+        const string plainTextToChunk =
+            "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
+        
+        string[] expectedChunks = [
+            "this is a relatively long text",
+            "that should produce multiple",
+            "chunks because of the chunking",
+            "configuration (max tokens per chunk)"
+        ];
+
+        var dto = new Dto { Name = plainTextToChunk };
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(dto);
+                session.SaveChanges();
+            }
+            
+            var aiTaskDone = Etl.WaitForEtlToComplete(store);
+            
+            var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
+                script: "embeddings.generate({ ChunkedName: text.splitParagraphs(this.Name, 10) });");
+
+            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
+            AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
+        }
+    }
 
     private class Dto
     {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
@@ -25,7 +25,7 @@ public class TasksManagementTests : RavenTestBase
         {
             Name = "ai-task-testing",
             ConnectionStringName = "ai-service-connection",
-            EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration() { Path = "PostContent" }, new EmbeddingPathConfiguration(){ Path = "Comments", ChunkingOptions = DefaultChunkingOptions }],
+            EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration() { Path = "PostContent", ChunkingOptions = DefaultChunkingOptions }, new EmbeddingPathConfiguration(){ Path = "Comments", ChunkingOptions = DefaultChunkingOptions }],
             Collection = "Posts",
             ChunkingOptionsForQuerying = DefaultChunkingOptions
         };
@@ -55,7 +55,7 @@ public class TasksManagementTests : RavenTestBase
         {
             Name = "ai-task-testing",
             ConnectionStringName = "ai-service-connection",
-            EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration() { Path = "PostContent" }, new EmbeddingPathConfiguration() { Path = "Comments", ChunkingOptions = DefaultChunkingOptions }],
+            EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration() { Path = "PostContent", ChunkingOptions = DefaultChunkingOptions }, new EmbeddingPathConfiguration() { Path = "Comments", ChunkingOptions = DefaultChunkingOptions }],
             Collection = "Posts",
             ChunkingOptionsForQuerying = DefaultChunkingOptions
         };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24816/Expose-OverlapTokens-in-ChunkingOptions

### Additional description

Exposed `OverlapTokens` chunking configuration option for `SplitPlainTextParagraphs` and `SplitMarkdownParagraphs`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
