### PR TITLE
RavenDB-25101 fix rollup when segment edge align with the aggregation

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -889,7 +889,7 @@ namespace Raven.Server.Documents.TimeSeries
                     // if the range it cover needs to be broken up to multiple ranges.
                     // For example, if the segment covers 3 days, but we have group by 1 hour,
                     // we still have to deal with the individual values
-                    if (it.Segment.End > rangeSpec.End || it.Segment.Summary.Version.ContainsLastValueDuplicate)
+                    if (it.Segment.End >= rangeSpec.End || it.Segment.Summary.Version.ContainsLastValueDuplicate)
                     {
                         AggregateIndividualItems(it.Segment.Values);
                     }

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_25101.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_25101.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.TimeSeries.Issues
+{
+    public class RavenDB_25101 : RavenTestBase
+    {
+        public RavenDB_25101(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries)]
+        public async Task CanExecuteRollupOnSegmentBoundary()
+        {
+            var rand = new Random(1337);
+            using (var store = GetDocumentStore())
+            {
+                var p1 = new TimeSeriesPolicy("ByMinute", TimeValue.FromMinutes(1));
+                var p2 = new TimeSeriesPolicy("By5Minute", TimeValue.FromMinutes(5));
+
+                var config = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        ["Users"] = new TimeSeriesCollectionConfiguration
+                        {
+                            Policies = new List<TimeSeriesPolicy>
+                            {
+                                p1, p2
+                            }
+                        },
+                    }
+                };
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+
+                var baseline = RavenTestHelper.UtcToday.AddDays(-100);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/karmel");
+
+                    for (int i = 0; i < 16; i++)
+                    {
+                        session.TimeSeriesFor("users/karmel", "Heartrate")
+                            .Append(baseline.AddMinutes(i), [rand.Next(), rand.Next(), rand.Next(), rand.Next(), rand.Next()], "watches/fitbit");
+                    }
+
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store.Database);
+                await database.TimeSeriesPolicyRunner.RunRollups();
+
+                using (var session = store.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/karmel", "Heartrate").Get().ToList();
+                    var tsSeconds = (int)(ts.Last().Timestamp - ts.First().Timestamp).TotalSeconds;
+
+                    var ts1 = session.TimeSeriesFor("users/karmel", p1.GetTimeSeriesName("Heartrate")).Get().ToList();
+                    var ts1Seconds = (int)(ts1.Last().Timestamp - ts1.First().Timestamp).TotalSeconds;
+
+                    var ts2 = session.TimeSeriesFor("users/karmel", p2.GetTimeSeriesName("Heartrate")).Get().ToList();
+                    var ts2Seconds = (int)(ts2.Last().Timestamp - ts2.First().Timestamp).TotalSeconds;
+
+                    Assert.Equal(ts1Seconds, tsSeconds);
+                    Assert.Equal(ts2Seconds, tsSeconds);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25101

### Additional description

There was an edge case that we missed a rollup entry, if the end of the source segment was exactly at the time of the aggregation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
