### PR TITLE
[Release-6.2] RavenDB-25082 - Debug package cannot produce information for sharding

### DIFF
--- a/src/Raven.Server/Config/ConfigurationEntryValue.cs
+++ b/src/Raven.Server/Config/ConfigurationEntryValue.cs
@@ -91,7 +91,7 @@ namespace Raven.Server.Config
 
     public sealed class ConfigurationEntryDatabaseValue : ConfigurationEntryServerValue
     {
-        public ConfigurationEntryDatabaseValue(RavenConfiguration configuration, DatabaseRecord dbRecord, ConfigurationEntryMetadata metadata, RavenServer.AuthenticationStatus authenticationStatus)
+        public ConfigurationEntryDatabaseValue(RavenConfiguration configuration, Dictionary<string, string> settings, ConfigurationEntryMetadata metadata, RavenServer.AuthenticationStatus authenticationStatus)
             : base(configuration.ServerWideSettings, metadata, authenticationStatus)
         {
             if (Metadata.Scope == ConfigurationEntryScope.ServerWideOnly)
@@ -105,7 +105,7 @@ namespace Raven.Server.Config
                 var hasValue = configuration.DoesKeyExistInSettings(key);
                 var value = configuration.GetSetting(key);
 
-                if (dbRecord.Settings.TryGetValue(key, out var valueInDbRecord) == false)
+                if (settings.TryGetValue(key, out var valueInDbRecord) == false)
                 {
                     if (hasValue &&
                         string.Equals(key, RavenConfiguration.GetKey(x => x.Core.DataDirectory), StringComparison.OrdinalIgnoreCase) == false &&

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractAdminConfigurationHandlerProcessorForGetSettings.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractAdminConfigurationHandlerProcessorForGetSettings.cs
@@ -3,13 +3,11 @@ using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http.Features.Authentication;
-using Raven.Client;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Config;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Documents.Handlers.Processors;
-using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -45,9 +43,8 @@ internal abstract class AbstractAdminConfigurationHandlerProcessorForGetSettings
 
         using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         {
-            var dbId = Constants.Documents.Prefix + RequestHandler.DatabaseName;
             using (context.OpenReadTransaction())
-            using (var dbDoc = RequestHandler.ServerStore.Cluster.Read(context, dbId, out long etag))
+            using (var dbDoc = RequestHandler.ServerStore.Cluster.ReadRawDatabaseRecord(context, RequestHandler.DatabaseName, out _))
             {
                 if (dbDoc == null)
                 {
@@ -55,7 +52,7 @@ internal abstract class AbstractAdminConfigurationHandlerProcessorForGetSettings
                     return;
                 }
 
-                databaseRecord = JsonDeserializationCluster.DatabaseRecord(dbDoc);
+                databaseRecord = dbDoc.MaterializedRecord;
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractAdminConfigurationHandlerProcessorForGetSettings.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Configuration/AbstractAdminConfigurationHandlerProcessorForGetSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -39,7 +40,7 @@ internal abstract class AbstractAdminConfigurationHandlerProcessorForGetSettings
         var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
         var status = feature?.Status ?? RavenServer.AuthenticationStatus.ClusterAdmin;
 
-        DatabaseRecord databaseRecord;
+        Dictionary<string, string> settings;
 
         using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         {
@@ -52,7 +53,7 @@ internal abstract class AbstractAdminConfigurationHandlerProcessorForGetSettings
                     return;
                 }
 
-                databaseRecord = dbDoc.MaterializedRecord;
+                settings = dbDoc.Settings;
             }
         }
 
@@ -63,7 +64,7 @@ internal abstract class AbstractAdminConfigurationHandlerProcessorForGetSettings
             if (scope.HasValue && scope != configurationEntryMetadata.Scope)
                 continue;
 
-            var entry = new ConfigurationEntryDatabaseValue(GetDatabaseConfiguration(), databaseRecord, configurationEntryMetadata, status);
+            var entry = new ConfigurationEntryDatabaseValue(GetDatabaseConfiguration(), settings, configurationEntryMetadata, status);
             settingsResult.Settings.Add(entry);
         }
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -340,21 +340,22 @@ namespace Raven.Server.Documents.Handlers.Debugging
                         {
                             if (rawRecord.Sharding.Orchestrator.Topology.RelevantFor(ServerStore.NodeTag) == false)
                                 continue;
+
+                            // write the main database record which includes the individual shards configuration
+                            await WriteDatabaseRecord(archive, databaseName, jsonOperationContext, context);
+
+                            foreach (var shard in rawRecord.Sharding.Shards)
+                            {
+                                await WriteInfo($"{databaseName}${shard.Key}", rawRecord);
+                            }
                         }
                         else
                         {
                             if (rawRecord.Topology.RelevantFor(ServerStore.NodeTag) == false)
                                 continue;
+
+                            await WriteInfo(databaseName, rawRecord);
                         }
-
-                        await WriteDatabaseRecord(archive, databaseName, jsonOperationContext, context);
-
-                        if (rawRecord.IsDisabled ||
-                            rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress ||
-                            IsDatabaseBeingDeleted(ServerStore.NodeTag, rawRecord))
-                            continue;
-
-                        await WriteDatabaseInfo(archive, jsonOperationContext, localEndpointClient, databaseName, token);
                     }
                 }
 
@@ -368,7 +369,19 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     }
 
                     return allDatabases.ToHashSet();
-        }
+                }
+
+                async Task WriteInfo(string databaseName, RawDatabaseRecord rawRecord)
+                {
+                    await WriteDatabaseRecord(archive, databaseName, jsonOperationContext, context);
+
+                    if (rawRecord.IsDisabled ||
+                        rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress ||
+                        IsDatabaseBeingDeleted(ServerStore.NodeTag, rawRecord))
+                        return;
+
+                    await WriteDatabaseInfo(archive, jsonOperationContext, localEndpointClient, databaseName, token);
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -19,6 +19,7 @@ using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Exceptions;
@@ -346,7 +347,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                             foreach (var shard in rawRecord.Sharding.Shards)
                             {
-                                await WriteInfo($"{databaseName}${shard.Key}", rawRecord);
+                                await WriteInfo($"{ShardHelper.ToShardName(databaseName, shard.Key)}", rawRecord);
                             }
                         }
                         else

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -433,7 +433,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 try
                 {
                     await InvokeAndWriteToArchive(archive, context, localEndpointClient, route, path, endpointParameters, token);
-                    debugInfoDict[route.Path] = sw.Elapsed;
                 }
                 catch (Exception e)
                 {
@@ -442,6 +441,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 }
                 finally
                 {
+                    debugInfoDict[route.Path] = sw.Elapsed;
                     if (_logger.IsOperationsEnabled)
                         _logger.Operations($"Finished gathering debug info from '{route.Path}' for Debug Package '{id}'. Took: {(int)sw.Elapsed.TotalMilliseconds} ms",
                             ex);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25082/Debug-package-cannot-produce-information-for-sharding

### Additional description

Since the main database doesn't exist independently but rather consists of its shards, we need to retrieve information from each shard for the debug package.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
