### PR TITLE
RavenDB-25071 - Use ForgetAbout after document disposal

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -17,6 +17,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Collection;
         public LazyStringValue Id;
         public DocumentFlags Flags;
+        public long StorageId;
+        public DocumentsOperationContext Context;
 
         public override DynamicJsonValue ToDebugJson()
         {
@@ -41,6 +43,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 Flags = doc.Flags,
                 TransactionMarker = doc.TransactionMarker,
                 LastModifiedTicks = doc.LastModified.Ticks,
+                StorageId = doc.StorageId,
+                Context = context,
             };
 
             return result;
@@ -209,6 +213,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             Data?.Dispose();
             Id?.Dispose();
             Collection?.Dispose();
+
+            Context?.Transaction?.InnerTransaction.ForgetAbout(StorageId);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25071/High-unmanaged-memory-during-replication

### Additional description

Add missing `ForgetAbout` during replication of a document.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
