### PR TITLE
RavenDB-25045 : Debug assert fail in ByteString

### DIFF
--- a/src/Raven.Server/Documents/CountersRepairTask.cs
+++ b/src/Raven.Server/Documents/CountersRepairTask.cs
@@ -42,7 +42,7 @@ public class CountersRepairTask
         StartAfterSliceHolder startAfterSliceHolder = null;
         string lastDocId = null;
 
-        if (lastProcessedKey != null)
+        if (string.IsNullOrEmpty(lastProcessedKey) == false)
         {
             startAfterSliceHolder = new StartAfterSliceHolder(lastProcessedKey);
         }
@@ -110,6 +110,7 @@ public class CountersRepairTask
 
                         if (docIdsToFix.Count == 0)
                         {
+                            startAfterSliceHolder?.Dispose();
                             MarkAsCompleted();
                             return;
                         }
@@ -120,10 +121,15 @@ public class CountersRepairTask
                         await _database.TxMerger.Enqueue(new ExecuteFixCounterGroupsCommand(_database, docIdsToFix, hasMore));
                         docIdsToFix.Clear();
 
-                        if (hasMore)
-                            break; // break from inner while loop in order to open a new read tx
-
+                        // need to dispose startAfterSliceHolder before we close the context
                         startAfterSliceHolder?.Dispose();
+
+                        if (hasMore)
+                        {
+                            startAfterSliceHolder = new StartAfterSliceHolder(lastDocId);
+                            break; // break from inner while loop in order to open a new read tx
+                        }
+
                         return;
                     }
                 }
@@ -136,10 +142,6 @@ public class CountersRepairTask
                 _logger.Warn($"An Error occured while executing FixCorruptedCountersTask. Last DocId : '{lastDocId}'", e);
             }
 
-        }
-        finally
-        {
-            startAfterSliceHolder?.Dispose();
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25045/Debug-assert-fail-in-ByteString

### Additional description

`CountersRepairTask `adjustments:
- don't initialize a `startAfterSliceHolder `if the `lastProcessedKey `is` string.Empty` (just start reading from the beginning)
- need to dispose the `startAfterSliceHolder `before we close the current context (otherwise we can fail on Debug.Assert when releasing the slices)


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
