### PR TITLE
RavenDB-22469 QueryPlan refactoring when using DeduplicationMatch

### DIFF
--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -13,6 +13,7 @@ namespace Corax.Querying.Matches;
 public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
     where TInner : IQueryMatch
 {
+    private bool _isGrowableBitArray = false;
     private TInner _inner;
     private readonly GrowableHashSet<long> _hashset;
     private GrowableBitArray _bitmap;
@@ -37,6 +38,7 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
         {
             _bitmap = new GrowableBitArray(indexSearcher.Allocator, (int)indexSearcher.LastEntryId);
             _fillFunc = &FillViaBitmap;
+            _isGrowableBitArray = true;
         }
 
         _inner = inner;
@@ -123,6 +125,11 @@ public unsafe struct DeduplicationMatch<TInner> : IQueryMatch
 
     public QueryInspectionNode Inspect()
     {
-        return new QueryInspectionNode(nameof(DeduplicationMatch<TInner>), new List<QueryInspectionNode>() { { new QueryInspectionNode("Inner", [_inner.Inspect()]) } });
+        return new QueryInspectionNode(nameof(DeduplicationMatch<TInner>),
+            parameters: new Dictionary<string, string>()
+            {
+                {"DataStructure", _isGrowableBitArray ? "Bitmap" : "HashSet"}
+            },
+            children: [_inner.Inspect()]);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22469
### Additional description

Better formatting:
<img width="688" height="944" alt="image" src="https://github.com/user-attachments/assets/a1d01812-20aa-4a38-8d52-64afc960ebb0" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
