### PR TITLE
RavenDB-25104 OpenTelemetry Monitoring - alerts refactoring

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1695,27 +1695,30 @@ namespace Raven.Server.Commercial
             throw GenerateLicenseLimit(LimitType.ReadOnlyCertificates, details);
         }
 
-        public bool CanUseOpenTelemetryMonitoring(bool withNotification, bool startUp)
+        public bool CanUseOpenTelemetryMonitoring(bool withNotification, bool metersRegistered)
         {
             if (IsValid(out _) == false)
                 return false;
 
-            if (LicenseStatus.HasMonitoringEndpoints)
+            switch (MetersRegistered: metersRegistered, LicenceHasMonitoringEndpoints: LicenseStatus.HasMonitoringEndpoints)
             {
-                if (startUp)
+                case (MetersRegistered: true, LicenceHasMonitoringEndpoints: true):
+                {
+                    DismissLicenseLimit(LimitType.MonitoringEndpoints);
                     return true;
-                const string details = "Your license allows you to run OpenTelemetry meters, but OpenTelemetry is initialized at process startup. To enable the OpenTelemetry feature, you must restart the process.";
-                throw GenerateLicenseLimit(LimitType.MonitoringEndpoints, details, addNotification: true);
-            }
-
-            {
-                const string details = "Your current license doesn't include the OpenTelemetry feature.";
-                var exception = GenerateLicenseLimit(LimitType.MonitoringEndpoints, details, addNotification: withNotification);
-
-                if (startUp)
+                }
+                case (MetersRegistered: false, LicenceHasMonitoringEndpoints: true):
+                {
+                    const string details = "Your license allows you to run OpenTelemetry meters, but OpenTelemetry is initialized at process startup. To enable the OpenTelemetry feature, you must restart the process.";
+                    GenerateLicenseLimit(LimitType.MonitoringEndpoints, details, addNotification: true);
                     return false;
-                
-                throw exception;
+                }
+                case (MetersRegistered: _, LicenceHasMonitoringEndpoints: false):
+                {
+                    const string details = "Your current license doesn't include the OpenTelemetry feature.";
+                    GenerateLicenseLimit(LimitType.MonitoringEndpoints, details, addNotification: withNotification);
+                    return false;
+                }
             }
         }
 

--- a/src/Raven.Server/Monitoring/OpenTelemetry/MetricsManager.cs
+++ b/src/Raven.Server/Monitoring/OpenTelemetry/MetricsManager.cs
@@ -6,41 +6,28 @@ namespace Raven.Server.Monitoring.OpenTelemetry;
 public class MetricsManager
 {
     private readonly RavenServer _server;
+    private readonly bool _metersRegisteredOnInitialize;
     private readonly SemaphoreSlim _locker = new(1, 1);
     private ServerMetrics _serverMetrics;
     private bool _metricsActivated;
     
-    public MetricsManager(RavenServer server)
+    public MetricsManager(RavenServer server, bool metersRegisteredOnInitialize)
     {
         _server = server;
+        _metersRegisteredOnInitialize = metersRegisteredOnInitialize;
         _server.ServerStore.LicenseManager.LicenseChanged += OnLicenseChanged;
     }
 
     private void OnLicenseChanged()
     {
-        if (_server.Configuration.Monitoring.OpenTelemetry.Enabled == false)
-            return;
-
-        _locker.Wait();
         try
         {
-            if (_metricsActivated)
-                return;
-            
-            var activate = _server.ServerStore.LicenseManager.CanUseOpenTelemetryMonitoring(withNotification: true, startUp: false);
-            if (activate)
-            {
-                Execute();
-            }
+            Execute();
         }
         catch (ObjectDisposedException)
         {
             // ignore
             // we are shutting down the server
-        }
-        finally
-        {
-            _locker.Release();
         }
     }
 
@@ -56,7 +43,7 @@ public class MetricsManager
             if (_metricsActivated)
                 return;
             
-            var activate = _server.ServerStore.LicenseManager.CanUseOpenTelemetryMonitoring(withNotification: true, startUp: true);
+            var activate = _server.ServerStore.LicenseManager.CanUseOpenTelemetryMonitoring(withNotification: true, metersRegistered: _metersRegisteredOnInitialize);
             if (activate)
             {
                 if (_serverMetrics != null)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -441,11 +441,9 @@ namespace Raven.Server
         
         private void StartOpenTelemetry()
         {
-            if (_openTelemetryInitialized == false)
-                return; // since we're not exposing there is no reason to initialize meters itself.
-            
-            MetricsManager = new MetricsManager(ServerStore.Server); 
-            MetricsManager.Execute();
+            MetricsManager = new MetricsManager(ServerStore.Server, _openTelemetryInitialized); 
+            if (_openTelemetryInitialized)
+                MetricsManager.Execute(); // initialize only when OpenTelemetry is configured in `Initialize()`
         }
 
         private void ConfigureOpenTelemetry(IServiceCollection services)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25104

### Additional description

In previous code, we could get false negative alert when activating OpenTelemetry monitoring with license update.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
