### PR TITLE
RavenDB-25018 Test fix

### DIFF
--- a/test/SlowTests/Issues/RavenDB-24649.cs
+++ b/test/SlowTests/Issues/RavenDB-24649.cs
@@ -27,7 +27,7 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
         using var store = GetDocumentStore(new Options(){RunInMemory = false});
         dbName = store.Database;
         var db = await GetDatabase(dbName);
-        db.Configuration.Indexing.ElapsedSinceQueriedPersistInterval = new TimeSetting(2, TimeUnit.Seconds);
+        db.Configuration.Indexing.ElapsedSinceQueriedPersistInterval = new TimeSetting(250, TimeUnit.Milliseconds);
 
         using (var session = store.OpenAsyncSession(database: dbName))
         {
@@ -46,7 +46,7 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
 
         // Wait that elapsed time will be increased.
         var elapsed1 = index.GetElapsedTimeFromLastQuery();
-        var elapsed2 = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult(index.GetElapsedTimeFromLastQuery()), elapsed1, timeout: Timeout, interval: Interval);
+        var elapsed2 = await WaitAndAssertForGreaterThanAsync(async () => await GetElapsedTimeFromLastQuery(), elapsed1, timeout: Timeout, interval: Interval);
 
         using (var session = store.OpenAsyncSession())
         {
@@ -56,7 +56,7 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
                 .ToListAsync();
             
             // Wait for changed elapsed time.
-            var currentElapsed = await WaitForNotEqualsAsync(() => Task.FromResult(index.GetElapsedTimeFromLastQuery()), elapsed2, timeout: Timeout, interval: Interval);
+            var currentElapsed = await WaitForNotEqualsAsync(async () => await GetElapsedTimeFromLastQuery(), elapsed2, timeout: Timeout, interval: Interval);
             Assert.True(currentElapsed != elapsed2, $"{currentElapsed} != {elapsed2}");
         }
 
@@ -75,13 +75,23 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
         await store.Maintenance.ForDatabase(dbName).SendAsync(new EnableIndexOperation(autoIndexName));
         var elapsedOnInit = index.GetElapsedTimeFromLastQuery();
         
-        //LastQueryingTime on index initialization is InitializationTime - ElapsedSinceQueried. An index on initialization performs indexing batch so that value must be greater than InitializationTime.
+        await GetElapsedTimeFromLastQuery(); // force update the index. 
+        await Indexes.WaitForIndexingAsync(store, dbName);
         var lastQueryTime = await WaitAndAssertForLessThanAsync(() => Task.FromResult(index.GetLastQueryingTime()!.Value), index.LastIndexingTime!.Value, timeout: Timeout, interval: Interval);
         Assert.True(lastQueryTime < index.LastIndexingTime, $"{lastQueryTime} < {index.LastIndexingTime}"); // 
         
         // Wait that elapsed time will be increased.
         var val = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult((index.LastIndexingTime - index.GetLastQueryingTime())!.Value), elapsedOnInit, timeout: Timeout, interval: Interval);
         Assert.True(val > elapsedOnInit, $"{val} > {elapsedOnInit}");
+
+        async Task<TimeSpan> GetElapsedTimeFromLastQuery()
+        {
+            using var session = store.OpenAsyncSession(database: dbName);
+            await session.StoreAsync(new Orders.Order());
+            await session.SaveChangesAsync();
+            await Indexes.WaitForIndexingAsync(store, dbName);
+            return index.GetElapsedTimeFromLastQuery();
+        }
     }
 
     private static string DisableDatabaseToggleResultToString(DisableDatabaseToggleResult result) =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25018
### Additional description

Instead of waiting for timeout in the indexing loop to increase elapsed time from last query, we will push documents to indexing, which update the time as well.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
