### PR TITLE
RavenDB-24698 fix Backups restore points listing

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -204,17 +204,19 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                         StartAfter = startAfter
                     }, _cancellationToken);
 
-                var result = new ListObjectsResult 
+                var result = new ListObjectsResult
                 {
                     ContinuationToken = response.NextContinuationToken,
                 };
 
                 if (listFolders)
                 {
-                    result.FileInfoDetails = response
-                        .CommonPrefixes
-                        .Select(x => new S3FileInfoDetails { FullPath = x })
-                        .ToList();
+                    if (response.CommonPrefixes != null)
+                    {
+                        result.FileInfoDetails = response
+                            .CommonPrefixes.Select(x => new S3FileInfoDetails { FullPath = x })
+                            .ToList();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24698

### Additional description

response.CommonPrefixes is null because the bucket only contains files, which are handled separately in the code.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
