### PR TITLE
RavenDB-25112 Fix checking Accept-Encoding and compressing files from directory in Studio

### DIFF
--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -171,12 +171,19 @@ namespace Raven.Server.Web
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected bool ClientAcceptsGzipResponse()
         {
-
             return
                 Server.Configuration.Http.UseResponseCompression &&
                 (HttpContext.Request.IsHttps == false ||
                     (HttpContext.Request.IsHttps && Server.Configuration.Http.AllowResponseCompressionOverHttps)) &&
-                GetHttpCompressionAlgorithmFromHeaders(HttpContext.Request.Headers, Constants.Headers.AcceptEncoding) == HttpCompressionAlgorithm.Gzip;
+                HasHttpAcceptEncoding(HttpContext.Request.Headers, Constants.Headers.Encodings.Gzip);
+        }
+
+        private static bool HasHttpAcceptEncoding(IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers, string encoding)
+        {
+            if (headers.TryGetValue(Constants.Headers.AcceptEncoding, out Microsoft.Extensions.Primitives.StringValues acceptEncodings) == false)
+                return false;
+
+            return acceptEncodings.ToString().Contains(encoding);
         }
 
         private static HttpCompressionAlgorithm? GetHttpCompressionAlgorithmFromHeaders(IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers, string encodingsHeader)

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -175,15 +175,22 @@ namespace Raven.Server.Web
                 Server.Configuration.Http.UseResponseCompression &&
                 (HttpContext.Request.IsHttps == false ||
                     (HttpContext.Request.IsHttps && Server.Configuration.Http.AllowResponseCompressionOverHttps)) &&
-                HasHttpAcceptEncoding(HttpContext.Request.Headers, Constants.Headers.Encodings.Gzip);
+                HasGzipHttpCompressionAlgorithmInHeaders(HttpContext.Request.Headers, Constants.Headers.AcceptEncoding);
         }
 
-        private static bool HasHttpAcceptEncoding(IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers, string encoding)
+        private static bool HasGzipHttpCompressionAlgorithmInHeaders(IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers, string encodingsHeader)
         {
-            if (headers.TryGetValue(Constants.Headers.AcceptEncoding, out Microsoft.Extensions.Primitives.StringValues acceptEncodings) == false)
+            if (headers.TryGetValue(encodingsHeader, out Microsoft.Extensions.Primitives.StringValues acceptedContentEncodings) == false)
                 return false;
 
-            return acceptEncodings.ToString().Contains(encoding);
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var encoding in acceptedContentEncodings)
+            {
+                if (encoding.Contains(Constants.Headers.Encodings.Gzip))
+                    return true;
+            }
+
+            return false;
         }
 
         private static HttpCompressionAlgorithm? GetHttpCompressionAlgorithmFromHeaders(IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers, string encodingsHeader)

--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -553,17 +553,18 @@ namespace Raven.Server.Web.System
                         if (ShouldSkipCache(info))
                             continue;
 
-                        StaticContentCache.TryAdd(file.Substring(wwwRootBasePath.Length + 1).Replace('\\', '/'),
-                            new Lazy<CachedStaticFile>(() =>
-                           {
-                               var serverRelativeFileName = file.Substring(wwwRootBasePath.Length);
-                               var fileETag = GenerateETagFor(ETagFileSystemFileSource, serverRelativeFileName.GetHashCode(),
-                                   info.LastWriteTimeUtc.Ticks);
-                               using (var stream = info.OpenRead())
-                               {
-                                   return BuildForCache(serverRelativeFileName, fileETag, info, stream);
-                               }
-                           }));
+                        var serverRelativeFileName = file.Substring(wwwRootBasePath.Length + 1).Replace('\\', '/');
+
+                        if (StaticContentCache.ContainsKey(serverRelativeFileName))
+                            continue;
+
+                        var fileETag = GenerateETagFor(ETagFileSystemFileSource, serverRelativeFileName.GetHashCode(), info.LastWriteTimeUtc.Ticks);
+
+                        using (var entry = info.OpenRead())
+                        {
+                            var cacheEntry = BuildForCache(serverRelativeFileName, fileETag, info, entry);
+                            StaticContentCache.TryAdd(serverRelativeFileName, new Lazy<CachedStaticFile>(cacheEntry));
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25112/Studio-responses-are-not-compressed

### Additional description

StudioHandle:
- The `serverRelativeFileName` passed to `BuildForCache` differed from the key in `StaticContentCache`

RequestHandler:
- `acceptedContentEncodings` in `GetHttpCompressionAlgorithmFromHeaders` can be e.g. string `gzip, br, zstd`. Currentyly it works only for single value

Note: ESET Antivirus may intercept and decompress responses, causing browsers to show missing `Content-Encoding` headers and larger transfer sizes, even though actual network traffic remains compressed

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
