### PR TITLE
RavenDB-24821 Open license modal when feature is not available for GenAI and Ai Agents

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentsInfoHub.tsx
@@ -20,7 +20,7 @@ export default function AiAgentsInfoHub() {
     });
 
     return (
-        <AboutViewFloating>
+        <AboutViewFloating defaultOpen={hasAiAgent ? null : "licensing"}>
             <AccordionItemWrapper
                 icon="about"
                 color="info"

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/EditGenAiTaskInfoHub.tsx
@@ -24,7 +24,7 @@ export default function EditGenAiTaskInfoHub() {
     });
 
     return (
-        <AboutViewFloating>
+        <AboutViewFloating defaultOpen={hasGenAi ? null : "licensing"}>
             <AccordionItemWrapper
                 icon="about"
                 color="info"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24821/License-restriction-modal-does-not-appear-when-clicking-inside-GenAI-task-with-insufficient-license

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
