### PR TITLE
RavenDB-22767 Custom in-memory logging to narrow down dangling transactions

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -87,6 +87,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.DecompressedBufferSize)] = new Size(lowLevelTransaction.DecompressedBufferBytes, SizeUnit.Bytes).ToString(),
                 [nameof(TxInfoResult.TotalEncryptionBufferSize)] = lowLevelTransaction.TotalEncryptionBufferInBytes.ToString(),
                 [nameof(TxInfoResult.IsDisposed)] = lowLevelTransaction.IsDisposed,
+                [nameof(TxInfoResult.DebugInfo)] = lowLevelTransaction.DebugInfo,
             };
         }
     }
@@ -108,5 +109,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public string DecompressedBufferSize;
         public string TotalEncryptionBufferSize;
         public bool IsDisposed;
+        public string DebugInfo;
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3335,7 +3335,8 @@ namespace Raven.Server.Documents.Indexes
             IndexQueryServerSide query,
             QueryOperationContext queryContext,
             bool pulseDocsReadingTransaction,
-            OperationCancelToken token)
+            OperationCancelToken token,
+            [CallerMemberName] string caller = null)
             where TQueryResult : QueryResultServerSide<Document>
         {
             QueryInternalPreparation(query);
@@ -3350,6 +3351,8 @@ namespace Raven.Server.Documents.Indexes
 
                 var stalenessScope = query.Timings?.For(nameof(QueryTimingsScope.Names.Staleness), start: false);
 
+                var docsTxOpenCount = 0;
+                
                 while (true)
                 {
                     AssertIndexState();
@@ -3363,8 +3366,14 @@ namespace Raven.Server.Documents.Indexes
                     using (_contextPool.AllocateOperationContext(out TransactionOperationContext indexContext))
                     using (var indexTx = indexContext.OpenReadTransaction())
                     {
+                        docsTxOpenCount++;
+                        
                         if (queryContext.AreTransactionsOpened() == false)
+                        {
                             resultToFill.ReadTransactionDispose = queryContext.OpenReadTransaction();
+                            queryContext.Documents?.Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add($"Query internal caller: {caller} (tx count: {docsTxOpenCount})");
+                            queryContext.Documents?.Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add($"Query: {query.Metadata.Query}, params: {query.QueryParameters?.ToString()}");
+                        }
 
                         // we have to open read tx for mapResults _after_ we open index tx
 
@@ -3377,6 +3386,8 @@ namespace Raven.Server.Documents.Indexes
                             isStale = IsStale(queryContext, indexContext, cutoffEtag?.DocEtag, cutoffEtag?.ReferenceEtag, cutoffEtag?.CompareExchangeReferenceEtag);
                             if (WillResultBeAcceptable(isStale, query, wait) == false)
                             {
+                                queryContext.Documents?.Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add("About to close transaction");
+                                
                                 resultToFill.ReadTransactionDispose?.Dispose();
                                 resultToFill.ReadTransactionDispose = null;
                                 queryContext.CloseTransaction();
@@ -3547,6 +3558,8 @@ namespace Raven.Server.Documents.Indexes
                                 }
                                 catch (Exception e)
                                 {
+                                    queryContext.Documents?.Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add($"Query execution exception: {e}");
+                                    
                                     if (resultToFill.SupportsExceptionHandling == false)
                                         throw;
 
@@ -3585,6 +3598,8 @@ namespace Raven.Server.Documents.Indexes
                             }
                         }
 
+                        queryContext.Documents?.Transaction?.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add($"Query processing completed");
+                        
                         return;
                     }
                 }

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -83,10 +83,18 @@ namespace Raven.Server.ServerWide.Context
 
         protected override DocumentsTransaction CloneReadTransaction(DocumentsTransaction previous)
         {
+            var hasDebugInfo = previous.InnerTransaction?.LowLevelTransaction?.DebugInfo != null;
+            
+            if (hasDebugInfo)
+                previous.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add("About to clone transaction");
+            
             var clonedTransaction = new DocumentsTransaction(this,
                 _documentDatabase.DocumentsStorage.Environment.CloneReadTransaction(previous.InnerTransaction, PersistentContext, Allocator),
                 _documentDatabase.Changes);
 
+            if (hasDebugInfo)
+                clonedTransaction.InnerTransaction?.LowLevelTransaction?.DebugInfo_Add("New cloned transaction");
+            
             previous.Dispose();
 
             return clonedTransaction;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -961,6 +961,16 @@ namespace Voron.Impl
         }
 
         public string CallerName { get; set; }
+        
+        public string DebugInfo { get; set; }
+        
+        public void DebugInfo_Add(string msg)
+        {
+            if (DebugInfo == null)
+                DebugInfo = msg;
+            else
+                DebugInfo += $" {msg}{System.Environment.NewLine}";
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767

### Additional description

Another phase of in-memory debug logging. For querying this time.

