### PR TITLE
RavenDB-25071 - use ForgetAbout after document disposal

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -17,6 +17,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Collection;
         public LazyStringValue Id;
         public DocumentFlags Flags;
+        public long StorageId;
+        public DocumentsOperationContext Context;
 
         public override long Size => GetReplicationBatchItemSize();
 
@@ -49,6 +51,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 Flags = doc.Flags,
                 TransactionMarker = doc.TransactionMarker,
                 LastModifiedTicks = doc.LastModified.Ticks,
+                StorageId = doc.StorageId,
+                Context = context,
             };
 
             return result;
@@ -223,6 +227,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             Data?.Dispose();
             Id?.Dispose();
             Collection?.Dispose();
+
+            Context?.Transaction?.InnerTransaction.ForgetAbout(StorageId);
         }
 
         public override string ToString()


### PR DESCRIPTION
Custom build with [pull/21412](https://github.com/ravendb/ravendb/pull/21412) based on v6.2.9