### PR TITLE
RavenDB-25111 ReadResult as a struct

### DIFF
--- a/bench/Voron.Benchmark/BTree/BTreeFillRandom.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeFillRandom.cs
@@ -27,10 +27,9 @@ namespace Voron.Benchmark.BTree
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static BTreeFillRandom()
         {
@@ -51,7 +50,7 @@ namespace Voron.Benchmark.BTree
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _pairs = new List<Tuple<Slice, Slice>>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/BTree/BTreeFillSequential.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeFillSequential.cs
@@ -27,10 +27,9 @@ namespace Voron.Benchmark.BTree
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static BTreeFillSequential()
         {
@@ -51,7 +50,7 @@ namespace Voron.Benchmark.BTree
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions*NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             // This will sort just the KEYS
             totalPairs.Sort((x, y) => SliceComparer.Compare(x.Item1, y.Item1));

--- a/bench/Voron.Benchmark/BTree/BTreeInsertRandom.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeInsertRandom.cs
@@ -45,10 +45,9 @@ namespace Voron.Benchmark.BTree
         public double GenerationDeletionProbability { get; set; } = 0.1;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static BTreeInsertRandom()
         {
@@ -60,8 +59,6 @@ namespace Voron.Benchmark.BTree
         {
             base.Setup();
 
-            var randomSeed = RandomSeed == -1 ? null : RandomSeed as int?;
-
             Utils.GenerateWornoutTree(
                 Env,
                 TreeNameSlice,
@@ -69,12 +66,12 @@ namespace Voron.Benchmark.BTree
                 GenerationBatchSize,
                 KeyLength,
                 GenerationDeletionProbability,
-                randomSeed);
+                RandomSeed);
 
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                randomSeed);
+                RandomSeed * 13);
 
             _pairs = new List<Tuple<Slice, Slice>>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/BTree/BTreeReadAndIterate.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeReadAndIterate.cs
@@ -48,10 +48,9 @@ namespace Voron.Benchmark.BTree
         public double GenerationDeletionProbability { get; set; } = 0.1;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 13;
 
         [Params(1, 2)]
         public int ReadParallelism { get; set; } = 1;
@@ -68,7 +67,6 @@ namespace Voron.Benchmark.BTree
         public override void Setup()
         {
             base.Setup();
-            var randomSeed = RandomSeed == -1 ? null : RandomSeed as int?;
 
             var treeKeys = Utils.GenerateWornoutTree(
                 Env,
@@ -77,7 +75,7 @@ namespace Voron.Benchmark.BTree
                 GenerationBatchSize,
                 KeyLength,
                 GenerationDeletionProbability,
-                randomSeed);
+                RandomSeed);
 
             // Distribute work amount, each one of the buckets is sorted
             for (var i = 0; i < ReadParallelism; i++)

--- a/bench/Voron.Benchmark/BTree/BTreeSimple.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeSimple.cs
@@ -1,0 +1,66 @@
+﻿using BenchmarkDotNet.Attributes;
+using Sparrow.Server;
+using Voron.Data.BTrees;
+
+namespace Voron.Benchmark.BTree
+{
+    public class BTreeSimple : StorageBenchmark
+    {
+        /// <summary>
+        /// Ensure we don't have to re-create the BTree between benchmarks
+        /// </summary>
+        public override bool DeleteBeforeEachBenchmark { get; protected set; } = false;
+
+        private static readonly Slice TreeNameSlice;
+        private static readonly Slice KeyValueSlice;
+
+        static BTreeSimple()
+        {
+            Slice.From(Configuration.Allocator, nameof(BTreeSimple), ByteStringType.Immutable, out TreeNameSlice);
+            Slice.From(Configuration.Allocator, nameof(KeyValueSlice), ByteStringType.Immutable, out KeyValueSlice);
+        }
+
+        [GlobalSetup]
+        public override void Setup()
+        {
+            base.Setup();
+
+            bool hasTree;
+            using (var tx = Env.ReadTransaction())
+            {
+                Tree tree = tx.ReadTree(TreeNameSlice);
+                hasTree = tree != null;
+            }
+
+            if (hasTree != false)
+                return;
+
+            // Create the tree as is does not exist
+            using (var tx = Env.WriteTransaction())
+            {
+                Tree tree = tx.CreateTree(TreeNameSlice);
+                tree.Add(KeyValueSlice, KeyValueSlice);
+                tx.Commit();
+            }
+        }
+
+        private const int OpsCount = 64;
+
+        [Benchmark(OperationsPerInvoke = OpsCount)]
+        public int ReadTree()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree(TreeNameSlice);
+
+                var count = 0;
+                for (int i = 0; i < OpsCount; i++)
+                {
+                    if (tree.Read(KeyValueSlice).HasValue)
+                        count++;
+                }
+                return count;
+            }
+        }
+    }
+}

--- a/bench/Voron.Benchmark/BTree/BTreeSimple.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeSimple.cs
@@ -56,7 +56,7 @@ namespace Voron.Benchmark.BTree
                 var count = 0;
                 for (int i = 0; i < OpsCount; i++)
                 {
-                    if (tree.Read(KeyValueSlice).HasValue)
+                    if (tree.TryRead(KeyValueSlice, out _))
                         count++;
                 }
                 return count;

--- a/bench/Voron.Benchmark/Configuration.cs
+++ b/bench/Voron.Benchmark/Configuration.cs
@@ -7,7 +7,7 @@ namespace Voron.Benchmark
     {
         public const int RecordsPerTransaction = 1000;
         public const int Transactions = 1000;
-        public const string Path = @"Z:\Bench";
+        public const string Path = @"C:\Bench";
 
         /// <summary>
         /// This is the global allocator for test strings

--- a/bench/Voron.Benchmark/Table/SecondaryIndexFillRandom.cs
+++ b/bench/Voron.Benchmark/Table/SecondaryIndexFillRandom.cs
@@ -32,10 +32,9 @@ namespace Voron.Benchmark.Table
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(12345)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static SecondaryIndexFillRandom()
         {
@@ -74,7 +73,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _valueBuilders = new List<TableValueBuilder>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/Table/TableFillRandom.cs
+++ b/bench/Voron.Benchmark/Table/TableFillRandom.cs
@@ -64,7 +64,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _valueBuilders = new List<TableValueBuilder>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/Table/TableFillSequential.cs
+++ b/bench/Voron.Benchmark/Table/TableFillSequential.cs
@@ -29,10 +29,9 @@ namespace Voron.Benchmark.Table
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static TableFillSequential()
         {
@@ -63,7 +62,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             // This will sort just the KEYS
             totalPairs.Sort((x, y) => SliceComparer.Compare(x.Item1, y.Item1));

--- a/bench/Voron.Benchmark/Table/TableInsertRandom.cs
+++ b/bench/Voron.Benchmark/Table/TableInsertRandom.cs
@@ -47,10 +47,9 @@ namespace Voron.Benchmark.Table
         public double GenerationDeletionProbability { get; set; } = 0.1;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         private const string TableName = "TestTable2";
 
@@ -83,7 +82,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _valueBuilders = new List<TableValueBuilder>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/Table/TableReadAndIterate.cs
+++ b/bench/Voron.Benchmark/Table/TableReadAndIterate.cs
@@ -52,10 +52,9 @@ namespace Voron.Benchmark.Table
         public double GenerationDeletionProbability { get; set; } = 0.5;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         [Params(1, 2)]
         public int ReadParallelism { get; set; } = 1;
@@ -88,7 +87,7 @@ namespace Voron.Benchmark.Table
                 GenerationBatchSize,
                 KeyLength,
                 GenerationDeletionProbability,
-                RandomSeed == -1 ? null : RandomSeed as int?
+                RandomSeed
             );
 
             // Distribute work amount, each one of the buckets is sorted

--- a/bench/Voron.Benchmark/Utils.cs
+++ b/bench/Voron.Benchmark/Utils.cs
@@ -8,13 +8,13 @@ namespace Voron.Benchmark
 {
     public class Utils
     {
-        public static List<Tuple<Slice, Slice>> GenerateUniqueRandomSlicePairs(int amount, int keyLength, int? randomSeed = null)
+        public static List<Tuple<Slice, Slice>> GenerateUniqueRandomSlicePairs(int amount, int keyLength, int randomSeed)
         {
             Debug.Assert(amount > 0);
             Debug.Assert(keyLength > 0);
 
             // Generate random key value pairs
-            var generator = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
+            var generator = new Random(randomSeed);
             var keyBuffer = new byte[keyLength];
 
             // This serves to ensure the uniqueness of keys globally (that way
@@ -68,12 +68,12 @@ namespace Voron.Benchmark
             int generationBatchSize,
             int keyLength,
             double generationDeletionProbability,
-            int? randomSeed
+            int randomSeed
             )
         {
-            List<Slice> treeKeys = new List<Slice>();
-            var generator = randomSeed.HasValue ? new Random(randomSeed.Value): new Random();
-            bool hasTree = false;
+            List<Slice> treeKeys = new();
+            var generator = new Random(randomSeed);
+            bool hasTree;
 
             using (var tx = env.ReadTransaction())
             {
@@ -122,7 +122,7 @@ namespace Voron.Benchmark
                                 values = GenerateUniqueRandomSlicePairs(
                                     generationTreeSize,
                                     keyLength,
-                                    randomSeed);
+                                    generator.Next());
                             }
 
                             var pair = values[0];
@@ -180,11 +180,11 @@ namespace Voron.Benchmark
             int generationBatchSize,
             int keyLength,
             double generationDeletionProbability,
-            int? randomSeed
+            int randomSeed
             )
         {
             var tableKeys = new List<Slice>();
-            var generator = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
+            var generator = new Random(randomSeed);
             bool hasTable;
 
             using (var tx = env.ReadTransaction())

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -496,7 +496,7 @@ public unsafe partial class IndexWriter
             // then we'll insert data to it as if it was any other term
             var entry = tree.Read(_indexedField.Name);
 
-            if (entry != null)
+            if (entry.IsNull == false)
             {
                 Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
                 Debug.Assert(entry.Reader.Length == sizeof((long, long)));

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -496,7 +496,7 @@ public unsafe partial class IndexWriter
             // then we'll insert data to it as if it was any other term
             var entry = tree.Read(_indexedField.Name);
 
-            if (entry.IsNull == false)
+            if (entry.HasValue)
             {
                 Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
                 Debug.Assert(entry.Reader.Length == sizeof((long, long)));

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -494,9 +494,7 @@ public unsafe partial class IndexWriter
         {
             // In the case where the field does not have any null values, we will create a *large* posting list (an empty one)
             // then we'll insert data to it as if it was any other term
-            var entry = tree.Read(_indexedField.Name);
-
-            if (entry.HasValue)
+            if (tree.TryRead(_indexedField.Name, out var entry))
             {
                 Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
                 Debug.Assert(entry.Reader.Length == sizeof((long, long)));

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -671,7 +671,16 @@ namespace Corax.Indexing
 
         private void ReadPersistedVectorRootPages(out long[] persistedVectorRootPages)
         {
-            persistedVectorRootPages = _indexMetadata?.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice)?.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray() ?? [];
+            persistedVectorRootPages = [];
+
+            if (_indexMetadata != null)
+            {
+                ReadResult entry = _indexMetadata.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice);
+                if (entry.IsNull == false)
+                {
+                    persistedVectorRootPages = entry.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray();
+                }
+            }
         }
 
         private void PersistVectorRootPages()

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -676,7 +676,7 @@ namespace Corax.Indexing
             if (_indexMetadata != null)
             {
                 ReadResult entry = _indexMetadata.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice);
-                if (entry.IsNull == false)
+                if (entry.HasValue)
                 {
                     persistedVectorRootPages = entry.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray();
                 }

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -675,8 +675,7 @@ namespace Corax.Indexing
 
             if (_indexMetadata != null)
             {
-                ReadResult entry = _indexMetadata.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice);
-                if (entry.HasValue)
+                if (_indexMetadata.TryRead(Constants.IndexWriter.VectorFieldsRootPagesSlice, out var entry))
                 {
                     persistedVectorRootPages = entry.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray();
                 }

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -151,7 +151,8 @@ public partial class IndexSearcher
     {
         double termRatioToWholeCollection;
         var totalTerms = tree.NumberOfEntries;
-        var totalSum = _metadataTree.Read(field.TermLengthSumName)?.Reader.ReadLittleEndianInt64() ?? totalTerms;
+        var entry = _metadataTree.Read(field.TermLengthSumName);
+        var totalSum = entry.IsNull ? totalTerms : entry.Reader.ReadLittleEndianInt64();
 
         if (totalTerms == 0 || totalSum == 0)
             termRatioToWholeCollection = 1;

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -152,7 +152,7 @@ public partial class IndexSearcher
         double termRatioToWholeCollection;
         var totalTerms = tree.NumberOfEntries;
         var entry = _metadataTree.Read(field.TermLengthSumName);
-        var totalSum = entry.IsNull ? totalTerms : entry.Reader.ReadLittleEndianInt64();
+        var totalSum = entry.HasValue ? entry.Reader.ReadLittleEndianInt64() : totalTerms;
 
         if (totalTerms == 0 || totalSum == 0)
             termRatioToWholeCollection = 1;

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -151,8 +151,7 @@ public partial class IndexSearcher
     {
         double termRatioToWholeCollection;
         var totalTerms = tree.NumberOfEntries;
-        var entry = _metadataTree.Read(field.TermLengthSumName);
-        var totalSum = entry.HasValue ? entry.Reader.ReadLittleEndianInt64() : totalTerms;
+        var totalSum = _metadataTree.TryRead(field.TermLengthSumName, out var entry) ? entry.Reader.ReadLittleEndianInt64() : totalTerms;
 
         if (totalTerms == 0 || totalSum == 0)
             termRatioToWholeCollection = 1;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -396,7 +396,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         if (_persistedDynamicTreeAnalyzer == null)
             return FieldIndexingMode.Normal; 
         var readResult = _persistedDynamicTreeAnalyzer.Read(name);
-        if (!readResult.HasValue)
+        if (readResult.HasValue == false)
             return FieldIndexingMode.Normal;
 
         var mode = (FieldIndexingMode)readResult.Reader.ReadByte();
@@ -676,7 +676,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
         
         var result = _fieldsTree.Read(fieldName);
-        if (!result.HasValue)
+        if (result.HasValue == false)
         {
             rootPage = notFound;
             return false;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -396,7 +396,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         if (_persistedDynamicTreeAnalyzer == null)
             return FieldIndexingMode.Normal; 
         var readResult = _persistedDynamicTreeAnalyzer.Read(name);
-        if (readResult.IsNull)
+        if (!readResult.HasValue)
             return FieldIndexingMode.Normal;
 
         var mode = (FieldIndexingMode)readResult.Reader.ReadByte();
@@ -676,7 +676,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
         
         var result = _fieldsTree.Read(fieldName);
-        if (result.IsNull)
+        if (!result.HasValue)
         {
             rootPage = notFound;
             return false;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -393,8 +393,10 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     public FieldIndexingMode GetFieldIndexingModeForDynamic(Slice name)
     {
         _persistedDynamicTreeAnalyzer ??= _transaction.ReadTree(Constants.IndexWriter.DynamicFieldsAnalyzersSlice);
-        var readResult = _persistedDynamicTreeAnalyzer?.Read(name);
-        if (readResult == null)
+        if (_persistedDynamicTreeAnalyzer == null)
+            return FieldIndexingMode.Normal; 
+        var readResult = _persistedDynamicTreeAnalyzer.Read(name);
+        if (readResult.IsNull)
             return FieldIndexingMode.Normal;
 
         var mode = (FieldIndexingMode)readResult.Reader.ReadByte();
@@ -611,7 +613,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             LoadSpecialTermMarkers(_nonExistingPostingListsTree, out _nonExistingTermsMarkers);
         }
 
-        _vectorFieldsMarkers ??= _metadataTree?.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice)?.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray() ?? [];
+        _vectorFieldsMarkers = _metadataTree == null ? [] : _metadataTree.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice).ToArrayEmptyOnNull<long>();
     }
 
     public bool IsVectorField(string fieldName)
@@ -665,10 +667,18 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     private bool TryGetRootPageByFieldName(Slice fieldName, out long rootPage)
     {
-        var result = _fieldsTree?.Read(fieldName);
-        if (result is null)
+        const long notFound = -1;
+
+        if (_fieldsTree == null)
         {
-            rootPage = -1;
+            rootPage = notFound;
+            return false;
+        }
+        
+        var result = _fieldsTree.Read(fieldName);
+        if (result.IsNull)
+        {
+            rootPage = notFound;
             return false;
         }
         

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -395,11 +395,10 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         _persistedDynamicTreeAnalyzer ??= _transaction.ReadTree(Constants.IndexWriter.DynamicFieldsAnalyzersSlice);
         if (_persistedDynamicTreeAnalyzer == null)
             return FieldIndexingMode.Normal; 
-        var readResult = _persistedDynamicTreeAnalyzer.Read(name);
-        if (readResult.HasValue == false)
+        if (_persistedDynamicTreeAnalyzer.TryRead(name, out var result) == false)
             return FieldIndexingMode.Normal;
 
-        var mode = (FieldIndexingMode)readResult.Reader.ReadByte();
+        var mode = (FieldIndexingMode)result.Reader.ReadByte();
         return mode;
     }
 
@@ -675,8 +674,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             return false;
         }
         
-        var result = _fieldsTree.Read(fieldName);
-        if (result.HasValue == false)
+        if (_fieldsTree.TryRead(fieldName, out var result) == false)
         {
             rootPage = notFound;
             return false;

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -390,12 +390,7 @@ namespace Raven.Server.Documents
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalChangeVectorSlice);
-            if (!val.HasValue)
-            {
-                return string.Empty;
-            }
-
-            return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
+            return val.ToStringValueOrDefault(string.Empty);
         }
 
         internal HashSet<string> UnusedDatabaseIds;
@@ -456,12 +451,7 @@ namespace Raven.Server.Documents
             var tx = context.Transaction.InnerTransaction;
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalFullChangeVectorSlice);
-            if (!val.HasValue)
-            {
-                return GetDatabaseChangeVector(context);
-            }
-            return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
-
+            return val.HasValue ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : GetDatabaseChangeVector(context);
         }
 
         public void SetFullDatabaseChangeVector(DocumentsOperationContext context, string changeVector)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -390,7 +390,7 @@ namespace Raven.Server.Documents
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalChangeVectorSlice);
-            if (val == null)
+            if (val.IsNull)
             {
                 return string.Empty;
             }
@@ -456,7 +456,7 @@ namespace Raven.Server.Documents
             var tx = context.Transaction.InnerTransaction;
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalFullChangeVectorSlice);
-            if (val == null)
+            if (val.IsNull)
             {
                 return GetDatabaseChangeVector(context);
             }
@@ -601,9 +601,7 @@ namespace Raven.Server.Documents
 
             var tree = tx.CreateTree(EtagsSlice);
             var readResult = tree.Read(LastEtagSlice);
-            long lastEtag = 0;
-            if (readResult != null)
-                lastEtag = readResult.Reader.ReadLittleEndianInt64();
+            var lastEtag = readResult.ReadLittleEndianInt64OrDefault(0);
 
             var lastDocumentEtag = ReadLastDocumentEtag(tx);
             if (lastDocumentEtag > lastEtag)
@@ -645,13 +643,8 @@ namespace Raven.Server.Documents
             {
                 return 0;
             }
-            var readResult = tree.Read(LastCompletedClusterTransactionIndexSlice);
-            if (readResult == null)
-            {
-                return 0;
-            }
 
-            return readResult.Reader.ReadLittleEndianInt64();
+            return tree.Read(LastCompletedClusterTransactionIndexSlice).ReadLittleEndianInt64OrDefault(0);
         }
 
         public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
@@ -667,9 +660,8 @@ namespace Raven.Server.Documents
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(FixCountersLastKeySlice);
-            if (val == null)
-                return null;
-            return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
+
+            return val.IsNull ? null : Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
         }
 
         public void SetLastFixedCounterKey(DocumentsOperationContext context, string lastKey)
@@ -2594,10 +2586,7 @@ namespace Raven.Server.Documents
         {
             var readTree = context.Transaction.InnerTransaction.ReadTree(LastReplicatedEtagsSlice);
             var readResult = readTree.Read(dbId);
-            if (readResult == null)
-                return 0;
-
-            return readResult.Reader.ReadLittleEndianInt64();
+            return readResult.IsNull ? 0 : readResult.Reader.ReadLittleEndianInt64();
         }
 
         public static void SetLastReplicatedEtagFrom(DocumentsOperationContext context, string dbId, long etag)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -390,7 +390,7 @@ namespace Raven.Server.Documents
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalChangeVectorSlice);
-            if (val.IsNull)
+            if (!val.HasValue)
             {
                 return string.Empty;
             }
@@ -456,7 +456,7 @@ namespace Raven.Server.Documents
             var tx = context.Transaction.InnerTransaction;
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalFullChangeVectorSlice);
-            if (val.IsNull)
+            if (!val.HasValue)
             {
                 return GetDatabaseChangeVector(context);
             }
@@ -661,7 +661,7 @@ namespace Raven.Server.Documents
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(FixCountersLastKeySlice);
 
-            return val.IsNull ? null : Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
+            return val.HasValue ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : null;
         }
 
         public void SetLastFixedCounterKey(DocumentsOperationContext context, string lastKey)
@@ -2586,7 +2586,7 @@ namespace Raven.Server.Documents
         {
             var readTree = context.Transaction.InnerTransaction.ReadTree(LastReplicatedEtagsSlice);
             var readResult = readTree.Read(dbId);
-            return readResult.IsNull ? 0 : readResult.Reader.ReadLittleEndianInt64();
+            return readResult.ReadLittleEndianInt64OrDefault(0);
         }
 
         public static void SetLastReplicatedEtagFrom(DocumentsOperationContext context, string dbId, long etag)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -450,8 +450,7 @@ namespace Raven.Server.Documents
         {
             var tx = context.Transaction.InnerTransaction;
             var tree = tx.ReadTree(GlobalTreeSlice);
-            var val = tree.Read(GlobalFullChangeVectorSlice);
-            return val.HasValue ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : GetDatabaseChangeVector(context);
+            return tree.TryRead(GlobalFullChangeVectorSlice, out var val) ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : GetDatabaseChangeVector(context);
         }
 
         public void SetFullDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
@@ -649,9 +648,7 @@ namespace Raven.Server.Documents
             if (tx == null)
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
-            var val = tree.Read(FixCountersLastKeySlice);
-
-            return val.HasValue ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : null;
+            return tree.TryRead(FixCountersLastKeySlice, out var val) ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : null;
         }
 
         public void SetLastFixedCounterKey(DocumentsOperationContext context, string lastKey)

--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -120,7 +120,7 @@ namespace Raven.Server.Documents.Indexes
         internal static long GetVersion(Tree tree, bool isNew)
         {
             var read = tree.Read(VersionSlice);
-            if (read != null)
+            if (read.IsNull == false)
                 return read.Reader.ReadLittleEndianInt64();
 
             return isNew
@@ -131,11 +131,11 @@ namespace Raven.Server.Documents.Indexes
         private static long GetCount(Tree tree, ref Mode mode)
         {
             var read = tree.Read(mode == Mode.X64 ? Count64Slice : Count32Slice);
-            if (read != null)
+            if (read.IsNull == false)
                 return read.Reader.ReadLittleEndianInt64();
 
             read = tree.Read(mode == Mode.X64 ? Count32Slice : Count64Slice);
-            if (read != null)
+            if (read.IsNull == false)
             {
                 mode = mode == Mode.X64 ? Mode.X86 : Mode.X64;
                 return read.Reader.ReadLittleEndianInt64();
@@ -380,10 +380,7 @@ namespace Raven.Server.Documents.Indexes
             private long ReadCount()
             {
                 var read = _tree.Read(_keySlice);
-                if (read == null)
-                    return 0;
-
-                return read.Reader.ReadLittleEndianInt64();
+                return read.IsNull ? 0 : read.Reader.ReadLittleEndianInt64();
             }
 
             internal bool Add(LazyStringValue key)
@@ -488,7 +485,7 @@ namespace Raven.Server.Documents.Indexes
                 Slice.From(_allocator, $"{_key:D5}/{number:D4}", out Slice partitionKey);
 
                 var read = _tree.Read(partitionKey);
-                if (read != null)
+                if (read.IsNull == false)
                 {
                     return _partitions[number] = new Partition
                     {

--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -120,7 +120,7 @@ namespace Raven.Server.Documents.Indexes
         internal static long GetVersion(Tree tree, bool isNew)
         {
             var read = tree.Read(VersionSlice);
-            if (read.IsNull == false)
+            if (read.HasValue)
                 return read.Reader.ReadLittleEndianInt64();
 
             return isNew
@@ -131,11 +131,11 @@ namespace Raven.Server.Documents.Indexes
         private static long GetCount(Tree tree, ref Mode mode)
         {
             var read = tree.Read(mode == Mode.X64 ? Count64Slice : Count32Slice);
-            if (read.IsNull == false)
+            if (read.HasValue)
                 return read.Reader.ReadLittleEndianInt64();
 
             read = tree.Read(mode == Mode.X64 ? Count32Slice : Count64Slice);
-            if (read.IsNull == false)
+            if (read.HasValue)
             {
                 mode = mode == Mode.X64 ? Mode.X86 : Mode.X64;
                 return read.Reader.ReadLittleEndianInt64();
@@ -380,7 +380,7 @@ namespace Raven.Server.Documents.Indexes
             private long ReadCount()
             {
                 var read = _tree.Read(_keySlice);
-                return read.IsNull ? 0 : read.Reader.ReadLittleEndianInt64();
+                return read.ReadLittleEndianInt64OrDefault(0);
             }
 
             internal bool Add(LazyStringValue key)
@@ -485,7 +485,7 @@ namespace Raven.Server.Documents.Indexes
                 Slice.From(_allocator, $"{_key:D5}/{number:D4}", out Slice partitionKey);
 
                 var read = _tree.Read(partitionKey);
-                if (read.IsNull == false)
+                if (read.HasValue)
                 {
                     return _partitions[number] = new Partition
                     {

--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -119,8 +119,7 @@ namespace Raven.Server.Documents.Indexes
 
         internal static long GetVersion(Tree tree, bool isNew)
         {
-            var read = tree.Read(VersionSlice);
-            if (read.HasValue)
+            if (tree.TryRead(VersionSlice, out var read))
                 return read.Reader.ReadLittleEndianInt64();
 
             return isNew
@@ -130,12 +129,10 @@ namespace Raven.Server.Documents.Indexes
 
         private static long GetCount(Tree tree, ref Mode mode)
         {
-            var read = tree.Read(mode == Mode.X64 ? Count64Slice : Count32Slice);
-            if (read.HasValue)
+            if (tree.TryRead(mode == Mode.X64 ? Count64Slice : Count32Slice, out var read))
                 return read.Reader.ReadLittleEndianInt64();
 
-            read = tree.Read(mode == Mode.X64 ? Count32Slice : Count64Slice);
-            if (read.HasValue)
+            if (tree.TryRead(mode == Mode.X64 ? Count32Slice : Count64Slice, out read))
             {
                 mode = mode == Mode.X64 ? Mode.X86 : Mode.X64;
                 return read.Reader.ReadLittleEndianInt64();
@@ -484,8 +481,7 @@ namespace Raven.Server.Documents.Indexes
 
                 Slice.From(_allocator, $"{_key:D5}/{number:D4}", out Slice partitionKey);
 
-                var read = _tree.Read(partitionKey);
-                if (read.HasValue)
+                if (_tree.TryRead(partitionKey, out var read))
                 {
                     return _partitions[number] = new Partition
                     {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -775,7 +775,7 @@ namespace Raven.Server.Documents.Indexes
                     if (configurationTree != null)
                     {
                         var result = configurationTree.Read(IndexStorage.IndexSchema.SearchEngineType);
-                        if (result != null)
+                        if (result.IsNull == false)
                             if (Enum.TryParse(result.Reader.ToStringValue(), out searchEngineTypeFromSchema) == false)
                                 searchEngineTypeFromSchema = SearchEngineType.None;
                     }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -980,11 +980,11 @@ namespace Raven.Server.Documents.Indexes
             using (var tx = context.OpenReadTransaction())
             {
                 var now = DocumentDatabase.Time.GetUtcNow();
-                State = _indexStorage.ReadState(tx);
-                var persistedElapsedTimeFromLastQuery = _indexStorage.ReadElapsedTimeFromLastQuery(tx) ?? TimeSpan.Zero;
+                State = IndexStorage.ReadState(tx);
+                var persistedElapsedTimeFromLastQuery = IndexStorage.ReadElapsedTimeFromLastQuery(tx) ?? TimeSpan.Zero;
                 _lastQueriedTimeTracker = new LastQueriedTimeTracker(now, persistedElapsedTimeFromLastQuery.Ticks);
                 
-                LastIndexingTime = _indexStorage.ReadLastIndexingTime(tx);
+                LastIndexingTime = IndexStorage.ReadLastIndexingTime(tx);
                 MaxNumberOfOutputsPerDocument = _indexStorage.ReadMaxNumberOfOutputsPerDocument(tx);
                 ArchivedDataProcessingBehavior = _indexStorage.ReadArchivedDataProcessingBehavior(tx);
                 CoraxComplexFieldIndexingBehavior = _indexStorage.ReadCoraxComplexFieldIndexingBehavior(tx);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -775,7 +775,7 @@ namespace Raven.Server.Documents.Indexes
                     if (configurationTree != null)
                     {
                         var result = configurationTree.Read(IndexStorage.IndexSchema.SearchEngineType);
-                        if (result.IsNull == false)
+                        if (result.HasValue)
                             if (Enum.TryParse(result.Reader.ToStringValue(), out searchEngineTypeFromSchema) == false)
                                 searchEngineTypeFromSchema = SearchEngineType.None;
                     }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -774,8 +774,7 @@ namespace Raven.Server.Documents.Indexes
                     var configurationTree = tx.ReadTree(IndexStorage.IndexSchema.ConfigurationTree);
                     if (configurationTree != null)
                     {
-                        var result = configurationTree.Read(IndexStorage.IndexSchema.SearchEngineType);
-                        if (result.HasValue)
+                        if (configurationTree.TryRead(IndexStorage.IndexSchema.SearchEngineType, out var result))
                             if (Enum.TryParse(result.Reader.ToStringValue(), out searchEngineTypeFromSchema) == false)
                                 searchEngineTypeFromSchema = SearchEngineType.None;
                     }

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var tree = tx.CreateTree("Definition");
             var result = tree.Read(DefinitionSlice);
-            if (result.IsNull)
+            if (!result.HasValue)
                 return null;
 
             var stream = result.Reader.AsStream();

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var tree = tx.CreateTree("Definition");
             var result = tree.Read(DefinitionSlice);
-            if (result == null)
+            if (result.IsNull)
                 return null;
 
             var stream = result.Reader.AsStream();

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var tree = tx.CreateTree("Definition");
             var result = tree.Read(DefinitionSlice);
-            if (!result.HasValue)
+            if (result.HasValue == false)
                 return null;
 
             var stream = result.Reader.AsStream();

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -395,8 +395,7 @@ namespace Raven.Server.Documents.Indexes
         protected static Stream GetIndexDefinitionStream(StorageEnvironment environment, Transaction tx)
         {
             var tree = tx.CreateTree("Definition");
-            var result = tree.Read(DefinitionSlice);
-            if (result.HasValue == false)
+            if (tree.TryRead(DefinitionSlice, out var result) == false)
                 return null;
 
             var stream = result.Reader.AsStream();

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.Indexes
                     statsTree.Add(IndexSchema.SourceTypeSlice, tmpSlice);
 
                 var createdTimestampResult = statsTree.Read(IndexSchema.CreatedTimestampSlice);
-                if (!createdTimestampResult.HasValue)
+                if (createdTimestampResult.HasValue == false)
                 {
                     var binaryDate = CreatedTimestampAsBinary = SystemTime.UtcNow.ToBinary();
                     using (Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long), out Slice tmpSlice))
@@ -315,14 +315,11 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public IndexState ReadState(RavenTransaction tx)
+        public static IndexState ReadState(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
             var state = statsTree.Read(IndexSchema.StateSlice);
-            if (!state.HasValue)
-                return IndexState.Normal;
-
-            return (IndexState)state.Reader.ReadLittleEndianInt32();
+            return state.HasValue ? (IndexState)state.Reader.ReadLittleEndianInt32() : IndexState.Normal;
         }
 
         public void DeleteErrors()
@@ -400,15 +397,12 @@ namespace Raven.Server.Documents.Indexes
             }
         }
         
-        public TimeSpan? ReadElapsedTimeFromLastQuery(RavenTransaction tx)
+        public static TimeSpan? ReadElapsedTimeFromLastQuery(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastQueryTimeSlice = statsTree.Read(IndexSchema.ElapsedSinceQueriedSlice);
-            if (!lastQueryTimeSlice.HasValue)
-                return null;
-
-            return new TimeSpan(ticks: lastQueryTimeSlice.Reader.ReadLittleEndianInt64());
+            return lastQueryTimeSlice.HasValue ? new TimeSpan(ticks: lastQueryTimeSlice.Reader.ReadLittleEndianInt64()) : null;
         }
 
         public void WriteElapsedSinceQueried(TimeSpan value)
@@ -429,15 +423,12 @@ namespace Raven.Server.Documents.Indexes
                 statsTree.Add(IndexSchema.ElapsedSinceQueriedSlice, timeElapsedFromLastQuerySlice);
         }
         
-        public DateTime? ReadLastIndexingTime(RavenTransaction tx)
+        public static DateTime? ReadLastIndexingTime(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
-            if (!lastIndexingTime.HasValue)
-                return null;
-
-            return DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64());
+            return lastIndexingTime.HasValue ? DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64()) : null;
         }
 
         public bool IsIndexInvalid(RavenTransaction tx)
@@ -562,7 +553,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.ArchivedDataProcessingBehaviorSlice);
-            if (!result.HasValue)
+            if (result.HasValue == false)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.ArchivedDataProcessingBehaviorSlice)}' tree.");
             }
@@ -584,7 +575,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.CoraxComplexFieldIndexingBehavior);
-            if (!result.HasValue)
+            if (result.HasValue == false)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.CoraxComplexFieldIndexingBehavior)}' key.");
             }
@@ -1092,7 +1083,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.TypeSlice);
-                if (!result.HasValue)
+                if (result.HasValue == false)
                     throw new InvalidOperationException($"Stats tree does not contain 'Type' entry in index '{name}'.");
 
                 return (IndexType)result.Reader.ReadLittleEndianInt32();
@@ -1108,10 +1099,9 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.DatabaseIdSlice);
-                if (!result.HasValue)
-                    return null; // backward compatibility
-
-                return result.Reader.ReadString(result.Reader.Length);
+                
+                // null handling for backward compatibility
+                return result.ToStringValueOrDefault(null);
             }
         }
 
@@ -1126,7 +1116,7 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 var result = configurationTree.Read(IndexSchema.SearchEngineType);
-                if (!result.HasValue)
+                if (result.HasValue == false)
                 {
                     return SearchEngineType.None;
                 }
@@ -1150,10 +1140,10 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.SourceTypeSlice);
-                if (!result.HasValue)
-                    return IndexSourceType.Documents; // backward compatibility
-
-                return (IndexSourceType)result.Reader.ReadLittleEndianInt32();
+                if (result.HasValue) 
+                    return (IndexSourceType)result.Reader.ReadLittleEndianInt32();
+                
+                return IndexSourceType.Documents; // backward compatibility
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.Indexes
                     statsTree.Add(IndexSchema.SourceTypeSlice, tmpSlice);
 
                 var createdTimestampResult = statsTree.Read(IndexSchema.CreatedTimestampSlice);
-                if (createdTimestampResult.IsNull)
+                if (!createdTimestampResult.HasValue)
                 {
                     var binaryDate = CreatedTimestampAsBinary = SystemTime.UtcNow.ToBinary();
                     using (Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long), out Slice tmpSlice))
@@ -174,7 +174,7 @@ namespace Raven.Server.Documents.Indexes
                 {
                     var result = configurationTree.Read(configurationKey);
                     string persistedConfigurationValue = null;
-                    if (result.IsNull == false)
+                    if (result.HasValue)
                         persistedConfigurationValue = result.Reader.ToStringValue();
                     else if (_index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.Analyzers)
                         persistedConfigurationValue = defaultAnalyzer;
@@ -200,7 +200,7 @@ namespace Raven.Server.Documents.Indexes
                     if (defaultEngineType == SearchEngineType.None)
                         throw new InvalidDataException($"Default search engine is {SearchEngineType.None}. Please set {configurationName}.");
                     var result = configurationTree.Read(configurationKey);
-                    if (result.IsNull == false)
+                    if (result.HasValue)
                     {
                         if (Enum.TryParse(result.Reader.ToStringValue(), out SearchEngineType persistedSearchEngineType) == false)
                         {
@@ -228,7 +228,7 @@ namespace Raven.Server.Documents.Indexes
                         configurationTree.Add(configurationKey, _index.Definition.ArchivedDataProcessingBehavior.ToString());
                     else
                     {
-                        if (configurationTree.Read(configurationKey).IsNull == false)
+                        if (configurationTree.Read(configurationKey).HasValue)
                             return; // do not overwrite default value if it exists already
                         
                         configurationTree.Add(configurationKey, defaultBehavior.ToString());
@@ -245,7 +245,7 @@ namespace Raven.Server.Documents.Indexes
                         configuredBehavior = _index.Configuration.CoraxStaticIndexComplexFieldIndexingBehavior;
 
                     var result = configurationTree.Read(configurationKey);
-                    if (result.IsNull == false)
+                    if (result.HasValue)
                     {
                         var behaviorStringValue = result.Reader.ToStringValue();
 
@@ -319,7 +319,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
             var state = statsTree.Read(IndexSchema.StateSlice);
-            if (state.IsNull)
+            if (!state.HasValue)
                 return IndexState.Normal;
 
             return (IndexState)state.Reader.ReadLittleEndianInt32();
@@ -405,7 +405,7 @@ namespace Raven.Server.Documents.Indexes
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastQueryTimeSlice = statsTree.Read(IndexSchema.ElapsedSinceQueriedSlice);
-            if (lastQueryTimeSlice.IsNull)
+            if (!lastQueryTimeSlice.HasValue)
                 return null;
 
             return new TimeSpan(ticks: lastQueryTimeSlice.Reader.ReadLittleEndianInt64());
@@ -434,7 +434,7 @@ namespace Raven.Server.Documents.Indexes
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
-            if (lastIndexingTime.IsNull)
+            if (!lastIndexingTime.HasValue)
                 return null;
 
             return DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64());
@@ -492,7 +492,7 @@ namespace Raven.Server.Documents.Indexes
             ReadResult entriesResult = statsTree.Read(IndexSchema.EntriesCount);
             
             long? entriesCount = null;
-            if (entriesResult.IsNull == false)
+            if (entriesResult.HasValue)
             {
                 var entriesCountReader = entriesResult.Reader;
                 var entriesCountSize = entriesCountReader.Length;
@@ -512,7 +512,7 @@ namespace Raven.Server.Documents.Indexes
                 }
             }
 
-            if (lastIndexingTime.IsNull == false)
+            if (lastIndexingTime.HasValue)
             {
                 stats.LastIndexingTime = DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64());
                 stats.MapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice).Reader.ReadLittleEndianInt32();
@@ -545,7 +545,7 @@ namespace Raven.Server.Documents.Indexes
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
 
-            if (lastIndexingTime.IsNull == false)
+            if (lastIndexingTime.HasValue)
             {
                 return statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument).Reader.ReadLittleEndianInt32();
             }
@@ -562,7 +562,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.ArchivedDataProcessingBehaviorSlice);
-            if (result.IsNull)
+            if (!result.HasValue)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.ArchivedDataProcessingBehaviorSlice)}' tree.");
             }
@@ -584,7 +584,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.CoraxComplexFieldIndexingBehavior);
-            if (result.IsNull)
+            if (!result.HasValue)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.CoraxComplexFieldIndexingBehavior)}' key.");
             }
@@ -1092,7 +1092,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.TypeSlice);
-                if (result.IsNull)
+                if (!result.HasValue)
                     throw new InvalidOperationException($"Stats tree does not contain 'Type' entry in index '{name}'.");
 
                 return (IndexType)result.Reader.ReadLittleEndianInt32();
@@ -1108,7 +1108,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.DatabaseIdSlice);
-                if (result.IsNull)
+                if (!result.HasValue)
                     return null; // backward compatibility
 
                 return result.Reader.ReadString(result.Reader.Length);
@@ -1126,7 +1126,7 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 var result = configurationTree.Read(IndexSchema.SearchEngineType);
-                if (result.IsNull)
+                if (!result.HasValue)
                 {
                     return SearchEngineType.None;
                 }
@@ -1150,7 +1150,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.SourceTypeSlice);
-                if (result.IsNull)
+                if (!result.HasValue)
                     return IndexSourceType.Documents; // backward compatibility
 
                 return (IndexSourceType)result.Reader.ReadLittleEndianInt32();

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.Indexes
                     statsTree.Add(IndexSchema.SourceTypeSlice, tmpSlice);
 
                 var createdTimestampResult = statsTree.Read(IndexSchema.CreatedTimestampSlice);
-                if (createdTimestampResult == null)
+                if (createdTimestampResult.IsNull)
                 {
                     var binaryDate = CreatedTimestampAsBinary = SystemTime.UtcNow.ToBinary();
                     using (Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long), out Slice tmpSlice))
@@ -174,7 +174,7 @@ namespace Raven.Server.Documents.Indexes
                 {
                     var result = configurationTree.Read(configurationKey);
                     string persistedConfigurationValue = null;
-                    if (result != null)
+                    if (result.IsNull == false)
                         persistedConfigurationValue = result.Reader.ToStringValue();
                     else if (_index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.Analyzers)
                         persistedConfigurationValue = defaultAnalyzer;
@@ -200,7 +200,7 @@ namespace Raven.Server.Documents.Indexes
                     if (defaultEngineType == SearchEngineType.None)
                         throw new InvalidDataException($"Default search engine is {SearchEngineType.None}. Please set {configurationName}.");
                     var result = configurationTree.Read(configurationKey);
-                    if (result != null)
+                    if (result.IsNull == false)
                     {
                         if (Enum.TryParse(result.Reader.ToStringValue(), out SearchEngineType persistedSearchEngineType) == false)
                         {
@@ -228,7 +228,7 @@ namespace Raven.Server.Documents.Indexes
                         configurationTree.Add(configurationKey, _index.Definition.ArchivedDataProcessingBehavior.ToString());
                     else
                     {
-                        if (configurationTree.Read(configurationKey) != null)
+                        if (configurationTree.Read(configurationKey).IsNull == false)
                             return; // do not overwrite default value if it exists already
                         
                         configurationTree.Add(configurationKey, defaultBehavior.ToString());
@@ -245,7 +245,7 @@ namespace Raven.Server.Documents.Indexes
                         configuredBehavior = _index.Configuration.CoraxStaticIndexComplexFieldIndexingBehavior;
 
                     var result = configurationTree.Read(configurationKey);
-                    if (result != null)
+                    if (result.IsNull == false)
                     {
                         var behaviorStringValue = result.Reader.ToStringValue();
 
@@ -269,8 +269,8 @@ namespace Raven.Server.Documents.Indexes
             if (_environment.IsNew == false)
             {
                 var tree = indexContext.Transaction.InnerTransaction.ReadTree(IndexSchema.LastDocumentEtagOnIndexCreationTree);
-                var result = tree?.Read(key);
-                return result?.Reader.ReadLittleEndianInt64() ?? 0;
+                var result = tree?.Read(key) ?? ReadResult.Null;
+                return result.ReadLittleEndianInt64OrDefault(0);
             }
 
             using (var queryContext = QueryOperationContext.Allocate(DocumentDatabase, _index))
@@ -319,7 +319,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
             var state = statsTree.Read(IndexSchema.StateSlice);
-            if (state == null)
+            if (state.IsNull)
                 return IndexState.Normal;
 
             return (IndexState)state.Reader.ReadLittleEndianInt32();
@@ -405,7 +405,7 @@ namespace Raven.Server.Documents.Indexes
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastQueryTimeSlice = statsTree.Read(IndexSchema.ElapsedSinceQueriedSlice);
-            if (lastQueryTimeSlice == null)
+            if (lastQueryTimeSlice.IsNull)
                 return null;
 
             return new TimeSpan(ticks: lastQueryTimeSlice.Reader.ReadLittleEndianInt64());
@@ -434,7 +434,7 @@ namespace Raven.Server.Documents.Indexes
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
-            if (lastIndexingTime == null)
+            if (lastIndexingTime.IsNull)
                 return null;
 
             return DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64());
@@ -444,22 +444,22 @@ namespace Raven.Server.Documents.Indexes
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
-            var mapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
-            var mapErrors = statsTree.Read(IndexSchema.MapErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+            var mapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+            var mapErrors = statsTree.Read(IndexSchema.MapErrorsSlice).ReadLittleEndianInt64OrDefault(0);
 
             long? reduceAttempts = null, reduceErrors = null;
 
             if (_index.Type.IsMapReduce())
             {
-                reduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
-                reduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                reduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+                reduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice).ReadLittleEndianInt64OrDefault(0);
             }
 
             long mapReferenceAttempts = 0, mapReferenceErrors = 0;
             if (_index.GetReferencedCollections()?.Count > 0)
             {
-                mapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
-                mapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                mapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+                mapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice).ReadLittleEndianInt64OrDefault(0);
             }
 
             return IndexFailureInformation.CheckIndexInvalid(mapAttempts, mapErrors,
@@ -489,15 +489,17 @@ namespace Raven.Server.Documents.Indexes
                 };
             }
 
-            var entriesCountReader = statsTree.Read(IndexSchema.EntriesCount)?.Reader;
+            ReadResult entriesResult = statsTree.Read(IndexSchema.EntriesCount);
+            
             long? entriesCount = null;
-            if (entriesCountReader.HasValue)
+            if (entriesResult.IsNull == false)
             {
-                var entriesCountSize = entriesCountReader.Value.Length;
+                var entriesCountReader = entriesResult.Reader;
+                var entriesCountSize = entriesCountReader.Length;
                 //backward compatibility https://github.com/ravendb/ravendb/commit/5c53b01ee2b4fad8f3ef410f3e4976144d72c023
                 entriesCount = entriesCountSize == sizeof(long)
-                    ? entriesCountReader.Value.ReadLittleEndianInt64()
-                    : entriesCountReader.Value.ReadLittleEndianInt32();
+                    ? entriesCountReader.ReadLittleEndianInt64()
+                    : entriesCountReader.ReadLittleEndianInt32();
             }
 
             if (entriesCount != null)
@@ -510,7 +512,7 @@ namespace Raven.Server.Documents.Indexes
                 }
             }
 
-            if (lastIndexingTime != null)
+            if (lastIndexingTime.IsNull == false)
             {
                 stats.LastIndexingTime = DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64());
                 stats.MapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice).Reader.ReadLittleEndianInt32();
@@ -521,16 +523,16 @@ namespace Raven.Server.Documents.Indexes
 
                 if (_index.Type.IsMapReduce())
                 {
-                    stats.ReduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
-                    stats.ReduceSuccesses = statsTree.Read(IndexSchema.ReduceSuccessesSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
-                    stats.ReduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.ReadLittleEndianInt64() ?? 0;
+                    stats.ReduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+                    stats.ReduceSuccesses = statsTree.Read(IndexSchema.ReduceSuccessesSlice).ReadLittleEndianInt64OrDefault(0);
+                    stats.ReduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice).ReadLittleEndianInt64OrDefault(0);
                 }
 
                 if (_index.GetReferencedCollections()?.Count > 0)
                 {
-                    stats.MapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-                    stats.MapReferenceSuccesses = statsTree.Read(IndexSchema.MapReferenceSuccessesSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
-                    stats.MapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice)?.Reader.ReadLittleEndianInt32() ?? 0;
+                    stats.MapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice).ReadLittleEndianInt32OrDefault(0);
+                    stats.MapReferenceSuccesses = statsTree.Read(IndexSchema.MapReferenceSuccessesSlice).ReadLittleEndianInt32OrDefault(0);
+                    stats.MapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice).ReadLittleEndianInt32OrDefault(0);
                 }
             }
 
@@ -543,7 +545,7 @@ namespace Raven.Server.Documents.Indexes
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
 
-            if (lastIndexingTime != null)
+            if (lastIndexingTime.IsNull == false)
             {
                 return statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument).Reader.ReadLittleEndianInt32();
             }
@@ -560,7 +562,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.ArchivedDataProcessingBehaviorSlice);
-            if (result == null)
+            if (result.IsNull)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.ArchivedDataProcessingBehaviorSlice)}' tree.");
             }
@@ -582,7 +584,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.CoraxComplexFieldIndexingBehavior);
-            if (result == null)
+            if (result.IsNull)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.CoraxComplexFieldIndexingBehavior)}' key.");
             }
@@ -663,11 +665,13 @@ namespace Raven.Server.Documents.Indexes
 
                 var tree = tx.ReadTree(_referencePrefix + collection);
 
-                var result = tree?.Read(referencedCollection.Name);
-                if (result == null)
-                    return 0;
-
-                return result.Reader.ReadLittleEndianInt64();
+                const long nonExistent = 0;
+                
+                if (tree == null)
+                    return nonExistent;
+                
+                var result = tree.Read(referencedCollection.Name);
+                return result.ReadLittleEndianInt64OrDefault(nonExistent);
             }
 
             public unsafe void WriteLastReferenceEtag(RavenTransaction tx, string collection, CollectionName referencedCollection, long etag)
@@ -705,13 +709,14 @@ namespace Raven.Server.Documents.Indexes
                     }
                 }
 
+                const long nonExistent = 0;
+                
                 var tree = tx.ReadTree(_referenceTombstonePrefix + collection);
-
-                var result = tree?.Read(referencedCollection.Name);
-                if (result == null)
-                    return 0;
-
-                return result.Reader.ReadLittleEndianInt64();
+                if (tree == null)
+                    return nonExistent;
+                
+                var result = tree.Read(referencedCollection.Name);
+                return result.ReadLittleEndianInt64OrDefault(nonExistent);
             }
 
             public unsafe void WriteLastReferenceTombstoneEtag(RavenTransaction tx, string collection, CollectionName referencedCollection, long etag)
@@ -983,13 +988,7 @@ namespace Raven.Server.Documents.Indexes
 
         internal static long ReadLastEtag(Transaction tx, string tree, Slice collection)
         {
-            var statsTree = tx.CreateTree(tree);
-            var readResult = statsTree.Read(collection);
-            long lastEtag = 0;
-            if (readResult != null)
-                lastEtag = readResult.Reader.ReadLittleEndianInt64();
-
-            return lastEtag;
+            return tx.CreateTree(tree).Read(collection).ReadLittleEndianInt64OrDefault(0);
         }
 
         public unsafe IndexFailureInformation UpdateStats(DateTime indexingTime, TimeSpan lastQueryElapsed, IndexingRunStats stats)
@@ -1013,12 +1012,12 @@ namespace Raven.Server.Documents.Indexes
                 result.MapSuccesses = statsTree.Increment(IndexSchema.MapSuccessesSlice, stats.MapSuccesses);
                 result.MapErrors = statsTree.Increment(IndexSchema.MapErrorsSlice, stats.MapErrors);
 
-                var currentMaxNumberOfOutputs = statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument)?.Reader.ReadLittleEndianInt32();
+                var currentMaxNumberOfOutputs = statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument).ReadLittleEndianInt32OrDefault(0);
 
                 using (statsTree.DirectAdd(IndexSchema.MaxNumberOfOutputsPerDocument, sizeof(int), out byte* ptr))
                 {
                     *(int*)ptr = currentMaxNumberOfOutputs > stats.MaxNumberOfOutputsPerDocument
-                        ? currentMaxNumberOfOutputs.Value
+                        ? currentMaxNumberOfOutputs
                         : stats.MaxNumberOfOutputsPerDocument;
                 }
 
@@ -1093,7 +1092,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.TypeSlice);
-                if (result == null)
+                if (result.IsNull)
                     throw new InvalidOperationException($"Stats tree does not contain 'Type' entry in index '{name}'.");
 
                 return (IndexType)result.Reader.ReadLittleEndianInt32();
@@ -1109,7 +1108,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.DatabaseIdSlice);
-                if (result == null)
+                if (result.IsNull)
                     return null; // backward compatibility
 
                 return result.Reader.ReadString(result.Reader.Length);
@@ -1127,14 +1126,15 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 var result = configurationTree.Read(IndexSchema.SearchEngineType);
-                if (result == null)
+                if (result.IsNull)
                 {
                     return SearchEngineType.None;
                 }
 
-                if (Enum.TryParse(result.Reader.ToStringValue(), out SearchEngineType persistedSearchEngineType) == false)
+                string searchEngineType = result.Reader.ToStringValue();
+                if (Enum.TryParse(searchEngineType, out SearchEngineType persistedSearchEngineType) == false)
                 {
-                    throw new InvalidOperationException($"Index '{name}' does not contain valid {nameof(SearchEngineType)} property. It contains: {result.Reader.ToStringValue()}.");
+                    throw new InvalidOperationException($"Index '{name}' does not contain valid {nameof(SearchEngineType)} property. It contains: {searchEngineType}.");
                 }
 
                 return persistedSearchEngineType;
@@ -1150,7 +1150,7 @@ namespace Raven.Server.Documents.Indexes
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
 
                 var result = statsTree.Read(IndexSchema.SourceTypeSlice);
-                if (result == null)
+                if (result.IsNull)
                     return IndexSourceType.Documents; // backward compatibility
 
                 return (IndexSourceType)result.Reader.ReadLittleEndianInt32();

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -132,8 +132,7 @@ namespace Raven.Server.Documents.Indexes
                 using (Slice.External(context.Allocator, (byte*)&sourceTypeInt, sizeof(int), out Slice tmpSlice))
                     statsTree.Add(IndexSchema.SourceTypeSlice, tmpSlice);
 
-                var createdTimestampResult = statsTree.Read(IndexSchema.CreatedTimestampSlice);
-                if (createdTimestampResult.HasValue == false)
+                if (statsTree.TryRead(IndexSchema.CreatedTimestampSlice, out var createdTimestampResult) == false)
                 {
                     var binaryDate = CreatedTimestampAsBinary = SystemTime.UtcNow.ToBinary();
                     using (Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long), out Slice tmpSlice))
@@ -172,9 +171,8 @@ namespace Raven.Server.Documents.Indexes
 
                 void AssertAndPersistAnalyzer(Tree configurationTree, string configurationKey, string expectedAnalyzer, string defaultAnalyzer)
                 {
-                    var result = configurationTree.Read(configurationKey);
                     string persistedConfigurationValue = null;
-                    if (result.HasValue)
+                    if (configurationTree.TryRead(configurationKey, out var result))
                         persistedConfigurationValue = result.Reader.ToStringValue();
                     else if (_index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.Analyzers)
                         persistedConfigurationValue = defaultAnalyzer;
@@ -199,8 +197,7 @@ namespace Raven.Server.Documents.Indexes
 
                     if (defaultEngineType == SearchEngineType.None)
                         throw new InvalidDataException($"Default search engine is {SearchEngineType.None}. Please set {configurationName}.");
-                    var result = configurationTree.Read(configurationKey);
-                    if (result.HasValue)
+                    if (configurationTree.TryRead(configurationKey, out var result))
                     {
                         if (Enum.TryParse(result.Reader.ToStringValue(), out SearchEngineType persistedSearchEngineType) == false)
                         {
@@ -228,7 +225,7 @@ namespace Raven.Server.Documents.Indexes
                         configurationTree.Add(configurationKey, _index.Definition.ArchivedDataProcessingBehavior.ToString());
                     else
                     {
-                        if (configurationTree.Read(configurationKey).HasValue)
+                        if (configurationTree.TryRead(configurationKey, out _))
                             return; // do not overwrite default value if it exists already
                         
                         configurationTree.Add(configurationKey, defaultBehavior.ToString());
@@ -244,8 +241,7 @@ namespace Raven.Server.Documents.Indexes
                     if (_index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.CoraxComplexFieldIndexingBehavior)
                         configuredBehavior = _index.Configuration.CoraxStaticIndexComplexFieldIndexingBehavior;
 
-                    var result = configurationTree.Read(configurationKey);
-                    if (result.HasValue)
+                    if (configurationTree.TryRead(configurationKey, out var result))
                     {
                         var behaviorStringValue = result.Reader.ToStringValue();
 
@@ -318,8 +314,7 @@ namespace Raven.Server.Documents.Indexes
         public static IndexState ReadState(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
-            var state = statsTree.Read(IndexSchema.StateSlice);
-            return state.HasValue ? (IndexState)state.Reader.ReadLittleEndianInt32() : IndexState.Normal;
+            return statsTree.TryRead(IndexSchema.StateSlice, out var state) ? (IndexState)state.Reader.ReadLittleEndianInt32() : IndexState.Normal;
         }
 
         public void DeleteErrors()
@@ -401,8 +396,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
-            var lastQueryTimeSlice = statsTree.Read(IndexSchema.ElapsedSinceQueriedSlice);
-            return lastQueryTimeSlice.HasValue ? new TimeSpan(ticks: lastQueryTimeSlice.Reader.ReadLittleEndianInt64()) : null;
+            return statsTree.TryRead(IndexSchema.ElapsedSinceQueriedSlice, out var result) ? new TimeSpan(ticks: result.Reader.ReadLittleEndianInt64()) : null;
         }
 
         public void WriteElapsedSinceQueried(TimeSpan value)
@@ -426,9 +420,7 @@ namespace Raven.Server.Documents.Indexes
         public static DateTime? ReadLastIndexingTime(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
-
-            var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
-            return lastIndexingTime.HasValue ? DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64()) : null;
+            return statsTree.TryRead(IndexSchema.LastIndexingTimeSlice, out var result) ? DateTime.FromBinary(result.Reader.ReadLittleEndianInt64()) : null;
         }
 
         public bool IsIndexInvalid(RavenTransaction tx)
@@ -468,7 +460,7 @@ namespace Raven.Server.Documents.Indexes
                 ErrorsCount = (int)(table?.NumberOfEntries ?? 0)
             };
 
-            var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
+          
 
             stats.Collections = new Dictionary<string, IndexStats.CollectionStats>();
             foreach (var collection in _index.Definition.Collections)
@@ -480,10 +472,8 @@ namespace Raven.Server.Documents.Indexes
                 };
             }
 
-            ReadResult entriesResult = statsTree.Read(IndexSchema.EntriesCount);
-            
             long? entriesCount = null;
-            if (entriesResult.HasValue)
+            if (statsTree.TryRead(IndexSchema.EntriesCount, out var entriesResult))
             {
                 var entriesCountReader = entriesResult.Reader;
                 var entriesCountSize = entriesCountReader.Length;
@@ -503,7 +493,7 @@ namespace Raven.Server.Documents.Indexes
                 }
             }
 
-            if (lastIndexingTime.HasValue)
+            if (statsTree.TryRead(IndexSchema.LastIndexingTimeSlice, out var lastIndexingTime))
             {
                 stats.LastIndexingTime = DateTime.FromBinary(lastIndexingTime.Reader.ReadLittleEndianInt64());
                 stats.MapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice).Reader.ReadLittleEndianInt32();

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         {
             var read = mapEntriesTree.Read(LastMapResultIdKey);
 
-            if (read == null)
+            if (read.IsNull)
                 return;
 
             NextMapResultId = *(long*)read.Reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         {
             var read = mapEntriesTree.Read(LastMapResultIdKey);
 
-            if (!read.HasValue)
+            if (read.HasValue == false)
                 return;
 
             NextMapResultId = *(long*)read.Reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         {
             var read = mapEntriesTree.Read(LastMapResultIdKey);
 
-            if (read.IsNull)
+            if (!read.HasValue)
                 return;
 
             NextMapResultId = *(long*)read.Reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -83,12 +83,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public unsafe void Initialize(Tree mapEntriesTree)
         {
-            var read = mapEntriesTree.Read(LastMapResultIdKey);
-
-            if (read.HasValue == false)
+            if (mapEntriesTree.TryRead(LastMapResultIdKey, out var result) == false)
                 return;
 
-            NextMapResultId = *(long*)read.Reader.Base;
+            NextMapResultId = *(long*)result.Reader.Base;
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         else
                         {
                             var read = Tree.Read(entrySlice);
-                            if (read.IsNull)
+                            if (!read.HasValue)
                                 throw new InvalidOperationException($"Could not find a map result with id '{id}' in '{Tree.Name}' tree");
                             return new ReadMapEntryScope(PtrSize.Create(read.Reader.Base, read.Reader.Length));
                         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         else
                         {
                             var read = Tree.Read(entrySlice);
-                            if (!read.HasValue)
+                            if (read.HasValue == false)
                                 throw new InvalidOperationException($"Could not find a map result with id '{id}' in '{Tree.Name}' tree");
                             return new ReadMapEntryScope(PtrSize.Create(read.Reader.Base, read.Reader.Length));
                         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         else
                         {
                             var read = Tree.Read(entrySlice);
-                            if (read == null)
+                            if (read.IsNull)
                                 throw new InvalidOperationException($"Could not find a map result with id '{id}' in '{Tree.Name}' tree");
                             return new ReadMapEntryScope(PtrSize.Create(read.Reader.Base, read.Reader.Length));
                         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -162,8 +162,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         }
                         else
                         {
-                            var read = Tree.Read(entrySlice);
-                            if (read.HasValue == false)
+                            if (Tree.TryRead(entrySlice, out var read) == false)
                                 throw new InvalidOperationException($"Could not find a map result with id '{id}' in '{Tree.Name}' tree");
                             return new ReadMapEntryScope(PtrSize.Create(read.Reader.Base, read.Reader.Length));
                         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             _parent = parent;
             _nestedValueKey = nestedValueKey;
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
             {
                 IsNew = true;
             }
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 var tmpPtr = tmp.Ptr;
                 var dataPosInTempPage = 0;
                 var readResult = _parent.Read(_nestedValueKey);
-                if (readResult.IsNull == false)
+                if (readResult.HasValue)
                 {
                     var reader = readResult.Reader;
                     var entry = (ResultHeader*)reader.Base;
@@ -82,7 +82,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         entry = (ResultHeader*)((byte*)entry + sizeof(ResultHeader) + entry->Size);
                     }
 
-                    if (readResult.IsNull == false)
+                    if (readResult.HasValue)
                     {
                         Memory.Copy(tmpPtr, readResult.Reader.Base, readResult.Reader.Length);
                         dataPosInTempPage = readResult.Reader.Length;
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public PtrSize Get(long id)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 throw new InvalidOperationException($"Could not find a map result wit id '{id}' within a nested values section stored under '{_nestedValueKey}' key");
 
             var reader = readResult.Reader;
@@ -127,7 +127,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public void MoveTo(Tree newHome)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return;
 
             var reader = readResult.Reader;
@@ -150,7 +150,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public int GetResults(JsonOperationContext context, List<BlittableJsonReaderObject> results)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return 0;
 
             var reader = readResult.Reader;
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public int GetResultsForDebug(JsonOperationContext context, Dictionary<long, BlittableJsonReaderObject> results)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return 0;
 
             var reader = readResult.Reader;
@@ -194,7 +194,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 tmp.Clear();
                 var tmpPtr = tmp.Ptr;
                 var readResult = _parent.Read(_nestedValueKey);
-                if (readResult.IsNull)
+                if (!readResult.HasValue)
                     return;
                 var reader = readResult.Reader;
                 var entry = (ResultHeader*)reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             _parent = parent;
             _nestedValueKey = nestedValueKey;
             var readResult = _parent.Read(_nestedValueKey);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
             {
                 IsNew = true;
             }
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public PtrSize Get(long id)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 throw new InvalidOperationException($"Could not find a map result wit id '{id}' within a nested values section stored under '{_nestedValueKey}' key");
 
             var reader = readResult.Reader;
@@ -127,7 +127,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public void MoveTo(Tree newHome)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return;
 
             var reader = readResult.Reader;
@@ -150,7 +150,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public int GetResults(JsonOperationContext context, List<BlittableJsonReaderObject> results)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return 0;
 
             var reader = readResult.Reader;
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public int GetResultsForDebug(JsonOperationContext context, Dictionary<long, BlittableJsonReaderObject> results)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return 0;
 
             var reader = readResult.Reader;
@@ -194,7 +194,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 tmp.Clear();
                 var tmpPtr = tmp.Ptr;
                 var readResult = _parent.Read(_nestedValueKey);
-                if (!readResult.HasValue)
+                if (readResult.HasValue == false)
                     return;
                 var reader = readResult.Reader;
                 var entry = (ResultHeader*)reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
@@ -26,14 +26,14 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             _parent = parent;
             _nestedValueKey = nestedValueKey;
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult != null)
+            if (readResult.IsNull)
             {
-                _dataSize = readResult.Reader.Length;
-                IsNew = false;
+                IsNew = true;
             }
             else
             {
-                IsNew = true;
+                _dataSize = readResult.Reader.Length;
+                IsNew = false;
             }
         }
 
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 var tmpPtr = tmp.Ptr;
                 var dataPosInTempPage = 0;
                 var readResult = _parent.Read(_nestedValueKey);
-                if (readResult != null)
+                if (readResult.IsNull == false)
                 {
                     var reader = readResult.Reader;
                     var entry = (ResultHeader*)reader.Base;
@@ -82,7 +82,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         entry = (ResultHeader*)((byte*)entry + sizeof(ResultHeader) + entry->Size);
                     }
 
-                    if (readResult != null)
+                    if (readResult.IsNull == false)
                     {
                         Memory.Copy(tmpPtr, readResult.Reader.Base, readResult.Reader.Length);
                         dataPosInTempPage = readResult.Reader.Length;
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public PtrSize Get(long id)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult == null)
+            if (readResult.IsNull)
                 throw new InvalidOperationException($"Could not find a map result wit id '{id}' within a nested values section stored under '{_nestedValueKey}' key");
 
             var reader = readResult.Reader;
@@ -127,7 +127,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public void MoveTo(Tree newHome)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult == null)
+            if (readResult.IsNull)
                 return;
 
             var reader = readResult.Reader;
@@ -150,7 +150,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public int GetResults(JsonOperationContext context, List<BlittableJsonReaderObject> results)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult == null)
+            if (readResult.IsNull)
                 return 0;
 
             var reader = readResult.Reader;
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public int GetResultsForDebug(JsonOperationContext context, Dictionary<long, BlittableJsonReaderObject> results)
         {
             var readResult = _parent.Read(_nestedValueKey);
-            if (readResult == null)
+            if (readResult.IsNull)
                 return 0;
 
             var reader = readResult.Reader;
@@ -194,7 +194,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 tmp.Clear();
                 var tmpPtr = tmp.Ptr;
                 var readResult = _parent.Read(_nestedValueKey);
-                if (readResult == null)
+                if (readResult.IsNull)
                     return;
                 var reader = readResult.Reader;
                 var entry = (ResultHeader*)reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
@@ -25,14 +25,13 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             _env = env;
             _parent = parent;
             _nestedValueKey = nestedValueKey;
-            var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.HasValue == false)
+            if (_parent.TryRead(_nestedValueKey, out var read) == false)
             {
                 IsNew = true;
             }
             else
             {
-                _dataSize = readResult.Reader.Length;
+                _dataSize = read.Reader.Length;
                 IsNew = false;
             }
         }
@@ -56,8 +55,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                 tmp.Clear();
                 var tmpPtr = tmp.Ptr;
                 var dataPosInTempPage = 0;
-                var readResult = _parent.Read(_nestedValueKey);
-                if (readResult.HasValue)
+                if (_parent.TryRead(_nestedValueKey, out var readResult))
                 {
                     var reader = readResult.Reader;
                     var entry = (ResultHeader*)reader.Base;
@@ -104,8 +102,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         }
         public PtrSize Get(long id)
         {
-            var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.HasValue == false)
+            if (_parent.TryRead(_nestedValueKey, out var readResult) == false)
                 throw new InvalidOperationException($"Could not find a map result wit id '{id}' within a nested values section stored under '{_nestedValueKey}' key");
 
             var reader = readResult.Reader;
@@ -126,8 +123,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public void MoveTo(Tree newHome)
         {
-            var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.HasValue == false)
+            if (_parent.TryRead(_nestedValueKey, out var readResult) == false)
                 return;
 
             var reader = readResult.Reader;
@@ -149,8 +145,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public int GetResults(JsonOperationContext context, List<BlittableJsonReaderObject> results)
         {
-            var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.HasValue == false)
+            if (_parent.TryRead(_nestedValueKey, out var readResult) == false)
                 return 0;
 
             var reader = readResult.Reader;
@@ -168,8 +163,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public int GetResultsForDebug(JsonOperationContext context, Dictionary<long, BlittableJsonReaderObject> results)
         {
-            var readResult = _parent.Read(_nestedValueKey);
-            if (readResult.HasValue == false)
+            if (_parent.TryRead(_nestedValueKey, out var readResult) == false)
                 return 0;
 
             var reader = readResult.Reader;
@@ -193,8 +187,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             {
                 tmp.Clear();
                 var tmpPtr = tmp.Ptr;
-                var readResult = _parent.Read(_nestedValueKey);
-                if (readResult.HasValue == false)
+                if (_parent.TryRead(_nestedValueKey, out var readResult) == false)
                     return;
                 var reader = readResult.Reader;
                 var entry = (ResultHeader*)reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
@@ -105,13 +105,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             var result = tree.Read(reduceResultId);
 
             // ReSharper disable once UseNullPropagation
-            if (result.IsNull)
-            {
-                // pattern id can be null here if it was invalid for a given reduce result
-                return null;
-            }
-
-            return result.Reader.ReadString(result.Reader.Length);
+            if (result.HasValue) 
+                return result.Reader.ReadString(result.Reader.Length);
+            
+            // pattern id can be null here if it was invalid for a given reduce result
+            return null;
         }
 
         public void DeletePatternGeneratedIdForReduceOutput(Transaction tx, string reduceResultId)

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             var result = tree.Read(reduceResultId);
 
             // ReSharper disable once UseNullPropagation
-            if (result == null)
+            if (result.IsNull)
             {
                 // pattern id can be null here if it was invalid for a given reduce result
                 return null;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
@@ -102,10 +102,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
         {
             var tree = tx.CreateTree(ReduceOutputsIdsToPatternReferenceIdsTree);
 
-            var result = tree.Read(reduceResultId);
-
             // ReSharper disable once UseNullPropagation
-            if (result.HasValue) 
+            if (tree.TryRead(reduceResultId, out var result)) 
                 return result.Reader.ReadString(result.Reader.Length);
             
             // pattern id can be null here if it was invalid for a given reduce result

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2788,15 +2788,11 @@ namespace Raven.Server.Documents.Revisions
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(DocumentsStorage.GlobalTreeSlice);
             var readResult = tree.Read(DocumentsStorage.RevisionsBinCleanerLastEtag);
-            if (readResult.IsNull)
-            {
-                // When we start passing the revisions (forward - from the oldest) on DeleteRevisionEtagSlice index,
-                // we want to skip the revisions with key 0, because they are not relevant (not 'Delete Revisions').
-                // so we start from etag (key) 1.
-                return 1;
-            }
 
-            return readResult.Reader.ReadLittleEndianInt64();
+            // When we start passing the revisions (forward - from the oldest) on DeleteRevisionEtagSlice index,
+            // we want to skip the revisions with key 0, because they are not relevant (not 'Delete Revisions').
+            // so we start from etag (key) 1.
+            return readResult.ReadLittleEndianInt64OrDefault(1);
         }
 
         public static unsafe void SetLastRevisionsBinCleanerLastEtag(DocumentsOperationContext context, long etag)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1751,7 +1751,7 @@ namespace Raven.Server.Documents.Revisions
         private static long CountOfRevisions(DocumentsOperationContext context, Slice prefix)
         {
             var numbers = context.Transaction.InnerTransaction.ReadTree(RevisionsCountSlice);
-            return numbers.Read(prefix)?.Reader.ReadLittleEndianInt64() ?? 0;
+            return numbers.Read(prefix).ReadLittleEndianInt64OrDefault(0);
         }
 
         public Document GetRevisionBefore(DocumentsOperationContext context, string id, DateTime max)
@@ -2788,7 +2788,7 @@ namespace Raven.Server.Documents.Revisions
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(DocumentsStorage.GlobalTreeSlice);
             var readResult = tree.Read(DocumentsStorage.RevisionsBinCleanerLastEtag);
-            if (readResult == null)
+            if (readResult.IsNull)
             {
                 // When we start passing the revisions (forward - from the oldest) on DeleteRevisionEtagSlice index,
                 // we want to skip the revisions with key 0, because they are not relevant (not 'Delete Revisions').

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents.Sharding
             mergedCvSlice = Slices.Empty;
 
             var readResult = tree.Read(keySlice);
-            if (readResult == null)
+            if (readResult.IsNull)
             {
                 stats = inMemoryStats;
             }

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -89,11 +89,7 @@ namespace Raven.Server.Documents.Sharding
             mergedCvSlice = Slices.Empty;
 
             var readResult = tree.Read(keySlice);
-            if (!readResult.HasValue)
-            {
-                stats = inMemoryStats;
-            }
-            else
+            if (readResult.HasValue)
             {
                 stats = *(Documents.BucketStats*)readResult.Reader.Base;
                 stats.Size += inMemoryStats.Size;
@@ -101,6 +97,10 @@ namespace Raven.Server.Documents.Sharding
                 stats.LastModifiedTicks = inMemoryStats.LastModifiedTicks;
 
                 mergedCv = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);
+            }
+            else
+            {
+                stats = inMemoryStats;
             }
 
             if (_mergedChangeVectors.TryGetValue(bucket, out var changeVector))

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents.Sharding
             mergedCvSlice = Slices.Empty;
 
             var readResult = tree.Read(keySlice);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
             {
                 stats = inMemoryStats;
             }

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -88,15 +88,14 @@ namespace Raven.Server.Documents.Sharding
             string mergedCv = null;
             mergedCvSlice = Slices.Empty;
 
-            var readResult = tree.Read(keySlice);
-            if (readResult.HasValue)
+            if (tree.TryRead(keySlice, out var result))
             {
-                stats = *(Documents.BucketStats*)readResult.Reader.Base;
+                stats = *(Documents.BucketStats*)result.Reader.Base;
                 stats.Size += inMemoryStats.Size;
                 stats.NumberOfDocuments += inMemoryStats.NumberOfDocuments;
                 stats.LastModifiedTicks = inMemoryStats.LastModifiedTicks;
 
-                mergedCv = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);
+                mergedCv = Documents.BucketStats.GetMergedChangeVector(result.Reader);
             }
             else
             {

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -122,7 +122,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return null;
 
             var reader = readResult.Reader;
@@ -275,7 +275,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return null;
 
             var cvStr = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -122,7 +122,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult == null)
+            if (readResult.IsNull)
                 return null;
 
             var reader = readResult.Reader;
@@ -275,7 +275,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult == null)
+            if (readResult.IsNull)
                 return null;
 
             var cvStr = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -122,7 +122,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return null;
 
             var reader = readResult.Reader;
@@ -275,7 +275,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return null;
 
             var cvStr = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -121,8 +121,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         using (context.Transaction.InnerTransaction.Allocator.Allocate(sizeof(int), out var keyBuffer))
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
-            var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult.HasValue == false)
+            if (tree.TryRead(new Slice(keyBuffer), out var readResult) == false)
                 return null;
 
             var reader = readResult.Reader;
@@ -274,8 +273,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         using (context.Transaction.InnerTransaction.Allocator.Allocate(sizeof(int), out var keyBuffer))
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
-            var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult.HasValue == false)
+            if (tree.TryRead(new Slice(keyBuffer), out var readResult) == false)
                 return null;
 
             var cvStr = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -372,7 +372,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
 
             var read = state.Read(CurrentTermSlice);
-            if (!read.HasValue || read.Reader.Length != sizeof(long))
+            if (read.HasValue == false || read.Reader.Length != sizeof(long))
             {
                 using (state.DirectAdd(CurrentTermSlice, sizeof(long), out byte* ptr))
                     *(long*)ptr = 0;
@@ -1183,20 +1183,21 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (!read.HasValue)
+            
+            if (read.HasValue)
             {
-                return new ClusterTopology(
-                    null,
-                    new Dictionary<string, string>(),
-                    new Dictionary<string, string>(),
-                    new Dictionary<string, string>(),
-                    "",
-                    -1
-                );
+                var json = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+                return JsonDeserializationRachis<ClusterTopology>.Deserialize(json);
             }
 
-            var json = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
-            return JsonDeserializationRachis<ClusterTopology>.Deserialize(json);
+            return new ClusterTopology(
+                null,
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                "",
+                -1
+            );
         }
 
         public unsafe BlittableJsonReaderObject GetTopologyRaw(ClusterOperationContext context)
@@ -1204,10 +1205,10 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (!read.HasValue)
+            if (read.HasValue == false)
                 return null;
 
-            BlittableJsonReaderObject topologyBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+            BlittableJsonReaderObject topologyBlittable = new(read.Reader.Base, read.Reader.Length, context);
 
             Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, topologyBlittable);
 
@@ -1721,12 +1722,13 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastTruncatedSlice);
-            if (!read.HasValue)
+            if (read.HasValue == false)
             {
                 lastTruncatedIndex = 0;
                 lastTruncatedTerm = 0;
                 return;
             }
+            
             var reader = read.Reader;
             lastTruncatedIndex = reader.ReadLittleEndianInt64();
             lastTruncatedTerm = reader.ReadLittleEndianInt64();
@@ -1771,7 +1773,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (!read.HasValue)
+            if (read.HasValue == false)
             {
                 index = 0;
                 term = 0;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -372,7 +372,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
 
             var read = state.Read(CurrentTermSlice);
-            if (read == null || read.Reader.Length != sizeof(long))
+            if (read.IsNull || read.Reader.Length != sizeof(long))
             {
                 using (state.DirectAdd(CurrentTermSlice, sizeof(long), out byte* ptr))
                     *(long*)ptr = 0;
@@ -389,24 +389,25 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
 
-            var readResult = state?.Read(TagSlice);
-            return readResult == null ? InitialTag : readResult.Reader.ToStringValue();
+            if (state == null)
+                return InitialTag;
+            
+            return state.Read(TagSlice).ToStringValueOrDefault(InitialTag);
         }
 
         public static string ReadNodeTag<T>(TransactionOperationContext<T> context) where T : RavenTransaction
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
+            if (state == null)
+                return InitialTag;
 
-            var readResult = state?.Read(TagSlice);
-            return readResult == null ? InitialTag : readResult.Reader.ToStringValue();
+            return state.Read(TagSlice).ToStringValueOrDefault(InitialTag);
         }
 
         public string ReadPreviousNodeTag(ClusterOperationContext context)
         {
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
-
-            var readResult = state.Read(PreviousTagSlice);
-            return readResult?.Reader.ToStringValue();
+            return state.Read(PreviousTagSlice).ToStringValueOrDefault(null);
         }
 
         internal void SwitchToSingleLeader(ClusterOperationContext context)
@@ -1182,7 +1183,7 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (read == null)
+            if (read.IsNull)
             {
                 return new ClusterTopology(
                     null,
@@ -1203,7 +1204,7 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (read == null)
+            if (read.IsNull)
                 return null;
 
             BlittableJsonReaderObject topologyBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
@@ -1720,7 +1721,7 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastTruncatedSlice);
-            if (read == null)
+            if (read.IsNull)
             {
                 lastTruncatedIndex = 0;
                 lastTruncatedTerm = 0;
@@ -1760,9 +1761,8 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read == null)
-                return 0;
-            return read.Reader.ReadLittleEndianInt64();
+            
+            return read.ReadLittleEndianInt64OrDefault(0);
         }
 
         public void GetLastCommitIndex(ClusterOperationContext context, out long index, out long term)
@@ -1771,7 +1771,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read == null)
+            if (read.IsNull)
             {
                 index = 0;
                 term = 0;
@@ -1799,7 +1799,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read != null)
+            if (read.IsNull == false)
             {
                 var reader = read.Reader;
                 var oldIndex = reader.ReadLittleEndianInt64();
@@ -2005,7 +2005,7 @@ namespace Raven.Server.Rachis
 
             // give the other side enough time to become the leader before challenging them
             Timeout.Defer(votedFor);
-                    }
+        }
 
         public (string VotedFor, long LastVotedTerm) GetWhoGotMyVoteIn(ClusterOperationContext context, long term)
         {
@@ -2013,15 +2013,15 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
             var read = state.Read(CurrentTermSlice);
-
-            var votedTerm = read?.Reader.ReadLittleEndianInt64();
+           
+            long? votedTerm = read.IsNull ? null : read.Reader.ReadLittleEndianInt64();
 
             if (votedTerm != term && votedTerm.HasValue)
                 return (null, votedTerm.Value);
 
             read = state.Read(VotedForSlice);
 
-            return (read?.Reader.ReadString(read.Reader.Length), votedTerm ?? 0);
+            return (read.Reader.ReadString(read.Reader.Length), votedTerm ?? 0);
         }
 
         public event EventHandler OnDispose;
@@ -2338,10 +2338,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
             var reader = state.Read(SnapshotRequestSlice);
 
-            if (reader == null)
-                return false;
-
-            return Convert.ToBoolean(reader.Reader.ReadByte());
+            return Convert.ToBoolean(reader.ReadByteOrDefault(0));
         }
 
         public void LeaderElectToLeaderChanged()

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -372,7 +372,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
 
             var read = state.Read(CurrentTermSlice);
-            if (read.IsNull || read.Reader.Length != sizeof(long))
+            if (!read.HasValue || read.Reader.Length != sizeof(long))
             {
                 using (state.DirectAdd(CurrentTermSlice, sizeof(long), out byte* ptr))
                     *(long*)ptr = 0;
@@ -1183,7 +1183,7 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (read.IsNull)
+            if (!read.HasValue)
             {
                 return new ClusterTopology(
                     null,
@@ -1204,7 +1204,7 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (read.IsNull)
+            if (!read.HasValue)
                 return null;
 
             BlittableJsonReaderObject topologyBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
@@ -1721,7 +1721,7 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastTruncatedSlice);
-            if (read.IsNull)
+            if (!read.HasValue)
             {
                 lastTruncatedIndex = 0;
                 lastTruncatedTerm = 0;
@@ -1771,7 +1771,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read.IsNull)
+            if (!read.HasValue)
             {
                 index = 0;
                 term = 0;
@@ -1799,7 +1799,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read.IsNull == false)
+            if (read.HasValue)
             {
                 var reader = read.Reader;
                 var oldIndex = reader.ReadLittleEndianInt64();
@@ -2014,7 +2014,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
             var read = state.Read(CurrentTermSlice);
            
-            long? votedTerm = read.IsNull ? null : read.Reader.ReadLittleEndianInt64();
+            long? votedTerm = read.HasValue ? read.Reader.ReadLittleEndianInt64() : null;
 
             if (votedTerm != term && votedTerm.HasValue)
                 return (null, votedTerm.Value);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -371,8 +371,7 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
 
-            var read = state.Read(CurrentTermSlice);
-            if (read.HasValue == false || read.Reader.Length != sizeof(long))
+            if (state.TryRead(CurrentTermSlice, out var read) == false || read.Reader.Length != sizeof(long))
             {
                 using (state.DirectAdd(CurrentTermSlice, sizeof(long), out byte* ptr))
                     *(long*)ptr = 0;
@@ -1182,9 +1181,8 @@ namespace Raven.Server.Rachis
         {
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
-            var read = state.Read(TopologySlice);
             
-            if (read.HasValue)
+            if (state.TryRead(TopologySlice, out var read))
             {
                 var json = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
                 return JsonDeserializationRachis<ClusterTopology>.Deserialize(json);
@@ -1204,8 +1202,7 @@ namespace Raven.Server.Rachis
         {
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
-            var read = state.Read(TopologySlice);
-            if (read.HasValue == false)
+            if (state.TryRead(TopologySlice, out var read) == false)
                 return null;
 
             BlittableJsonReaderObject topologyBlittable = new(read.Reader.Base, read.Reader.Length, context);
@@ -1721,8 +1718,7 @@ namespace Raven.Server.Rachis
             where TTransaction : RavenTransaction
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
-            var read = state.Read(LastTruncatedSlice);
-            if (read.HasValue == false)
+            if (state.TryRead(LastTruncatedSlice, out var read) == false)
             {
                 lastTruncatedIndex = 0;
                 lastTruncatedTerm = 0;
@@ -1772,8 +1768,7 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
-            var read = state.Read(LastCommitSlice);
-            if (read.HasValue == false)
+            if (state.TryRead(LastCommitSlice, out var read) == false)
             {
                 index = 0;
                 term = 0;
@@ -1800,8 +1795,7 @@ namespace Raven.Server.Rachis
             Debug.Assert(term != 0);
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
-            var read = state.Read(LastCommitSlice);
-            if (read.HasValue)
+            if (state.TryRead(LastCommitSlice, out var read))
             {
                 var reader = read.Reader;
                 var oldIndex = reader.ReadLittleEndianInt64();
@@ -2014,9 +2008,8 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
 
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
-            var read = state.Read(CurrentTermSlice);
-           
-            long? votedTerm = read.HasValue ? read.Reader.ReadLittleEndianInt64() : null;
+            ;
+            long? votedTerm = state.TryRead(CurrentTermSlice, out var read) ? read.Reader.ReadLittleEndianInt64() : null;
 
             if (votedTerm != term && votedTerm.HasValue)
                 return (null, votedTerm.Value);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3117,7 +3117,7 @@ namespace Raven.Server.ServerWide
         {
             var localState = context.Transaction.InnerTransaction.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(thumbprint);
-            if (read.IsNull)
+            if (!read.HasValue)
                 return null;
             
             BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3117,9 +3117,10 @@ namespace Raven.Server.ServerWide
         {
             var localState = context.Transaction.InnerTransaction.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(thumbprint);
-            if (read == null)
+            if (read.IsNull)
                 return null;
-            BlittableJsonReaderObject localStateBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+            
+            BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);
 
             Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, localStateBlittable);
             return localStateBlittable;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3117,7 +3117,7 @@ namespace Raven.Server.ServerWide
         {
             var localState = context.Transaction.InnerTransaction.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(thumbprint);
-            if (!read.HasValue)
+            if (read.HasValue == false)
                 return null;
             
             BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3116,8 +3116,7 @@ namespace Raven.Server.ServerWide
             where TTransaction : RavenTransaction
         {
             var localState = context.Transaction.InnerTransaction.ReadTree(LocalNodeStateTreeName);
-            var read = localState.Read(thumbprint);
-            if (read.HasValue == false)
+            if (localState.TryRead(thumbprint, out var read) == false)
                 return null;
             
             BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.ServerWide
                         return;
 
                     var result = tree.Read(nameof(ServerStatistics));
-                    if (result == null)
+                    if (result.IsNull)
                         return;
 
                     using (var json = context.Sync.ReadForMemory(result.Reader.AsStream(), nameof(ServerStatistics)))

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.ServerWide
                         return;
 
                     var result = tree.Read(nameof(ServerStatistics));
-                    if (result.IsNull)
+                    if (!result.HasValue)
                         return;
 
                     using (var json = context.Sync.ReadForMemory(result.Reader.AsStream(), nameof(ServerStatistics)))

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.ServerWide
                         return;
 
                     var result = tree.Read(nameof(ServerStatistics));
-                    if (!result.HasValue)
+                    if (result.HasValue == false)
                         return;
 
                     using (var json = context.Sync.ReadForMemory(result.Reader.AsStream(), nameof(ServerStatistics)))

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -129,8 +129,7 @@ namespace Raven.Server.ServerWide
                     if (tree == null)
                         return;
 
-                    var result = tree.Read(nameof(ServerStatistics));
-                    if (result.HasValue == false)
+                    if (tree.TryRead(nameof(ServerStatistics), out var result) == false)
                         return;
 
                     using (var json = context.Sync.ReadForMemory(result.Reader.AsStream(), nameof(ServerStatistics)))

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1830,7 +1830,7 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.CreateTree("SecretKeys");
 
-            if (overwrite == false && tree.Read(name).IsNull == false)
+            if (overwrite == false && !tree.Read(name).HasValue == false)
                 throw new InvalidOperationException($"Attempt to overwrite secret key {name}, which isn\'t permitted (you\'ll lose access to the encrypted db).");
 
             using (var rawRecord = Cluster.ReadRawDatabaseRecord(context, name))
@@ -1864,7 +1864,7 @@ namespace Raven.Server.ServerWide
                 return null;
             
             var readResult = tree.Read(name);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return null;
 
             var protectedData = new byte[readResult.Reader.Length];

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1830,7 +1830,7 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.CreateTree("SecretKeys");
 
-            if (overwrite == false && tree.Read(name) != null)
+            if (overwrite == false && tree.Read(name).IsNull == false)
                 throw new InvalidOperationException($"Attempt to overwrite secret key {name}, which isn\'t permitted (you\'ll lose access to the encrypted db).");
 
             using (var rawRecord = Cluster.ReadRawDatabaseRecord(context, name))
@@ -1860,8 +1860,11 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.ReadTree("SecretKeys");
 
-            var readResult = tree?.Read(name);
-            if (readResult == null)
+            if (tree == null)
+                return null;
+            
+            var readResult = tree.Read(name);
+            if (readResult.IsNull)
                 return null;
 
             var protectedData = new byte[readResult.Reader.Length];

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1830,7 +1830,7 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.CreateTree("SecretKeys");
 
-            if (overwrite == false && !tree.Read(name).HasValue == false)
+            if (overwrite == false && tree.Read(name).HasValue)
                 throw new InvalidOperationException($"Attempt to overwrite secret key {name}, which isn\'t permitted (you\'ll lose access to the encrypted db).");
 
             using (var rawRecord = Cluster.ReadRawDatabaseRecord(context, name))
@@ -1864,7 +1864,7 @@ namespace Raven.Server.ServerWide
                 return null;
             
             var readResult = tree.Read(name);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return null;
 
             var protectedData = new byte[readResult.Reader.Length];

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1830,7 +1830,7 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.CreateTree("SecretKeys");
 
-            if (overwrite == false && tree.Read(name).HasValue)
+            if (overwrite == false && tree.TryRead(name, out _))
                 throw new InvalidOperationException($"Attempt to overwrite secret key {name}, which isn\'t permitted (you\'ll lose access to the encrypted db).");
 
             using (var rawRecord = Cluster.ReadRawDatabaseRecord(context, name))
@@ -1863,8 +1863,7 @@ namespace Raven.Server.ServerWide
             if (tree == null)
                 return null;
             
-            var readResult = tree.Read(name);
-            if (readResult.HasValue == false)
+            if (tree.TryRead(name, out var readResult) == false)
                 return null;
 
             var protectedData = new byte[readResult.Reader.Length];

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -266,10 +266,10 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                 // let's remove remaining counter trees from the root
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice).IsNull == false)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice).HasValue)
                     step.WriteTx.DeleteTree(CounterKeysSlice);
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice).IsNull == false)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice).HasValue)
                     step.WriteTx.DeleteFixedTree(AllCountersEtagSlice.ToString());
             }
 
@@ -496,12 +496,12 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
             var dbId = metadataTree.Read("db-id");
-            if (dbId.IsNull)
+            if (!dbId.HasValue)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");
 
             var buffer = new byte[16];
-            Debug.Assert(dbId.IsNull == false);
+            Debug.Assert(dbId.HasValue);
             // ReSharper disable once PossibleNullReferenceException
             var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
             if (dbIdBytes != 16)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -266,10 +266,10 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                 // let's remove remaining counter trees from the root
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice) != null)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice).IsNull == false)
                     step.WriteTx.DeleteTree(CounterKeysSlice);
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice) != null)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice).IsNull == false)
                     step.WriteTx.DeleteFixedTree(AllCountersEtagSlice.ToString());
             }
 
@@ -496,12 +496,12 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
             var dbId = metadataTree.Read("db-id");
-            if (dbId == null)
+            if (dbId.IsNull)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");
 
             var buffer = new byte[16];
-            Debug.Assert(dbId != null);
+            Debug.Assert(dbId.IsNull == false);
             // ReSharper disable once PossibleNullReferenceException
             var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
             if (dbIdBytes != 16)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -496,7 +496,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
             var dbId = metadataTree.Read("db-id");
-            if (!dbId.HasValue)
+            if (dbId.HasValue == false)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");
 

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -266,10 +266,10 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                 // let's remove remaining counter trees from the root
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice).HasValue)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.TryRead(CounterKeysSlice, out  _ ))
                     step.WriteTx.DeleteTree(CounterKeysSlice);
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice).HasValue)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.TryRead(AllCountersEtagSlice, out _))
                     step.WriteTx.DeleteFixedTree(AllCountersEtagSlice.ToString());
             }
 
@@ -495,13 +495,11 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
-            var dbId = metadataTree.Read("db-id");
-            if (dbId.HasValue == false)
+            if (metadataTree.TryRead("db-id", out var dbId) == false)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");
 
             var buffer = new byte[16];
-            Debug.Assert(dbId.HasValue);
             // ReSharper disable once PossibleNullReferenceException
             var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
             if (dbIdBytes != 16)

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
@@ -155,7 +155,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
         {
             var localState = tx.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(key);
-            if (read.IsNull)
+            if (!read.HasValue)
                 return null;
             
             BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
@@ -155,9 +155,10 @@ namespace Raven.Server.Storage.Schema.Updates.Server
         {
             var localState = tx.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(key);
-            if (read == null)
+            if (read.IsNull)
                 return null;
-            BlittableJsonReaderObject localStateBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+            
+            BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);
 
             Transaction.DebugDisposeReaderAfterTransaction(tx, localStateBlittable);
             return localStateBlittable;

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
@@ -155,7 +155,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
         {
             var localState = tx.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(key);
-            if (!read.HasValue)
+            if (read.HasValue == false)
                 return null;
             
             BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
@@ -154,8 +154,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
         public unsafe BlittableJsonReaderObject GetLocalStateByThumbprint(Transaction tx, JsonOperationContext context, string key)
         {
             var localState = tx.ReadTree(LocalNodeStateTreeName);
-            var read = localState.Read(key);
-            if (read.HasValue == false)
+            if (localState.TryRead(key, out var read) == false)
                 return null;
             
             BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
             step.WriteTx.DeleteTable(oldTableName);
 
             // remove the remaining CompareExchange global index
-            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex).IsNull == false)
+            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex).HasValue)
                 step.WriteTx.DeleteTree(ClusterStateMachine.CompareExchangeIndex);
 
             return true;

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
             step.WriteTx.DeleteTable(oldTableName);
 
             // remove the remaining CompareExchange global index
-            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex) != null)
+            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex).IsNull == false)
                 step.WriteTx.DeleteTree(ClusterStateMachine.CompareExchangeIndex);
 
             return true;

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
             step.WriteTx.DeleteTable(oldTableName);
 
             // remove the remaining CompareExchange global index
-            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex).HasValue)
+            if (step.WriteTx.LowLevelTransaction.RootObjects.TryRead(ClusterStateMachine.CompareExchangeIndex, out _))
                 step.WriteTx.DeleteTree(ClusterStateMachine.CompareExchangeIndex);
 
             return true;

--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -330,7 +330,7 @@ namespace Voron.Data.BTrees
                     return null;
             }
 
-            return new DecompressedReadResult(GetValueReaderFromHeader(node), decompressed);
+            return new DecompressedReadResult(new ReadResult(GetValueReaderFromHeader(node)), decompressed);
         }
 
         public struct DecompressionInput

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -193,7 +193,7 @@ namespace Voron.Data.BTrees
         public long GetLookupRootPage(Slice name)
         {
             var result = Read(name);
-            if (result.IsNull)
+            if (!result.HasValue)
                 return -1;
             var header = (LookupState*)result.Reader.Base;
             if (header->RootObjectType != RootObjectType.Lookup)

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -14,8 +14,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public long Increment(string key, long delta)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return Increment(keySlice, delta);
             }
@@ -24,8 +23,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Add(string key, Stream value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 Add(keySlice, value);
             }
@@ -34,8 +32,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Add(string key, byte[] value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 Add(keySlice, value);
             }
@@ -44,10 +41,8 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Add(string key, string value)
         {
-            Slice keySlice;
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 Add(keySlice, valueSlice);
             }
@@ -62,8 +57,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public DirectAddScope DirectAdd(string key, int len, TreeNodeFlags nodeType, out byte* ptr)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return DirectAdd(keySlice, len, nodeType, out ptr);
             }
@@ -72,8 +66,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Delete(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 Delete(keySlice);
             }
@@ -82,8 +75,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public ReadResult Read(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return Read(keySlice);
             }
@@ -92,8 +84,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public bool Exists(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return Exists(keySlice);
             }
@@ -102,10 +93,8 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(string key, string value)
         {
-            Slice keySlice;
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiAdd(keySlice, valueSlice);
             }
@@ -114,8 +103,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(string key, Slice value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 MultiAdd(keySlice, value);
             }
@@ -124,8 +112,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(Slice key, string value)
         {
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiAdd(key, valueSlice);
             }
@@ -134,10 +121,8 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiDelete(string key, string value)
         {
-            Slice keySlice;
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiDelete(keySlice, valueSlice);
             }
@@ -146,8 +131,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiDelete(Slice key, string value)
         {
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiDelete(key, valueSlice);
             }
@@ -156,8 +140,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiDelete(string key, Slice value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 MultiDelete(keySlice, value);
             }
@@ -166,8 +149,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public IIterator MultiRead(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return MultiRead(keySlice);
             }
@@ -211,7 +193,7 @@ namespace Voron.Data.BTrees
         public long GetLookupRootPage(Slice name)
         {
             var result = Read(name);
-            if (result == null)
+            if (result.IsNull)
                 return -1;
             var header = (LookupState*)result.Reader.Base;
             if (header->RootObjectType != RootObjectType.Lookup)

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -193,7 +193,7 @@ namespace Voron.Data.BTrees
         public long GetLookupRootPage(Slice name)
         {
             var result = Read(name);
-            if (!result.HasValue)
+            if (result.HasValue == false)
                 return -1;
             var header = (LookupState*)result.Reader.Base;
             if (header->RootObjectType != RootObjectType.Lookup)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -230,7 +230,7 @@ namespace Voron.Data.BTrees
             long currentValue = 0;
 
             var read = Read(key);
-            if (read.IsNull == false)
+            if (read.HasValue)
                 currentValue = *(long*)read.Reader.Base;
 
             var value = currentValue + delta;
@@ -246,7 +246,7 @@ namespace Voron.Data.BTrees
         public long? ReadInt64(Slice key)
         {
             var read = Read(key);
-            if (read.IsNull)
+            if (!read.HasValue)
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(long));
             return *(long*)read.Reader.Base;
@@ -258,7 +258,7 @@ namespace Voron.Data.BTrees
         public int? ReadInt32(Slice key)
         {
             var read = Read(key);
-            if (read.IsNull) 
+            if (!read.HasValue) 
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(int));
             return *(int*)read.Reader.Base;
@@ -271,7 +271,7 @@ namespace Voron.Data.BTrees
             where T : unmanaged
         {
             var read = Read(key);
-            if (read.IsNull) 
+            if (!read.HasValue) 
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(T));
             return *(T*)read.Reader.Base;

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -246,7 +246,7 @@ namespace Voron.Data.BTrees
         public long? ReadInt64(Slice key)
         {
             var read = Read(key);
-            if (!read.HasValue)
+            if (read.HasValue == false)
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(long));
             return *(long*)read.Reader.Base;
@@ -258,7 +258,7 @@ namespace Voron.Data.BTrees
         public int? ReadInt32(Slice key)
         {
             var read = Read(key);
-            if (!read.HasValue) 
+            if (read.HasValue == false) 
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(int));
             return *(int*)read.Reader.Base;
@@ -271,7 +271,7 @@ namespace Voron.Data.BTrees
             where T : unmanaged
         {
             var read = Read(key);
-            if (!read.HasValue) 
+            if (read.HasValue == false) 
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(T));
             return *(T*)read.Reader.Base;

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -230,7 +230,7 @@ namespace Voron.Data.BTrees
             long currentValue = 0;
 
             var read = Read(key);
-            if (read != null)
+            if (read.IsNull == false)
                 currentValue = *(long*)read.Reader.Base;
 
             var value = currentValue + delta;
@@ -246,7 +246,7 @@ namespace Voron.Data.BTrees
         public long? ReadInt64(Slice key)
         {
             var read = Read(key);
-            if (read == null)
+            if (read.IsNull)
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(long));
             return *(long*)read.Reader.Base;
@@ -258,11 +258,10 @@ namespace Voron.Data.BTrees
         public int? ReadInt32(Slice key)
         {
             var read = Read(key);
-            if (read == null) 
+            if (read.IsNull) 
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(int));
             return *(int*)read.Reader.Base;
-
         }
         
         /// <summary>
@@ -272,11 +271,10 @@ namespace Voron.Data.BTrees
             where T : unmanaged
         {
             var read = Read(key);
-            if (read == null) 
+            if (read.IsNull) 
                 return null;
             Debug.Assert(read.Reader.Length == sizeof(T));
             return *(T*)read.Reader.Base;
-
         }
 
         public void Add(Slice key, byte value)
@@ -1157,10 +1155,7 @@ namespace Voron.Data.BTrees
 
             var p = FindPageFor(key, out TreeNodeHeader* node);
 
-            if (p.LastMatch != 0)
-                return null;
-
-            return new ReadResult(GetValueReaderFromHeader(node));
+            return p.LastMatch != 0 ? ReadResult.Null : new ReadResult(GetValueReaderFromHeader(node));
         }
 
         public bool Exists(Slice key)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1148,7 +1148,7 @@ namespace Voron.Data.BTrees
 
             return new TreeIterator(this, _llt, prefetch);
         }
-
+        
         public ReadResult Read(Slice key)
         {
             AssertNotDisposed();
@@ -1156,6 +1156,30 @@ namespace Voron.Data.BTrees
             var p = FindPageFor(key, out TreeNodeHeader* node);
 
             return p.LastMatch != 0 ? ReadResult.Null : new ReadResult(GetValueReaderFromHeader(node));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool TryRead(string key, out ReadResult result)
+        {
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            {
+                return TryRead(keySlice, out result);
+            }
+        }
+        
+        public bool TryRead(Slice key, out ReadResult result)
+        {
+            AssertNotDisposed();
+
+            var p = FindPageFor(key, out TreeNodeHeader* node);
+
+            if (p.LastMatch != 0)
+            {
+                Unsafe.SkipInit(out result);
+                return false;
+            }
+            result= new ReadResult(GetValueReaderFromHeader(node));
+            return false;
         }
 
         public bool Exists(Slice key)

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -351,7 +351,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         Lookup<CompactKeyLookup> inner;
         var llt = parent.Llt;
         var existing = parent.Read(name);
-        if (!existing.HasValue)
+        if (existing.HasValue == false)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -351,7 +351,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         Lookup<CompactKeyLookup> inner;
         var llt = parent.Llt;
         var existing = parent.Read(name);
-        if (existing.IsNull)
+        if (!existing.HasValue)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;
@@ -399,14 +399,14 @@ public sealed partial class CompactTree : IPrepareForCommit
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
         var existingDictionary = llt.RootObjects.Read(dictionarySlice);
-        return existingDictionary.IsNull == false;
+        return existingDictionary.HasValue;
     }
     
     public static unsafe long GetDictionaryId(LowLevelTransaction llt)
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
         var read = llt.RootObjects.Read(dictionarySlice);
-        if (read.IsNull == false)
+        if (read.HasValue)
         {
             return ((PersistentDictionaryRootHeader*)read.Reader.Base)->PageNumber;
         }

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -351,7 +351,7 @@ public sealed partial class CompactTree : IPrepareForCommit
         Lookup<CompactKeyLookup> inner;
         var llt = parent.Llt;
         var existing = parent.Read(name);
-        if (existing == null)
+        if (existing.IsNull)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;
@@ -399,14 +399,14 @@ public sealed partial class CompactTree : IPrepareForCommit
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
         var existingDictionary = llt.RootObjects.Read(dictionarySlice);
-        return existingDictionary != null;
+        return existingDictionary.IsNull == false;
     }
     
     public static unsafe long GetDictionaryId(LowLevelTransaction llt)
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
         var read = llt.RootObjects.Read(dictionarySlice);
-        if (read != null)
+        if (read.IsNull == false)
         {
             return ((PersistentDictionaryRootHeader*)read.Reader.Base)->PageNumber;
         }

--- a/src/Voron/Data/Compression/DecompressedReadResult.cs
+++ b/src/Voron/Data/Compression/DecompressedReadResult.cs
@@ -2,18 +2,13 @@
 
 namespace Voron.Data.Compression
 {
-    public sealed class DecompressedReadResult : ReadResult, IDisposable
+    /// <summary>
+    /// A wrapper around <see cref="ReadResult"/> allowing scoping it with <see cref="IDisposable"/>.
+    /// </summary>
+    public sealed class DecompressedReadResult(ReadResult result, DecompressedLeafPage page) : IDisposable
     {
-        private readonly DecompressedLeafPage _page;
-
-        public DecompressedReadResult(ValueReader reader, DecompressedLeafPage page) : base(reader)
-        {
-            _page = page;
-        }
-
-        public void Dispose()
-        {
-            _page?.Dispose();
-        }
+        public ValueReader Reader => result.Reader; 
+        
+        public void Dispose() => page?.Dispose();
     }
 }

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -328,7 +328,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         LookupState header;
 
         var existing = parent.Read(name);
-        if (existing.IsNull)
+        if (!existing.HasValue)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -328,7 +328,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         LookupState header;
 
         var existing = parent.Read(name);
-        if (!existing.HasValue)
+        if (existing.HasValue == false)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -328,7 +328,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         LookupState header;
 
         var existing = parent.Read(name);
-        if (existing == null)
+        if (existing.IsNull)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -95,7 +95,7 @@ namespace Voron.Data.Tables
                 if (_activeDataSmallSection == null)
                 {
                     var readResult = _tableTree.Read(TableSchema.ActiveSectionSlice);
-                    if (readResult == null)
+                    if (readResult.IsNull)
                         throw new VoronErrorException($"Could not find active sections for {Name}");
 
                     long pageNumber = readResult.Reader.ReadLittleEndianInt64();
@@ -206,16 +206,20 @@ namespace Voron.Data.Tables
         public bool VerifyKeyExists(Slice key)
         {
             var pkTree = GetTree(_schema.Key);
-            var readResult = pkTree?.Read(key);
-            return readResult != null;
+            if (pkTree == null)
+                return false;
+            return pkTree.Read(key).IsNull == false;
         }
 
         private bool TryFindIdFromPrimaryKey(Slice key, out long id)
         {
             id = -1;
             var pkTree = GetTree(_schema.Key);
-            var readResult = pkTree?.Read(key);
-            if (readResult == null)
+            if (pkTree == null)
+                return false;
+            
+            var readResult = pkTree.Read(key);
+            if (readResult.IsNull)
                 return false;
 
             id = readResult.Reader.ReadLittleEndianInt64();
@@ -855,8 +859,8 @@ namespace Voron.Data.Tables
                 var dictionariesTree = tx.ReadTree(TableSchema.CompressionDictionariesSlice);
                 var rev = Bits.SwapBytes(id);
                 using var _ = Slice.From(tx.Allocator, (byte*)&rev, sizeof(int), out var slice);
-                var readResult = dictionariesTree?.Read(slice);
-                if (readResult == null)
+                ReadResult readResult;
+                if (dictionariesTree == null || (readResult = dictionariesTree.Read(slice)).IsNull)
                 {
                     // we may be checking an empty section, so let's return an empty
                     // dictionary there
@@ -1273,7 +1277,7 @@ namespace Voron.Data.Tables
             var pkTree = GetTree(_schema.Key);
 
             var readResult = pkTree.Read(key);
-            if (readResult == null)
+            if (readResult.IsNull)
                 return false;
 
             // This is an implementation detail. We read the absolute location pointer (absolute offset on the file)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -95,7 +95,7 @@ namespace Voron.Data.Tables
                 if (_activeDataSmallSection == null)
                 {
                     var readResult = _tableTree.Read(TableSchema.ActiveSectionSlice);
-                    if (readResult.IsNull)
+                    if (!readResult.HasValue)
                         throw new VoronErrorException($"Could not find active sections for {Name}");
 
                     long pageNumber = readResult.Reader.ReadLittleEndianInt64();
@@ -208,7 +208,7 @@ namespace Voron.Data.Tables
             var pkTree = GetTree(_schema.Key);
             if (pkTree == null)
                 return false;
-            return pkTree.Read(key).IsNull == false;
+            return pkTree.Read(key).HasValue;
         }
 
         private bool TryFindIdFromPrimaryKey(Slice key, out long id)
@@ -219,7 +219,7 @@ namespace Voron.Data.Tables
                 return false;
             
             var readResult = pkTree.Read(key);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return false;
 
             id = readResult.Reader.ReadLittleEndianInt64();
@@ -860,7 +860,7 @@ namespace Voron.Data.Tables
                 var rev = Bits.SwapBytes(id);
                 using var _ = Slice.From(tx.Allocator, (byte*)&rev, sizeof(int), out var slice);
                 ReadResult readResult;
-                if (dictionariesTree == null || (readResult = dictionariesTree.Read(slice)).IsNull)
+                if (dictionariesTree == null || !(readResult = dictionariesTree.Read(slice)).HasValue)
                 {
                     // we may be checking an empty section, so let's return an empty
                     // dictionary there
@@ -1277,7 +1277,7 @@ namespace Voron.Data.Tables
             var pkTree = GetTree(_schema.Key);
 
             var readResult = pkTree.Read(key);
-            if (readResult.IsNull)
+            if (!readResult.HasValue)
                 return false;
 
             // This is an implementation detail. We read the absolute location pointer (absolute offset on the file)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -95,7 +95,7 @@ namespace Voron.Data.Tables
                 if (_activeDataSmallSection == null)
                 {
                     var readResult = _tableTree.Read(TableSchema.ActiveSectionSlice);
-                    if (!readResult.HasValue)
+                    if (readResult.HasValue == false)
                         throw new VoronErrorException($"Could not find active sections for {Name}");
 
                     long pageNumber = readResult.Reader.ReadLittleEndianInt64();
@@ -219,7 +219,7 @@ namespace Voron.Data.Tables
                 return false;
             
             var readResult = pkTree.Read(key);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return false;
 
             id = readResult.Reader.ReadLittleEndianInt64();
@@ -860,7 +860,7 @@ namespace Voron.Data.Tables
                 var rev = Bits.SwapBytes(id);
                 using var _ = Slice.From(tx.Allocator, (byte*)&rev, sizeof(int), out var slice);
                 ReadResult readResult;
-                if (dictionariesTree == null || !(readResult = dictionariesTree.Read(slice)).HasValue)
+                if (dictionariesTree == null || (readResult = dictionariesTree.Read(slice)).HasValue == false)
                 {
                     // we may be checking an empty section, so let's return an empty
                     // dictionary there
@@ -1277,7 +1277,7 @@ namespace Voron.Data.Tables
             var pkTree = GetTree(_schema.Key);
 
             var readResult = pkTree.Read(key);
-            if (!readResult.HasValue)
+            if (readResult.HasValue == false)
                 return false;
 
             // This is an implementation detail. We read the absolute location pointer (absolute offset on the file)

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -224,7 +224,7 @@ namespace Voron.Impl
             var clonedName = name.Clone(Allocator);
             
             var existing = LowLevelTransaction.RootObjects.Read(name);
-            if (existing.IsNull)
+            if (!existing.HasValue)
             {
                 var state = new PostingListState();
                 PostingList.Create(this.LowLevelTransaction, ref state);
@@ -663,7 +663,7 @@ namespace Voron.Impl
                 if (indexDef.IsGlobal) // must not delete global indexes
                     continue;
 
-                if (tableTree.Read(indexDef.Name).IsNull)
+                if (!tableTree.Read(indexDef.Name).HasValue)
                     continue;
 
                 var indexTree = table.GetTree(indexDef);
@@ -678,7 +678,7 @@ namespace Voron.Impl
                 if (indexDef.IsGlobal)  // must not delete global indexes
                     continue;
 
-                if (tableTree.Read(indexDef.Name).IsNull)
+                if (!tableTree.Read(indexDef.Name).HasValue)
                     continue;
 
                 var index = table.GetFixedSizeTree(indexDef);
@@ -692,7 +692,7 @@ namespace Voron.Impl
 
             table.ActiveDataSmallSection.FreeRawDataSectionPages();
 
-            if (tableTree.Read(TableSchema.ActiveCandidateSectionSlice).IsNull == false)
+            if (tableTree.Read(TableSchema.ActiveCandidateSectionSlice).HasValue)
             {
                 using (var it = table.ActiveCandidateSection.Iterate())
                 {
@@ -708,7 +708,7 @@ namespace Voron.Impl
                 DeleteFixedTree(table.ActiveCandidateSection, isInRoot: false);
             }
 
-            if (tableTree.Read(TableSchema.InactiveSectionSlice).IsNull == false)
+            if (tableTree.Read(TableSchema.InactiveSectionSlice).HasValue)
                 DeleteFixedTree(table.InactiveSections, isInRoot: false);
 
             DeleteTree(name);

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -224,7 +224,7 @@ namespace Voron.Impl
             var clonedName = name.Clone(Allocator);
             
             var existing = LowLevelTransaction.RootObjects.Read(name);
-            if (existing == null)
+            if (existing.IsNull)
             {
                 var state = new PostingListState();
                 PostingList.Create(this.LowLevelTransaction, ref state);
@@ -663,7 +663,7 @@ namespace Voron.Impl
                 if (indexDef.IsGlobal) // must not delete global indexes
                     continue;
 
-                if (tableTree.Read(indexDef.Name) == null)
+                if (tableTree.Read(indexDef.Name).IsNull)
                     continue;
 
                 var indexTree = table.GetTree(indexDef);
@@ -678,7 +678,7 @@ namespace Voron.Impl
                 if (indexDef.IsGlobal)  // must not delete global indexes
                     continue;
 
-                if (tableTree.Read(indexDef.Name) == null)
+                if (tableTree.Read(indexDef.Name).IsNull)
                     continue;
 
                 var index = table.GetFixedSizeTree(indexDef);
@@ -692,7 +692,7 @@ namespace Voron.Impl
 
             table.ActiveDataSmallSection.FreeRawDataSectionPages();
 
-            if (tableTree.Read(TableSchema.ActiveCandidateSectionSlice) != null)
+            if (tableTree.Read(TableSchema.ActiveCandidateSectionSlice).IsNull == false)
             {
                 using (var it = table.ActiveCandidateSection.Iterate())
                 {
@@ -708,7 +708,7 @@ namespace Voron.Impl
                 DeleteFixedTree(table.ActiveCandidateSection, isInRoot: false);
             }
 
-            if (tableTree.Read(TableSchema.InactiveSectionSlice) != null)
+            if (tableTree.Read(TableSchema.InactiveSectionSlice).IsNull == false)
                 DeleteFixedTree(table.InactiveSections, isInRoot: false);
 
             DeleteTree(name);

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -224,7 +224,7 @@ namespace Voron.Impl
             var clonedName = name.Clone(Allocator);
             
             var existing = LowLevelTransaction.RootObjects.Read(name);
-            if (!existing.HasValue)
+            if (existing.HasValue == false)
             {
                 var state = new PostingListState();
                 PostingList.Create(this.LowLevelTransaction, ref state);
@@ -663,7 +663,7 @@ namespace Voron.Impl
                 if (indexDef.IsGlobal) // must not delete global indexes
                     continue;
 
-                if (!tableTree.Read(indexDef.Name).HasValue)
+                if (tableTree.Read(indexDef.Name).HasValue == false)
                     continue;
 
                 var indexTree = table.GetTree(indexDef);
@@ -678,7 +678,7 @@ namespace Voron.Impl
                 if (indexDef.IsGlobal)  // must not delete global indexes
                     continue;
 
-                if (!tableTree.Read(indexDef.Name).HasValue)
+                if (tableTree.Read(indexDef.Name).HasValue == false)
                     continue;
 
                 var index = table.GetFixedSizeTree(indexDef);

--- a/src/Voron/ReadResult.cs
+++ b/src/Voron/ReadResult.cs
@@ -1,12 +1,29 @@
 namespace Voron
 {
-    public class ReadResult
+    /// <summary>
+    /// A struct representing a read result.
+    /// If the read returns a null, <see cref="IsNull"/> is true. Otherwise, the <see cref="ValueReader"/> can be accessed via <see cref="Reader"/>.
+    /// </summary>
+    public readonly unsafe struct ReadResult(byte* val, int len)
     {
-        public ReadResult(ValueReader reader)
-        {
-            Reader = reader;
-        }
-         
-        public ValueReader Reader { get; private set; }
+        public ReadResult(in ValueReader reader) : this(reader.Base, reader.Length) { }
+
+        public ValueReader Reader => new(val, len);
+
+        public bool IsNull => val == null;
+
+        public static readonly ReadResult Null = default;
+
+        // The null handling helper methods.
+        
+        public T[] ToArrayEmptyOnNull<T>() where T : unmanaged => IsNull ? [] : Reader.ToUnmanagedSpan<T>().ToSpan().ToArray();
+
+        public long ReadLittleEndianInt64OrDefault(long defaultValue = 0) => IsNull ? defaultValue : Reader.ReadLittleEndianInt64();
+        
+        public int ReadLittleEndianInt32OrDefault(int defaultValue = 0) => IsNull ? defaultValue : Reader.ReadLittleEndianInt32();
+        
+        public byte ReadByteOrDefault(byte defaultValue = 0) => IsNull ? defaultValue : Reader.ReadByte();
+
+        public string ToStringValueOrDefault(string defaultValue = null) => IsNull ? defaultValue : Reader.ToStringValue();
     }
 }

--- a/src/Voron/ReadResult.cs
+++ b/src/Voron/ReadResult.cs
@@ -2,7 +2,7 @@ namespace Voron
 {
     /// <summary>
     /// A struct representing a read result.
-    /// If the read returns a null, <see cref="IsNull"/> is true. Otherwise, the <see cref="ValueReader"/> can be accessed via <see cref="Reader"/>.
+    /// If the read returns a null, <see cref="HasValue"/> is false. Otherwise, the <see cref="ValueReader"/> can be accessed via <see cref="Reader"/>.
     /// </summary>
     public readonly unsafe struct ReadResult(byte* val, int len)
     {
@@ -10,20 +10,20 @@ namespace Voron
 
         public ValueReader Reader => new(val, len);
 
-        public bool IsNull => val == null;
+        public bool HasValue => val != null;
 
         public static readonly ReadResult Null = default;
 
         // The null handling helper methods.
         
-        public T[] ToArrayEmptyOnNull<T>() where T : unmanaged => IsNull ? [] : Reader.ToUnmanagedSpan<T>().ToSpan().ToArray();
+        public T[] ToArrayEmptyOnNull<T>() where T : unmanaged => HasValue ? Reader.ToUnmanagedSpan<T>().ToSpan().ToArray() : [];
 
-        public long ReadLittleEndianInt64OrDefault(long defaultValue = 0) => IsNull ? defaultValue : Reader.ReadLittleEndianInt64();
+        public long ReadLittleEndianInt64OrDefault(long defaultValue = 0) => HasValue ? Reader.ReadLittleEndianInt64() : defaultValue;
         
-        public int ReadLittleEndianInt32OrDefault(int defaultValue = 0) => IsNull ? defaultValue : Reader.ReadLittleEndianInt32();
+        public int ReadLittleEndianInt32OrDefault(int defaultValue = 0) => HasValue ? Reader.ReadLittleEndianInt32() : defaultValue;
         
-        public byte ReadByteOrDefault(byte defaultValue = 0) => IsNull ? defaultValue : Reader.ReadByte();
+        public byte ReadByteOrDefault(byte defaultValue = 0) => HasValue ? Reader.ReadByte() : defaultValue;
 
-        public string ToStringValueOrDefault(string defaultValue = null) => IsNull ? defaultValue : Reader.ToStringValue();
+        public string ToStringValueOrDefault(string defaultValue = null) => HasValue ? Reader.ToStringValue() : defaultValue;
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -321,12 +321,12 @@ namespace Voron
                 Debug.Assert(metadataTree != null);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbId = metadataTree.Read("db-id");
-                if (dbId == null)
+                if (dbId.IsNull)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "Could not find db id in metadata tree, possible mismatch / corruption?");
 
                 var buffer = new byte[16];
-                Debug.Assert(dbId != null);
+                Debug.Assert(dbId.IsNull == false);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
                 if (dbIdBytes != 16)
@@ -364,7 +364,7 @@ namespace Voron
                     var metadataTree = readTx.ReadTree(Constants.MetadataTreeNameSlice);
 
                     var schemaVersion = metadataTree.Read("schema-version");
-                    if (schemaVersion == null)
+                    if (schemaVersion.IsNull)
                         SchemaErrorException.Raise(this, "Could not find schema version in metadata tree, possible mismatch / corruption?");
 
                     schemaVersionVal = schemaVersion.Reader.ReadLittleEndianInt32();

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -321,7 +321,7 @@ namespace Voron
                 Debug.Assert(metadataTree != null);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbId = metadataTree.Read("db-id");
-                if (!dbId.HasValue)
+                if (dbId.HasValue == false)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "Could not find db id in metadata tree, possible mismatch / corruption?");
 
@@ -364,7 +364,7 @@ namespace Voron
                     var metadataTree = readTx.ReadTree(Constants.MetadataTreeNameSlice);
 
                     var schemaVersion = metadataTree.Read("schema-version");
-                    if (!schemaVersion.HasValue)
+                    if (schemaVersion.HasValue == false)
                         SchemaErrorException.Raise(this, "Could not find schema version in metadata tree, possible mismatch / corruption?");
 
                     schemaVersionVal = schemaVersion.Reader.ReadLittleEndianInt32();

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -321,12 +321,12 @@ namespace Voron
                 Debug.Assert(metadataTree != null);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbId = metadataTree.Read("db-id");
-                if (dbId.IsNull)
+                if (!dbId.HasValue)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "Could not find db id in metadata tree, possible mismatch / corruption?");
 
                 var buffer = new byte[16];
-                Debug.Assert(dbId.IsNull == false);
+                Debug.Assert(dbId.HasValue);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
                 if (dbIdBytes != 16)
@@ -364,7 +364,7 @@ namespace Voron
                     var metadataTree = readTx.ReadTree(Constants.MetadataTreeNameSlice);
 
                     var schemaVersion = metadataTree.Read("schema-version");
-                    if (schemaVersion.IsNull)
+                    if (!schemaVersion.HasValue)
                         SchemaErrorException.Raise(this, "Could not find schema version in metadata tree, possible mismatch / corruption?");
 
                     schemaVersionVal = schemaVersion.Reader.ReadLittleEndianInt32();

--- a/src/Voron/ValueReader.cs
+++ b/src/Voron/ValueReader.cs
@@ -141,16 +141,19 @@ namespace Voron
 
         public string ReadString(int length)
         {
-            var arraySegment = ReadBytes(length);
-            return Encodings.Utf8.GetString(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+            var count = Math.Min(length, _len - _pos);
+            if (count <= 0)
+                return "";
+
+            string result = Encodings.Utf8.GetString(Base + _pos, count);
+            
+            // Move forward
+            _pos += count;
+            
+            return result;
         }
 
-        public string ToStringValue()
-        {
-            int length = _len - _pos;
-            var arraySegment = ReadBytes(length);
-            return Encodings.Utf8.GetString(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
-        }
+        public string ToStringValue() => ReadString(_len - _pos);
 
         public override string ToString()
         {

--- a/test/FastTests/Voron/Journal/BasicActions.cs
+++ b/test/FastTests/Voron/Journal/BasicActions.cs
@@ -41,7 +41,7 @@ namespace FastTests.Voron.Journal
                 using (var tx = Env.ReadTransaction())
                 {
                     var tree = tx.CreateTree("foo");
-                    Assert.False(tree.Read("item/" + i).IsNull);
+                    Assert.True(tree.Read("item/" + i).HasValue);
                 }
             }
         }
@@ -64,7 +64,7 @@ namespace FastTests.Voron.Journal
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Assert.True(tree.Read("items/1").IsNull);
+                Assert.False(tree.Read("items/1").HasValue);
             }
         }
 

--- a/test/FastTests/Voron/Journal/BasicActions.cs
+++ b/test/FastTests/Voron/Journal/BasicActions.cs
@@ -41,7 +41,7 @@ namespace FastTests.Voron.Journal
                 using (var tx = Env.ReadTransaction())
                 {
                     var tree = tx.CreateTree("foo");
-                    Assert.NotNull(tree.Read("item/" + i));
+                    Assert.False(tree.Read("item/" + i).IsNull);
                 }
             }
         }
@@ -64,7 +64,7 @@ namespace FastTests.Voron.Journal
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Assert.Null(tree.Read("items/1"));
+                Assert.True(tree.Read("items/1").IsNull);
             }
         }
 

--- a/test/FastTests/Voron/Optimizations/Writes.cs
+++ b/test/FastTests/Voron/Optimizations/Writes.cs
@@ -60,7 +60,7 @@ namespace FastTests.Voron.Optimizations
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Assert.True(tree.Read(new string('0', keySize)).IsNull);
+                Assert.False(tree.Read(new string('0', keySize)).HasValue);
 
                 var readResult = tree.Read(new string('4', 1000));
 

--- a/test/FastTests/Voron/Optimizations/Writes.cs
+++ b/test/FastTests/Voron/Optimizations/Writes.cs
@@ -60,7 +60,7 @@ namespace FastTests.Voron.Optimizations
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Assert.Null(tree.Read(new string('0', keySize)));
+                Assert.True(tree.Read(new string('0', keySize)).IsNull);
 
                 var readResult = tree.Read(new string('4', 1000));
 

--- a/test/FastTests/Voron/Tables/RavenDB_17760.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_17760.cs
@@ -328,7 +328,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = GetStatsFor(tx, bucket);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var size = *(int*)readResult.Reader.Base;
                 Assert.Equal(41, size);
@@ -346,7 +346,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = GetStatsFor(tx, bucket);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var size = *(int*)readResult.Reader.Base;
                 Assert.Equal(43, size);
@@ -432,7 +432,7 @@ namespace FastTests.Voron.Tables
                 var keySlice = new Slice(keyBuffer);
                 var readResult = tree.Read(keySlice);
                 long size = 0;
-                if (readResult != null)
+                if (readResult.IsNull == false)
                 {
                     var reader = readResult.Reader;
                     size = *(long*)reader.Base;

--- a/test/FastTests/Voron/Tables/RavenDB_17760.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_17760.cs
@@ -328,7 +328,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = GetStatsFor(tx, bucket);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var size = *(int*)readResult.Reader.Base;
                 Assert.Equal(41, size);
@@ -346,7 +346,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = GetStatsFor(tx, bucket);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var size = *(int*)readResult.Reader.Base;
                 Assert.Equal(43, size);
@@ -432,7 +432,7 @@ namespace FastTests.Voron.Tables
                 var keySlice = new Slice(keyBuffer);
                 var readResult = tree.Read(keySlice);
                 long size = 0;
-                if (readResult.IsNull == false)
+                if (readResult.HasValue)
                 {
                     var reader = readResult.Reader;
                     size = *(long*)reader.Base;

--- a/test/FastTests/Voron/Trees/Basic.cs
+++ b/test/FastTests/Voron/Trees/Basic.cs
@@ -178,7 +178,7 @@ namespace FastTests.Voron.Trees
                     {
                         var key = "test-" + j.ToString("000") + "-" + i.ToString("000");
 
-                        Assert.False(tree.Read(key).IsNull);
+                        Assert.True(tree.Read(key).HasValue);
                     }
                 }
             }

--- a/test/FastTests/Voron/Trees/Basic.cs
+++ b/test/FastTests/Voron/Trees/Basic.cs
@@ -178,7 +178,7 @@ namespace FastTests.Voron.Trees
                     {
                         var key = "test-" + j.ToString("000") + "-" + i.ToString("000");
 
-                        Assert.True(tree.Read(key) != null);
+                        Assert.False(tree.Read(key).IsNull);
                     }
                 }
             }

--- a/test/FastTests/Voron/Trees/Deletes.cs
+++ b/test/FastTests/Voron/Trees/Deletes.cs
@@ -59,7 +59,7 @@ namespace FastTests.Voron.Trees
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("foo");
-                Assert.True(tree.Read("a").IsNull);
+                Assert.False(tree.Read("a").HasValue);
                 tx.Commit();
             }
         }

--- a/test/FastTests/Voron/Trees/Deletes.cs
+++ b/test/FastTests/Voron/Trees/Deletes.cs
@@ -59,12 +59,9 @@ namespace FastTests.Voron.Trees
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("foo");
-                Assert.Null(tree.Read("a"));
-
+                Assert.True(tree.Read("a").IsNull);
                 tx.Commit();
             }
-
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]
@@ -75,7 +72,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < 1000; i++)
                 {
-                    tree.Add(string.Format("{0,5}", i), StreamFor("abcdefg"));
+                    tree.Add($"{i,5}", StreamFor("abcdefg"));
                 }
                 tx.Commit();
             }
@@ -83,7 +80,7 @@ namespace FastTests.Voron.Trees
             var expected = new List<string>();
             for (int i = 15; i < 1000; i++)
             {
-                expected.Add(string.Format("{0,5}", i));
+                expected.Add($"{i,5}");
             }
 
             using (var tx = Env.WriteTransaction())
@@ -91,7 +88,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.ReadTree("foo");
                 for (int i = 0; i < 15; i++)
                 {
-                    tree.Delete(string.Format("{0,5}", i));
+                    tree.Delete($"{i,5}");
                 }
                 tx.Commit();
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_12931.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12931.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                Assert.True(tx.LowLevelTransaction.RootObjects.Read("docs").IsNull);
+                Assert.False(tx.LowLevelTransaction.RootObjects.Read("docs").HasValue);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_12931.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12931.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                Assert.Null(tx.LowLevelTransaction.RootObjects.Read("docs"));
+                Assert.True(tx.LowLevelTransaction.RootObjects.Read("docs").IsNull);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_13195.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13195.cs
@@ -92,8 +92,8 @@ namespace SlowTests.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                Assert.True(tx.LowLevelTransaction.RootObjects.Read("first").IsNull);
-                Assert.True(tx.LowLevelTransaction.RootObjects.Read("second").IsNull);
+                Assert.False(tx.LowLevelTransaction.RootObjects.Read("first").HasValue);
+                Assert.False(tx.LowLevelTransaction.RootObjects.Read("second").HasValue);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_13195.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13195.cs
@@ -92,8 +92,8 @@ namespace SlowTests.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                Assert.Null(tx.LowLevelTransaction.RootObjects.Read("first"));
-                Assert.Null(tx.LowLevelTransaction.RootObjects.Read("second"));
+                Assert.True(tx.LowLevelTransaction.RootObjects.Read("first").IsNull);
+                Assert.True(tx.LowLevelTransaction.RootObjects.Read("second").IsNull);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_16193.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16193.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Indexes;
@@ -64,7 +65,8 @@ namespace SlowTests.Issues
                     using (var tx = indexStorage.Environment().ReadTransaction())
                     {
                         var statsTree = tx.ReadTree(IndexSchema.StatsTree);
-                        return Task.FromResult(statsTree.Read(IndexSchema.EntriesCount));
+                        const string nonNull = IndexSchema.StatsTree;
+                        return Task.FromResult(statsTree.Read(IndexSchema.EntriesCount).IsNull ? null : nonNull);
                     }
                 });
 

--- a/test/SlowTests.Issues/Issues/RavenDB_16193.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16193.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
                     {
                         var statsTree = tx.ReadTree(IndexSchema.StatsTree);
                         const string nonNull = IndexSchema.StatsTree;
-                        return Task.FromResult(statsTree.Read(IndexSchema.EntriesCount).IsNull ? null : nonNull);
+                        return Task.FromResult(statsTree.Read(IndexSchema.EntriesCount).HasValue ? nonNull : null);
                     }
                 });
 

--- a/test/SlowTests/Voron/Backups/Incremental.cs
+++ b/test/SlowTests/Voron/Backups/Incremental.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 500; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -143,7 +143,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 1000; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -213,7 +213,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 10; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -279,7 +279,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 5; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -527,7 +527,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 500; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Backups/Incremental.cs
+++ b/test/SlowTests/Voron/Backups/Incremental.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 500; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.False(readResult.IsNull);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -143,7 +143,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 1000; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.False(readResult.IsNull);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -213,7 +213,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 10; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.False(readResult.IsNull);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -279,7 +279,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 5; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.False(readResult.IsNull);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -527,7 +527,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 500; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.False(readResult.IsNull);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/BigValue.cs
+++ b/test/SlowTests/Voron/BigValue.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Voron
                 Slice key;
                 Slice.From(tx.Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);

--- a/test/SlowTests/Voron/BigValue.cs
+++ b/test/SlowTests/Voron/BigValue.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Voron
                 Slice key;
                 Slice.From(tx.Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);

--- a/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
+++ b/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Voron.Bugs
                     for (int i = 0; i < 100; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
+++ b/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Voron.Bugs
                     for (int i = 0; i < 100; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.False(readResult.IsNull);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
+++ b/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
@@ -105,18 +105,16 @@ namespace SlowTests.Voron.Bugs
                         Assert.Equal(inMemoryKey, key);
 
                         var docReadResult = docsTree.Read(key);
+                        Assert.False(docReadResult.IsNull);
 
-                        Assert.NotNull(docReadResult);
-
-                        var metadataReader = metadataTree.Read(key).Reader;
-
-                        Assert.NotNull(metadataReader);
+                        ReadResult metaResult = metadataTree.Read(key);
+                        Assert.False(metaResult.IsNull);
+                        var metadataReader = metaResult.Reader;
 
                         var etagFromMetadata = new byte[16];
                         metadataReader.Read(etagFromMetadata, 0, 16);
 
                         var readEtag = new Guid(etagFromMetadata);
-
 
                         Assert.Equal(etag, readEtag);
 

--- a/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
+++ b/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
@@ -105,10 +105,10 @@ namespace SlowTests.Voron.Bugs
                         Assert.Equal(inMemoryKey, key);
 
                         var docReadResult = docsTree.Read(key);
-                        Assert.False(docReadResult.IsNull);
+                        Assert.True(docReadResult.HasValue);
 
                         ReadResult metaResult = metadataTree.Read(key);
-                        Assert.False(metaResult.IsNull);
+                        Assert.True(metaResult.HasValue);
                         var metadataReader = metaResult.Reader;
 
                         var etagFromMetadata = new byte[16];

--- a/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
+++ b/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Voron.Bugs
                 {
                     var readResult = tree.Read("foo/" + i);
 
-                    Assert.NotNull(readResult);
+                    Assert.False(readResult.IsNull);
                     Assert.Equal(value1.Length, readResult.Reader.Length);
 
                     var memoryStream = new MemoryStream(readResult.Reader.Length);
@@ -118,7 +118,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("foo/0");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
 
                 var memoryStream = new MemoryStream();
@@ -135,7 +135,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("foo/0");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
 
                 var memoryStream = new MemoryStream();

--- a/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
+++ b/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Voron.Bugs
                 {
                     var readResult = tree.Read("foo/" + i);
 
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
                     Assert.Equal(value1.Length, readResult.Reader.Length);
 
                     var memoryStream = new MemoryStream(readResult.Reader.Length);
@@ -118,7 +118,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("foo/0");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
 
                 var memoryStream = new MemoryStream();
@@ -135,7 +135,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("foo/0");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
 
                 var memoryStream = new MemoryStream();

--- a/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
+++ b/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Voron.Bugs
                 {
                     var readResult = tree.Read(item.Key.ToString("0000000000000000"));
 
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
 
                     Assert.Equal(item.Value.Length, readResult.Reader.Length);
                 }

--- a/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
+++ b/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Voron.Bugs
                 {
                     var readResult = tree.Read(item.Key.ToString("0000000000000000"));
 
-                    Assert.NotNull(readResult);
+                    Assert.False(readResult.IsNull);
 
                     Assert.Equal(item.Value.Length, readResult.Reader.Length);
                 }

--- a/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Voron.Bugs
 
                     using (var txr = env.ReadTransaction())
                     {
-                        Assert.NotNull(txr.CreateTree("tree0").Read("key/1"));
+                        Assert.False(txr.CreateTree("tree0").Read("key/1").IsNull);
                     }
                 }
             }

--- a/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Voron.Bugs
 
                     using (var txr = env.ReadTransaction())
                     {
-                        Assert.False(txr.CreateTree("tree0").Read("key/1").IsNull);
+                        Assert.True(txr.CreateTree("tree0").Read("key/1").HasValue);
                     }
                 }
             }

--- a/test/SlowTests/Voron/Bugs/PageTableIssue.cs
+++ b/test/SlowTests/Voron/Bugs/PageTableIssue.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Voron.Bugs
 
                 Env.FlushLogToDataFile();
 
-                Assert.NotNull(txr.CreateTree("foo").Read("foos/1"));
+                Assert.False(txr.CreateTree("foo").Read("foos/1").IsNull);
             }
         }
     }

--- a/test/SlowTests/Voron/Bugs/PageTableIssue.cs
+++ b/test/SlowTests/Voron/Bugs/PageTableIssue.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Voron.Bugs
 
                 Env.FlushLogToDataFile();
 
-                Assert.False(txr.CreateTree("foo").Read("foos/1").IsNull);
+                Assert.True(txr.CreateTree("foo").Read("foos/1").HasValue);
             }
         }
     }

--- a/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
+++ b/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Voron.Bugs
 
                 Env.FlushLogToDataFile();
 
-                Assert.NotNull(txr.CreateTree( "foo").Read("bars/1"));
+                Assert.False(txr.CreateTree( "foo").Read("bars/1").IsNull);
             }
         } 
 

--- a/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
+++ b/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Voron.Bugs
 
                 Env.FlushLogToDataFile();
 
-                Assert.False(txr.CreateTree( "foo").Read("bars/1").IsNull);
+                Assert.True(txr.CreateTree( "foo").Read("bars/1").HasValue);
             }
         } 
 

--- a/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
+++ b/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
@@ -63,12 +63,12 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("item/1");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(4000, readResult.Reader.Length);
 
                 readResult = tree.Read("item/2");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(3999, readResult.Reader.Length);
             }
         }
@@ -109,12 +109,12 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("item/1");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(4000, readResult.Reader.Length);
 
                 readResult = tree.Read("item/2");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(3999, readResult.Reader.Length);
             }
         }
@@ -138,7 +138,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("items/1");
 
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
                 Assert.Equal(3, readResult.Reader.Length);
             }
         }

--- a/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
+++ b/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
@@ -63,12 +63,12 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("item/1");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(4000, readResult.Reader.Length);
 
                 readResult = tree.Read("item/2");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(3999, readResult.Reader.Length);
             }
         }
@@ -109,12 +109,12 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("item/1");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(4000, readResult.Reader.Length);
 
                 readResult = tree.Read("item/2");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(3999, readResult.Reader.Length);
             }
         }
@@ -138,7 +138,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("items/1");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(3, readResult.Reader.Length);
             }
         }

--- a/test/SlowTests/Voron/Checksum.cs
+++ b/test/SlowTests/Voron/Checksum.cs
@@ -86,7 +86,7 @@ namespace SlowTests.Voron
                             {
                                 var readResult = tree.Read($"{treeName}/items/{i}");
 
-                                Assert.False(readResult.IsNull);
+                                Assert.True(readResult.HasValue);
 
                                 if (i % 2 == 0)
                                 {

--- a/test/SlowTests/Voron/Checksum.cs
+++ b/test/SlowTests/Voron/Checksum.cs
@@ -84,9 +84,9 @@ namespace SlowTests.Voron
 
                             for (int i = 0; i < recordCount; i++)
                             {
-                                var readResult = tree.Read(string.Format("{0}/items/{1}", treeName, i));
+                                var readResult = tree.Read($"{treeName}/items/{i}");
 
-                                Assert.NotNull(readResult);
+                                Assert.False(readResult.IsNull);
 
                                 if (i % 2 == 0)
                                 {

--- a/test/SlowTests/Voron/Full.cs
+++ b/test/SlowTests/Voron/Full.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Voron
                         for (int i = 0; i < 1000; i++)
                         {
                             var readResult = tree.Read("items/" + i);
-                            Assert.False(readResult.IsNull);
+                            Assert.True(readResult.HasValue);
                             var memoryStream = new MemoryStream();
                             readResult.Reader.CopyTo(memoryStream);
                             Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Full.cs
+++ b/test/SlowTests/Voron/Full.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Voron
                         for (int i = 0; i < 1000; i++)
                         {
                             var readResult = tree.Read("items/" + i);
-                            Assert.NotNull(readResult);
+                            Assert.False(readResult.IsNull);
                             var memoryStream = new MemoryStream();
                             readResult.Reader.CopyTo(memoryStream);
                             Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Issues/RavenDB_13384.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13384.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Voron.Issues
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = tx.ReadTree("tree").Read("item");
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 var buf = new byte[3];
                 var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
@@ -106,7 +106,7 @@ namespace SlowTests.Voron.Issues
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = tx.ReadTree("tree").Read("item");
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 var buf = new byte[3];
                 var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
@@ -137,7 +137,7 @@ namespace SlowTests.Voron.Issues
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = tx.ReadTree("tree").Read("item");
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 var buf = new byte[3];
                 var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);

--- a/test/SlowTests/Voron/Issues/RavenDB_13384.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13384.cs
@@ -61,10 +61,10 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.ReadTransaction())
             {
-                var result = tx.ReadTree("tree").Read("item");
-                Assert.NotNull(result);
+                var readResult = tx.ReadTree("tree").Read("item");
+                Assert.False(readResult.IsNull);
                 var buf = new byte[3];
-                var read = result.Reader.Read(buf, 0, 3);
+                var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
                 Assert.True(buf.SequenceEqual(new byte[] { 1, 2, 3 }), "buf.SequenceEqual(new byte[] { 1, 2, 3 })");
             }
@@ -105,10 +105,10 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.ReadTransaction())
             {
-                var result = tx.ReadTree("tree").Read("item");
-                Assert.NotNull(result);
+                var readResult = tx.ReadTree("tree").Read("item");
+                Assert.False(readResult.IsNull);
                 var buf = new byte[3];
-                var read = result.Reader.Read(buf, 0, 3);
+                var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
                 Assert.True(buf.SequenceEqual(new byte[] { 4, 5, 6 }), "buf.SequenceEqual(new byte[] { 4, 5, 6 })");
             }
@@ -136,10 +136,10 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.ReadTransaction())
             {
-                var result = tx.ReadTree("tree").Read("item");
-                Assert.NotNull(result);
+                var readResult = tx.ReadTree("tree").Read("item");
+                Assert.False(readResult.IsNull);
                 var buf = new byte[3];
-                var read = result.Reader.Read(buf, 0, 3);
+                var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
                 Assert.True(buf.SequenceEqual(new byte[] { 7, 8, 9 }), "buf.SequenceEqual(new byte[] { 7, 8, 9 })");
             }

--- a/test/SlowTests/Voron/Issues/RavenDB_18059.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_18059.cs
@@ -96,7 +96,7 @@ public class RavenDB_18059 : StorageTest
                 for (int i = 0; i < 5000; i++)
                 {
                     var readResult = tree.Read("items/" + i);
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
                     var memoryStream = new MemoryStream();
                     readResult.Reader.CopyTo(memoryStream);
                     Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Issues/RavenDB_18059.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_18059.cs
@@ -96,7 +96,7 @@ public class RavenDB_18059 : StorageTest
                 for (int i = 0; i < 5000; i++)
                 {
                     var readResult = tree.Read("items/" + i);
-                    Assert.NotNull(readResult);
+                    Assert.False(readResult.IsNull);
                     var memoryStream = new MemoryStream();
                     readResult.Reader.CopyTo(memoryStream);
                     Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/LongKeys.cs
+++ b/test/SlowTests/Voron/LongKeys.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Voron
                 {
                     var key = keys[i];
 
-                    Assert.False(tree.Read(key).IsNull);
+                    Assert.True(tree.Read(key).HasValue);
                 }
             }
 
@@ -124,7 +124,7 @@ namespace SlowTests.Voron
                 {
                     var key = keys[i];
 
-                    Assert.False(tree.Read(key).IsNull);
+                    Assert.True(tree.Read(key).HasValue);
                 }
             }
 
@@ -189,7 +189,7 @@ namespace SlowTests.Voron
                 {
                     var key = addedKeys[i];
 
-                    Assert.False(tree.Read(key).IsNull);
+                    Assert.True(tree.Read(key).HasValue);
                 }
             }
 

--- a/test/SlowTests/Voron/LongKeys.cs
+++ b/test/SlowTests/Voron/LongKeys.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Voron
                 {
                     var key = keys[i];
 
-                    Assert.NotNull(tree.Read(key));
+                    Assert.False(tree.Read(key).IsNull);
                 }
             }
 
@@ -124,7 +124,7 @@ namespace SlowTests.Voron
                 {
                     var key = keys[i];
 
-                    Assert.NotNull(tree.Read(key));
+                    Assert.False(tree.Read(key).IsNull);
                 }
             }
 
@@ -189,7 +189,7 @@ namespace SlowTests.Voron
                 {
                     var key = addedKeys[i];
 
-                    Assert.NotNull(tree.Read(key));
+                    Assert.False(tree.Read(key).IsNull);
                 }
             }
 

--- a/test/SlowTests/Voron/Recovery.cs
+++ b/test/SlowTests/Voron/Recovery.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 100; i++)
                     {
-                        Assert.False(tree.Read("key" + i).IsNull);
+                        Assert.True(tree.Read("key" + i).HasValue);
                     }
                 }
             }
@@ -174,12 +174,12 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 1000; i++)
                     {
-                        Assert.False(aTree.Read("key" + i).IsNull);
+                        Assert.True(aTree.Read("key" + i).HasValue);
                     }
 
                     for (var i = 0; i < 1; i++)
                     {
-                        Assert.False(bTree.Read("key" + i).IsNull);
+                        Assert.True(bTree.Read("key" + i).HasValue);
                     }
                 }
             }
@@ -232,12 +232,12 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 1000; i++)
                     {
-                        Assert.False(aTree.Read("key" + i).IsNull);
+                        Assert.True(aTree.Read("key" + i).HasValue);
                     }
 
                     for (var i = 0; i < 5; i++)
                     {
-                        Assert.False(bTree.Read("key" + i).IsNull);
+                        Assert.True(bTree.Read("key" + i).HasValue);
                     }
                 }
             }
@@ -302,7 +302,7 @@ namespace SlowTests.Voron
                     for (var i = 0; i < count; i++)
                     {
                         var readResult = aTree.Read("a" + i);
-                        Assert.False(readResult.IsNull);
+                        Assert.True(readResult.HasValue);
                         Assert.Equal(expectedString, readResult.Reader.ToStringValue());
                     }
 

--- a/test/SlowTests/Voron/Recovery.cs
+++ b/test/SlowTests/Voron/Recovery.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 100; i++)
                     {
-                        Assert.NotNull(tree.Read("key" + i));
+                        Assert.False(tree.Read("key" + i).IsNull);
                     }
                 }
             }
@@ -174,22 +174,20 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 1000; i++)
                     {
-                        Assert.NotNull(aTree.Read("key" + i));
+                        Assert.False(aTree.Read("key" + i).IsNull);
                     }
 
                     for (var i = 0; i < 1; i++)
                     {
-                        Assert.NotNull(bTree.Read("key" + i));
+                        Assert.False(bTree.Read("key" + i).IsNull);
                     }
                 }
             }
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions2()
         {
-
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPathForTests(DataDir)))
             {
                 using (var tx = env.WriteTransaction())
@@ -234,16 +232,15 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 1000; i++)
                     {
-                        Assert.NotNull(aTree.Read("key" + i));
+                        Assert.False(aTree.Read("key" + i).IsNull);
                     }
 
                     for (var i = 0; i < 5; i++)
                     {
-                        Assert.NotNull(bTree.Read("key" + i));
+                        Assert.False(bTree.Read("key" + i).IsNull);
                     }
                 }
             }
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]
@@ -304,9 +301,9 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < count; i++)
                     {
-                        var read = aTree.Read("a" + i);
-                        Assert.NotNull(read);
-                        Assert.Equal(expectedString, read.Reader.ToStringValue());
+                        var readResult = aTree.Read("a" + i);
+                        Assert.False(readResult.IsNull);
+                        Assert.Equal(expectedString, readResult.Reader.ToStringValue());
                     }
 
                     using (var iterator = bTree.MultiRead("a"))

--- a/test/SlowTests/Voron/RecoveryMultipleJournals.cs
+++ b/test/SlowTests/Voron/RecoveryMultipleJournals.cs
@@ -59,10 +59,8 @@ namespace SlowTests.Voron
                 for (var i = 0; i < 1000; i++)
                 {
                     var readResult = tx.CreateTree("tree").Read("a" + i);
-                    Assert.NotNull(readResult);
-                    {
-                        Assert.Equal(100, readResult.Reader.Length);
-                    }
+                    Assert.False(readResult.IsNull);
+                    Assert.Equal(100, readResult.Reader.Length);
                 }
                 tx.Commit();
             }
@@ -178,11 +176,11 @@ namespace SlowTests.Voron
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("tree");
-                Assert.NotNull(tree.Read("exists"));
-                Assert.Null(tree.Read("a1"));
-                Assert.Null(tree.Read("a100"));
-                Assert.Null(tree.Read("a500"));
-                Assert.Null(tree.Read("a1000"));
+                Assert.False(tree.Read("exists").IsNull);
+                Assert.True(tree.Read("a1").IsNull);
+                Assert.True(tree.Read("a100").IsNull);
+                Assert.True(tree.Read("a500").IsNull);
+                Assert.True(tree.Read("a1000").IsNull);
 
                 tx.Commit();
             }

--- a/test/SlowTests/Voron/RecoveryMultipleJournals.cs
+++ b/test/SlowTests/Voron/RecoveryMultipleJournals.cs
@@ -268,9 +268,8 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                Assert.Null(tx.CreateTree("tree").Read("a1001"));
+                Assert.True(tx.CreateTree("tree").Read("a1001").IsNull);
             }
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]

--- a/test/SlowTests/Voron/RecoveryMultipleJournals.cs
+++ b/test/SlowTests/Voron/RecoveryMultipleJournals.cs
@@ -59,7 +59,7 @@ namespace SlowTests.Voron
                 for (var i = 0; i < 1000; i++)
                 {
                     var readResult = tx.CreateTree("tree").Read("a" + i);
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
                     Assert.Equal(100, readResult.Reader.Length);
                 }
                 tx.Commit();
@@ -176,11 +176,11 @@ namespace SlowTests.Voron
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("tree");
-                Assert.False(tree.Read("exists").IsNull);
-                Assert.True(tree.Read("a1").IsNull);
-                Assert.True(tree.Read("a100").IsNull);
-                Assert.True(tree.Read("a500").IsNull);
-                Assert.True(tree.Read("a1000").IsNull);
+                Assert.True(tree.Read("exists").HasValue);
+                Assert.False(tree.Read("a1").HasValue);
+                Assert.False(tree.Read("a100").HasValue);
+                Assert.False(tree.Read("a500").HasValue);
+                Assert.False(tree.Read("a1000").HasValue);
 
                 tx.Commit();
             }
@@ -268,7 +268,7 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                Assert.True(tx.CreateTree("tree").Read("a1001").IsNull);
+                Assert.False(tx.CreateTree("tree").Read("a1001").HasValue);
             }
         }
 

--- a/test/SlowTests/Voron/Snapshots.cs
+++ b/test/SlowTests/Voron/Snapshots.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Voron
                 for (var i = 0; i < DocumentCount; i++)
                 {
                     var readResult = snapshot.CreateTree("tree1").Read("docs/" + i);
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
                     var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
                     Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
@@ -115,7 +115,7 @@ namespace SlowTests.Voron
                 for (var i = 0; i < DocumentCount; i++)
                 {
                     var readResult = snapshot.ReadTree("tree1").Read("docs/" + i);
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
 
                     var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
                     Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());

--- a/test/SlowTests/Voron/Snapshots.cs
+++ b/test/SlowTests/Voron/Snapshots.cs
@@ -59,14 +59,10 @@ namespace SlowTests.Voron
 
                 for (var i = 0; i < DocumentCount; i++)
                 {
-                    var result = snapshot.CreateTree("tree1").Read("docs/" + i);
-                    Assert.NotNull(result);
-
-                    {
-                        var bytes = result.Reader.ReadBytes(result.Reader.Length);
-                        Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
-
-                    }
+                    var readResult = snapshot.CreateTree("tree1").Read("docs/" + i);
+                    Assert.False(readResult.IsNull);
+                    var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
+                    Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
             }
         }
@@ -118,13 +114,11 @@ namespace SlowTests.Voron
 
                 for (var i = 0; i < DocumentCount; i++)
                 {
-                    var result = snapshot.ReadTree("tree1").Read("docs/" + i);
-                    Assert.NotNull(result);
+                    var readResult = snapshot.ReadTree("tree1").Read("docs/" + i);
+                    Assert.False(readResult.IsNull);
 
-                    {
-                        var bytes = result.Reader.ReadBytes(result.Reader.Length);
-                        Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
-                    }
+                    var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
+                    Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
             }
         }

--- a/test/SlowTests/Voron/SplittingVeryBig.cs
+++ b/test/SlowTests/Voron/SplittingVeryBig.cs
@@ -42,12 +42,12 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var read = tx.CreateTree("tree").Read("key1");
-                Assert.NotNull(read);
+                var readResult = tx.CreateTree("tree").Read("key1");
+                Assert.False(readResult.IsNull);
 
-                var reader = read.Reader;
-                Assert.Equal(buffer.Length, read.Reader.Length);
-                var bytes = reader.ReadBytes(read.Reader.Length);
+                var reader = readResult.Reader;
+                Assert.Equal(buffer.Length, readResult.Reader.Length);
+                var bytes = reader.ReadBytes(readResult.Reader.Length);
                 Assert.Equal(buffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
             }
         }
@@ -90,15 +90,12 @@ namespace SlowTests.Voron
 
                 using (var tx = env.ReadTransaction())
                 {
-                    var read = tx.CreateTree("tree").Read("key1");
-                    Assert.NotNull(read);
+                    var readResult = tx.CreateTree("tree").Read("key1");
+                    Assert.False(readResult.IsNull);
 
-                    {
-                        Assert.Equal(buffer.Length, read.Reader.Length);
-                        var bytes = read.Reader.ReadBytes(read.Reader.Length);
-                        Assert.Equal(buffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
-
-                    }
+                    Assert.Equal(buffer.Length, readResult.Reader.Length);
+                    var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
+                    Assert.Equal(buffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
             }
         }

--- a/test/SlowTests/Voron/SplittingVeryBig.cs
+++ b/test/SlowTests/Voron/SplittingVeryBig.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Voron
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = tx.CreateTree("tree").Read("key1");
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var reader = readResult.Reader;
                 Assert.Equal(buffer.Length, readResult.Reader.Length);
@@ -91,7 +91,7 @@ namespace SlowTests.Voron
                 using (var tx = env.ReadTransaction())
                 {
                     var readResult = tx.CreateTree("tree").Read("key1");
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
 
                     Assert.Equal(buffer.Length, readResult.Reader.Length);
                     var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);

--- a/test/SlowTests/Voron/Storage/BigValue.cs
+++ b/test/SlowTests/Voron/Storage/BigValue.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Voron.Storage
             {
                 var tree = tx.CreateTree("foo");
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
-                Assert.True(tree.Read(key).IsNull);
+                Assert.False(tree.Read(key).HasValue);
             }
 
             if (restartCount >= 2)
@@ -70,7 +70,7 @@ namespace SlowTests.Voron.Storage
             {
                 var tree = tx.CreateTree("foo");
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
-                Assert.True(tree.Read(key).IsNull);
+                Assert.False(tree.Read(key).HasValue);
             }
 
             using (var tx = Env.WriteTransaction())
@@ -89,7 +89,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -106,7 +106,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -122,7 +122,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -141,7 +141,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -185,7 +185,7 @@ namespace SlowTests.Voron.Storage
                     Slice key;
                     Slice.From(Allocator, BitConverter.GetBytes(i), out key);
                     var readResult = tree.Read(key);
-                    Assert.False(readResult.IsNull);
+                    Assert.True(readResult.HasValue);
 
                     var memoryStream = new MemoryStream();
                     readResult.Reader.CopyTo(memoryStream);

--- a/test/SlowTests/Voron/Storage/BigValue.cs
+++ b/test/SlowTests/Voron/Storage/BigValue.cs
@@ -59,10 +59,8 @@ namespace SlowTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Slice key;
-                Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
-                var readResult = tree.Read(key);
-                Assert.Null(readResult);
+                Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
+                Assert.True(tree.Read(key).IsNull);
             }
 
             if (restartCount >= 2)
@@ -71,10 +69,8 @@ namespace SlowTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Slice key;
-                Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
-                var readResult = tree.Read(key);
-                Assert.Null(readResult);
+                Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
+                Assert.True(tree.Read(key).IsNull);
             }
 
             using (var tx = Env.WriteTransaction())
@@ -82,8 +78,7 @@ namespace SlowTests.Voron.Storage
                 buffer = new byte[1024 * 1024 * 3 + 1238];
                 random.NextBytes(buffer);
                 var tree = tx.CreateTree("foo");
-                Slice key;
-                Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
+                Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
                 tree.Add(key, new MemoryStream(buffer));
                 tx.Commit();
             }
@@ -94,7 +89,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -111,7 +106,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -127,7 +122,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -146,7 +141,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.False(readResult.IsNull);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -190,7 +185,7 @@ namespace SlowTests.Voron.Storage
                     Slice key;
                     Slice.From(Allocator, BitConverter.GetBytes(i), out key);
                     var readResult = tree.Read(key);
-                    Assert.NotNull(readResult);
+                    Assert.False(readResult.IsNull);
 
                     var memoryStream = new MemoryStream();
                     readResult.Reader.CopyTo(memoryStream);

--- a/test/SlowTests/Voron/Storage/Increments.cs
+++ b/test/SlowTests/Voron/Storage/Increments.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Voron.Storage
             {
                 var readResult = tx.ReadTree("tree0").Read("key/1");
 
-                Assert.False(readResult.IsNull);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(12, readResult.Reader.ReadLittleEndianInt64());
             }
         }

--- a/test/SlowTests/Voron/Storage/Increments.cs
+++ b/test/SlowTests/Voron/Storage/Increments.cs
@@ -38,10 +38,10 @@ namespace SlowTests.Voron.Storage
 
             using (var tx = Env.ReadTransaction())
             {
-                var read = tx.ReadTree("tree0").Read("key/1");
+                var readResult = tx.ReadTree("tree0").Read("key/1");
 
-                Assert.NotNull(read);
-                Assert.Equal(12, read.Reader.ReadLittleEndianInt64());
+                Assert.False(readResult.IsNull);
+                Assert.Equal(12, readResult.Reader.ReadLittleEndianInt64());
             }
         }
 

--- a/test/StressTests/Voron/PageSplitterStressTests.cs
+++ b/test/StressTests/Voron/PageSplitterStressTests.cs
@@ -102,7 +102,7 @@ namespace StressTests.Voron
                             keys.Add(iterator.CurrentKey.ToString());
                             Assert.True(ids.Contains(iterator.CurrentKey.ToString()));
                             var readResult = readTree.Read( iterator.CurrentKey);
-                            Assert.False(readResult.IsNull);
+                            Assert.True(readResult.HasValue);
 
                             count++;
                         }

--- a/test/StressTests/Voron/PageSplitterStressTests.cs
+++ b/test/StressTests/Voron/PageSplitterStressTests.cs
@@ -102,11 +102,7 @@ namespace StressTests.Voron
                             keys.Add(iterator.CurrentKey.ToString());
                             Assert.True(ids.Contains(iterator.CurrentKey.ToString()));
                             var readResult = readTree.Read( iterator.CurrentKey);
-                            if (readResult == null)
-                            {
-
-                            }
-                            Assert.NotNull(readResult);
+                            Assert.False(readResult.IsNull);
 
                             count++;
                         }

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -519,7 +519,7 @@ namespace Tests.Infrastructure
             {
                 var tree = context.Transaction.InnerTransaction.ReadTree("values");
                 var read = tree.Read(name);
-                return read?.Reader.ToStringValue();
+                return read.IsNull ? null : read.Reader.ToStringValue();
             }
 
             protected override void Apply(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index, Leader leader, ServerStore serverStore)
@@ -537,7 +537,7 @@ namespace Tests.Infrastructure
                         Assert.True(cmd.TryGet(nameof(TestCommand.Name), out string name0));
                         Assert.True(cmd.TryGet(nameof(TestCommand.Value), out int val0));
                         var tree0 = context.Transaction.InnerTransaction.CreateTree("values");
-                        var current0 = tree0.Read(name0)?.Reader.ToStringValue();
+                        var current0 = tree0.Read(name0).ToStringValueOrDefault(null);
                         tree0.Add(name0, current0 + val0);
                         break;
 
@@ -552,7 +552,7 @@ namespace Tests.Infrastructure
                         Assert.True(cmd.TryGet(nameof(TestCommandWithRaftId.Name), out string name2));
                         Assert.True(cmd.TryGet(nameof(TestCommandWithRaftId.Value), out int val2));
                         var tree2 = context.Transaction.InnerTransaction.CreateTree("values");
-                        var current2 = tree2.Read(name2)?.Reader.ToStringValue();
+                        var current2 = tree2.Read(name2).ToStringValueOrDefault(null);
                         tree2.Add(name2, current2 + val2);
                         break;
                 }

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -519,7 +519,7 @@ namespace Tests.Infrastructure
             {
                 var tree = context.Transaction.InnerTransaction.ReadTree("values");
                 var read = tree.Read(name);
-                return read.IsNull ? null : read.Reader.ToStringValue();
+                return read.HasValue ? read.Reader.ToStringValue() : null;
             }
 
             protected override void Apply(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index, Leader leader, ServerStore serverStore)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25111/ReadResult-should-be-a-struct

### Additional description

This PR turns a `ReadResult` into a struct. This effectively removes one object allocation from all paths that used `Tree.Read`. This mostly touches `Indexes` but also `Revisions` and `DocumentStorage`.

For sake of benchmarking, I used `Voron.Benchmark` -> `BTreeReadAndIterate`.  I made the benchmarks stable, by removing the seeding from time. Now, each run will be exactly the same

### Benchmarks

Combined

| Method   | Mean     | Error    | StdDev   | StdErr   | Min      | Q1       | Median   | Q3       | Max      | Op/s         |
|---------|---------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|-------------:|
| ReadTree  |  51.17 ns | 0.987 ns | 1.878 ns | 0.280 ns | 48.97 ns | 49.95 ns | 50.46 ns | 52.30 ns | 56.54 ns | 19,540,818.1 |
| ReadTree  (after) | 47.46 ns | 0.900 ns | 0.752 ns | 0.209 ns | 46.15 ns | 47.09 ns | 47.28 ns | 47.74 ns | 48.98 ns | 21,069,695.7 |

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
