### PR TITLE
RavenDB-24935 Set index to 0 for cloning compare exchange item

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/cmpXchg/editCmpXchg.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/cmpXchg/editCmpXchg.ts
@@ -394,7 +394,9 @@ class editCmpXchg extends shardViewModelBase {
 
         this.spinners.save(true);
 
-        new saveCompareExchangeItemCommand(this.db, this.key(), this.loadedIndex(), valueDto, metadataDto)
+        const index = this.isCreatingNewItem() ? 0 : this.loadedIndex();
+
+        new saveCompareExchangeItemCommand(this.db, this.key(), index, valueDto, metadataDto)
             .execute()
             .done(saveResult => this.onValueSaved(saveResult))
             .fail(() => this.spinners.save(false));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24935/Cannot-clone-cmpXchg-item-from-Studio

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
