### PR TITLE
RavenDB-25058 Fix restoring Incremental timeseries with dead values

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1548,6 +1548,12 @@ namespace Raven.Server.Documents.TimeSeries
                         throw new InvalidDataException($"The entries of '{Name}' incremental time-series for document '{DocumentId}' must be sorted by their timestamps. " +
                                                        $"Got: current '{_current.Timestamp:O}'.");
 
+                    if (_current.Status == TimeSeriesValuesSegment.Dead || _next.Status == TimeSeriesValuesSegment.Dead)
+                    {
+                        // dead values doesn't have tags, so we let the caller handle this
+                        break;
+                    }
+
                     if (_current.Timestamp == _next.Timestamp)
                     {
                         var tagCompare = _current.Tag.CompareTo(_next.Tag);
@@ -1586,11 +1592,8 @@ namespace Raven.Server.Documents.TimeSeries
 
             private void AssertTag(SingleResult next)
             {
-                if (FromReplication)
-                {
-                    if (next.Status == TimeSeriesValuesSegment.Dead)
-                        return;
-                }
+                if (next.Status == TimeSeriesValuesSegment.Dead)
+                    return;
 
                 if (next.Tag?.Length != _tagLength)
                     throw new InvalidDataException($"Tag of '{Name}' time-series for document '{DocumentId}' are illegal (Tag:{next.Tag})");

--- a/test/SlowTests/Server/Documents/PeriodicBackup/BackupAndRestoreForIncrementalTimeSeries.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/BackupAndRestoreForIncrementalTimeSeries.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.PeriodicBackup
+{
+    public class BackupAndRestoreForIncrementalTimeSeries : ClusterTestBase
+    {
+        public BackupAndRestoreForIncrementalTimeSeries(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task IncrementalTimeSeriesCanRestoreDeadValue()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var config = Backup.CreateBackupConfiguration(backupPath);
+            config.BackupType = BackupType.Snapshot;
+
+            using (var store = GetDocumentStore())
+            {
+                var baseline = RavenTestHelper.UtcToday;
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "oren" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Increment(baseline, 1);
+                    session.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Increment(baseline.AddDays(20), 1);
+
+
+                    await session.SaveChangesAsync();
+                }
+
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Delete(baseline.AddDays(20));
+
+                    await session.SaveChangesAsync();
+                }
+
+                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
+
+                using (var restored = RestoreAndGetStore(store, backupPath, out var releaseDatabase))
+                using (releaseDatabase)
+                {
+                    var stats = await restored.Maintenance.SendAsync(new GetStatisticsOperation());
+                    Assert.Equal(1, stats.CountOfDocuments);
+                    Assert.Equal(1, stats.CountOfTimeSeriesSegments);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task IncrementalTimeSeriesCanRestoreDeadValueInCluster(Options options)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var config = Backup.CreateBackupConfiguration(backupPath);
+            config.BackupType = BackupType.Snapshot;
+            
+            var baseline = RavenTestHelper.UtcToday;
+
+            var cluster = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true);
+            using (var store = GetDocumentStore(new Options(options)
+            {
+                Server = cluster.Leader,
+                ReplicationFactor = 3
+            }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "oren" }, "users/1");
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Increment(baseline, 1);
+                    session.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Increment(baseline.AddDays(20), 1);
+                    session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    await session.SaveChangesAsync();
+                }
+
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(cluster.Leader, config, store);
+                
+                var stores = GetDocumentStores(cluster.Nodes, store.Database, disableTopologyUpdates: true);
+                using (var sessionA = stores[0].OpenAsyncSession())
+                {
+                    sessionA.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Increment(baseline.AddDays(20), 1);
+                    sessionA.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    await sessionA.SaveChangesAsync();
+                }
+
+                using (var sessionB = stores[1].OpenAsyncSession())
+                {
+                    sessionB.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Delete(baseline.AddDays(20));
+                    sessionB.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    await sessionB.SaveChangesAsync();
+                }
+
+                using (var sessionC = stores[2].OpenAsyncSession())
+                {
+                    sessionC.IncrementalTimeSeriesFor("users/1", "INC:Heartrate").Increment(baseline.AddDays(20), 1);
+                    sessionC.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                    await sessionC.SaveChangesAsync();
+                }
+
+                await Backup.RunBackupAsync(cluster.Leader, backupTaskId, store, isFullBackup: false);
+
+                using (var restored = RestoreAndGetStore(store, backupPath, out var releaseDatabase))
+                using (releaseDatabase)
+                {
+                    var stats = await restored.Maintenance.SendAsync(new GetStatisticsOperation());
+                    Assert.Equal(1, stats.CountOfDocuments);
+                    Assert.Equal(1, stats.CountOfTimeSeriesSegments);
+
+                    using (var session = restored.OpenAsyncSession())
+                    {
+                        var user1 = await session.LoadAsync<User>("users/1");
+                        Assert.Equal("oren", user1.Name);
+
+                        var values = (await session.IncrementalTimeSeriesFor("users/1", "INC:Heartrate")
+                                .GetAsync())
+                            .ToList();
+
+                        Assert.Equal(2, values.Count);
+                        Assert.Equal(baseline, values[0].Timestamp, RavenTestHelper.DateTimeComparer.Instance);
+                        Assert.Equal(1, values[0].Value);
+
+                        Assert.Equal(baseline.AddDays(20), values[1].Timestamp, RavenTestHelper.DateTimeComparer.Instance);
+                        Assert.Equal(1, values[1].Value);
+                    }
+                }
+            }
+        }
+
+        public IDocumentStore RestoreAndGetStore(IDocumentStore store, string backupPath, out IDisposable releaseDatabase, TimeSpan? timeout = null)
+        {
+            var restoredDatabaseName = GetDatabaseName();
+
+            releaseDatabase = Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+            {
+                BackupLocation = Directory.GetDirectories(backupPath).First(),
+                DatabaseName = restoredDatabaseName
+            }, timeout);
+
+            var options = new Options
+            {
+                ModifyDatabaseName = s => restoredDatabaseName,
+                CreateDatabase = false,
+                DeleteDatabaseOnDispose = true,
+                Server = GetServers().First()
+            };
+
+            options.ModifyDocumentStore = null;
+
+            return GetDocumentStore(options);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25058

### Additional description

Incremental time-series use a specific tag, which we check whenever a value is appended. 
However, when a timestamp is deleted, the tag is removed. 
This means that restoring a deleted value will fail.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
