### PR TITLE
RavenDB-25064 - Add the total allocated to the allocations event listener event

### DIFF
--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -14,11 +14,9 @@ public class EventsListener : AbstractEventListener
     private readonly Dictionary<string, IEventsHandler> _handlerByEventName = new();
     private DotNetEventType _dotNetEventType;
 
-    private readonly Dictionary<string, AllocationsHandler.AllocationInfo> _allocations = new();
-    private ulong _totalAllocated = 0;
+    private AllocationsInfo _allocationInfo = new();
     private readonly StringBuilder _sb = new();
 
-    private Stopwatch _stopwatchSinceLastAllocation;
     private long _allocationsLoggingIntervalInMs;
     private int _allocationsLoggingCount;
     private readonly InternalEvent _internalEvent = new();
@@ -40,11 +38,12 @@ public class EventsListener : AbstractEventListener
     {
         return e =>
         {
-            _stopwatchSinceLastAllocation ??= Stopwatch.StartNew();
+            var allocationsInfo = _allocationInfo;
+            allocationsInfo.StopwatchSinceLastAllocation ??= Stopwatch.StartNew();
 
-            if (_allocations.TryGetValue(e.AllocationType, out var allocation) == false)
+            if (allocationsInfo.Allocations.TryGetValue(e.AllocationType, out var allocation) == false)
             {
-                _allocations[e.AllocationType] = e;
+                allocationsInfo.Allocations[e.AllocationType] = e;
             }
             else
             {
@@ -54,18 +53,18 @@ public class EventsListener : AbstractEventListener
                 allocation.NumberOfLargeObjectAllocations += e.NumberOfLargeObjectAllocations;
             }
 
-            _totalAllocated += e.SmallObjectAllocations + e.LargeObjectAllocations;
+            allocationsInfo.TotalAllocated += e.SmallObjectAllocations + e.LargeObjectAllocations;
 
-            if (_stopwatchSinceLastAllocation.ElapsedMilliseconds >= _allocationsLoggingIntervalInMs)
+            if (allocationsInfo.StopwatchSinceLastAllocation.ElapsedMilliseconds >= _allocationsLoggingIntervalInMs)
             {
                 var count = _allocationsLoggingCount;
                 _sb.Clear();
 
-                _sb.Append($"Top {_allocationsLoggingCount} allocations for the past {_allocationsLoggingIntervalInMs:#,#;;0}ms: (total allocated: {new Size((long)_totalAllocated, SizeUnit.Bytes)}): ");
+                _sb.Append($"Top {_allocationsLoggingCount} allocations for the past {_allocationsLoggingIntervalInMs:#,#;;0}ms: (total allocated: {new Size((long)allocationsInfo.TotalAllocated, SizeUnit.Bytes)}): ");
                 _sb.AppendLine();
 
                 var first = true;
-                foreach (var alloc in _allocations.Values.OrderByDescending(x => x.Allocations))
+                foreach (var alloc in allocationsInfo.Allocations.Values.OrderByDescending(x => x.Allocations))
                 {
                     if (first == false)
                         _sb.AppendLine();
@@ -79,9 +78,7 @@ public class EventsListener : AbstractEventListener
 
                 _internalEvent.SetString(_sb.ToString());
                 onEvent.Invoke(_internalEvent);
-                _stopwatchSinceLastAllocation.Restart();
-                _allocations.Clear();
-                _totalAllocated = 0;
+                allocationsInfo.Clear();
             }
         };
     }
@@ -140,9 +137,7 @@ public class EventsListener : AbstractEventListener
 
         if (eventTypes.Contains(EventType.Allocations) == false)
         {
-            _allocations.Clear();
-            _totalAllocated = 0;
-            _stopwatchSinceLastAllocation = null;
+            _allocationInfo = new AllocationsInfo();
         }
 
         var newDotNetEventType = GetDotNetEventTypes(eventTypes);
@@ -196,5 +191,19 @@ public class EventsListener : AbstractEventListener
             throw new InvalidOperationException($"Failed to determine which event type to log, {string.Join(", ", eventTypes.Select(et => et.ToString()))}");
 
         return dotNetEventType.Value;
+    }
+
+    private class AllocationsInfo
+    {
+        public readonly Dictionary<string, AllocationsHandler.AllocationInfo> Allocations = new();
+        public ulong TotalAllocated = 0;
+        public Stopwatch StopwatchSinceLastAllocation;
+
+        public void Clear()
+        {
+            StopwatchSinceLastAllocation.Restart();
+            Allocations.Clear();
+            TotalAllocated = 0;
+        }
     }
 }

--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Text;
+using Sparrow;
 
 namespace Raven.Server.EventListener;
 
@@ -14,6 +15,7 @@ public class EventsListener : AbstractEventListener
     private DotNetEventType _dotNetEventType;
 
     private readonly Dictionary<string, AllocationsHandler.AllocationInfo> _allocations = new();
+    private ulong _totalAllocated = 0;
     private readonly StringBuilder _sb = new();
 
     private Stopwatch _stopwatchSinceLastAllocation;
@@ -52,12 +54,14 @@ public class EventsListener : AbstractEventListener
                 allocation.NumberOfLargeObjectAllocations += e.NumberOfLargeObjectAllocations;
             }
 
+            _totalAllocated += e.SmallObjectAllocations + e.LargeObjectAllocations;
+
             if (_stopwatchSinceLastAllocation.ElapsedMilliseconds >= _allocationsLoggingIntervalInMs)
             {
                 var count = _allocationsLoggingCount;
                 _sb.Clear();
 
-                _sb.Append($"Top {_allocationsLoggingCount} allocations for the past {_allocationsLoggingIntervalInMs:#,#;;0}ms: ");
+                _sb.Append($"Top {_allocationsLoggingCount} allocations for the past {_allocationsLoggingIntervalInMs:#,#;;0}ms: (total allocated: {new Size((long)_totalAllocated, SizeUnit.Bytes)}): ");
                 _sb.AppendLine();
 
                 var first = true;
@@ -77,6 +81,7 @@ public class EventsListener : AbstractEventListener
                 onEvent.Invoke(_internalEvent);
                 _stopwatchSinceLastAllocation.Restart();
                 _allocations.Clear();
+                _totalAllocated = 0;
             }
         };
     }
@@ -136,6 +141,7 @@ public class EventsListener : AbstractEventListener
         if (eventTypes.Contains(EventType.Allocations) == false)
         {
             _allocations.Clear();
+            _totalAllocated = 0;
             _stopwatchSinceLastAllocation = null;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25064/Add-the-total-allocated-to-the-allocations-event-listener-event

### Additional description

Modified the allocation summary message to include the total amount of memory allocated during the interval.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
