### PR TITLE
RavenDB-24021 - TcpConnectionOptions leak

### DIFF
--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -105,36 +105,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
             return _lastStats;
         }
 
-        public void StartPullReplicationAsHub(IDisposable replicationScope, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures supportedVersions)
-        {
-            SupportedFeatures = supportedVersions;
-            _stream = stream;
-            _scope = replicationScope;
-            OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
-            _longRunningSendingWork =
-                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
-                    _database.Name, Destination.FromString(), pullReplicationAsHub: true));
-        }
-
-        private void PullReplication()
-        {
-            NativeMemory.EnsureRegistered();
-
-            AddReplicationPulse(ReplicationPulseDirection.OutgoingInitiate);
-            if (Logger.IsInfoEnabled)
-                Logger.Info($"Start pull replication as hub {FromToString}");
-
-            using (_scope)
-            using (_stream)
-            using (_interruptibleRead = new InterruptibleRead<DocumentsContextPool, DocumentsOperationContext>(_parent.ContextPool, _stream))
-            using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (context.GetMemoryBuffer(out _buffer))
-            {
-                InitialHandshake();
-                Replicate();
-            }
-        }
-
         protected override void AssertDatabaseNotDisposed()
         {
             var database = _parent.Database;
@@ -442,7 +412,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
         private void OnSuccessfulReplication() => SuccessfulReplication?.Invoke(this);
 
         internal TestingStuff ForTestingPurposes;
-        private IDisposable _scope;
 
         internal TestingStuff ForTestingPurposesOnly()
         {

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -105,10 +105,11 @@ namespace Raven.Server.Documents.Replication.Outgoing
             return _lastStats;
         }
 
-        public void StartPullReplicationAsHub(Stream stream, TcpConnectionHeaderMessage.SupportedFeatures supportedVersions)
+        public void StartPullReplicationAsHub(IDisposable replicationScope, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures supportedVersions)
         {
             SupportedFeatures = supportedVersions;
             _stream = stream;
+            _scope = replicationScope;
             OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
             _longRunningSendingWork =
                 PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
@@ -123,6 +124,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Start pull replication as hub {FromToString}");
 
+            using (_scope)
             using (_stream)
             using (_interruptibleRead = new InterruptibleRead<DocumentsContextPool, DocumentsOperationContext>(_parent.ContextPool, _stream))
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -440,6 +442,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         private void OnSuccessfulReplication() => SuccessfulReplication?.Invoke(this);
 
         internal TestingStuff ForTestingPurposes;
+        private IDisposable _scope;
 
         internal TestingStuff ForTestingPurposesOnly()
         {

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         /// <summary>
         /// The replication scope that should be disposed when the replication is done.
         /// </summary>
-        private IDisposable _scope;
+        private IDisposable _replicationScope;
 
         public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsHub node, TcpConnectionInfo connectionInfo) :
             base(parent, database, node, connectionInfo)
@@ -64,7 +64,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
             SupportedFeatures = supportedVersions;
             _stream = stream;
-            _scope = replicationScope;
+            _replicationScope = replicationScope;
             OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
             _longRunningSendingWork =
                 PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Start pull replication as hub {FromToString}");
 
-            using (_scope)
+            using (_replicationScope)
             using (_stream)
             using (_interruptibleRead = new InterruptibleRead<DocumentsContextPool, DocumentsOperationContext>(_parent.ContextPool, _stream))
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -1,11 +1,19 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.ServerWide.Commands;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Replication.Stats;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Server.Utils;
+using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Replication.Outgoing
 {
@@ -17,7 +25,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         public string CertificateThumbprint;
 
-        protected OutgoingPullReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo) : 
+        protected OutgoingPullReplicationHandler(ReplicationLoader parent, DocumentDatabase database, ReplicationNode node, TcpConnectionInfo connectionInfo) :
             base(parent, database, node, connectionInfo)
         {
         }
@@ -42,10 +50,46 @@ namespace Raven.Server.Documents.Replication.Outgoing
         // we need to associate this instance to the replication definition.
         public string PullReplicationDefinitionName;
 
-        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsHub node, TcpConnectionInfo connectionInfo) : 
+        /// <summary>
+        /// The replication scope that should be disposed when the replication is done.
+        /// </summary>
+        private IDisposable _scope;
+
+        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsHub node, TcpConnectionInfo connectionInfo) :
             base(parent, database, node, connectionInfo)
         {
         }
+
+        public void StartPullReplicationAsHub(IDisposable replicationScope, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures supportedVersions)
+        {
+            SupportedFeatures = supportedVersions;
+            _stream = stream;
+            _scope = replicationScope;
+            OutgoingReplicationThreadName = $"Pull replication as hub {FromToString}";
+            _longRunningSendingWork =
+                PoolOfThreads.GlobalRavenThreadPool.LongRunning(x => HandleReplicationErrors(PullReplication), null, ThreadNames.ForOutgoingReplication(OutgoingReplicationThreadName,
+                    _database.Name, Destination.FromString(), pullReplicationAsHub: true));
+        }
+
+        private void PullReplication()
+        {
+            NativeMemory.EnsureRegistered();
+
+            AddReplicationPulse(ReplicationPulseDirection.OutgoingInitiate);
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Start pull replication as hub {FromToString}");
+
+            using (_scope)
+            using (_stream)
+            using (_interruptibleRead = new InterruptibleRead<DocumentsContextPool, DocumentsOperationContext>(_parent.ContextPool, _stream))
+            using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using (context.GetMemoryBuffer(out _buffer))
+            {
+                InitialHandshake();
+                Replicate();
+            }
+        }
+
         public override string FromToString => $"{base.FromToString} (pull definition: {PullReplicationDefinitionName})";
     }
 
@@ -53,7 +97,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
     {
         private readonly PullReplicationAsSink _node;
 
-        public OutgoingPullReplicationHandlerAsSink(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsSink node, TcpConnectionInfo connectionInfo) : 
+        public OutgoingPullReplicationHandlerAsSink(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsSink node, TcpConnectionInfo connectionInfo) :
             base(parent, database, node, connectionInfo)
         {
             _node = node;

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -427,6 +427,8 @@ namespace Raven.Server.Documents.Replication
                             if (pullReplicationDefinition.Mode.HasFlag(PullReplicationMode.HubToSink) == false)
                                 throw new InvalidOperationException($"Replication hub {header.AuthorizeInfo.AuthorizationFor} does not support Pull Replication");
                             CreatePullReplicationAsHub(tcpConnectionOptions, initialRequest, supportedVersions, pullReplicationDefinition, header);
+                            
+                            // The early return
                             return;
 
                         case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication:
@@ -438,7 +440,7 @@ namespace Raven.Server.Documents.Replication
                             allowedPaths = DetailedReplicationHubAccess.Preferred(header.ReplicationHubAccess.AllowedSinkToHubPaths, header.ReplicationHubAccess.AllowedHubToSinkPaths);
                             preventDeletionsMode = pullReplicationDefinition.PreventDeletionsMode;
 
-                            // same as normal incoming replication, just using the filtering
+                            // Use the same as in normal incoming replication, just using the filtering.
                             break;
 
                         default:
@@ -515,7 +517,8 @@ namespace Raven.Server.Documents.Replication
             outgoingReplication.SuccessfulTwoWaysCommunication += OnOutgoingSendingSucceeded;
             outgoingReplication.SuccessfulReplication += ResetReplicationFailuresInfo;
 
-            outgoingReplication.StartPullReplicationAsHub(tcpConnectionOptions.Stream, supportedVersions);
+            // tcp ownership - the tcp is passed as a scope of the replication so that it can be properly disposed.
+            outgoingReplication.StartPullReplicationAsHub(tcpConnectionOptions, tcpConnectionOptions.Stream, supportedVersions);
             OutgoingReplicationAdded?.Invoke(outgoingReplication);
         }
 
@@ -676,6 +679,7 @@ namespace Raven.Server.Documents.Replication
         protected virtual IncomingReplicationHandler CreateIncomingReplicationHandler(TcpConnectionOptions tcpConnectionOptions, JsonOperationContext.MemoryBuffer buffer,
             PullReplicationParams incomingPullParams, ReplicationLatestEtagRequest getLatestEtagMessage)
         {
+            // tcp ownership - both IncomingReplicationHandler and IncomingPullReplicationHandler properly manage the ownership and the disposal
             if (incomingPullParams == null)
             {
                 return new IncomingReplicationHandler(

--- a/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
@@ -50,7 +51,15 @@ namespace Raven.Server.Documents.TcpHandlers
             _connectedAt = DateTime.UtcNow;
 
             Id = Interlocked.Increment(ref _sequence);
+
+#if !RELEASE
+            _ctorStackTrace = new StackTrace();
+#endif
         }
+
+#if !RELEASE
+        private readonly StackTrace _ctorStackTrace;
+#endif
 
         public long Id { get; set; }
         public JsonContextPool ContextPool;
@@ -150,7 +159,7 @@ namespace Raven.Server.Documents.TcpHandlers
 #if !RELEASE
         ~TcpConnectionOptions()
         {
-            throw new LowMemoryException($"Detected a leak on TcpConnectionOptions ('{ToString()}') when running the finalizer.");
+            throw new LowMemoryException($"Detected a leak on TcpConnectionOptions ('{ToString()}') when running the finalizer. The instance was created at {_ctorStackTrace}");
         }
 #endif
 

--- a/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
@@ -51,15 +51,7 @@ namespace Raven.Server.Documents.TcpHandlers
             _connectedAt = DateTime.UtcNow;
 
             Id = Interlocked.Increment(ref _sequence);
-
-#if !RELEASE
-            _ctorStackTrace = new StackTrace();
-#endif
         }
-
-#if !RELEASE
-        private readonly StackTrace _ctorStackTrace;
-#endif
 
         public long Id { get; set; }
         public JsonContextPool ContextPool;
@@ -159,7 +151,7 @@ namespace Raven.Server.Documents.TcpHandlers
 #if !RELEASE
         ~TcpConnectionOptions()
         {
-            throw new LowMemoryException($"Detected a leak on TcpConnectionOptions ('{ToString()}') when running the finalizer. The instance was created at {_ctorStackTrace}");
+            throw new LowMemoryException($"Detected a leak on TcpConnectionOptions ('{ToString()}') when running the finalizer.");
         }
 #endif
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2809,6 +2809,7 @@ namespace Raven.Server
             switch (header.Operation)
             {
                 case TcpConnectionHeaderMessage.OperationTypes.Subscription:
+                    // tcp ownership - properly scoped by SubscriptionBinder method
                     CreateSubscriptionConnection(ServerStore, result, tcp, bufferToCopy);
                     break;
 
@@ -2829,9 +2830,9 @@ namespace Raven.Server
                     throw new InvalidOperationException("Unknown operation for TCP " + header.Operation);
             }
 
-            //since the responses to TCP connections mostly continue to run
-            //beyond this point, no sense to dispose the connection now, so set it to null.
-            //this way the responders are responsible to dispose the connection and the context
+            // Since the responses to TCP connections mostly continue to run beyond this point,
+            // there's no sense to dispose the connection now, so set it to null.
+            // This way the responders are responsible to dispose the connection and the context.
             // ReSharper disable once RedundantAssignment
             tcp = null;
             return false;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24021/Sparrow.LowMemory.LowMemoryException-Detected-a-leak-on-TcpConnectionOptions

### Additional description

This PR addresses the lack of ownership over `TcpConnectionOptions` when starting outgoing replication as a hub. After the fix, the options are scoped in the way the stream is and are properly disposed. I haven't found other paths having this issue. They seem to manage the options properly.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
