### PR TITLE
RavenDB-24757 / RavenDB-14548 Added missing handling of 7.x tasks in TasksInfoAnalyzer of Debug Package analyzer

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/Analyzers/Database/TasksInfoAnalyzer.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/Analyzers/Database/TasksInfoAnalyzer.cs
@@ -125,6 +125,15 @@ public class TasksInfoAnalyzer(
                 case OngoingTaskType.Subscription:
                     taskCounts.SubscriptionCount++;
                     break;
+                case OngoingTaskType.SnowflakeEtl:
+                    taskCounts.SnowflakeEtlCount++;
+                    break;
+                case OngoingTaskType.EmbeddingsGeneration:
+                    taskCounts.EmbeddingsGenerationCount++;
+                    break;
+                case OngoingTaskType.GenAi:
+                    taskCounts.GenAiCount++;
+                    break;
                 default:
                     throw new NotSupportedException($"Unknown task type: {ongoingTask.TaskType}");
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24757

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/20871 - 7,x tasks handling support.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
