### PR TITLE
RavenDB-7070 migrated obsoletes introduced by .NET 10

### DIFF
--- a/bench/TimeSeries.Benchmark/Program.cs
+++ b/bench/TimeSeries.Benchmark/Program.cs
@@ -438,11 +438,11 @@ namespace TimeSeries.Benchmark
                     await _onFire.Task;
                 }
 
-                while (file.EndOfStream == false)
+                while (true)
                 {
                     var line = await file.ReadLineAsync();
                     if (line == null)
-                        continue;
+                        break;
 
                     var parts = line.Split(',');
 
@@ -456,7 +456,7 @@ namespace TimeSeries.Benchmark
                         {
                             line = await file.ReadLineAsync();
                             if (line == null)
-                                continue;
+                                break;
 
                             parts = line.Split(',');
                             var time = new DateTime(long.Parse(parts[0]));

--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Raven.Client;
 using Raven.Client.Http;
 using Raven.Server.Config;
@@ -57,46 +58,50 @@ public sealed class LetsEncryptSimulationHelper
         configuration.Initialize();
         var guid = Guid.NewGuid().ToString();
 
-        IWebHost webHost = null;
+        IHost webHost = null;
         try
         {
             try
             {
                 var responder = new UniqueResponseResponder(guid);
 
-                var webHostBuilder = new WebHostBuilder()
-                    .CaptureStartupErrors(captureStartupErrors: true)
-                    .UseKestrel(options =>
+                var webHostBuilder = new HostBuilder()
+                    .ConfigureWebHost(configure =>
                     {
-                        var httpsConnectionMiddleware = new HttpsConnectionMiddleware(serverStore.Server, options, serverCertificate);
-
-                        if (addresses.Length == 0)
-                        {
-                            var defaultIp = new IPEndPoint(IPAddress.Parse(Constants.Network.AnyIp), port == 0 ? Constants.Network.DefaultSecuredRavenDbHttpPort : port);
-
-                            options.Listen(defaultIp, listenOptions =>
+                        configure
+                            .CaptureStartupErrors(captureStartupErrors: true)
+                            .UseKestrel(options =>
                             {
-                                listenOptions
-                                    .UseHttps()
-                                    .Use(httpsConnectionMiddleware.OnConnectionAsync);
-                            });
-                            if (Logger.IsInfoEnabled)
-                                Logger.Info($"List of ip addresses for node '{nodeTag}' is empty. WebHost listening to {defaultIp}");
-                        }
+                                var httpsConnectionMiddleware = new HttpsConnectionMiddleware(serverStore.Server, options, serverCertificate);
 
-                        foreach (var address in addresses)
-                        {
-                            options.Listen(address, listenOptions =>
-                            {
-                                listenOptions
-                                    .UseHttps()
-                                    .Use(httpsConnectionMiddleware.OnConnectionAsync);
-                            });
-                        }
+                                if (addresses.Length == 0)
+                                {
+                                    var defaultIp = new IPEndPoint(IPAddress.Parse(Constants.Network.AnyIp), port == 0 ? Constants.Network.DefaultSecuredRavenDbHttpPort : port);
+
+                                    options.Listen(defaultIp, listenOptions =>
+                                    {
+                                        listenOptions
+                                            .UseHttps()
+                                            .Use(httpsConnectionMiddleware.OnConnectionAsync);
+                                    });
+                                    if (Logger.IsInfoEnabled)
+                                        Logger.Info($"List of ip addresses for node '{nodeTag}' is empty. WebHost listening to {defaultIp}");
+                                }
+
+                                foreach (var address in addresses)
+                                {
+                                    options.Listen(address, listenOptions =>
+                                    {
+                                        listenOptions
+                                            .UseHttps()
+                                            .Use(httpsConnectionMiddleware.OnConnectionAsync);
+                                    });
+                                }
+                            })
+                            .UseSetting(WebHostDefaults.ApplicationKey, "Setup simulation")
+                            .UseShutdownTimeout(TimeSpan.FromMilliseconds(150));
                     })
-                    .UseSetting(WebHostDefaults.ApplicationKey, "Setup simulation")
-                    .ConfigureServices(collection => { collection.AddSingleton(typeof(IStartup), responder); })
-                    .UseShutdownTimeout(TimeSpan.FromMilliseconds(150));
+                    .ConfigureServices(collection => { collection.AddSingleton(typeof(IStartup), responder); });
 
                 webHost = webHostBuilder.Build();
                 serverStore.Server._forTestingPurposes?.UnbindSocketForPort(port);

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -19,12 +19,14 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using NLog.Web;
@@ -103,9 +105,9 @@ namespace Raven.Server
 
         public readonly ServerStore ServerStore;
 
-        private IWebHost _webHost;
+        private IHost _webHost;
 
-        private IWebHost _redirectingWebHost;
+        private IHost _redirectingWebHost;
 
         private readonly RavenLogger _tcpLogger;
         private bool _openTelemetryInitialized;
@@ -271,12 +273,15 @@ namespace Raven.Server
                     _forTestingPurposes?.UnbindSocketForPort(ListenEndpoints.Port);
                 }
 
-                var webHostBuilder = new WebHostBuilder()
-                    .CaptureStartupErrors(captureStartupErrors: true)
-                    .UseKestrel(ConfigureKestrel)
-                    .UseUrls(Configuration.Core.ServerUrls)
-                    .UseStartup<RavenServerStartup>()
-                    .UseShutdownTimeout(TimeSpan.FromSeconds(1))
+                var webHostBuilder = new HostBuilder()
+                    .ConfigureWebHost(configure =>
+                    {
+                        configure.CaptureStartupErrors(captureStartupErrors: true)
+                            .UseKestrel(ConfigureKestrel)
+                            .UseUrls(Configuration.Core.ServerUrls)
+                            .UseStartup<RavenServerStartup>()
+                            .UseShutdownTimeout(TimeSpan.FromSeconds(1));
+                    })
                     .ConfigureServices(services =>
                     {
                         ConfigureOpenTelemetry(services);
@@ -341,7 +346,8 @@ namespace Raven.Server
             {
                 _webHost.Start();
 
-                var serverAddressesFeature = _webHost.ServerFeatures.Get<IServerAddressesFeature>();
+                var server = _webHost.Services.GetService<IServer>();
+                var serverAddressesFeature = server.Features.Get<IServerAddressesFeature>();
                 WebUrl = GetWebUrl(serverAddressesFeature.Addresses.First()).TrimEnd('/');
 
                 if (Certificate.Certificate != null)
@@ -1022,11 +1028,14 @@ namespace Raven.Server
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"HTTPS is on. Setting up a new web host to redirect incoming HTTP traffic on port 80 to HTTPS on port 443. The new web host is listening to {string.Join(", ", serverUrlsToRedirect)}");
 
-                var webHostBuilder = new WebHostBuilder()
-                    .UseKestrel()
-                    .UseUrls(serverUrlsToRedirect)
-                    .UseStartup<RedirectServerStartup>()
-                    .UseShutdownTimeout(TimeSpan.FromSeconds(1));
+                var webHostBuilder = new HostBuilder()
+                    .ConfigureWebHost(configure =>
+                    {
+                        configure.UseKestrel()
+                            .UseUrls(serverUrlsToRedirect)
+                            .UseStartup<RedirectServerStartup>()
+                            .UseShutdownTimeout(TimeSpan.FromSeconds(1));
+                    });
 
                 _redirectingWebHost = webHostBuilder.Build();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-7070

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
