### PR TITLE
RavenDB-25000 Corax: pass `DocumentsContext` into `IndexEntries` operation.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1262,7 +1262,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 take = CoraxConstants.IndexSearcher.TakeAll;
 
             IQueryMatch queryMatch;
-            var builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, null, null, query, _index, query.QueryParameters, QueryBuilderFactories, _fieldMappings, null, null, -1, deduplicationDisabled: false, indexReadOperation: this, token: token);
+            var builderParameters = new CoraxQueryBuilder.Parameters(IndexSearcher, _allocator, null, documentsContext, query, _index, query.QueryParameters, QueryBuilderFactories, _fieldMappings, null, null, -1, deduplicationDisabled: false, indexReadOperation: this, token: token);
             if ((queryMatch = CoraxQueryBuilder.BuildQuery(builderParameters, out _)) is null)
                 yield break;
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using FastTests;
+using Orders;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Queries;
+using Raven.Server.Documents.Indexes.Static;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.Embeddings;
+
+public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public void CanUseEmbeddingGenerationTaskInIndexEntriesQuery()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        var etl = Etl.WaitForEtlToComplete(store);
+        var cityConfig = new EmbeddingPathConfiguration()
+        {
+            Path = "ShipTo.City",
+            ChunkingOptions = new ChunkingOptions()
+            {
+                ChunkingMethod = ChunkingMethod.PlainTextSplit,
+                MaxTokensPerChunk = 2048
+            }
+        };
+
+        var countryConfig = new EmbeddingPathConfiguration()
+        {
+            Path = "ShipTo.Country",
+            ChunkingOptions = new ChunkingOptions()
+            {
+                ChunkingMethod = ChunkingMethod.PlainTextSplitLines,
+                MaxTokensPerChunk = 2048
+            }
+        };
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Order() { ShipTo = new Address() { City = "London", Country = "UK" } });
+            session.SaveChanges();
+        }
+
+        var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [cityConfig, countryConfig], collectionName: "Orders");
+        etl.Wait(DefaultEtlTimeout);
+        var index = new Index();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+
+        using (var commands = store.Commands())
+        {
+            var command = new QueryCommand(commands.Session, new IndexQuery
+            {
+                Query = $@"from index '{index.IndexName}' where vector.search(VectorCity, ""uk"", 0.82, 20)"
+            });
+
+            commands.RequestExecutor.Execute(command, commands.Context);
+
+            var results = new DynamicArray(command.Result.Results);
+            Assert.Equal(1, results.Count());
+        }
+
+        using (var commands = store.Commands())
+        {
+            var command = new QueryCommand(commands.Session, new IndexQuery
+            {
+                Query = $@"from index '{index.IndexName}' where vector.search(VectorCity, ""uk"", 0.82, 20)"
+            }, indexEntriesOnly: true);
+
+            commands.RequestExecutor.Execute(command, commands.Context);
+
+            var results = new DynamicArray(command.Result.Results);
+            Assert.Equal(1, results.Count());
+        }
+    }
+
+    private class Index : AbstractIndexCreationTask<Order>
+    {
+        public Index()
+        {
+            Map = docs => from doc in docs
+                select new
+                {
+                    VectorCity = LoadVector("ShipTo.City", "localaitask"),
+                    VectoryCountry = LoadVector("ShipTo.Country", "localaitask")
+                };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25000
### Additional description

We need DocumentsContext in VectorSearch to be able to retrieve embedding from cache.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
