### PR TITLE
RavenDB-24845 : AI Agent - support an array or a list in SetUserPrompt

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -22,7 +22,7 @@ internal class AiConversation : IAiConversationOperations
     private string _conversationId;
     private List<AiAgentActionRequest> _actionRequests;
     private readonly List<AiAgentActionResponse> _actionResponses = [];
-    private string _userPrompt;
+    private readonly List<ContentPart> _promptParts = new();
     private string _changeVector;
     public string ChangeVector => _changeVector;
 
@@ -94,8 +94,17 @@ internal class AiConversation : IAiConversationOperations
     public void SetUserPrompt(string userPrompt)
     {
         ValidationMethods.AssertNotNullOrEmpty(userPrompt, nameof(userPrompt));
+        _promptParts.Clear();
+        AddUserPrompt(userPrompt);
+    }
 
-        _userPrompt = userPrompt;
+    public void AddUserPrompt(params IEnumerable<string> prompts)
+    {
+        foreach (string prompt in prompts)
+        {
+            ValidationMethods.AssertNotNullOrEmpty(prompt, nameof(prompt));
+            _promptParts.Add(new TextPart(prompt));
+        }
     }
 
     public void Handle<TArgs>(string actionName, Func<TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError) where TArgs : class
@@ -224,7 +233,7 @@ internal class AiConversation : IAiConversationOperations
             // if this is null, it is the first time we call RunAsync, so we are going to the server to get the pending actions
             _actionRequests != null &&
             // otherwise, we already went to the server and have nothing new to tell it, so we are done
-            string.IsNullOrEmpty(_userPrompt) && _actionResponses.Count == 0)
+            _promptParts.Count == 0 && _actionResponses.Count == 0)
         {
             return new AiAnswer<TAnswer>
             {
@@ -232,7 +241,7 @@ internal class AiConversation : IAiConversationOperations
             };
         }
 
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _userPrompt, _actionResponses, _options, _changeVector, streamPropertyPath, streamedChunksCallback);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, _actionResponses, _options, _changeVector, streamPropertyPath, streamedChunksCallback);
 
         try
         {
@@ -255,7 +264,7 @@ internal class AiConversation : IAiConversationOperations
         finally
         {
             // clear the user prompt and tool responses after running the conversation
-            _userPrompt = null;
+            _promptParts.Clear();
             _actionResponses.Clear();
         }
     }

--- a/src/Raven.Client/Documents/AI/AiMessagePromptTypes.cs
+++ b/src/Raven.Client/Documents/AI/AiMessagePromptTypes.cs
@@ -1,12 +1,12 @@
 ﻿namespace Raven.Client.Documents.AI
 {
-    public class AiMessagePromptFields
+    internal class AiMessagePromptFields
     {
         public const string Text = "text";
         public const string Type = "type";
     }
 
-    public class AiMessagePromptTypes
+    internal class AiMessagePromptTypes
     {
         public const string Text = "text";
     }

--- a/src/Raven.Client/Documents/AI/AiMessagePromptTypes.cs
+++ b/src/Raven.Client/Documents/AI/AiMessagePromptTypes.cs
@@ -1,0 +1,13 @@
+﻿namespace Raven.Client.Documents.AI
+{
+    public class AiMessagePromptFields
+    {
+        public const string Text = "text";
+        public const string Type = "type";
+    }
+
+    public class AiMessagePromptTypes
+    {
+        public const string Text = "text";
+    }
+}

--- a/src/Raven.Client/Documents/AI/ContentPart.cs
+++ b/src/Raven.Client/Documents/AI/ContentPart.cs
@@ -1,0 +1,28 @@
+﻿using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.AI
+{
+    public abstract class ContentPart(string type)
+    {
+        public string Type { get; } = type;
+        public abstract DynamicJsonValue ToJson();
+    }
+
+    public sealed class TextPart : ContentPart
+    {
+        public string Text { get; set; }
+
+        public TextPart(string text) : base(AiMessagePromptTypes.Text)
+        {
+            this.Text = text;
+        }
+        public override DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [AiMessagePromptFields.Type] = this.Type,
+                [AiMessagePromptFields.Text] = this.Text
+            };
+        }
+    }
+}

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -202,6 +202,14 @@ public interface IAiConversationOperations
     void SetUserPrompt(string userPrompt);
 
     /// <summary>
+    /// Adds the next user prompt or prompts to send to the AI agent.
+    /// </summary>
+    /// <param name="userPrompt">
+    /// The text of the user’s message.
+    /// </param>
+    void AddUserPrompt(params IEnumerable<string> userPrompt);
+
+    /// <summary>
     /// This is called if the model invoked an action that has no register handler using
     /// <see cref="Handle"/> or <see cref="Receive"/>. If there is no event handler for
     /// this event and an unexpected action is raised by the model, and exception will

--- a/src/Raven.Client/Documents/Operations/AI/Agents/ConversionRequestBody.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/ConversionRequestBody.cs
@@ -8,15 +8,18 @@ namespace Raven.Client.Documents.Operations.AI.Agents;
 internal class ConversionRequestBody : IDynamicJson
 {
     public List<AiAgentActionResponse> ActionResponses { get; set; }
-    public string UserPrompt { get; set; }
+
+    public IEnumerable<ContentPart> UserPrompt { get; set; }
     public AiConversationCreationOptions CreationOptions { get; set; }
     public DynamicJsonValue ToJson()
     {
-        return new DynamicJsonValue
+        var json = new DynamicJsonValue
         {
             [nameof(ActionResponses)] = ActionResponses == null ? null : new DynamicJsonArray(ActionResponses.Select(r => r.ToJson())),
-            [nameof(UserPrompt)] = UserPrompt,
             [nameof(CreationOptions)] = (CreationOptions ?? new AiConversationCreationOptions()).ToJson()
         };
+        json[nameof(UserPrompt)] = UserPrompt == null ? null : new DynamicJsonArray(UserPrompt.Select(part => part.ToJson()));
+
+        return json;
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/RunConversationOperation.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Operations.AI.Agents;
 public class RunConversationOperation<TSchema> : IMaintenanceOperation<ConversationResult<TSchema>>
 {
     private readonly string _agentId;
-    private readonly string _userPrompt;
+    private readonly IEnumerable<ContentPart> _promptParts;
     private readonly AiConversationCreationOptions _options;
 
     private readonly string _conversationId;
@@ -31,17 +31,17 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
     public RunConversationOperation(
         string agentId,
         string conversationId,
-        string userPrompt,
+        List<ContentPart> promptParts,
         List<AiAgentActionResponse> actionResponses,
         AiConversationCreationOptions options,
-        string changeVector) : this(agentId, conversationId, userPrompt, actionResponses, options, changeVector, null, null)
+        string changeVector) : this(agentId, conversationId, promptParts, actionResponses, options, changeVector, null, null)
     {
     }
 
     public RunConversationOperation(
         string agentId,
         string conversationId,
-        string userPrompt,
+        IEnumerable<ContentPart> promptParts,
         List<AiAgentActionResponse> actionResponses,
         AiConversationCreationOptions options,
         string changeVector,
@@ -55,7 +55,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
 
         _agentId = agentId;
         _conversationId = conversationId;
-        _userPrompt = userPrompt;
+        _promptParts = promptParts;
         _changeVector = changeVector;
         _actionResponses = actionResponses;
         _options = options;
@@ -64,6 +64,19 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
         _streamedChunksCallback = streamedChunksCallback;
     }
 
+    [Obsolete("Use the constructor that accepts a List or an Array instead. This is for backward compatibility.", error: false)]
+    public RunConversationOperation(
+            string agentId,
+            string conversationId,
+            string userPrompt,
+            List<AiAgentActionResponse> actionResponses,
+            AiConversationCreationOptions options,
+            string changeVector,
+            string streamPropertyPath,
+            Func<string, Task> streamedChunksCallback)
+        : this(agentId, conversationId, new List<ContentPart> { new TextPart(userPrompt) }, actionResponses, options, changeVector, streamPropertyPath, streamedChunksCallback)
+    {
+    }
     public virtual RavenCommand<ConversationResult<TSchema>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
         return new RunConversationOperationCommand(this, conventions);
@@ -106,7 +119,7 @@ public class RunConversationOperation<TSchema> : IMaintenanceOperation<Conversat
             var body = new ConversionRequestBody
             {
                 ActionResponses = _parent._actionResponses,
-                UserPrompt = _parent._userPrompt,
+                UserPrompt = _parent._promptParts,
                 CreationOptions = _parent._options
             };
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         {
             var body = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "ai-agent", token);
             body.TryGet(nameof(ConversionRequestBody.ActionResponses), out BlittableJsonReaderArray actionResponses);
-            body.TryGet(nameof(ConversionRequestBody.UserPrompt), out string userPrompt);
+            body.TryGet(nameof(ConversionRequestBody.UserPrompt), out object userPrompt);
             body.TryGet(nameof(ConversionRequestBody.CreationOptions), out BlittableJsonReaderObject optionsBlittable);
 
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -73,7 +73,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
 
     public class AiAgentTestRequest
     {
-        public string UserPrompt;
+        public object UserPrompt;
         public BlittableJsonReaderObject CreationOptions;
         public AiAgentConfiguration Configuration;
         public BlittableJsonReaderArray ActionResponses;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -66,7 +66,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 };
             }
 
-            if (string.IsNullOrEmpty(_request.UserPrompt))
+            if (RequestBody.HasUserPrompt(_request.Content) == false)
             {
                 throw new InvalidOperationException(
                     $"Cannot start a new conversation '{_conversationId}' without a user prompt.");
@@ -445,7 +445,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
     private async Task<bool> TryHandleActionResponses(JsonOperationContext context)
     {
         var hasActionResponse = _request.ActionResponses is { Length: > 0 };
-        var hasUserPrompt = string.IsNullOrEmpty(_request.UserPrompt) == false;
+        var hasUserPrompt = RequestBody.HasUserPrompt(_request.Content);
 
         if (hasActionResponse && hasUserPrompt)
             throw new InvalidOperationException($"Cannot have a conversation '{_conversationId}' with open action calls and user prompt.");
@@ -482,12 +482,12 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             throw new InvalidOperationException($"Cannot have a conversation '{_conversationId}' without open action calls or user prompt.");
 
 
-        if (string.IsNullOrEmpty(_request.UserPrompt) == false)
+        if (RequestBody.HasUserPrompt(_request.Content))
         {
             _document.AddMessage(context, context.ReadObject(new DynamicJsonValue
             {
                 ["role"] = "user",
-                ["content"] = _request.UserPrompt
+                ["content"] = _request.Content
             }, "user/msg"), usage: null);
         }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/RequestBody.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/RequestBody.cs
@@ -9,15 +9,28 @@ namespace Raven.Server.Documents.Handlers.AI.Agents;
 public class RequestBody
 {
     public BlittableJsonReaderObject Parameters { get; set; }
-    public string UserPrompt { get; set; }
+    public object UserPrompt { private get; set; }
     public BlittableJsonReaderArray ActionResponses { get; set; }
     public AiConversationCreationOptions CreationOptions { get; set; }
 
     public List<AiAttachment> Attachments { get; set; }
 
+    public object Content
+    {
+        get
+        {
+            if (UserPrompt is BlittableJsonReaderArray array)
+            {
+                return array;
+            }
+
+            return UserPrompt?.ToString();
+        }
+    }
+
     public void ValidateForStart()
     {
-        if (string.IsNullOrEmpty(UserPrompt))
+        if (HasUserPrompt(UserPrompt)== false)
             throw new ArgumentException("User prompt is missing.");
 
         if (Parameters == null)
@@ -26,10 +39,40 @@ public class RequestBody
 
     public void ValidateForResume()
     {
-        if (string.IsNullOrEmpty(UserPrompt))
+        if (HasUserPrompt(UserPrompt) == false)
             throw new ArgumentException("User prompt is missing.");
 
         if (ActionResponses == null)
             throw new ArgumentException(nameof(ActionResponses));
+    }
+
+    public static bool HasUserPrompt(object content)
+    {
+        if (content == null)
+            return false;
+
+        switch (content)
+        {
+            case string promptAsString:
+                return string.IsNullOrEmpty(promptAsString) == false;
+
+            case BlittableJsonReaderArray arr:
+                if (arr.Length == 0)
+                    return false;
+
+                foreach (var part in arr)
+                {
+                    if (part is not BlittableJsonReaderObject obj)
+                    {
+                        return false;
+                    }
+
+                    if (obj.TryGet(AiMessagePromptTypes.Text, out string textValue) == false || string.IsNullOrEmpty(textValue))
+                        return false;
+                }
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/src/Raven.Studio/.storybook/storeDecorator.tsx
+++ b/src/Raven.Studio/.storybook/storeDecorator.tsx
@@ -56,4 +56,6 @@ function useTheme(theme: Theme) {
     themeLink.rel = "stylesheet";
     themeLink.href = stylesheetPrefix + fileName;
     document.head.insertBefore(themeLink, document.head.firstChild);
+
+    document.body.setAttribute("data-theme", theme);
 }

--- a/src/Raven.Studio/typescript/commands/database/aiAgents/runAiAgentCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/aiAgents/runAiAgentCommand.ts
@@ -2,10 +2,14 @@ import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
 import aiAgentsTypes = require("components/pages/database/aiHub/aiAgents/utils/aiAgentsTypes");
 
-class runAiAgentCommand extends commandBase {
+export interface RunAiAgentRequestDto extends Omit<Raven.Client.Documents.Operations.AI.Agents.ConversionRequestBody, "UserPrompt"> {
+    UserPrompt: string | { type: "text", text: string }[];
+}
+
+export default class runAiAgentCommand extends commandBase {
     constructor(
         private db: string,
-        private dto: Raven.Client.Documents.Operations.AI.Agents.ConversionRequestBody,
+        private dto: RunAiAgentRequestDto,
         private agentId: string,
         private conversationId: string,
         private changeVector: string
@@ -27,5 +31,3 @@ class runAiAgentCommand extends commandBase {
         );
     }
 }
-
-export = runAiAgentCommand;

--- a/src/Raven.Studio/typescript/components/common/Dropdown.scss
+++ b/src/Raven.Studio/typescript/components/common/Dropdown.scss
@@ -1,5 +1,5 @@
 .custom-dropdown-toggle {
     &.no-caret:after {
-        display: none;
+        display: none !important;
     }
 }

--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -40,6 +40,7 @@ type FormInputProps = Omit<OmitIndexSignature<RavenFormControlProps>, "addon"> &
         type: InputType;
         passwordPreview?: boolean;
         rows?: number | string;
+        isHideErrorMessage?: boolean;
     };
 
 export interface FormCheckboxesOption<T extends string | number = string> {
@@ -498,8 +499,19 @@ function FormInputGeneral<
     TFieldValues extends FieldValues = FieldValues,
     TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(props: FormElementProps<TFieldValues, TName> & Omit<FormInputProps, "size">) {
-    const { name, control, defaultValue, rules, shouldUnregister, children, type, addon, passwordPreview, ...rest } =
-        props;
+    const {
+        name,
+        control,
+        defaultValue,
+        rules,
+        shouldUnregister,
+        children,
+        type,
+        addon,
+        passwordPreview,
+        isHideErrorMessage,
+        ...rest
+    } = props;
 
     const {
         field: { onChange, onBlur, value, ref },
@@ -564,7 +576,7 @@ function FormInputGeneral<
                     </InputGroup>
                 </div>
             </div>
-            {error && <FormValidationMessage>{error.message}</FormValidationMessage>}
+            {!isHideErrorMessage && error && <FormValidationMessage>{error.message}</FormValidationMessage>}
         </>
     );
 }

--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -40,7 +40,6 @@ type FormInputProps = Omit<OmitIndexSignature<RavenFormControlProps>, "addon"> &
         type: InputType;
         passwordPreview?: boolean;
         rows?: number | string;
-        isHideErrorMessage?: boolean;
     };
 
 export interface FormCheckboxesOption<T extends string | number = string> {
@@ -499,19 +498,8 @@ function FormInputGeneral<
     TFieldValues extends FieldValues = FieldValues,
     TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(props: FormElementProps<TFieldValues, TName> & Omit<FormInputProps, "size">) {
-    const {
-        name,
-        control,
-        defaultValue,
-        rules,
-        shouldUnregister,
-        children,
-        type,
-        addon,
-        passwordPreview,
-        isHideErrorMessage,
-        ...rest
-    } = props;
+    const { name, control, defaultValue, rules, shouldUnregister, children, type, addon, passwordPreview, ...rest } =
+        props;
 
     const {
         field: { onChange, onBlur, value, ref },
@@ -576,7 +564,7 @@ function FormInputGeneral<
                     </InputGroup>
                 </div>
             </div>
-            {!isHideErrorMessage && error && <FormValidationMessage>{error.message}</FormValidationMessage>}
+            {error && <FormValidationMessage>{error.message}</FormValidationMessage>}
         </>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -22,8 +22,16 @@ import AiTokensUsagePopoverBody from "components/common/AiTokensUsagePopoverBody
 import AiAgentLinkedConversationsDropdown from "../partials/AiAgentLinkedConversationsDropdown";
 
 export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatAiAgentQueryParams>) {
-    const { handleSend, reloadForm, handleNewChat, chatForm, asyncGetDefaultValues, handleSubmit, runChat } =
-        useChatAiAgent(queryParams);
+    const {
+        handleSend,
+        reloadForm,
+        handleNewChat,
+        chatForm,
+        asyncGetDefaultValues,
+        handleSubmit,
+        runChat,
+        promptsFieldsArray,
+    } = useChatAiAgent(queryParams);
 
     const dispatch = useAppDispatch();
     const { appUrl } = useAppUrls();
@@ -116,6 +124,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
                                     handleSend={handleSend}
                                     runChat={runChat}
                                     isHistory={queryParams?.isHistory}
+                                    promptsFieldsArray={promptsFieldsArray}
                                 />
                             </form>
                         </FormProvider>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
@@ -9,7 +9,7 @@ import { useServices } from "components/hooks/useServices";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { useEffect } from "react";
 import { useAsyncCallback } from "react-async-hook";
-import { useForm, useWatch } from "react-hook-form";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { AiAgentToolCall } from "../../utils/aiAgentsTypes";
 import { ChatAiAgentFormData, chatAiAgentYupResolver } from "../utils/chatAiAgentValidation";
 
@@ -77,13 +77,13 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
         }
 
         return {
-            prompt: "",
+            prompts: [{ text: "" }],
             parameters: config.Parameters.map((x) => ({ name: x.Name, value: "" })),
             isEnableDocumentExpiration: !isDocumentExpirationEnabled,
             isDocumentExpireInCustomizeEnabled: false,
             persistenceConversationIdPrefix: "",
             persistenceExpiresInSeconds: TimeInSeconds.Day * 30,
-        };
+        } satisfies Required<ChatAiAgentFormData>;
     });
 
     const areParametersRequired = !window.location.href.includes("conversationId");
@@ -103,6 +103,11 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
 
     const { control, handleSubmit, setValue } = chatForm;
 
+    const promptsFieldsArray = useFieldArray({
+        control,
+        name: "prompts",
+    });
+
     const formValues = useWatch({
         control,
     });
@@ -117,7 +122,7 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
             })
         ).unwrap();
 
-        setValue("prompt", "");
+        setValue("prompts", [{ text: "" }]);
     };
 
     const handleSend = async () => {
@@ -144,6 +149,7 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
         dispatch(chatAiAgentActions.messagesSet([]));
         dispatch(chatAiAgentActions.documentSet(null));
         dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(false));
+        dispatch(chatAiAgentActions.activePromptIndexSet(0));
         chatForm.reset();
     };
 
@@ -155,6 +161,7 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
         handleSubmit,
         runChat,
         asyncGetDefaultValues,
+        promptsFieldsArray,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.scss
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.scss
@@ -2,19 +2,53 @@
 @use "Content/scss/colors";
 @use "Content/scss/sizes";
 
-.gradient-top {
-    border-radius: sizes.$border-radius-sm;
+.chat-ai-agent-bottom-section {
+    .prompt-wrapper {
+        position: relative;
+        padding: sizes.$gutter-xs;
+        border-radius: sizes.$border-radius;
+        border: 1px solid colors.$border-color-light-var;
+        background-color: colors.$input-bg-var;
+        z-index: 10;
+        box-shadow: 0px -10px 10px var(--bs-body-bg);
 
-    &::before {
-        content: "";
-        position: absolute;
-        top: -#{sizes.$gutter-sm};
-        left: 0;
-        right: 0;
-        height: 36px;
-        z-index: 4;
-        background: linear-gradient(0deg, var(--bs-body-bg) 0%, transparent 1000%);
-        filter: blur(sizes.$gutter-xxs);
-        margin: 0 -#{sizes.$gutter-sm};
+        .prompt-textarea {
+            z-index: 11;
+            border-radius: sizes.$border-radius;
+            field-sizing: content;
+            min-height: 60px;
+            max-height: 200px;
+            resize: none;
+            border: none !important;
+            box-shadow: none !important;
+            background-image: none !important;
+
+            &:focus {
+                border: none;
+                box-shadow: none;
+            }
+        }
+
+        .validation-message {
+            display: none;
+        }
+
+        .prompt-actions {
+            color: colors.$text-color-var;
+
+            .btn-link {
+                color: colors.$text-color-var;
+            }
+        }
+
+        body[data-theme="blue"] & {
+            .prompt-actions {
+                color: colors.$gray;
+
+                .btn-link {
+                    color: colors.$gray;
+                }
+            }
+        }
     }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
@@ -1,11 +1,10 @@
 import classNames from "classnames";
 import AceEditor from "components/common/ace/AceEditor";
-import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormInput } from "components/common/Form";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { useRef, useEffect } from "react";
 import Spinner from "react-bootstrap/Spinner";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useFormContext, useWatch, UseFieldArrayReturn } from "react-hook-form";
 import AiAgentMessages from "../../partials/AiAgentMessages";
 import AiAgentParametersField from "../../partials/AiAgentParametersField";
 import { AiAgentToolCall } from "../../utils/aiAgentsTypes";
@@ -17,15 +16,23 @@ import Button from "react-bootstrap/Button";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppUrls } from "components/hooks/useAppUrls";
 import "./ChatAiAgentFormBody.scss";
+import ChatAiAgentPromptActions from "./ChatAiAgentPromptActions";
 
 interface ChatAiAgentFormBodyProps {
     height: number;
     handleSend: () => Promise<void>;
     runChat: (toolCallParameters?: AiAgentToolCall[]) => Promise<void>;
     isHistory: boolean;
+    promptsFieldsArray: UseFieldArrayReturn<ChatAiAgentFormData, "prompts", "id">;
 }
 
-export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHistory }: ChatAiAgentFormBodyProps) {
+export default function ChatAiAgentFormBody({
+    height,
+    handleSend,
+    runChat,
+    isHistory,
+    promptsFieldsArray,
+}: ChatAiAgentFormBodyProps) {
     const dispatch = useAppDispatch();
 
     const messagesPanelRef = useRef<HTMLDivElement>(null);
@@ -41,6 +48,7 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
     const isWaitingForActionToolSubmit = useAppSelector(chatAiAgentSelectors.isWaitingForActionToolSubmit);
     const isDocumentDeleted = useAppSelector(chatAiAgentSelectors.isDocumentDeleted);
     const isDocumentChanged = useAppSelector(chatAiAgentSelectors.isDocumentChanged);
+    const activePromptIndex = useAppSelector(chatAiAgentSelectors.activePromptIndex);
 
     const { appUrl } = useAppUrls();
 
@@ -128,7 +136,7 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
                 </div>
             </div>
             {!isHistory && (
-                <div className="d-flex justify-content-center ps-2 pe-3 pb-4">
+                <div className="d-flex justify-content-center pb-4">
                     <div className="w-100" style={{ maxWidth: "800px" }}>
                         {isDocumentChanged && !isDocumentDeleted && (
                             <RichAlert variant="warning" className="p-1 mb-2">
@@ -156,10 +164,10 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
                                 type="textarea"
                                 as="textarea"
                                 control={control}
-                                name="prompt"
+                                name={`prompts.${activePromptIndex}.text`}
                                 placeholder="Ask the agent anything"
                                 className="rounded-2"
-                                rows={3}
+                                rows={4}
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter" && !e.shiftKey) {
                                         e.preventDefault();
@@ -168,18 +176,14 @@ export default function ChatAiAgentFormBody({ height, handleSend, runChat, isHis
                                 }}
                                 disabled={isPromptDisabled}
                                 style={{ zIndex: 5 }}
+                                key={promptsFieldsArray.fields[activePromptIndex].id}
+                                isHideErrorMessage
                             />
-                            {formValues.prompt && (
-                                <ButtonWithSpinner
-                                    type="submit"
-                                    variant="secondary"
-                                    icon="arrow-up"
-                                    isSpinning={isLoading}
-                                    disabled={isPromptDisabled}
-                                    className="position-absolute rounded-pill"
-                                    style={{ right: "10px", bottom: "10px", zIndex: 5 }}
-                                />
-                            )}
+                            <ChatAiAgentPromptActions
+                                promptsFieldsArray={promptsFieldsArray}
+                                isPromptDisabled={isPromptDisabled}
+                                isLoading={isLoading}
+                            />
                         </div>
                     </div>
                 </div>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
@@ -52,7 +52,7 @@ export default function ChatAiAgentFormBody({
 
     const { appUrl } = useAppUrls();
 
-    const { control, handleSubmit } = useFormContext<ChatAiAgentFormData>();
+    const { control, handleSubmit, formState } = useFormContext<ChatAiAgentFormData>();
 
     const formValues = useWatch({
         control,
@@ -84,6 +84,7 @@ export default function ChatAiAgentFormBody({
     };
 
     const isPromptDisabled = isLoading || isWaitingForActionToolSubmit || isDocumentDeleted || isDocumentChanged;
+    const hasPromptErrors = formState.errors.prompts?.length > 0;
 
     return (
         <>
@@ -136,7 +137,7 @@ export default function ChatAiAgentFormBody({
                 </div>
             </div>
             {!isHistory && (
-                <div className="d-flex justify-content-center pb-4">
+                <div className="d-flex justify-content-center pb-4 chat-ai-agent-bottom-section">
                     <div className="w-100" style={{ maxWidth: "800px" }}>
                         {isDocumentChanged && !isDocumentDeleted && (
                             <RichAlert variant="warning" className="p-1 mb-2">
@@ -159,15 +160,18 @@ export default function ChatAiAgentFormBody({
                                 .
                             </RichAlert>
                         )}
-                        <div className="position-relative gradient-top">
+                        <div
+                            className={classNames("prompt-wrapper", {
+                                "border-danger": hasPromptErrors,
+                            })}
+                        >
                             <FormInput
                                 type="textarea"
                                 as="textarea"
                                 control={control}
                                 name={`prompts.${activePromptIndex}.text`}
                                 placeholder="Ask the agent anything"
-                                className="rounded-2"
-                                rows={4}
+                                className="prompt-textarea"
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter" && !e.shiftKey) {
                                         e.preventDefault();
@@ -175,14 +179,13 @@ export default function ChatAiAgentFormBody({
                                     }
                                 }}
                                 disabled={isPromptDisabled}
-                                style={{ zIndex: 5 }}
                                 key={promptsFieldsArray.fields[activePromptIndex].id}
-                                isHideErrorMessage
                             />
                             <ChatAiAgentPromptActions
                                 promptsFieldsArray={promptsFieldsArray}
                                 isPromptDisabled={isPromptDisabled}
                                 isLoading={isLoading}
+                                hasPromptErrors={hasPromptErrors}
                             />
                         </div>
                     </div>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentPromptActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentPromptActions.tsx
@@ -1,0 +1,113 @@
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { UseFieldArrayReturn, useFormContext } from "react-hook-form";
+import { ChatAiAgentFormData } from "../utils/chatAiAgentValidation";
+import Button from "react-bootstrap/Button";
+import "./ChatAiAgentFormBody.scss";
+import { Icon } from "components/common/Icon";
+import Dropdown from "react-bootstrap/Dropdown";
+import { CustomDropdownToggle } from "components/common/Dropdown";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { useAppDispatch, useAppSelector } from "components/store";
+import { chatAiAgentActions, chatAiAgentSelectors } from "../store/chatAiAgentSlice";
+
+interface ChatAiAgentPromptActionsProps {
+    promptsFieldsArray: UseFieldArrayReturn<ChatAiAgentFormData, "prompts", "id">;
+    isPromptDisabled: boolean;
+    isLoading: boolean;
+}
+
+export default function ChatAiAgentPromptActions({
+    promptsFieldsArray,
+    isPromptDisabled,
+    isLoading,
+}: ChatAiAgentPromptActionsProps) {
+    const dispatch = useAppDispatch();
+    const { formState } = useFormContext<ChatAiAgentFormData>();
+    const activePromptIndex = useAppSelector(chatAiAgentSelectors.activePromptIndex);
+
+    const setActivePromptIndex = (index: number) => {
+        dispatch(chatAiAgentActions.activePromptIndexSet(index));
+    };
+
+    const promptsErrors = formState.errors.prompts;
+    const promptsCount = promptsFieldsArray.fields.length;
+
+    return (
+        <div className="position-absolute hstack gap-1" style={{ right: "10px", bottom: "10px", zIndex: 10 }}>
+            {promptsErrors?.length > 0 && (
+                <PopoverWithHoverWrapper message={promptsCount > 1 ? "Prompts are required" : "Prompt is required"}>
+                    <Icon icon="warning" color="danger" margin="m-0" />
+                </PopoverWithHoverWrapper>
+            )}
+            {promptsCount > 1 && (
+                <div className="hstack">
+                    <Button
+                        variant="link"
+                        onClick={() => setActivePromptIndex(activePromptIndex - 1)}
+                        disabled={activePromptIndex === 0}
+                        className="text-reset ps-0"
+                    >
+                        <Icon icon="chevron-left" margin="m-0" />
+                    </Button>
+                    <span>
+                        {activePromptIndex + 1} of {promptsCount}
+                    </span>
+                    <Button
+                        variant="link"
+                        onClick={() => setActivePromptIndex(activePromptIndex + 1)}
+                        disabled={activePromptIndex === promptsCount - 1}
+                        className="text-reset pe-0"
+                    >
+                        <Icon icon="chevron-right" margin="m-0" />
+                    </Button>
+                </div>
+            )}
+            <Dropdown>
+                <Dropdown.Toggle
+                    as={CustomDropdownToggle}
+                    isCaretHidden
+                    variant="link"
+                    className="text-reset"
+                    disabled={isPromptDisabled}
+                >
+                    <Icon icon="more" margin="m-0" />
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+                    <Dropdown.Item
+                        title="Add prompt"
+                        onClick={() => {
+                            setActivePromptIndex(promptsCount);
+                            promptsFieldsArray.append({ text: "" });
+                        }}
+                    >
+                        <Icon icon="plus" />
+                        <span>Add another prompt</span>
+                    </Dropdown.Item>
+                    {promptsCount > 1 && (
+                        <Dropdown.Item
+                            title="Remove prompt"
+                            onClick={() => {
+                                if (activePromptIndex !== 0) {
+                                    setActivePromptIndex(activePromptIndex - 1);
+                                }
+
+                                promptsFieldsArray.remove(activePromptIndex);
+                            }}
+                        >
+                            <Icon icon="trash" />
+                            <span>Remove prompt</span>
+                        </Dropdown.Item>
+                    )}
+                </Dropdown.Menu>
+            </Dropdown>
+            <ButtonWithSpinner
+                type="submit"
+                variant="secondary"
+                icon="arrow-up"
+                isSpinning={isLoading}
+                disabled={isPromptDisabled}
+                className="rounded-pill"
+            />
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentPromptActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentPromptActions.tsx
@@ -1,5 +1,5 @@
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
-import { UseFieldArrayReturn, useFormContext } from "react-hook-form";
+import { UseFieldArrayReturn } from "react-hook-form";
 import { ChatAiAgentFormData } from "../utils/chatAiAgentValidation";
 import Button from "react-bootstrap/Button";
 import "./ChatAiAgentFormBody.scss";
@@ -14,27 +14,27 @@ interface ChatAiAgentPromptActionsProps {
     promptsFieldsArray: UseFieldArrayReturn<ChatAiAgentFormData, "prompts", "id">;
     isPromptDisabled: boolean;
     isLoading: boolean;
+    hasPromptErrors: boolean;
 }
 
 export default function ChatAiAgentPromptActions({
     promptsFieldsArray,
     isPromptDisabled,
     isLoading,
+    hasPromptErrors,
 }: ChatAiAgentPromptActionsProps) {
     const dispatch = useAppDispatch();
-    const { formState } = useFormContext<ChatAiAgentFormData>();
     const activePromptIndex = useAppSelector(chatAiAgentSelectors.activePromptIndex);
 
     const setActivePromptIndex = (index: number) => {
         dispatch(chatAiAgentActions.activePromptIndexSet(index));
     };
 
-    const promptsErrors = formState.errors.prompts;
     const promptsCount = promptsFieldsArray.fields.length;
 
     return (
-        <div className="position-absolute hstack gap-1" style={{ right: "10px", bottom: "10px", zIndex: 10 }}>
-            {promptsErrors?.length > 0 && (
+        <div className="hstack gap-1 justify-content-end prompt-actions">
+            {hasPromptErrors && (
                 <PopoverWithHoverWrapper message={promptsCount > 1 ? "Prompts are required" : "Prompt is required"}>
                     <Icon icon="warning" color="danger" margin="m-0" />
                 </PopoverWithHoverWrapper>
@@ -45,7 +45,7 @@ export default function ChatAiAgentPromptActions({
                         variant="link"
                         onClick={() => setActivePromptIndex(activePromptIndex - 1)}
                         disabled={activePromptIndex === 0}
-                        className="text-reset ps-0"
+                        className="ps-0"
                     >
                         <Icon icon="chevron-left" margin="m-0" />
                     </Button>
@@ -56,20 +56,14 @@ export default function ChatAiAgentPromptActions({
                         variant="link"
                         onClick={() => setActivePromptIndex(activePromptIndex + 1)}
                         disabled={activePromptIndex === promptsCount - 1}
-                        className="text-reset pe-0"
+                        className="pe-0"
                     >
                         <Icon icon="chevron-right" margin="m-0" />
                     </Button>
                 </div>
             )}
             <Dropdown>
-                <Dropdown.Toggle
-                    as={CustomDropdownToggle}
-                    isCaretHidden
-                    variant="link"
-                    className="text-reset"
-                    disabled={isPromptDisabled}
-                >
+                <Dropdown.Toggle as={CustomDropdownToggle} isCaretHidden variant="link" disabled={isPromptDisabled}>
                     <Icon icon="more" margin="m-0" />
                 </Dropdown.Toggle>
                 <Dropdown.Menu>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -7,6 +7,7 @@ import { createSuccessState, createIdleState, createFailureState } from "compone
 import document from "models/database/documents/document";
 import { aiAgentsUtils } from "../../utils/aiAgentsUtils";
 import { ChatAiAgentFormData } from "../utils/chatAiAgentValidation";
+import { RunAiAgentRequestDto } from "commands/database/aiAgents/runAiAgentCommand";
 
 interface EditAiAgentState {
     config: loadableData<Raven.Client.Documents.Operations.AI.Agents.AiAgentConfiguration>;
@@ -20,6 +21,7 @@ interface EditAiAgentState {
     isDocumentExpirationEnabled: loadableData<boolean>;
     isDocumentDeleted: boolean;
     isDocumentChanged: boolean;
+    activePromptIndex: number;
 }
 
 const initialState: EditAiAgentState = {
@@ -34,6 +36,7 @@ const initialState: EditAiAgentState = {
     isDocumentExpirationEnabled: createIdleState(),
     isDocumentDeleted: false,
     isDocumentChanged: false,
+    activePromptIndex: 0,
 };
 
 export const chatAiAgentSlice = createSlice({
@@ -63,6 +66,9 @@ export const chatAiAgentSlice = createSlice({
         },
         isDocumentChangedSet: (state, action: PayloadAction<boolean>) => {
             state.isDocumentChanged = action.payload;
+        },
+        activePromptIndexSet: (state, action: PayloadAction<number>) => {
+            state.activePromptIndex = action.payload;
         },
         reset: () => initialState,
     },
@@ -157,10 +163,11 @@ const runChat = createAsyncThunk(
         const conversationId = state.chatAiAgent.conversationId;
         const config = state.chatAiAgent.config;
         const changeVector = state.chatAiAgent.document.data?.["@metadata"]?.["@change-vector"] ?? "";
+
         const result = await services.aiAgentService.runAiAgent(
             databaseName,
             {
-                UserPrompt: toolCallParameters?.length > 0 ? null : formValues.prompt,
+                UserPrompt: getUserPrompt(toolCallParameters?.length ?? 0, formValues.prompts),
                 ActionResponses: toolCallParameters?.map((x) => ({
                     ToolId: x.id,
                     Content: x.arguments,
@@ -181,10 +188,30 @@ const runChat = createAsyncThunk(
             conversationId != null ? conversationId : formValues.persistenceConversationIdPrefix,
             changeVector
         );
+        dispatch(chatAiAgentActions.activePromptIndexSet(0));
         dispatch(chatAiAgentActions.conversationIdSet(result.ConversationId));
         await dispatch(chatAiAgentActions.getDocument({ databaseName, id: result.ConversationId })).unwrap();
     }
 );
+
+function getUserPrompt(
+    toolCallParametersCount: number,
+    prompts: ChatAiAgentFormData["prompts"]
+): RunAiAgentRequestDto["UserPrompt"] {
+    if (toolCallParametersCount > 0) {
+        return null;
+    }
+
+    if (!prompts?.length) {
+        throw new Error("Prompt is required");
+    }
+
+    if (prompts.length > 1) {
+        return prompts.map((x) => ({ type: "text", text: x.text }));
+    }
+
+    return prompts[0].text;
+}
 
 const getIsDocumentExpirationEnabled = createAsyncThunk(
     chatAiAgentSlice.name + "/getIsDocumentExpirationEnabled",
@@ -221,4 +248,5 @@ export const chatAiAgentSelectors = {
     isDocumentExpirationEnabled: (state: RootState) => state.chatAiAgent.isDocumentExpirationEnabled,
     isDocumentDeleted: (state: RootState) => state.chatAiAgent.isDocumentDeleted,
     isDocumentChanged: (state: RootState) => state.chatAiAgent.isDocumentChanged,
+    activePromptIndex: (state: RootState) => state.chatAiAgent.activePromptIndex,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/utils/chatAiAgentValidation.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/utils/chatAiAgentValidation.tsx
@@ -2,7 +2,11 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
 const schema = yup.object({
-    prompt: yup.string().nullable().required(),
+    prompts: yup.array().of(
+        yup.object({
+            text: yup.string().nullable().required(),
+        })
+    ),
     parameters: yup.array().of(
         yup.object({
             name: yup.string().nullable(),

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -201,7 +201,20 @@ interface UserMessageProps {
 }
 
 function UserMessage({ message, toolQueries, toolActions }: UserMessageProps) {
-    const isMessageWithParameters = message.content.startsWith("AI Agent Parameters:");
+    const getMessageContent = (): string | { type: "text"; text: string }[] => {
+        try {
+            return JSON.parse(message.content);
+        } catch {
+            return message.content;
+        }
+    };
+
+    const messageContent = getMessageContent();
+
+    const isContentString = typeof messageContent === "string";
+    const isContentArray = Array.isArray(messageContent);
+
+    const isMessageWithParameters = isContentString && messageContent.startsWith("AI Agent Parameters:");
 
     if (isMessageWithParameters) {
         return null;
@@ -216,7 +229,19 @@ function UserMessage({ message, toolQueries, toolActions }: UserMessageProps) {
                     style={{ maxWidth: "75%" }}
                 >
                     <div className="overflow-auto" style={{ maxHeight: "200px", whiteSpace: "pre-wrap" }}>
-                        {message.content}
+                        {isContentString && messageContent}
+                        {isContentArray && (
+                            <div className="vstack gap-2 align-items-start">
+                                {messageContent.map((x, idx) => (
+                                    <div key={idx} className="vstack gap-1 align-items-start">
+                                        <Badge bg="primary" pill style={{ fontSize: "12px" }}>
+                                            Prompt #{idx + 1}
+                                        </Badge>
+                                        <div className="text-start">{x.text}</div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                     </div>
                     {message.toolCalls?.length > 0 && (
                         <div className="vstack gap-2">

--- a/src/Raven.Studio/typescript/viewmodels/shell/chooseTheme.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell/chooseTheme.ts
@@ -32,6 +32,7 @@ class chooseTheme extends dialogViewModelBase {
     useTheme(theme: string) {
         localStorage.setItem(chooseTheme.themeLocalStorageKey, theme);
         this.updateStylesheet(chooseTheme.themeToStylesheet[theme]);
+        document.body.setAttribute("data-theme", theme);
         this.close();
     }
     

--- a/src/Raven.Studio/wwwroot/index.html
+++ b/src/Raven.Studio/wwwroot/index.html
@@ -138,6 +138,37 @@
                 }
             }
         </style>
+        <script type="text/javascript">
+            if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+                var msViewportStyle = document.createElement("style");
+                var mq = "@@-ms-viewport{width:auto!important}";
+                msViewportStyle.appendChild(document.createTextNode(mq));
+                document.getElementsByTagName("head")[0].appendChild(msViewportStyle);
+            }
+        </script>
+    </head>
+    <body class="loading-active">
+    
+        <div class="splash-screen">
+            <div class="spinner-box">
+                <div class="orbit orbit-1">
+                    <i class="splash-screen-icon-raven"></i>
+                </div>
+                <div class="orbit orbit-2">
+                    <i class="orbit-icon"></i>
+                    <i class="orbit-icon orbit-icon-2-2"></i>
+                </div>
+                <div class="orbit orbit-3">
+                    <i class="orbit-icon"></i>
+                    <i class="orbit-icon orbit-icon-3-2"></i>
+                </div>
+            </div>
+        </div>
+        
+        <div id="applicationHost"></div>
+        <div id="bs5-modal" class="bs5"></div>
+
+        <iframe id="downloadFrame" style="display: none" name="hidden-form"></iframe>
 
         <script type="text/javascript">
             var themeToCss = {
@@ -194,39 +225,9 @@
             
             head.appendChild(bs5link);
             head.appendChild(link);
-        </script>
 
-        <script type="text/javascript">
-            if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
-                var msViewportStyle = document.createElement("style");
-                var mq = "@@-ms-viewport{width:auto!important}";
-                msViewportStyle.appendChild(document.createTextNode(mq));
-                document.getElementsByTagName("head")[0].appendChild(msViewportStyle);
-            }
+            document.body.setAttribute("data-theme", themeToUse);
         </script>
-    </head>
-    <body class="loading-active">
-    
-        <div class="splash-screen">
-            <div class="spinner-box">
-                <div class="orbit orbit-1">
-                    <i class="splash-screen-icon-raven"></i>
-                </div>
-                <div class="orbit orbit-2">
-                    <i class="orbit-icon"></i>
-                    <i class="orbit-icon orbit-icon-2-2"></i>
-                </div>
-                <div class="orbit orbit-3">
-                    <i class="orbit-icon"></i>
-                    <i class="orbit-icon orbit-icon-3-2"></i>
-                </div>
-            </div>
-        </div>
-        
-        <div id="applicationHost"></div>
-        <div id="bs5-modal" class="bs5"></div>
-
-        <iframe id="downloadFrame" style="display: none" name="hidden-form"></iframe>
 
         <!-- splash screen -->
         <script type="text/javascript">

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
@@ -46,7 +47,7 @@ public class RavenDB_24407 : RavenTestBase
         public string Role { get; set; }
 
         [JsonProperty("content")]
-        public string Content { get; set; }
+        public JToken Content { get; set; }
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -92,7 +93,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             using (var session = store.OpenAsyncSession())
             {
                 var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
-                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content.ToString()); // query results
                 Assert.Equal(1, toolCallAnswer.Count);
                 Assert.Equal("Aviv", toolCallAnswer.FirstOrDefault()?.Author);
             }
@@ -150,7 +151,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             using (var session = store.OpenAsyncSession())
             {
                 var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
-                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content.ToString()); // query results
                 Assert.Equal(1, toolCallAnswer.Count);
                 Assert.Equal("Shahar", toolCallAnswer.FirstOrDefault()?.Author);
             }
@@ -208,7 +209,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             using (var session = store.OpenAsyncSession())
             {
                 var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
-                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content.ToString()); // query results
                 Assert.Equal(1, toolCallAnswer.Count);
                 Assert.Equal("Shahar", toolCallAnswer.FirstOrDefault()?.Author);
             }
@@ -265,7 +266,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             using (var session = store.OpenAsyncSession())
             {
                 var messages = (await session.LoadAsync<Chat>(chat.Id)).Messages;
-                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content); // query results
+                var toolCallAnswer = JsonConvert.DeserializeObject<List<Question>>(messages[4].Content.ToString()); // query results
                 Assert.Equal(1, toolCallAnswer.Count);
                 Assert.Equal("Karmel", toolCallAnswer.FirstOrDefault()?.Author);
             }
@@ -282,7 +283,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             public string Role { get; set; }
 
             [JsonPropertyName("content")]
-            public string Content { get; set; }
+            public JToken Content { get; set; }
 
             [JsonPropertyName("date")]
             public DateTime Date { get; set; }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24845.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24845.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_24845 : RavenTestBase
+    {
+        public RavenDB_24845(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class OutputSchema
+        {
+            public string Answer { get; set; } = "your answer";
+            public static readonly OutputSchema Instance = new();
+        }
+        private class ConversationTestDto
+        {
+            public List<MessageDto> Messages { get; set; }
+        }
+
+        private class MessageDto
+        {
+            public string Role { get; set; }
+
+            public JToken Content { get; set; }
+        }
+
+        public string[] ExpectedStrings = new[] { "single string", "second string", "third string" };
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithSingleString(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            chat.SetUserPrompt("single string");
+            var result = await chat.RunAsync<OutputSchema>();
+            
+            Assert.Equal(AiConversationResult.Done, result.Status);
+            using (var session = store.OpenAsyncSession())
+            {
+                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
+                Assert.NotNull(conversationDoc);
+                
+                var lastMessage = conversationDoc.Messages.Last(m => m.Role =="user");
+                Assert.Equal("user", lastMessage.Role);
+
+                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                Assert.Single(contentArr);
+                var firstPart = contentArr[0];
+                Assert.Equal("text", firstPart["type"]?.ToString());
+                Assert.Equal("single string", firstPart["text"]?.ToString());
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithEmptyString(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            var e1 = Assert.Throws<ArgumentException>(() => chat.SetUserPrompt(string.Empty));
+            Assert.Contains("cannot be null or empty", e1.Message);
+            var e2 = Assert.Throws<ArgumentException>(() => chat.AddUserPrompt(string.Empty));
+            Assert.Contains("cannot be null or empty", e2.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithMultipleStrings(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            chat.AddUserPrompt("single string", "second string", "third string");
+            var result = await chat.RunAsync<OutputSchema>();
+            Assert.Equal(AiConversationResult.Done, result.Status);
+            using (var session = store.OpenAsyncSession())
+            {
+                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
+                Assert.NotNull(conversationDoc);
+
+                var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                Assert.Equal("user", lastMessage.Role);
+
+                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                Assert.Equal(3, contentArr.Count);
+
+                for (int i = 0; i < contentArr.Count; i++)
+                {
+                    var part = contentArr[i];
+                    Assert.Equal("text", part["type"]?.ToString());
+                    Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithMultipleStringsAndNull(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            var e = Assert.Throws<ArgumentNullException>(() => chat.AddUserPrompt("single string", null, "third string"));
+            Assert.Contains("Value cannot be null.", e.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithMultipleStringsAndEmptyString(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            var e = Assert.Throws<ArgumentException>(() => chat.AddUserPrompt("single string", "", "third string"));
+            Assert.Contains("cannot be null or empty", e.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithEmptyArray(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            chat.AddUserPrompt(Array.Empty<string>());
+            var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<OutputSchema>());
+            Assert.Contains("without a user prompt.", e.InnerException?.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithStringArray(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            chat.AddUserPrompt(ExpectedStrings);
+            var result = await chat.RunAsync<OutputSchema>();
+
+            Assert.Equal(AiConversationResult.Done, result.Status);
+            using (var session = store.OpenAsyncSession())
+            {
+                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
+                Assert.NotNull(conversationDoc);
+
+                var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                Assert.Equal("user", lastMessage.Role);
+
+                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                Assert.Equal(3, contentArr.Count);
+                for (int i = 0; i < contentArr.Count; i++)
+                {
+                    var part = contentArr[i];
+                    Assert.Equal("text", part["type"]?.ToString());
+                    Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithEmptyList(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            chat.AddUserPrompt(new List<string>());
+            var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<OutputSchema>());
+            Assert.Contains("without a user prompt.", e.InnerException?.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSetUserPromptWithStringList(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
+            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
+            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            var list = ExpectedStrings.ToList();
+            chat.AddUserPrompt(list);
+            var result = await chat.RunAsync<OutputSchema>();
+            
+            Assert.Equal(AiConversationResult.Done, result.Status);
+            using (var session = store.OpenAsyncSession())
+            {
+                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
+                Assert.NotNull(conversationDoc);
+
+                var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                Assert.Equal("user", lastMessage.Role);
+
+                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                Assert.Equal(3, contentArr.Count);
+                for (int i = 0; i < contentArr.Count; i++)
+                {
+                    var part = contentArr[i];
+                    Assert.Equal("text", part["type"]?.ToString());
+                    Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24845/AI-Agent-support-arrays-lists-in-setUserPrompt

### Additional description

The Ai Agent `SetUserPrompt` is now supporting Arrays and Lists.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
