### PR TITLE
RavenDB-25080 Moved the test that allocates over 2GB into StressTests…

### DIFF
--- a/test/SlowTests/Corax/GrowableBitArrayTests.cs
+++ b/test/SlowTests/Corax/GrowableBitArrayTests.cs
@@ -54,21 +54,7 @@ public class GrowableBitArrayTests : NoDisposalNeeded
             Assert.True(lookup.Add(i), i.ToString());
         }
     }
-
-    [RavenFact(RavenTestCategory.Corax)]
-    public void CanSetSecondBitmap()
-    {
-        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
-        using var lookup = new GrowableBitArray(allocator, GrowableBitArray.MaxCapacityPerBitmapInBits + 2);
-        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits));
-        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits));
-        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+1));
-        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+1));
-        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
-        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
-        Assert.Throws<ArgumentOutOfRangeException>(() => lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+3));
-    }
-
+    
     [RavenTheory(RavenTestCategory.Corax)]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]

--- a/test/StressTests/Corax/GrowableBitArrayTests.cs
+++ b/test/StressTests/Corax/GrowableBitArrayTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Corax.Utils;
+using FastTests;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Corax;
+
+public class GrowableBitArrayTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenMultiplatformFact(RavenTestCategory.Corax, architecture: RavenArchitecture.AllX64)]
+    public void CanSetSecondBitmap()
+    {
+        using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var lookup = new GrowableBitArray(allocator, GrowableBitArray.MaxCapacityPerBitmapInBits + 2);
+        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits));
+        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits));
+        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+1));
+        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+1));
+        Assert.True(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
+        Assert.False(lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => lookup.Add(GrowableBitArray.MaxCapacityPerBitmapInBits+3));
+    }
+
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25080

### Additional description

The test allocates over 2GB and throws exception on x86 runtimes due to limits.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
