### PR TITLE
[Release-5.4] RavenDB-25103 Pull replication (hub) will work correctly if a sink uses `Use the server certificate` option and its certificate has only 'TLS Server Authentication' EKU

### DIFF
--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -141,7 +141,7 @@ namespace Raven.Server.Web.System
                     {
                         if (serverStore.Cluster.TryReadPullReplicationDefinition(database, remoteTask, context, out var pullReplication))
                         {
-                            var cert = httpContext.Connection.ClientCertificate;
+                            var cert = RavenServer.GetCertificateForAuthorization(httpContext.Connection.ClientCertificate);
 #pragma warning disable CS0618 // Type or member is obsolete
                             if (pullReplication.Certificates != null && pullReplication.Certificates.Count > 0)
                             {

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -123,5 +123,67 @@ namespace StressTests.Server.Replication
             }
             return resList;
         }
+
+        [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task PullReplicationWithSinkServerCertificateUsage(bool with2Eku)
+        {
+            var hubSettings = new ConcurrentDictionary<string, string>();
+            var sinkSettings = new ConcurrentDictionary<string, string>();
+
+            var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true, with2Eku: with2Eku);
+            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates);
+
+            var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: false, with2Eku: with2Eku);
+            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates);
+
+            var hubDB = GetDatabaseName();
+            var sinkDB = GetDatabaseName();
+            var pullReplicationName = $"{hubDB}-pull";
+
+            var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = hubSettings, RegisterForDisposal = true });
+            var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = sinkSettings, RegisterForDisposal = true });
+
+            // let's export a sink's server certificate and register it on a hub
+            var pullReplicationCertificate = CertificateLoaderUtil.CreateCertificate(sinkCerts.ServerCertificate.Value.Export(X509ContentType.Cert));
+            Assert.False(pullReplicationCertificate.HasPrivateKey);
+
+            using (var hubStore = GetDocumentStore(new Options
+                   {
+                       ClientCertificate = hubCerts.ServerCertificateForCommunication.Value,
+                       Server = hubServer,
+                       ModifyDatabaseName = _ => hubDB
+                   }))
+            using (var sinkStore = GetDocumentStore(new Options
+                   {
+                       ClientCertificate = sinkCerts.ServerCertificateForCommunication.Value,
+                       Server = sinkServer,
+                       ModifyDatabaseName = _ => sinkDB
+                   }))
+            {
+                await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(pullReplicationName)));
+                await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(pullReplicationName, new ReplicationHubAccess
+                {
+                    Name = pullReplicationCertificate.Thumbprint,
+                    CertificateBase64 = Convert.ToBase64String(pullReplicationCertificate.Export(X509ContentType.Cert))
+                }));
+
+                var configurationResult = await SetupPullReplicationAsync(
+                    pullReplicationName,
+                    sinkStore,
+                    null /* it forces to use server certificate */,
+                    hubStore);
+
+                using (var hubSession = hubStore.OpenSession())
+                {
+                    hubSession.Store(new User(), "foo/bar");
+                    hubSession.SaveChanges();
+                }
+
+                var timeout = 5000;
+                Assert.True(WaitForDocument(sinkStore, "foo/bar", timeout), sinkStore.Identifier);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25103

### Additional description

It fixes hub / sink replication if a sink has 1EKU server certificate and uses `Use the server certificate` option

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
