### PR TITLE
RavenDB-24953 Strengthen the expected exceptions check conditions

### DIFF
--- a/test/SlowTests/Issues/RavenDB_22498.cs
+++ b/test/SlowTests/Issues/RavenDB_22498.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Converters;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide.Operations;
@@ -308,7 +309,7 @@ public class RavenDB_22498 : RavenTestBase
                         await store.Maintenance.SendAsync(new PutIndexesOperation(def));
                         await store.Maintenance.SendAsync(new DeleteIndexOperation(def.Name));
                     }
-                    catch
+                    catch (IndexCompilationException)
                     {
                         errorCount++;
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24953

### Additional description

Probably transient error during tests:

https://issues.hibernatingrhinos.com/issue/RavenDB-24953/SlowTests.Issues.RavenDB22498.CanConvertAutoIndexesSlowinputFile-SlowTests.Data.RavenDB22498.AutoIndexes.SlowTests-expectedCount#focus=Comments-67-1068862.0-0

### Type of change

- [ ] Bug fix
- [x] Test fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
