### PR TITLE
RavenDB-23231 avoid sync over async with ETL mre wait

### DIFF
--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -76,6 +76,9 @@ namespace Sparrow.Server
             return new FrozenAwaiter(_tcs, this);
         }
 
+        [Obsolete("Do not use it! this is here only to handle tests that are void")]
+        internal bool Wait(TimeSpan timeout) => WaitAsync(timeout).GetAwaiter().GetResult();
+        
         public readonly struct FrozenAwaiter
         {
             private readonly TaskCompletionSource<bool> _tcs;

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -584,14 +584,14 @@ namespace FastTests.Client.Subscriptions
                     Strategy = SubscriptionOpeningStrategy.OpenIfFree,
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
                 });
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 PutUserDoc(store);
                 var t = subscriptionWorker.Run(x =>
                 {
-                    mre.Set();
+                    amre.Set();
                 });
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
-                mre.Reset();
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
+                amre.Reset();
 
                 throwingSubscriptionWorker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
@@ -612,12 +612,12 @@ namespace FastTests.Client.Subscriptions
 
                 t = notThrowingSubscriptionWorker.Run(x =>
                 {
-                    mre.Set();
+                    amre.Set();
                 });
 
                 PutUserDoc(store);
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
             }
             finally
             {
@@ -1294,16 +1294,16 @@ namespace FastTests.Client.Subscriptions
 
             await using (var sub = store.Subscriptions.GetSubscriptionWorker<ProjectionObject>(name))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var subscriptionTask = sub.Run(batch =>
                 {
                     Assert.NotEmpty(batch.Items);
                     var projectionObject = batch.Items.First().Result;
                     Assert.Equal("SomeValue", projectionObject.SomeProp);
-                    mre.Set();
+                    amre.Set();
                 });
                 var timeout = TimeSpan.FromSeconds(30);
-                if (await mre.WaitAsync(timeout) == false)
+                if (await amre.WaitAsync(timeout) == false)
                 {
                     if (subscriptionTask.IsFaulted)
                         await subscriptionTask;
@@ -1337,16 +1337,16 @@ namespace FastTests.Client.Subscriptions
 
             await using (var sub = store.Subscriptions.GetSubscriptionWorker<ProjectionObject>(name))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var subscriptionTask = sub.Run(batch =>
                 {
                     Assert.NotEmpty(batch.Items);
                     string resultOrderId = batch.Items.First().Result.ProjectionId;
                     Assert.Equal(entity.Id, resultOrderId);
-                    mre.Set();
+                    amre.Set();
                 });
                 var timeout = TimeSpan.FromSeconds(30);
-                if (await mre.WaitAsync(timeout) == false)
+                if (await amre.WaitAsync(timeout) == false)
                 {
                     if (subscriptionTask.IsFaulted)
                         await subscriptionTask;
@@ -1373,13 +1373,13 @@ namespace FastTests.Client.Subscriptions
             var state = await store.Subscriptions.GetSubscriptionStateAsync(name);
             await using (var sub = store.Subscriptions.GetSubscriptionWorker<ProjectionObject>(name))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var subscriptionTask = sub.Run(batch =>
                 {
-                    mre.Set();
+                    amre.Set();
                 });
                 var timeout = TimeSpan.FromSeconds(30);
-                Assert.True(await mre.WaitAsync(timeout));
+                Assert.True(await amre.WaitAsync(timeout));
                 var taskInfoById = store.Maintenance.Send(new GetOngoingTaskInfoOperation(state.SubscriptionId, OngoingTaskType.Subscription));
                 Assert.NotNull(taskInfoById);
                 Assert.Equal(OngoingTaskState.Enabled, taskInfoById.TaskState);

--- a/test/FastTests/Sharding/Subscriptions/ShardedSubscriptionBasicTests.cs
+++ b/test/FastTests/Sharding/Subscriptions/ShardedSubscriptionBasicTests.cs
@@ -51,7 +51,7 @@ namespace FastTests.Sharding.Subscriptions
                     session.SaveChanges();
                 }
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)))
                 {
                     var c = 0;
@@ -62,12 +62,12 @@ namespace FastTests.Sharding.Subscriptions
                             names.Remove(item.Result.Name);
                             if (++c == 3)
                             {
-                                mre.Set();
+                                amre.Set();
                             }
                         }
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                     Assert.Empty(names);
                 }
             }

--- a/test/InterversionTests/EtlTests.cs
+++ b/test/InterversionTests/EtlTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -46,7 +47,7 @@ namespace InterversionTests
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest54.OpenSession())
                 {
@@ -64,7 +65,7 @@ namespace InterversionTests
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest54.OpenSession())
                 {

--- a/test/RachisTests/DatabaseCluster/EtlFailover.cs
+++ b/test/RachisTests/DatabaseCluster/EtlFailover.cs
@@ -13,7 +13,9 @@ using Raven.Client.Exceptions.Cluster;
 using Raven.Client.ServerWide;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -191,7 +193,7 @@ namespace RachisTests.DatabaseCluster
                 var database = await srcNodes.Servers.Single(s => s.ServerStore.NodeTag == myTag)
                     .ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(srcDb);
 
-                var etlDone = new ManualResetEventSlim();
+                var etlDone = new AsyncManualResetEvent();
                 database.EtlLoader.BatchCompleted += x =>
                 {
                     if (x.Statistics.LoadSuccesses > 0)
@@ -207,7 +209,7 @@ namespace RachisTests.DatabaseCluster
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
                 Assert.True(WaitForDocument<User>(dest, "users/1", u => u.Name == "Joe Doe", 30_000));
 
                 // BEFORE THE FIX: this will change the database record and restart the ETL, which would fail the test.
@@ -234,7 +236,7 @@ namespace RachisTests.DatabaseCluster
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
                 Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", 30_000));
             }
         }

--- a/test/RachisTests/SubscriptionFailoverWIthWaitingChains.cs
+++ b/test/RachisTests/SubscriptionFailoverWIthWaitingChains.cs
@@ -46,14 +46,14 @@ namespace RachisTests
                 });
 
                 ConcurrentSet<string> redirects = new ConcurrentSet<string>();
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var processedItems = new List<string>();
                 subsWorker.AfterAcknowledgment += batch =>
                 {
                     foreach (var item in batch.Items)
                         processedItems.Add(item.Result.Name);
 
-                    mre.Set();
+                    amre.Set();
                     return Task.CompletedTask;
                 };
                 subsWorker.OnSubscriptionConnectionRetry += ex =>
@@ -81,7 +81,7 @@ namespace RachisTests
                     Assert.NotNull(node);
 
                     if (i != 0)
-                        mre.Reset();
+                        amre.Reset();
 
                     using (var session = store.OpenSession())
                     {
@@ -92,7 +92,7 @@ namespace RachisTests
                         session.SaveChanges();
                     }
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)), "no ack");
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)), "no ack");
 
                     var res = await DisposeServerAndWaitForFinishOfDisposalAsync(node);
                     Assert.Equal(currentResponsibleNode, res.NodeTag);
@@ -143,7 +143,7 @@ namespace RachisTests
 
             using (var store = GetDocumentStore(options))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User());
@@ -163,13 +163,13 @@ namespace RachisTests
                         Assert.True(ae.InnerExceptions.Count(e => e.GetType() == typeof(IOException) || e.GetType() == typeof(EndOfStreamException)) > 0);
                     else
                         Assert.True(ex.GetType() == typeof(IOException) || ex.GetType() == typeof(EndOfStreamException));
-                    mre.Set();
+                    amre.Set();
                 };
                 server.ForTestingPurposesOnly().ThrowExceptionInListenToNewTcpConnection = true;
                 try
                 {
                     var task = subsWorker.Run(x => { });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                 }
                 finally
                 {

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -682,7 +682,7 @@ namespace RachisTests
             {
                 Servers.ForEach(x => x.ForTestingPurposesOnly().GatherVerboseDatabaseDisposeInformation = true);
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var subscriptionManager = new DocumentSubscriptions(store))
                 {
                     var reqEx = store.GetRequestExecutor();
@@ -723,11 +723,11 @@ namespace RachisTests
                             return;
 
                         redirects[subscription.CurrentNodeTag] = ex.ToString();
-                        mre.Set();
+                        amre.Set();
                     };
                     var expectedTag = onlineServer.NodeTag;
                     _ = subscription.Run(x => { });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)), $"Could not redirect to alive node in time{Environment.NewLine}Redirects:{Environment.NewLine}{string.Join(Environment.NewLine, redirects.Select(x => $"Tag: {x.Key}, Exception: {x.Value}").ToList())}");
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)), $"Could not redirect to alive node in time{Environment.NewLine}Redirects:{Environment.NewLine}{string.Join(Environment.NewLine, redirects.Select(x => $"Tag: {x.Key}, Exception: {x.Value}").ToList())}");
 
                     Assert.True(redirects.Keys.Contains(expectedTag), $"Could not find '{expectedTag}' in Redirects:{Environment.NewLine}{string.Join(Environment.NewLine, redirects.Select(x => $"Tag: {x.Key}, Exception: {x.Value}").ToList())}");
                     Assert.False(redirects.Keys.Contains(disposedTag), $"Found disposed '{disposedTag}' in Redirects:{Environment.NewLine}{string.Join(Environment.NewLine, redirects.Select(x => $"Tag: {x.Key}, Exception: {x.Value}").ToList())}");
@@ -750,7 +750,7 @@ namespace RachisTests
             {
                 Servers.ForEach(x => x.ForTestingPurposesOnly().GatherVerboseDatabaseDisposeInformation = true);
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var subscriptionManager = new DocumentSubscriptions(store))
                 {
                     var name = await subscriptionManager.CreateAsync(new SubscriptionCreationOptions<User>());
@@ -777,7 +777,7 @@ namespace RachisTests
 
                     subscription.OnEstablishedSubscriptionConnection += () =>
                     {
-                        mre.Set();
+                        amre.Set();
                     };
                     subscription.AfterAcknowledgment += batch =>
                     {
@@ -789,7 +789,7 @@ namespace RachisTests
                     };
                     _ = subscription.Run(x => { });
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)), $"Could not connect subscription in time{Environment.NewLine}Redirects:{Environment.NewLine}{string.Join(Environment.NewLine, redirects.Select(x => $"Tag: {x.Key}, Exception: {x.Value}").ToList())}");
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)), $"Could not connect subscription in time{Environment.NewLine}Redirects:{Environment.NewLine}{string.Join(Environment.NewLine, redirects.Select(x => $"Tag: {x.Key}, Exception: {x.Value}").ToList())}");
 
                     subscription.OnSubscriptionConnectionRetry += ex =>
                     {

--- a/test/SlowTests.Issues/Issues/RavenDB-11166.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-11166.cs
@@ -57,7 +57,7 @@ namespace SlowTests.Issues
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Dog>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -71,9 +71,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -124,7 +124,7 @@ namespace SlowTests.Issues
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Revision<Dog>>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -142,9 +142,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    await mre.WaitAsync(TimeSpan.FromSeconds(60));
+                    await amre.WaitAsync(TimeSpan.FromSeconds(60));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -201,7 +201,7 @@ namespace SlowTests.Issues
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Revision<Dog>>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -219,9 +219,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    await mre.WaitAsync(TimeSpan.FromSeconds(60));
+                    await amre.WaitAsync(TimeSpan.FromSeconds(60));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -260,7 +260,7 @@ select f(dog)
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Dog>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -274,9 +274,9 @@ select f(dog)
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -315,7 +315,7 @@ select f(dog)
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Dog>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -334,9 +334,9 @@ select f(dog)
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB-16659.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16659.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
         public async Task DeleteDatabaseDuringRestore()
         {
             DoNotReuseServer();
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
             var mre2 = new ManualResetEvent(false);
             var backupPath = NewDataPath();
 
@@ -55,12 +55,12 @@ namespace SlowTests.Issues
                         new RestoreBackupOperation(new RestoreBackupConfiguration
                         { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
                     Server.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () => {
-                        mre.Set();
+                        amre.Set();
                         mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
                     };
 
                     var op  = await store.Maintenance.Server.SendAsync(restoreOperation);
-                    var res = await mre.WaitAsync(TimeSpan.FromSeconds(30));
+                    var res = await amre.WaitAsync(TimeSpan.FromSeconds(30));
                     Assert.True(res);
 
                     var val = await WaitForValueAsync(async () => await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName)) != null, true, 30_000);

--- a/test/SlowTests.Issues/Issues/RavenDB-16751.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16751.cs
@@ -5,6 +5,7 @@ using FastTests;
 using FastTests.Utils;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,7 +51,7 @@ public class RavenDB_16751 : RavenTestBase
                                                             loadToUsers(this);");
 
             var etlDone = Etl.WaitForEtlToComplete(src);
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
             
             // Assert
             List<User> revisions;

--- a/test/SlowTests.Issues/Issues/RavenDB-16975.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16975.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Issues
                 });
                 await using (var sub = store.Subscriptions.GetSubscriptionWorker<Person>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -47,10 +47,10 @@ namespace SlowTests.Issues
                             Assert.Equal(0, batch.NumberOfIncludes);
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
                     
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -85,7 +85,7 @@ select f(people)
 
                 await using (var sub = store.Subscriptions.GetSubscriptionWorker<Person>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -94,9 +94,9 @@ select f(people)
                             Assert.Equal(0, batch.NumberOfIncludes);
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB-17096.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17096.cs
@@ -146,15 +146,15 @@ namespace SlowTests.Issues
 
         private static AsyncManualResetEvent WaitForEtl(DocumentDatabase database, Func<string, EtlProcessStatistics, bool> predicate)
         {
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             database.EtlLoader.BatchCompleted += x =>
             {
                 if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
-                    mre.Set();
+                    amre.Set();
             };
 
-            return mre;
+            return amre;
         }
 
         private async Task<string> AddDebugInfoAsync(DocumentStore store, int membersCount)

--- a/test/SlowTests.Issues/Issues/RavenDB-17451.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17451.cs
@@ -135,11 +135,11 @@ namespace SlowTests.Issues
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16)
                 }))
                 {
-                     var mre = new AsyncManualResetEvent();
+                     var amre = new AsyncManualResetEvent();
 
                      subscription.OnEstablishedSubscriptionConnection += () =>
                      {
-                         mre.Set();
+                         amre.Set();
                      };
 
                     var list = new BlockingCollection<User>();
@@ -151,7 +151,7 @@ namespace SlowTests.Issues
                         }
                     }));
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)), "await mre.WaitAsync(TimeSpan.FromSeconds(15))");
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)), "await amre.WaitAsync(TimeSpan.FromSeconds(15))");
 
                     User user;
                     for (var i = 0; i < 10; i++)

--- a/test/SlowTests.Issues/Issues/RavenDB-17624.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17624.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
             using var worker = store.Subscriptions
                .GetSubscriptionWorker<Command>(workerOptions);
 
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
             var cts = new CancellationTokenSource();
             var last = DateTime.UtcNow;
             InvalidOperationException exception = null;
@@ -66,10 +66,10 @@ namespace SlowTests.Issues
                     return Task.CompletedTask;
                 });
 
-                mre.Set();
+                amre.Set();
             }, cts.Token);
 
-            Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)));
             Assert.NotNull(exception);
             Assert.Equal("Session can only be opened once per each Subscription batch", exception.Message);
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-17650.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17650.cs
@@ -521,10 +521,10 @@ namespace SlowTests.Issues
             });
 
             var cts = new CancellationTokenSource();
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
-            var t = worker.Run(batch => { mre.Set(); }, cts.Token);
-            await mre.WaitAsync(cts.Token);
+            var t = worker.Run(batch => { amre.Set(); }, cts.Token);
+            await amre.WaitAsync(cts.Token);
 
             // disable database
             var disableSucceeded = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));

--- a/test/SlowTests.Issues/Issues/RavenDB-17745.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17745.cs
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore())
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 db.ForTestingPurposesOnly().BulkInsert_StreamReadTimeout = _readTimeout;
                 var bulkInsertOptions = new BulkInsertOptions();
@@ -132,10 +132,10 @@ namespace SlowTests.Issues
                 {
                     bulkInsertOptions.ForTestingPurposesOnly().OnSendHeartBeat_DoBulkStore = () =>
                     {
-                        mre.Set();
+                        amre.Set();
                     };
 
-                    Assert.True(await mre.WaitAsync(_delay * 3));
+                    Assert.True(await amre.WaitAsync(_delay * 3));
 
                     await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB-19696.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19696.cs
@@ -6,6 +6,7 @@ using Raven.Client;
 using Raven.Client.Documents.Operations.ETL;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -68,7 +69,7 @@ public class RavenDB_19696 : RavenTestBase
             
             Etl.AddEtl(store, configuration, connectionString);
 
-            etlDone.Wait(TimeSpan.FromSeconds(10));
+            await etlDone.WaitAsync(TimeSpan.FromSeconds(10));
             
             using (var session = replica.OpenSession())
             {
@@ -135,7 +136,7 @@ public class RavenDB_19696 : RavenTestBase
 
             Etl.AddEtl(store, configuration, connectionString);
             
-            etlDone.Wait(TimeSpan.FromSeconds(10));
+            await etlDone.WaitAsync(TimeSpan.FromSeconds(10));
             
             using (var session = replica.OpenSession())
             {
@@ -202,7 +203,7 @@ public class RavenDB_19696 : RavenTestBase
 
             Etl.AddEtl(store, configuration, connectionString);
             
-            etlDone.Wait(TimeSpan.FromSeconds(10));
+            await etlDone.WaitAsync(TimeSpan.FromSeconds(10));
             
             using (var session = replica.OpenSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-20136.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-20136.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                if (loadDone1.Wait(TimeSpan.FromSeconds(30)) == false)
+                if (await loadDone1.WaitAsync(TimeSpan.FromSeconds(30)) == false)
                 {
                     var loadError = await Etl.TryGetLoadErrorAsync(src.Database, configuration);
                     var transformationError = await Etl.TryGetTransformationErrorAsync(src.Database, configuration);
@@ -64,7 +64,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                if (loadDone2.Wait(TimeSpan.FromSeconds(30)) == false)
+                if (await loadDone2.WaitAsync(TimeSpan.FromSeconds(30)) == false)
                 {
                     var loadError = await Etl.TryGetLoadErrorAsync(src.Database, configuration);
                     var transformationError = await Etl.TryGetTransformationErrorAsync(src.Database, configuration);
@@ -85,7 +85,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Assert.True(deleteDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await deleteDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dst.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-23473.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23473.cs
@@ -73,7 +73,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
 
             var sub = await store.Subscriptions.CreateAsync<Question>(new SubscriptionCreationOptions<Question>());
             var worker = store.Subscriptions.GetSubscriptionWorker<Question>(sub);
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
             List<float> vector = [];
             var t = worker.Run(async x =>
             {
@@ -99,7 +99,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
                 }
 
                 await session.SaveChangesAsync();
-                mre.Set();
+                amre.Set();
             });
 
             for (int i = 0; i < 5; i++)
@@ -111,7 +111,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
                 }
             }
 
-            Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+            Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
 
             await Indexes.WaitForIndexingAsync(store);
             var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);

--- a/test/SlowTests.Issues/Issues/RavenDB-24640.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24640.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var testDoc = new TestDocument { Name = "Foo", Id = "TestDocuments-1-A" };
 
 
@@ -75,13 +75,13 @@ namespace SlowTests.Issues
                             await session.SaveChangesAsync();
                         }
 
-                        if (mre.IsSet == false)
+                        if (amre.IsSet == false)
                         {
-                            mre.Set();
+                            amre.Set();
                         }
 
                     });
-                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)));
+                Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)));
 
 
                 using (var commands = store.Commands())

--- a/test/SlowTests.Issues/Issues/RavenDB-7275.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-7275.cs
@@ -64,14 +64,14 @@
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(200)
                     });
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     
 
                     subscription.AfterAcknowledgment += b => { mre.Set(); return Task.CompletedTask; };
 
                     GC.KeepAlive(subscription.Run(x => { }));
 
-                    await mre.WaitAsync(TimeSpan.FromSeconds(20));
+                    await amre.WaitAsync(TimeSpan.FromSeconds(20));
                 }
             }
         }
@@ -133,13 +133,13 @@
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(200)
                     });
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
 
                     subscription.AfterAcknowledgment += b => { mre.Set(); return Task.CompletedTask; };
 
                     GC.KeepAlive(subscription.Run(x => { }));
 
-                    await mre.WaitAsync(TimeSpan.FromSeconds(20));
+                    await amre.WaitAsync(TimeSpan.FromSeconds(20));
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB14709.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB14709.cs
@@ -56,15 +56,15 @@ namespace SlowTests.Issues
                 }
             });
 
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             subscription.AfterAcknowledgment += batch =>
             {
-                mre.Set();
+                amre.Set();
                 return Task.CompletedTask;
             };
 
-            Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+            Assert.True(await amre.WaitAsync(_reasonableWaitTime));
             await subscription.DisposeAsync();
             await subscriptionTask;
             Assert.NotEmpty(names);

--- a/test/SlowTests.Issues/Issues/RavenDB_12127.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12127.cs
@@ -57,13 +57,13 @@ namespace SlowTests.Issues
                 {
                     sub.SubscriptionTcpVersion = 40;
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_12257.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12257.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Product>(name))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -65,9 +65,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -135,7 +135,7 @@ namespace SlowTests.Issues
 
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Order>(name))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -148,9 +148,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_12259.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12259.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Issues
                     Projection = company => new { Name = company.Name }
                 });
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 using (var worker = store.Subscriptions.GetSubscriptionWorker(name))
                 {
@@ -59,15 +59,15 @@ namespace SlowTests.Issues
                             Assert.Equal(1, s.Advanced.NumberOfRequests);
                         }
 
-                        mre.Set();
+                        amre.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(10)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(10)));
                     await worker.DisposeAsync();
                     await r;// no error
                 }
 
-                mre.Reset();
+                amre.Reset();
 
                 name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Company>());
 
@@ -90,10 +90,10 @@ namespace SlowTests.Issues
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
 
-                        mre.Set();
+                        amre.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(10)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(10)));
                     await worker.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_13478.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13478.cs
@@ -68,7 +68,7 @@ namespace SlowTests.Issues
             {
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Product>(name))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -87,9 +87,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(expectedNumberOfRequests, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_13762.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13762.cs
@@ -80,7 +80,7 @@ namespace SlowTests.Issues
                 }))
                 {
                     Exception exception = null;
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     GC.KeepAlive(sub.Run(x =>
                     {
                         try
@@ -98,11 +98,11 @@ namespace SlowTests.Issues
                         }
                         finally
                         {
-                            mre.Set();
+                            amre.Set();
                         }
                     }));
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                     if (exception != null)
                         throw exception;

--- a/test/SlowTests.Issues/Issues/RavenDB_16262.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16262.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
             {
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Product>(name))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -63,9 +63,9 @@ namespace SlowTests.Issues
                             }
                             Assert.Equal(expectedNumberOfRequests, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_16303.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16303.cs
@@ -10,7 +10,9 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Server.SqlMigration;
+using Sparrow.Server;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -47,7 +49,7 @@ namespace SlowTests.Issues
 
                     await store.Maintenance.SendAsync(operation);
 
-                    var etlDone = new ManualResetEventSlim();
+                    var etlDone = new AsyncManualResetEvent();
                     var configuration = new SqlEtlConfiguration
                     {
                         Name = sqlEtlConfigurationName,
@@ -91,7 +93,7 @@ loadToTestGuidEtls(item);"
                         await session.SaveChangesAsync();
                     }
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                     Assert.Equal(0, errors);
 
                     CheckCount(provider, connectionString, 1);
@@ -125,7 +127,7 @@ loadToTestGuidEtls(item);"
 
                     await store.Maintenance.SendAsync(operation);
 
-                    var etlDone = new ManualResetEventSlim();
+                    var etlDone = new AsyncManualResetEvent();
                     var configuration = new SqlEtlConfiguration
                     {
                         Name = sqlEtlConfigurationName,
@@ -170,7 +172,7 @@ loadToTestGuidEtls(item);"
                         session.SaveChanges();
                     }
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                     Assert.Equal(0, errors);
 
                     CheckCount(provider, connectionString, 1);

--- a/test/SlowTests.Issues/Issues/RavenDB_16336.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16336.cs
@@ -78,11 +78,11 @@ namespace SlowTests.Issues
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
 
                 SubscriptionBatchPerformanceStats stats = null;
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 db.SubscriptionStorage.OnEndBatch += (s, aggregator) =>
                 {
                     stats = aggregator.ToBatchPerformanceStats();
-                    mre.Set();
+                    amre.Set();
                 };
                 var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
                 {
@@ -92,7 +92,7 @@ namespace SlowTests.Issues
                         .IncludeTimeSeries(timeSeries, TimeSeriesRangeType.Last, 100)
                 });
 
-                await AssertSubscription(store, name, mre);
+                await AssertSubscription(store, name, amre);
 
                 Assert.NotNull(stats);
                 Assert.Equal(expectedCountersSize, stats.SizeOfIncludedCountersInBytes);
@@ -100,7 +100,7 @@ namespace SlowTests.Issues
             }
         }
 
-        private static async Task AssertSubscription(DocumentStore store, string name, AsyncManualResetEvent mre)
+        private static async Task AssertSubscription(DocumentStore store, string name, AsyncManualResetEvent amre)
         {
             var baseline = new DateTime(2021, 1, 1);
             using (var sub = store.Subscriptions.GetSubscriptionWorker<Product>(name))
@@ -128,7 +128,7 @@ namespace SlowTests.Issues
                         Assert.Equal(0, s.Advanced.NumberOfRequests);
                     }
                 });
-                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                 await sub.DisposeAsync();
                 await r; // no error
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_21866.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21866.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using FastTests;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -52,7 +53,7 @@ function loadTimeSeriesOfEventDocumentsBehavior(docId, timeSeriesName) {
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(etlDone.Wait(TimeSpan.FromSeconds(15)));
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(15)));
 
             using (var session = dest.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB_24342.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_24342.cs
@@ -59,7 +59,7 @@ for(const comment of this.Comments)
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(etl.Wait(TimeSpan.FromSeconds(30)));
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
 
             using var verify = store.OpenAsyncSession();
             var ids = (await verify.Query<Comment>(collectionName: "someNewCollection").Select(x => x.Id).ToListAsync());

--- a/test/SlowTests.Issues/Issues/RavenDB_3232.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_3232.cs
@@ -173,7 +173,7 @@ namespace SlowTests.Issues
 
                 Assert.Contains($"The field 'LastName' is not indexed in '{oldIndexDef.Name}', cannot query/sort on fields that are not indexed in query: from index '{oldIndexDef.Name}' where LastName = $p0 limit $p1, $p2", e.InnerException.Message);
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 var changes = await store.Changes().EnsureConnectedNow();
                 var observable = changes.ForAllIndexes();
@@ -181,14 +181,14 @@ namespace SlowTests.Issues
                 observable.Subscribe(change =>
                 {
                     if (change.Type == IndexChangeTypes.SideBySideReplace)
-                        mre.Set();
+                        amre.Set();
                 });
 
                 await store.Maintenance.SendAsync(new StartIndexingOperation());
 
                 Indexes.WaitForIndexing(store);
 
-                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)));
+                Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)));
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_6285.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_6285.cs
@@ -20,11 +20,11 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 var changes = await store.Changes().EnsureConnectedNow();
                 var observable = changes.ForAllDocuments();
-                observable.Subscribe(x => mre.Set());
+                observable.Subscribe(x => amre.Set());
                 await observable.EnsureSubscribedNow();
 
                 using (var session = store.OpenSession())
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(45)));
+                Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(45)));
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_7253.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_7253.cs
@@ -29,8 +29,8 @@ namespace SlowTests.Issues
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(200)
                 });
 
-                var mre = new AsyncManualResetEvent();
-                subscription.AfterAcknowledgment += b => { mre.Set(); return Task.CompletedTask; };
+                var amre = new AsyncManualResetEvent();
+                subscription.AfterAcknowledgment += b => { amre.Set(); return Task.CompletedTask; };
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User());
@@ -38,7 +38,7 @@ namespace SlowTests.Issues
                 }
                 var task = subscription.Run(user => { });
 
-                await mre.WaitAsync(TimeSpan.FromSeconds(20));
+                await amre.WaitAsync(TimeSpan.FromSeconds(20));
 
                 await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: true));
 

--- a/test/SlowTests.Issues/Issues/RavenDB_7589.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_7589.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Issues
         {
             DoNotReuseServer();
 
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             Server.ServerStore.Cluster.Changes.DatabaseChanged += (arg1,arg2,arg3,arg4, _) =>
             {
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
                 var value = Interlocked.Increment(ref _numberOfDatabasesRemoved);
 
                 if (value == 3)
-                    mre.Set();
+                    amre.Set();
 
                 return Task.CompletedTask;
             };
@@ -141,7 +141,7 @@ namespace SlowTests.Issues
                 Assert.Equal(2, identities["addresses|"]);
             }
 
-            Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(10)));
 
             using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())

--- a/test/SlowTests.Issues/Issues/RavenDb6055.cs
+++ b/test/SlowTests.Issues/Issues/RavenDb6055.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
                     Assert.Equal("Auto/Users/ByFirstName", indexes[0].Name);
                 }
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 var allIndexes = store.Changes()
                     .ForAllIndexes();
@@ -56,7 +56,7 @@ namespace SlowTests.Issues
                     .Subscribe(x =>
                     {
                         if (x.Type == IndexChangeTypes.IndexRemoved)
-                            mre.Set();
+                            amre.Set();
                     });
                 await allIndexes.EnsureSubscribedNow();
                 using (var session = store.OpenAsyncSession())
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
                         .ToListAsync();
                 }
 
-                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 WaitForUserToContinueTheTest(store);
                 

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -128,8 +128,8 @@ namespace SlowTests.Authentication
             Server.Dispose();
             UseNewLocalServer(sockets: setupInfo.Sockets);
 
-            var mre = new AsyncManualResetEvent();
-            Server.ServerCertificateChanged += (sender, args) => mre.Set();
+            var amre = new AsyncManualResetEvent();
+            Server.ServerCertificateChanged += (sender, args) => amre.Set();
 
             var ct = Certificates.GenerateAndSaveSelfSignedCertificate(with2Eku);
             var first = Server.Certificate.ServerCertificate.Thumbprint;
@@ -147,7 +147,7 @@ namespace SlowTests.Authentication
                 await store.Maintenance.Server.SendAsync(op2);
             }
 
-            await mre.WaitAsync(TimeSpan.FromSeconds(15));
+            await amre.WaitAsync(TimeSpan.FromSeconds(15));
             Assert.NotEqual(first, Server.Certificate.ServerCertificate.Thumbprint);
         }
 
@@ -315,10 +315,10 @@ namespace SlowTests.Authentication
 
                 Server.Time.UtcDateTime = () => DateTime.UtcNow.AddDays(80);
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var clusterReplacementConfirmed = new AsyncManualResetEvent();
 
-                Server.ServerCertificateChanged += (sender, args) => mre.Set();
+                Server.ServerCertificateChanged += (sender, args) => amre.Set();
                 Server.ServerStore.ForTestingPurposesOnly().OnConfirmCertificateReplacedValueChanged += clusterReplacementConfirmed.Set;
 
                 var command = new ForceRenewCertCommand(store.Conventions, context);
@@ -327,7 +327,7 @@ namespace SlowTests.Authentication
 
                 Assert.True(command.Result.Success, "ForceRenewCertCommand returned false");
 
-                var result = await mre.WaitAsync(Debugger.IsAttached ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(4));
+                var result = await amre.WaitAsync(Debugger.IsAttached ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(4));
 
                 if (result == false && Server.RefreshTask.IsCompleted)
                 {

--- a/test/SlowTests/Bugs/CustomEntityName.cs
+++ b/test/SlowTests/Bugs/CustomEntityName.cs
@@ -168,7 +168,7 @@ namespace SlowTests.Bugs
         [MemberData(nameof(GetCharactersToTest))]
         public async Task FindCollectionName_WhenSubscribeToApiChanges(char c)
         {
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             using var store = GetDocumentStore(new Options
             {
@@ -179,7 +179,7 @@ namespace SlowTests.Bugs
             await subscription.EnsureConnectedNow();
             var observableWithTask = subscription
                 .ForDocumentsInCollection<User>();
-            observableWithTask.Subscribe(change => mre.Set());
+            observableWithTask.Subscribe(change => amre.Set());
             await observableWithTask.EnsureSubscribedNow();
 
             using (var session = store.OpenAsyncSession())
@@ -188,7 +188,7 @@ namespace SlowTests.Bugs
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(15)));
+            Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)));
         }
 
         private class MultiMapIndex : AbstractMultiMapIndexCreationTask<IndexResult>
@@ -317,7 +317,7 @@ namespace SlowTests.Bugs
 
             await using (var sub = store.Subscriptions.GetSubscriptionWorker<User>(name))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var r = sub.Run(batch =>
                 {
                     Assert.NotEmpty(batch.Items);
@@ -329,9 +329,9 @@ namespace SlowTests.Bugs
                         }
                         Assert.Equal(0, s.Advanced.NumberOfRequests);
                     }
-                    mre.Set();
+                    amre.Set();
                 });
-                var isSet = await mre.WaitAsync(TimeSpan.FromSeconds(30));
+                var isSet = await amre.WaitAsync(TimeSpan.FromSeconds(30));
 
                 await sub.DisposeAsync();
                 await r;// no error

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -327,7 +327,7 @@ namespace SlowTests.Client.Subscriptions
                     var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
                     await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        var mre = new AsyncManualResetEvent();
+                        var amre = new AsyncManualResetEvent();
 
                         var _ = Subscription2.Run(async x =>
                         {
@@ -336,11 +336,11 @@ namespace SlowTests.Client.Subscriptions
                                 con2Docs.Add(item.Id);
                             }
 
-                            mre.Set();
+                            amre.Set();
                             await tcs.Task;
                         });
 
-                        await mre.WaitAsync();
+                        await amre.WaitAsync();
 
                         var exception = string.Empty;
                         var t = subscription.Run(x =>
@@ -499,7 +499,7 @@ namespace SlowTests.Client.Subscriptions
                     var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
                     await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        var mre = new AsyncManualResetEvent();
+                        var amre = new AsyncManualResetEvent();
 
                         var _ = subscription2.Run(async x =>
                         {
@@ -508,11 +508,11 @@ namespace SlowTests.Client.Subscriptions
                                 con2Docs.Add(item.Id);
                             }
 
-                            mre.Set();
+                            amre.Set();
                             await tcs.Task;
                         });
 
-                        await mre.WaitAsync();
+                        await amre.WaitAsync();
 
                         using (var session = store.OpenAsyncSession())
                         {
@@ -598,7 +598,7 @@ namespace SlowTests.Client.Subscriptions
                     var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
                     await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        var mre = new AsyncManualResetEvent();
+                        var amre = new AsyncManualResetEvent();
 
                         var _ = Subscription2.Run(async x =>
                         {
@@ -607,11 +607,11 @@ namespace SlowTests.Client.Subscriptions
                                 con2Docs.Add(item.Id);
                             }
 
-                            mre.Set();
+                            amre.Set();
                             await tcs.Task;
                         });
 
-                        await mre.WaitAsync();
+                        await amre.WaitAsync();
 
                         using (var session = store.OpenAsyncSession())
                         {
@@ -697,7 +697,7 @@ namespace SlowTests.Client.Subscriptions
                     var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
                     await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        var mre = new AsyncManualResetEvent();
+                        var amre = new AsyncManualResetEvent();
 
                         var _ = Subscription2.Run(async x =>
                         {
@@ -706,11 +706,11 @@ namespace SlowTests.Client.Subscriptions
                                 con2Docs.Add(item.Id);
                             }
 
-                            mre.Set();
+                            amre.Set();
                             await tcs.Task;
                         });
 
-                        await mre.WaitAsync();
+                        await amre.WaitAsync();
 
                         using (var session = store.OpenAsyncSession())
                         {
@@ -1063,7 +1063,7 @@ namespace SlowTests.Client.Subscriptions
                     session.SaveChanges();
                 }
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var id = store.Subscriptions.Create(new SubscriptionCreationOptions()
                 {
                     Query = "from Users where Name != 'R'"
@@ -1097,12 +1097,12 @@ namespace SlowTests.Client.Subscriptions
                         var res = Interlocked.Add(ref count, x.NumberOfItemsInBatch);
                         if (res >= collectionSize)
                         {
-                            mre.Set();
+                            amre.Set();
                         }
 
                     });
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
 
                     using (var session = store.OpenSession())
                     {

--- a/test/SlowTests/Client/Subscriptions/RavenDB-15553.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-15553.cs
@@ -55,7 +55,7 @@ namespace SlowTests.Client.Subscriptions
 
                     var subscription = store.Subscriptions.GetSubscriptionWorker<Team>(subscriptionName);
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var names = new List<string>();
 
                     await session.StoreAsync(new Team
@@ -87,10 +87,10 @@ namespace SlowTests.Client.Subscriptions
                         names.AddRange(x.Items.Select(i => i.Result.Name).ToList());
                         count+= x.Items.Count;
                         if(count >= 3)
-                            mre.Set();
+                            amre.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                     names.Sort();
                     Assert.Equal(new[] { "Marketing", "R&D", "Support" }, names);
                 }

--- a/test/SlowTests/Client/Subscriptions/RavenDB-8814.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-8814.cs
@@ -42,7 +42,7 @@ namespace SlowTests.Client.Subscriptions
 
                 var subscription = store.Subscriptions.GetSubscriptionWorker<dynamic>(subscriptionName);
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 int resultsCount = 0;
 
                 using (var session = store.OpenAsyncSession())
@@ -65,10 +65,10 @@ namespace SlowTests.Client.Subscriptions
                 {
                     foo = x.Items.First().Result.Foo;
                     resultsCount = x.Items.Count;
-                    mre.Set();
+                    amre.Set();
                 });
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                 Assert.Equal("Bar", foo);
                 Assert.Equal(1, resultsCount);
 

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
@@ -46,11 +46,11 @@ namespace SlowTests.Client.Subscriptions
                     session.SaveChanges();
                 }
 
-                var mre = new AsyncManualResetEvent();
-                var t = subscription.Run(x => mre.Set());
+                var amre = new AsyncManualResetEvent();
+                var t = subscription.Run(x => amre.Set());
                 GC.KeepAlive(t);
 
-                Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
 
                 await Assert.ThrowsAsync<SubscriptionInUseException>(() => store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3491.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3491.cs
@@ -235,10 +235,10 @@ namespace SlowTests.Client.Subscriptions
                         var keys = new BlockingCollection<string>();
                         var ages = new BlockingCollection<int>();
 
-                        var mre = new AsyncManualResetEvent();
+                        var amre = new AsyncManualResetEvent();
                         subscription.AfterAcknowledgment += batch =>
                         {
-                            mre.Set();
+                            amre.Set();
                             return Task.CompletedTask;
                         };
 
@@ -294,7 +294,7 @@ namespace SlowTests.Client.Subscriptions
                         Assert.True(ages.TryTake(out age, _waitForDocTimeout));
                         Assert.Equal(34, age);
 
-                        Assert.True(await mre.WaitAsync(TimeSpan.FromMilliseconds(250)));
+                        Assert.True(await amre.WaitAsync(TimeSpan.FromMilliseconds(250)));
                     }
                 }
 

--- a/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Client.Subscriptions
                 });
 
                 var results = new List<User>();
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 using (var session = store.OpenSession())
                 {
@@ -56,11 +56,11 @@ namespace SlowTests.Client.Subscriptions
 
                 subscription.AfterAcknowledgment += x =>
                 {
-                    mre.Set();
+                    amre.Set();
                     return Task.CompletedTask;
                 };
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 var currentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
@@ -95,7 +95,7 @@ namespace SlowTests.Client.Subscriptions
                 });
 
                 var results = new List<User>();
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 using (var session = store.OpenSession())
                 {
@@ -110,12 +110,12 @@ namespace SlowTests.Client.Subscriptions
 
                 subscription.AfterAcknowledgment += x =>
                 {
-                    mre.Set();
+                    amre.Set();
                     return Task.CompletedTask;
                 };
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
-                mre.Reset();
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
+                amre.Reset();
                 Assert.Equal("David", results[0].Name);
                 results.Clear();
                 var currentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
@@ -166,7 +166,7 @@ namespace SlowTests.Client.Subscriptions
 
                 subscription.AfterAcknowledgment += x =>
                 {
-                    mre.Set();
+                    amre.Set();
                     return Task.CompletedTask;
                 };
 
@@ -177,7 +177,7 @@ namespace SlowTests.Client.Subscriptions
                     session.SaveChanges();
                 }
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                 Assert.Equal("Jorgen", results[0].Name);
             }
         }

--- a/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
@@ -99,7 +99,7 @@ namespace SlowTests.Client.Subscriptions
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
                 }))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var names = new HashSet<string>();
                     GC.KeepAlive(sub.Run(x =>
                     {
@@ -108,11 +108,11 @@ namespace SlowTests.Client.Subscriptions
                             names.Add(item.Result.Current?.Name + item.Result.Previous?.Name);
 
                             if (names.Count == 100)
-                                mre.Set();
+                                amre.Set();
                         }
                     }));
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 }
             }
@@ -178,7 +178,7 @@ namespace SlowTests.Client.Subscriptions
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
                 }))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var names = new HashSet<string>();
                     var maxAge = -1;
                     GC.KeepAlive(sub.Run(a =>
@@ -193,11 +193,11 @@ namespace SlowTests.Client.Subscriptions
                             }
                             names.Add(x.Current?.Name + x.Previous?.Name);
                             if (names.Count == 10)
-                                mre.Set();
+                                amre.Set();
                         }
                     }));
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 }
             }
@@ -281,7 +281,7 @@ select { Id: id(d.Current), Age: d.Current.Age }
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
                 }))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var names = new HashSet<string>();
                     GC.KeepAlive(sub.Run(x =>
                     {
@@ -289,11 +289,11 @@ select { Id: id(d.Current), Age: d.Current.Age }
                         {
                             names.Add(item.Result.Id + item.Result.Age);
                             if (names.Count == 90)
-                                mre.Set();
+                                amre.Set();
                         }
                     }));
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 }
             }
@@ -372,7 +372,7 @@ select { Id: id(d.Current), Age: d.Current.Age }
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
                 }))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var names = new HashSet<string>();
                     var maxAge = -1;
                     GC.KeepAlive(sub.Run(x =>
@@ -386,11 +386,11 @@ select { Id: id(d.Current), Age: d.Current.Age }
                             }
 
                             if (names.Count == 9)
-                                mre.Set();
+                                amre.Set();
                         }
                     }));
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 }
             }

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -172,7 +172,7 @@ namespace SlowTests.Client.Subscriptions
                         Assert.True(subscriptionStataList.Any(x => x.SubscriptionName.Equals("sub1")));
                         Assert.True(subscriptionStataList.Any(x => x.SubscriptionName.Equals("sub2")));
 
-                        var mre = new AsyncManualResetEvent();
+                        var amre = new AsyncManualResetEvent();
                         using (var worker = store2.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("sub1")
                         {
                             MaxDocsPerBatch = 5,
@@ -181,10 +181,10 @@ namespace SlowTests.Client.Subscriptions
                         {
                             var t = worker.Run(_ =>
                             {
-                                mre.Set();
+                                amre.Set();
                             });
 
-                            Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                            Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                         }
                     }
                 }
@@ -232,7 +232,7 @@ namespace SlowTests.Client.Subscriptions
                         await session.SaveChangesAsync();
                     }
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     using (var worker = store2.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("sub1")
                     {
                         MaxDocsPerBatch = 5,
@@ -241,10 +241,10 @@ namespace SlowTests.Client.Subscriptions
                     {
                         var t = worker.Run(_ =>
                         {
-                            mre.Set();
+                            amre.Set();
                         });
 
-                        Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                        Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                     }
                 }
             }
@@ -829,7 +829,7 @@ namespace SlowTests.Client.Subscriptions
             using (var store = GetDocumentStore())
             {
                 var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions() { Query = @"from Dogs" });
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new Dog(DateTime.Now) { Name = 1 });
@@ -843,11 +843,11 @@ namespace SlowTests.Client.Subscriptions
 
                     subscription.OnUnexpectedSubscriptionError += x =>
                     {
-                        mre.Set();
+                        amre.Set();
                     };
                     var t = subscription.Run(x => { });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                 }
                 finally
                 {
@@ -1129,7 +1129,7 @@ namespace SlowTests.Client.Subscriptions
         [RavenFact(RavenTestCategory.Subscriptions)]
         public async Task DisposeSubscriptionWorkerShouldNotThrow()
         {
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
             var mre2 = new AsyncManualResetEvent();
             using (var store = GetDocumentStore(new Options()
             {
@@ -1139,7 +1139,7 @@ namespace SlowTests.Client.Subscriptions
                     {
                         if (args.Url.Contains("info/remote-task/tcp?database="))
                         {
-                            mre.Set();
+                            amre.Set();
                             await mre2.WaitAsync(_reasonableWaitTime);
                         }
                     };
@@ -1152,7 +1152,7 @@ namespace SlowTests.Client.Subscriptions
 
                 var t = worker.Run(x => { });
 
-                await mre.WaitAsync(_reasonableWaitTime);
+                await amre.WaitAsync(_reasonableWaitTime);
                 await worker.DisposeAsync(false);
                 mre2.Set();
 
@@ -1590,9 +1590,9 @@ namespace SlowTests.Client.Subscriptions
                     ConnectionStreamTimeout = TimeSpan.FromSeconds(15),
                 };
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 await using var subscription = store.Subscriptions.GetSubscriptionWorker<User>(ops);
-                subscription.OnEstablishedSubscriptionConnection += () => mre.Set();
+                subscription.OnEstablishedSubscriptionConnection += () => amre.Set();
 
                 var processingSubs = subscription.Run(ProcessDocuments);
                 await using var subscription2 = store.Subscriptions.GetSubscriptionWorker<User>(ops);
@@ -1604,7 +1604,7 @@ namespace SlowTests.Client.Subscriptions
                 subscription3.OnSubscriptionConnectionRetry += exception => exceptions.Add(exception);
                 subscription3.OnUnexpectedSubscriptionError += exception => exceptions.Add(exception);
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 var waitingSubs1 = subscription2.Run(ProcessDocuments);
                 var waitingSubs2 = subscription3.Run(ProcessDocuments);

--- a/test/SlowTests/Client/Subscriptions/TestSubscriptionOnDisabledDatabase.cs
+++ b/test/SlowTests/Client/Subscriptions/TestSubscriptionOnDisabledDatabase.cs
@@ -56,17 +56,17 @@ namespace SlowTests.Client.Subscriptions
                     }
                 });
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 subscription.AfterAcknowledgment += batch =>
                 {
                     if (names.Count != 0 && names.Count % 30 == 0)
-                        mre.Set();
+                        amre.Set();
                     return Task.CompletedTask;
                 };
               
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
-                mre.Reset();
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
+                amre.Reset();
 
                 store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
 
@@ -99,7 +99,7 @@ namespace SlowTests.Client.Subscriptions
                 subscription.AfterAcknowledgment += batch =>
                 {
                     if (names.Count != 0 && names.Count % 30 == 0)
-                        mre.Set();
+                        amre.Set();
                     return Task.CompletedTask;
                 };
 
@@ -120,7 +120,7 @@ namespace SlowTests.Client.Subscriptions
                
                 try
                 {
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                 }
                 catch (Exception e)
                 {

--- a/test/SlowTests/Core/Session/Advanced.cs
+++ b/test/SlowTests/Core/Session/Advanced.cs
@@ -554,10 +554,10 @@ namespace SlowTests.Core.Session
                 using (store.AggressivelyCacheFor(TimeSpan.FromHours(1)))
                 using (var changes = await store.Changes().EnsureConnectedNow())
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
 
                     var observable = changes.ForAllDocuments();
-                    var documentSubscription = observable.Subscribe(x => mre.Set());
+                    var documentSubscription = observable.Subscribe(x => amre.Set());
                     await observable.EnsureSubscribedNow();
 
                     using (var session = store.OpenAsyncSession())
@@ -570,7 +570,7 @@ namespace SlowTests.Core.Session
                         await session.SaveChangesAsync();
                     }
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(30)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(30)));
                     documentSubscription.Dispose();
 
                     var requestExecutor = store.GetRequestExecutor();

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -337,7 +337,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 aiTaskDone.Reset();
                 session.Store(dto);
                 session.SaveChanges();
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
                 var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
@@ -365,7 +365,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 dto.Age = 37;
                 session.SaveChanges();
 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
                 var stats2 = etlProcess.GetPerformanceStats()
                     .Where(x => x.NumberOfLoadedItems > 0)
@@ -402,7 +402,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (configuration, _) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
             var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
@@ -440,7 +440,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (configuration, _) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
             var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
@@ -548,7 +548,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
             var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
@@ -582,7 +582,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 session.SaveChanges();
             }
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
             AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Name1"], dto.Id);
 
             using (var session = store.OpenSession())

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -368,7 +368,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 await session1.StoreAsync(dto3);
                 await session1.SaveChangesAsync();
 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
                 var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBackupRestore.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBackupRestore.cs
@@ -13,6 +13,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents.ETL;
 using Sparrow.Json;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -84,7 +85,7 @@ public class GenAiBackupRestore(ITestOutputHelper output) : RavenTestBase(output
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
             string srcHash;
             using (var session = store.OpenSession())

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -21,6 +21,7 @@ using SlowTests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -153,7 +154,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromSeconds(60)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)));
 
         var secondBatchCompleted = await WaitForValueAsync(() =>
         {
@@ -367,7 +368,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        etl.Wait();
+        await etl.WaitAsync(TimeSpan.FromSeconds(60));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -397,7 +398,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        etl.Wait();
+        await etl.WaitAsync(TimeSpan.FromSeconds(60));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -547,7 +548,8 @@ for (const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(60)), await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+        var r = await etl.WaitAsync(TimeSpan.FromSeconds(60));
+        Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -637,7 +639,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         string originalHash;
         using (var session = store.OpenAsyncSession())
@@ -712,7 +714,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         // assert that context was sent again
 
@@ -834,7 +836,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(30)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
 
         using (var session = store.OpenSession())
         {
@@ -904,7 +906,8 @@ for(const comment of this.Comments)
 
         store.Maintenance.Send(new AddGenAiOperation(config, StartingPointChangeVector.BeginningOfTime));
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(120)), await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(120)));
+        var r = await etl.WaitAsync(TimeSpan.FromSeconds(120));
+        Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(120)));
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
@@ -18,6 +18,7 @@ using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -261,7 +262,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
                 session.SaveChanges();
             }
 
-            Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
             EtlErrorInfo error = null;
             var value = await WaitForValueAsync(async () =>
@@ -396,7 +397,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
             session.SaveChanges();
         }
 
-        Assert.False(etlDone.Wait(TimeSpan.FromSeconds(10)));
+        Assert.False(await etlDone.WaitAsync(TimeSpan.FromSeconds(10)));
 
         using (var session = store.OpenSession())
         {
@@ -510,7 +511,7 @@ this.Comments[idx].IsSpam = $output.Blocked;";
         // assert that the comment with model failure is processed in the next ETL batch
         var etlDone = Etl.WaitForEtlToComplete(store);
 
-        Assert.True(etlDone.Wait(TimeSpan.FromSeconds(60)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)));
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiStats.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiStats.cs
@@ -13,6 +13,7 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -69,7 +70,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         var stats = etlProcess.GetPerformanceStats()
             .Where(x => x.NumberOfLoadedItems > 0)
@@ -106,7 +107,7 @@ for(const comment of this.Comments)
 
             await session.SaveChangesAsync();
 
-            Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
             EtlPerformanceStats[] stats2 = null;
 
@@ -172,7 +173,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         var db = await GetDatabase(store.Database);
         var etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;
@@ -253,7 +254,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         var db = await GetDatabase(store.Database);
 
@@ -426,7 +427,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         var db = await GetDatabase(store.Database);
         var etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24621.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24621.cs
@@ -71,7 +71,7 @@ ai.genContext({})
             session.Advanced.Attachments.Store("items/1", "image.png", new MemoryStream(Convert.FromBase64String(HeartPngBase64)));
             await session.SaveChangesAsync();
         }
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120 )));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120 )));
         using (var session = store.OpenAsyncSession())
         {
             var item = await session.LoadAsync<Item>("items/1");
@@ -128,7 +128,7 @@ ai.genContext({
             session.Advanced.Attachments.Store("txs/2025-01-01", "transactions.csv", new MemoryStream(Csv.ToArray()));
             await session.SaveChangesAsync();
         }
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120 )));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120 )));
         using (var session = store.OpenAsyncSession())
         {
             Transaction tx = await session.LoadAsync<Transaction>("txs/2025-01-01");

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
@@ -93,7 +93,7 @@ ai.genContext({}).withPng(img1);
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
@@ -230,7 +230,7 @@ ai.genContext({
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
@@ -336,7 +336,7 @@ ai.genContext({})
 
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
@@ -411,7 +411,7 @@ for(const comment of this.Comments)
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -434,7 +434,7 @@ for(const comment of this.Comments)
             session.Advanced.Attachments.Store("Post/1", "star.png", heart); // changing star to be heart
             await session.SaveChangesAsync();
         }
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         await WaitForAssertionAsync(async () =>
         {
@@ -451,7 +451,7 @@ for(const comment of this.Comments)
             session.Advanced.Attachments.Delete("Post/1", "star.png");
             await session.SaveChangesAsync();
         }
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         await WaitForAssertionAsync(async () =>
         {
@@ -490,7 +490,7 @@ for(const comment of this.Comments)
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         var hash1 = string.Empty;
         var hash2 = string.Empty;
@@ -512,7 +512,7 @@ for(const comment of this.Comments)
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         await WaitForAssertionAsync(async () =>
         {

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
@@ -93,7 +93,7 @@ ai.genContext({}).withPdf(pdf);
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
             using (var session = store.OpenAsyncSession())
             {
                 var item1 = await session.LoadAsync<Item>(FirstItemId);
@@ -163,7 +163,7 @@ ai.genContext({}).withPdf(pdf);
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
             // Wait until hashes reflect the change
             string hash1 = string.Empty, hash2 = string.Empty;
@@ -186,7 +186,7 @@ ai.genContext({}).withPdf(pdf);
                 await session.SaveChangesAsync();
             }
 
-            Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
             await WaitForAssertionAsync(async () =>
             {

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
@@ -88,7 +88,7 @@ ai.genContext({})
                 session.Advanced.Attachments.Store(FirstItemId, Image+actualFormat, file1);
                 await session.SaveChangesAsync();
             }
-            Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
+            Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
         
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             Assert.False(ValidateErrorNotification(db, string.Empty));
@@ -134,7 +134,7 @@ ai.genContext({})
                 session.Advanced.Attachments.Store(FirstItemId, "image.png", file1);
                 await session.SaveChangesAsync();
             }
-            etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30));
+            await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30));
 
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             Assert.True(ValidateErrorNotification(db, $"Attachment must be loaded or base64 string (on type image/png)"));
@@ -182,7 +182,7 @@ ai.genContext({})
                 session.Advanced.Attachments.Store(FirstItemId, "image.png", file1);
                 await session.SaveChangesAsync();
             }
-            Assert.False(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
+            Assert.False(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
 
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             Assert.True(ValidateErrorNotification(db, "You uploaded an unsupported image."));

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24867.cs
@@ -85,7 +85,7 @@ if (this.Name === 'aviv') {
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         using (var session = store.OpenAsyncSession())
         {
@@ -162,7 +162,7 @@ if (this.Name === 'Aviv') {
             await session.SaveChangesAsync();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 120)));
 
         using (var session = store.OpenAsyncSession())
         {

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24298.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24298.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Server.Documents.AI;
 using Sparrow.Json;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -48,7 +49,7 @@ public class RavenDB_24298(ITestOutputHelper output) : RavenTestBase(output)
             session.SaveChanges();
         }
 
-        Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
         var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
         var taskId = taskInfo.TaskId;

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalDataSubscriptionsTests.cs
@@ -534,7 +534,7 @@ public class DataArchivalDataSubscriptionsTests : RavenTestBase
             });
 
 
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
             var mre2 = new AsyncManualResetEvent();
 
             var exceptions = new List<Exception>();
@@ -546,12 +546,12 @@ public class DataArchivalDataSubscriptionsTests : RavenTestBase
             // fetch all docs from storage to the received subscription batch, then wait on mre2
             var fetchFromStorageTask = subscription.Run(async x =>
             {
-                mre.Set();
+                amre.Set();
                 Assert.True(await mre2.WaitAsync(reasonableWaitTime), "await mre2.WaitAsync(_reasonableWaitTime)");
             });
 
             // wait for setting mre above
-            Assert.True(await mre.WaitAsync(reasonableWaitTime), "await mre.WaitAsync(_reasonableWaitTime)");
+            Assert.True(await amre.WaitAsync(reasonableWaitTime), "await amre.WaitAsync(_reasonableWaitTime)");
 
 
             // drop subscription

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalEtlTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalEtlTests.cs
@@ -11,6 +11,7 @@ using Raven.Client.Util;
 using SlowTests.Core.Utils.Entities;
 using Sparrow;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -76,7 +77,7 @@ public class DataArchivalEtlTests : RavenTestBase
             }
             
             
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
                 
             // Make sure that the company has been skipped from ETL
             using (var session = dest.OpenAsyncSession())
@@ -105,7 +106,7 @@ public class DataArchivalEtlTests : RavenTestBase
                 Assert.Equal(true, metadata[Constants.Documents.Metadata.Archived]);
             }
             
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
             
             // Make sure that the company has been propagated to the destination upon archival 
             using (var session = dest.OpenAsyncSession())
@@ -180,7 +181,7 @@ public class DataArchivalEtlTests : RavenTestBase
             });
             
             var etlDone = Etl.WaitForEtlToComplete(src);
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
                 
             // Make sure that the company has been skipped from ETL
             using (var session = dest.OpenAsyncSession())
@@ -198,7 +199,7 @@ public class DataArchivalEtlTests : RavenTestBase
             }
 
             
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
             
             // Make sure that the company has been propagated to the destination upon archival 
             using (var session = dest.OpenAsyncSession())

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -10,7 +10,9 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Client.Util;
 using Raven.Server.Documents.ETL.Providers.ElasticSearch;
+using Sparrow.Server;
 using Tests.Infrastructure.ConnectionString;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -140,9 +142,9 @@ loadToOrders" + IndexSuffix + @"(orderData);";
             }
         }
 
-        protected async Task AssertEtlDoneAsync(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
+        protected async Task AssertEtlDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
         {
-            if (etlDone.Wait(timeout) == false)
+            if (await etlDone.WaitAsync(timeout) == false)
             {
                 var loadError = await Etl.TryGetLoadErrorAsync(databaseName, config);
                 var transformationError = await Etl.TryGetTransformationErrorAsync(databaseName, config);

--- a/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
@@ -30,6 +30,7 @@ using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -328,7 +329,7 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
             }
 
 
-            Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
             using (var session = dest.OpenAsyncSession())
             {
@@ -1803,7 +1804,7 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
                 var etlDone = Etl.WaitForEtlToComplete(src, (_, statistics) => statistics.LastProcessedEtag >= lastEtag);
                 Etl.AddEtl(src, dest, collections, script, applyToAllDocuments: collections.Length == 0);
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 TimeSeriesEntry[] actual = null;
                 await AssertWaitForValueAsync(async () =>

--- a/test/SlowTests/Server/Documents/ETL/Olap/AzureTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/AzureTests.cs
@@ -18,6 +18,7 @@ using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -86,7 +87,7 @@ loadToOrders(partitionBy(key),
 ";
                     SetupAzureEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -153,7 +154,7 @@ loadToOrders(partitionBy(key),
 ";
                     SetupAzureEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -323,7 +324,7 @@ loadToOrders(partitionBy(key), orderData);
 
 
                     SetupAzureEtl(store, script, settings);
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -474,7 +475,7 @@ loadToOrders(partitionBy(['order_date', key]),
 
                     SetupAzureEtl(store, settings, configuration);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -534,7 +535,7 @@ loadToOrders(noPartition(),
 ";
                     SetupAzureEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -669,7 +670,7 @@ loadToOrders(partitionBy(
 ";
                     SetupAzureEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     var expectedFields = new[] { "RequireAt", "ShipVia", "Company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
@@ -796,7 +797,7 @@ loadToOrders(partitionBy(['year', year], ['month', month], ['source', $customPar
                     var etlDone = Etl.WaitForEtlToComplete(store);
                     SetupAzureEtl(store, script, settings, customPartition);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = RavenAzureClient.Create(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))

--- a/test/SlowTests/Server/Documents/ETL/Olap/FailoverTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/FailoverTests.cs
@@ -168,16 +168,16 @@ loadToOrders(partitionBy(key),
         {
             var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName);
 
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             database.EtlLoader.BatchCompleted += x =>
             {
                 if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
-                    mre.Set();
+                    amre.Set();
             };
 
 
-            return mre;
+            return amre;
         }
 
         private async Task<string> GetPerformanceStats(RavenServer server, string database, TimeSpan timeout)

--- a/test/SlowTests/Server/Documents/ETL/Olap/GoogleCloudTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/GoogleCloudTests.cs
@@ -16,6 +16,7 @@ using Raven.Server.Documents.ETL.Providers.OLAP;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -84,7 +85,7 @@ loadToOrders(partitionBy(key),
 ";
                     SetupGoogleCloudOlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -149,7 +150,7 @@ loadToOrders(partitionBy(key),
 ";
                     SetupGoogleCloudOlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -317,7 +318,7 @@ loadToOrders(partitionBy(key), orderData);
 ";
 
                     SetupGoogleCloudOlapEtl(store, script, settings);
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -467,7 +468,7 @@ loadToOrders(partitionBy(['order_date', key]),
 
                     SetupGoogleCloudOlapEtl(store, settings, configuration);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -527,7 +528,7 @@ loadToOrders(noPartition(),
 ";
                     SetupGoogleCloudOlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -659,7 +660,7 @@ loadToOrders(partitionBy(
 ";
                     SetupGoogleCloudOlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     var expectedFields = new[] { "RequireAt", "ShipVia", "Company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
@@ -737,7 +738,7 @@ loadToOrders(partitionBy(['year', year], ['month', month], ['source', $customPar
                     const string customPartition = "shop-16";
                     SetupGoogleCloudOlapEtl(store, script, settings, customPartition: customPartition);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -842,7 +843,7 @@ for (var i = 0; i < this.Lines.length; i++){
 })}";
                     SetupGoogleCloudOlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var client = new RavenGoogleCloudClient(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))

--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -20,6 +20,7 @@ using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Platform;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -132,7 +133,7 @@ loadTo(""Orders"", partitionBy(key),
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(2, files.Length);
@@ -240,7 +241,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -350,7 +351,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(7, files.Length);
@@ -436,7 +437,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(24, files.Length);
@@ -512,7 +513,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -606,7 +607,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -743,7 +744,7 @@ loadToOrders(partitionBy(key), o);
 
                 Etl.AddEtl(store, configuration, connectionString);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -805,7 +806,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -952,7 +953,7 @@ loadToOrders(partitionBy(key), o);
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, configuration, path, connectionStringName);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -1038,7 +1039,7 @@ loadToOrders(noPartition(),
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -1158,7 +1159,7 @@ loadToOrders(partitionBy(
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(4, files.Length);
@@ -1275,7 +1276,7 @@ loadToOrders(partitionBy(
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, configuration, path, connectionStringName);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -1361,7 +1362,7 @@ for (var i = 0; i < this.Lines.length; i++) {
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(expectedCount, files.Length);
@@ -1423,7 +1424,7 @@ for (var i = 0; i < this.Lines.length; i++) {
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -1528,7 +1529,7 @@ loadToUsers(noPartition(), {
 
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, configuration, path, connectionStringName);
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -1658,7 +1659,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['month', orderDate.
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 string[] files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories)
                     .OrderBy(x => x)
@@ -1802,7 +1803,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
 
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 string[] files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories)
                     .OrderBy(x => x)
@@ -1891,7 +1892,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 var result = Etl.AddEtl(store, configuration, connectionString);
                 var taskId = result.TaskId;
 
-                Assert.True(etlDone.Wait(_defaultTimeout), await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
+                var r = await etlDone.WaitAsync(_defaultTimeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
 
@@ -1941,7 +1943,9 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 }
 
                 etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
-                Assert.True(etlDone.Wait(_defaultTimeout), await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
+
+                r = await etlDone.WaitAsync(_defaultTimeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
                 Assert.Equal(10, files.Count);
@@ -2045,7 +2049,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     ? _defaultTimeout * 2
                     : _defaultTimeout;
 
-                Assert.True(etlDone.Wait(timeout), await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
+                var r = await etlDone.WaitAsync(timeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
 
@@ -2085,7 +2090,9 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 }
 
                 etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
-                Assert.True(etlDone.Wait(timeout), await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
+                
+                r = await etlDone.WaitAsync(timeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
 
                 files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
                 Assert.Equal(10, files.Count);
@@ -2173,7 +2180,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                 var result = Etl.AddEtl(store, configuration, connectionString);
                 var taskId = result.TaskId;
 
-                Assert.True(etlDone.Wait(_defaultTimeout), await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
+                var r = await etlDone.WaitAsync(_defaultTimeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).ToList();
 
@@ -2211,8 +2219,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                     await session.SaveChangesAsync();
                 }
 
-                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
-                Assert.True(etlDone.Wait(_defaultTimeout), await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
+                r = await etlDone.WaitAsync(_defaultTimeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
                 Assert.Equal(10, files.Count);
@@ -2297,7 +2305,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 var result = Etl.AddEtl(store, configuration, connectionString);
                 var taskId = result.TaskId;
 
-                Assert.True(etlDone.Wait(_defaultTimeout), await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
+                var r = await etlDone.WaitAsync(_defaultTimeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
 
@@ -2357,7 +2366,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 }
 
                 etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
-                Assert.True(etlDone.Wait(_defaultTimeout), await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
+                r = await etlDone.WaitAsync(_defaultTimeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 files = Directory.GetFiles(newPath, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
                 Assert.Equal(5, files.Count);
@@ -2405,7 +2415,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
 
                 SetupLocalOlapEtl(store, script, path);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 string[] files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
 

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using Order = Tests.Infrastructure.Entities.Order;
@@ -77,7 +78,8 @@ loadTo(""Orders"", partitionBy(key),
                 var result = Etl.AddEtl(store, configuration, connectionString);
 
                 var timeout = TimeSpan.FromMinutes(1);
-                Assert.True(etlDone.Wait(timeout), await Etl.GetEtlDebugInfo(store.Database, timeout, options.DatabaseMode));
+                var r = await etlDone.WaitAsync(timeout);
+                Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, timeout, options.DatabaseMode));
 
                 var files = Directory.GetFiles(path, searchPattern: LocalTests.AllFilesPattern, SearchOption.AllDirectories);
                 var expected = options.DatabaseMode == RavenDatabaseMode.Single ? 2 : 6;

--- a/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/S3Tests.cs
@@ -20,6 +20,7 @@ using Raven.Server.Documents.PeriodicBackup.Restore;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -89,7 +90,7 @@ loadToOrders(partitionBy(key),
 ";
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -154,7 +155,7 @@ loadToOrders(partitionBy(key),
 ";
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -336,7 +337,8 @@ loadToOrders(partitionBy(key), orderData);
                         ? TimeSpan.FromMinutes(2)
                         : TimeSpan.FromMinutes(1);
 
-                    Assert.True(await etlDone.WaitAsync(timeout), await Etl.GetEtlDebugInfo(store.Database, timeout));
+                    var r = await etlDone.WaitAsync(timeout);
+                    Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, timeout));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -489,7 +491,7 @@ loadToOrders(partitionBy(['order_date', key]),
 
                     SetupS3OlapEtl(store, settings, configuration);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -549,7 +551,7 @@ loadToOrders(noPartition(),
 ";
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -681,7 +683,7 @@ loadToOrders(partitionBy(
 ";
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     var expectedFields = new[] { "RequireAt", "ShipVia", "Company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
 
@@ -810,7 +812,7 @@ loadToOrders(partitionBy(['year', year], ['month', month], ['source', $customPar
                     const string customPartition = "shop-16";
                     SetupS3OlapEtl(store, script, settings, customPartitionValue: customPartition);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -854,7 +856,7 @@ loadToOrders(noPartition(), {
 ;
                     SetupS3OlapEtl(store, script, settings, transformationName: "script#1=$'/orders'");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -960,7 +962,7 @@ for (var i = 0; i < this.Lines.length; i++){
 })}";
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -1018,7 +1020,7 @@ for (var i = 0; i < this.Lines.length; i++){
 ";
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -1124,7 +1126,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     var result = Etl.AddEtl(store, configuration, connectionString);
                     var taskId = result.TaskId;
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -1194,7 +1196,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     Assert.NotNull(update.RaftCommandIndex);
 
                     etlDone = Etl.WaitForEtlToComplete(store);
-                    Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                    Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))
@@ -1255,7 +1257,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
 
                     SetupS3OlapEtl(store, script, settings);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
                     using (var s3Client = new RavenAwsS3Client(settings, EtlTestBase.DefaultBackupConfiguration, cancellationToken: cts.Token))

--- a/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
@@ -3,6 +3,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ETL.Queue;
+using Sparrow.Server;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,9 +16,9 @@ public abstract class QueueEtlTestBase : RavenTestBase
     {
     }
 
-    protected async Task AssertEtlDoneAsync(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
+    protected async Task AssertEtlDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
     {
-        if (etlDone.Wait(timeout) == false)
+        if (await etlDone.WaitAsync(timeout) == false)
         {
             var loadError = await Etl.TryGetLoadErrorAsync(databaseName, config);
             var transformationError = await Etl.TryGetTransformationErrorAsync(databaseName, config);

--- a/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
@@ -14,6 +14,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Employee = Orders.Employee;
 using Xunit.Abstractions;
@@ -248,7 +249,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenAsyncSession())
                 {
@@ -267,7 +268,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenAsyncSession())
                 {
@@ -722,7 +723,7 @@ loadToOrders(orderData);
 
                 var timeout = TimeSpan.FromSeconds(30);
 
-                Assert.True(etlDone.Wait(timeout), await AddDebugInfo(src, dest, timeout, srcDbMode));
+                Assert.True(await etlDone.WaitAsync(timeout), await AddDebugInfo(src, dest, timeout, srcDbMode));
 
                 using (var session = dest.OpenSession())
                 {
@@ -770,7 +771,7 @@ loadToOrders(orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(timeout);
+                await etlDone.WaitAsync(timeout);
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.ETL.Providers.Raven;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -66,7 +67,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 process.Start(null);
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dst.OpenSession())
                 {
@@ -130,7 +131,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dst.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12800.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12800.cs
@@ -7,6 +7,7 @@ using Raven.Server.Config;
 using Raven.Server.Documents.ETL.Providers.Raven;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -60,7 +61,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var etlDone = Etl.WaitForEtlToComplete(src, (n, s) => s.LoadSuccesses >= 5);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var database = await GetDatabase(src.Database);
 
@@ -78,7 +79,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     return s.LoadSuccesses >= 6;
                 });
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)), $"ETL sent only {loadSuccesses} docs");;
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)), $"ETL sent only {loadSuccesses} docs");;
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13220.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13220.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -102,7 +103,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenAsyncSession())
                 {
@@ -203,7 +204,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenAsyncSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6257.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6257.cs
@@ -8,6 +8,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,7 +37,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 etlDone.Reset();
 
@@ -47,7 +48,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var db = await GetDatabase(src.Database);
 
@@ -82,7 +83,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 etlDone = Etl.WaitForEtlToComplete(src, (n, s) => s.LoadSuccesses >= 6);
 
@@ -93,7 +94,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var db = await GetDatabase(src.Database);
 

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6711_RavenEtl.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6711_RavenEtl.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -115,7 +116,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -140,7 +141,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_12079.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_12079.cs
@@ -10,6 +10,7 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.LowMemory;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -52,7 +53,7 @@ namespace SlowTests.Server.Documents.ETL
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 for (int i = 0; i < numberOfDocs; i++)
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_16804.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_16804.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ETL;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using User = SlowTests.Core.Utils.Entities.User;
@@ -56,7 +57,7 @@ namespace SlowTests.Server.Documents.ETL
                     await session.SaveChangesAsync();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(10)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(10)));
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(src);
                 var etlProcess = database.EtlLoader.Processes.First();

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_20757.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_20757.cs
@@ -195,12 +195,12 @@ public class RavenDB_20757 : ReplicationTestBase
     private static async Task<AsyncManualResetEvent> WaitForEtl(RavenServer server, string database)
     {
         var documentDatabase = await GetDatabase(server, database);
-        var mre = new AsyncManualResetEvent();
+        var amre = new AsyncManualResetEvent();
         documentDatabase.EtlLoader.BatchCompleted += x =>
         {
             if (x.Statistics.LoadSuccesses > 0)
-                mre.Set();
+                amre.Set();
         };
-        return mre;
+        return amre;
     }
 }

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
@@ -16,6 +16,8 @@ using Npgsql;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Common.Test;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL;
+using Sparrow.Server;
+using Tests.Infrastructure.Extensions;
 
 namespace SlowTests.Server.Documents.ETL.SQL;
 
@@ -152,7 +154,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
 
                 store.Maintenance.Send(operation);
 
-                var etlDone = new ManualResetEventSlim();
+                var etlDone = new AsyncManualResetEvent();
                 var configuration = new SqlEtlConfiguration
                 {
                     Name = sqlEtlConfigurationName,
@@ -197,7 +199,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
                 Assert.Equal(0, errors);
 
                 AssertCounts(connectionString, 1, 2, new[] { 3, 2 }, new[] { "Milk", "Bear" });

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -27,6 +27,7 @@ using SlowTests.Server.Documents.Migration;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Tests.Infrastructure.ConnectionString;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -86,7 +87,7 @@ loadToOrders(orderData);
 
                     SetupSqlEtl(store, connectionString, DefaultScript);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     Assert.Equal(testCount, GetOrdersCount(connectionString));
                 }
@@ -175,7 +176,7 @@ DROP DATABASE [SqlReplication-{dbName}]";
 
                     SetupSqlEtl(store, connectionString, DefaultScript);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -231,7 +232,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
 
                     SetupSqlEtl(store, connectionString, script);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -297,7 +298,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
                         FactoryName = "Microsoft.Data.SqlClient"
                     });
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -346,7 +347,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
 };
 loadToOrders(orderData);");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -398,7 +399,7 @@ loadToOrders(orderData);");
 };
 loadToOrders(orderData);");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -438,7 +439,7 @@ loadToOrders(orderData);");
 
                     SetupSqlEtl(store, connectionString, "if(this.OrderLines.length > 0) { \r\n" + DefaultScript + " \r\n}");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     AssertCounts(1, 1, connectionString);
 
@@ -450,7 +451,7 @@ loadToOrders(orderData);");
                         await session.SaveChangesAsync();
                     }
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                     AssertCounts(0, 0, connectionString);
                 }
             }
@@ -498,7 +499,7 @@ loadToOrders(orderData);");
 
                     SetupSqlEtl(store, connectionString, DefaultScript);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     AssertCounts(1, 2, connectionString);
 
@@ -511,7 +512,7 @@ loadToOrders(orderData);");
                         await session.SaveChangesAsync();
                     }
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                     AssertCounts(1, 0, connectionString);
                 }
             }
@@ -544,7 +545,7 @@ loadToOrders(orderData);");
 
                     SetupSqlEtl(store, connectionString, DefaultScript);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     AssertCounts(1, 2, connectionString);
 
@@ -553,7 +554,7 @@ loadToOrders(orderData);");
                     using (var commands = store.Commands())
                         await commands.DeleteAsync("orders/1-A", null);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     AssertCounts(0, 0, connectionString);
                 }
@@ -587,7 +588,7 @@ loadToOrders(orderData);");
 
                     SetupSqlEtl(store, connectionString, DefaultScript, insertOnly: true);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     AssertCounts(1, 2, connectionString);
 
@@ -600,7 +601,7 @@ loadToOrders(orderData);");
                         await session.SaveChangesAsync();
                     }
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                     // we end up with duplicates
                     AssertCounts(2, 5, connectionString);
                 }
@@ -627,7 +628,7 @@ loadToOrders(orderData);");
                     var str = string.Format("{0}/admin/logs/watch", store.Urls.First().Replace("http", "ws"));
                     var sb = new StringBuilder();
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
 
                     await client.ConnectAsync(new Uri(str), CancellationToken.None);
                     var task = Task.Run(async () =>
@@ -638,7 +639,7 @@ loadToOrders(orderData);");
                             var value = await ReadFromWebSocket(buffer, client);
                             lock (sb)
                             {
-                                mre.Set();
+                                amre.Set();
                                 sb.AppendLine(value);
                             }
 
@@ -648,7 +649,7 @@ loadToOrders(orderData);");
 
                         }
                     });
-                    await mre.WaitAsync(TimeSpan.FromSeconds(60));
+                    await amre.WaitAsync(TimeSpan.FromSeconds(60));
                     SetupSqlEtl(store, connectionString, @"output ('Tralala'); 
 
 undefined();
@@ -883,7 +884,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -958,7 +959,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -1049,7 +1050,7 @@ for (var i = 0; i < attachments.length; i++)
                         }
                     }, new SqlConnectionString { Name = "test", FactoryName = "Microsoft.Data.SqlClient", ConnectionString = connectionString });
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -1101,7 +1102,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -1155,7 +1156,7 @@ loadToOrders(orderData);
 
                     SetupSqlEtl(store, connectionString, DefaultScript, collections: new List<string> { "Orders", "FavouriteOrders" });
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -1277,7 +1278,7 @@ loadToUsers(
                             }
                     }, new SqlConnectionString { Name = "test", FactoryName = "Microsoft.Data.SqlClient", ConnectionString = connectionString });
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -1339,7 +1340,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     var database = await GetDatabase(store.Database);
 
@@ -1351,7 +1352,7 @@ loadToOrders(orderData);
 
                     etlDone = Etl.WaitForEtlToComplete(store, (n, s) => s.LoadSuccesses >= 6);
 
-                    Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                    Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
@@ -27,6 +27,7 @@ using SlowTests.Core.Utils.Entities;
 using Snowflake.Data.Client;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using TestSnowflakeConnectionString = Tests.Infrastructure.ConnectionString.SnowflakeConnectionString;
@@ -236,7 +237,7 @@ loadToRegions({
                 
                 SetupSnowflakeEtl(store, connectionString, DefaultScript, insertOnly: true);
 
-                etlDone.Wait(TimeSpan.FromSeconds(10));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(10));
 
                 AssertCounts(1, 2, connectionString);
 
@@ -249,7 +250,7 @@ loadToRegions({
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                 // we end up with duplicates
                 AssertCounts(2, 5, connectionString);
             }
@@ -274,7 +275,7 @@ loadToRegions({
 
                 SetupComplexDataSnowflakeEtl(store, connectionString, DefaultScriptRegionsTableWithTerritoriesArrayColumn, insertOnly: true);
 
-                etlDone.Wait(TimeSpan.FromSeconds(10));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(10));
                 
                 AssertCountsRegions(1, connectionString);
             }
@@ -319,7 +320,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
 
                 SetupSnowflakeEtl(store, connectionString, script);
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -365,7 +366,7 @@ TotalCost: 0
 };
 loadToOrders(orderData);");
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -410,7 +411,7 @@ TotalCost: 0
 };
 loadToOrders(orderData);");
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -450,7 +451,7 @@ loadToOrders(orderData);");
 
                 SetupSnowflakeEtl(store, connectionString, "if(this.OrderLines.length > 0) { \r\n" + DefaultScript + " \r\n}");
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 AssertCounts(1, 1, connectionString);
 
@@ -462,7 +463,7 @@ loadToOrders(orderData);");
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                 AssertCounts(0, 0, connectionString);
             }
         }
@@ -495,7 +496,7 @@ loadToOrders(orderData);");
 
                 SetupSnowflakeEtl(store, connectionString, DefaultScript);
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 AssertCounts(1, 2, connectionString);
 
@@ -508,7 +509,7 @@ loadToOrders(orderData);");
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                 AssertCounts(1, 0, connectionString);
             }
         }
@@ -542,7 +543,7 @@ loadToOrders(orderData);");
 
                 SetupSnowflakeEtl(store, connectionString, DefaultScript, insertOnly: true);
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 AssertCounts(1, 2, connectionString);
 
@@ -555,7 +556,7 @@ loadToOrders(orderData);");
                     await session.SaveChangesAsync();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                 // we end up with duplicates
                 AssertCounts(2, 5, connectionString);
             }
@@ -582,7 +583,7 @@ loadToOrders(orderData);");
                 var str = string.Format("{0}/admin/logs/watch", store.Urls.First().Replace("http", "ws"));
                 var sb = new StringBuilder();
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
 
                 await client.ConnectAsync(new Uri(str), CancellationToken.None);
                 var task = Task.Run(async () =>
@@ -593,7 +594,7 @@ loadToOrders(orderData);");
                         var value = await ReadFromWebSocket(buffer, client);
                         lock (sb)
                         {
-                            mre.Set();
+                            amre.Set();
                             sb.AppendLine(value);
                         }
 
@@ -603,7 +604,7 @@ loadToOrders(orderData);");
 
                     }
                 });
-                await mre.WaitAsync(TimeSpan.FromSeconds(60));
+                await amre.WaitAsync(TimeSpan.FromSeconds(60));
                 SetupSnowflakeEtl(store, connectionString, @"output ('Tralala'); 
 
 undefined();
@@ -931,7 +932,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -1015,7 +1016,7 @@ for (var i = 0; i < attachments.length; i++)
                     }
                 }, new SnowflakeConnectionString() { Name = "test", ConnectionString = connectionString });
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -1062,7 +1063,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -1116,7 +1117,7 @@ loadToOrders(orderData);
 
                 SetupSnowflakeEtl(store, connectionString, DefaultScript, collections: new List<string> { "Orders", "FavouriteOrders" });
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 using (var con = new SnowflakeDbConnection())
                 {
@@ -1220,7 +1221,7 @@ var orderData = {
 
 loadToOrders(orderData);
 ");
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
                 using (var con = new SnowflakeDbConnection())
                 {
                     con.ConnectionString = connectionString;
@@ -1272,7 +1273,7 @@ loadToOrders(orderData);
 
                 SetupSnowflakeEtl(store, connectionString, DefaultScript);
 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 AssertCounts(1, 2, connectionString);
 
@@ -1281,7 +1282,7 @@ loadToOrders(orderData);
                 using (var commands = store.Commands())
                     await commands.DeleteAsync("orders/1-A", null);
                 
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 AssertCounts(0, 0, connectionString);
             }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3756,18 +3756,18 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
             }))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var task = subscription.Run(batch =>
                 {
                     foreach (var b in batch.Items)
                     {
                         lastCv = b.ChangeVector;
                     }
-                    mre.Set();
+                    amre.Set();
                 });
 
-                await mre.WaitAsync(_reasonableWaitTime);
-                mre.Reset();
+                await amre.WaitAsync(_reasonableWaitTime);
+                amre.Reset();
                 List<SubscriptionState> subscriptionsConfig;
                 await WaitForValueAsync(async () =>
                 {
@@ -3794,7 +3794,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     session.SaveChanges();
                 }
-                await mre.WaitAsync(_reasonableWaitTime);
+                await amre.WaitAsync(_reasonableWaitTime);
 
                 subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
                 Assert.Equal(1, subscriptionsConfig.Count);
@@ -3856,17 +3856,17 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
             }))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var task = subscription.Run(batch =>
                 {
                     foreach (var b in batch.Items)
                     {
                         lastCv = b.ChangeVector;
                     }
-                    mre.Set();
+                    amre.Set();
                 });
 
-                await mre.WaitAsync(_reasonableWaitTime);
+                await amre.WaitAsync(_reasonableWaitTime);
 
                 var subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
 

--- a/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
@@ -41,7 +41,7 @@ public class RavenDB_22105 : RabbitMqQueueSinkTestBase
             new List<string>() { UsersQueueName });
 
         var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 1);
-        AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using (var session = store.OpenSession())
         {
@@ -81,7 +81,7 @@ public class RavenDB_22105 : RabbitMqQueueSinkTestBase
 
         var etlDone2 = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 1);
 
-        AssertQueueSinkDone(etlDone2, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertQueueSinkDoneAsync(etlDone2, TimeSpan.FromMinutes(1), store.Database, config);
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/QueueSink/KafkaQueueSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/KafkaQueueSinkTests.cs
@@ -94,7 +94,7 @@ namespace SlowTests.Server.Documents.QueueSink
             var config = SetupKafkaQueueSink(store, "put(this.Id, this)", new List<string>() { UsersQueueName });
 
             var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 2);
-            AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config).GetAwaiter().GetResult();
 
             using var session = store.OpenSession();
 
@@ -136,7 +136,7 @@ namespace SlowTests.Server.Documents.QueueSink
             var config = SetupKafkaQueueSink(store, script, new List<string>() { UsersQueueName });
 
             var queueSinkDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 2);
-            AssertQueueSinkDone(queueSinkDone, TimeSpan.FromMinutes(1), store.Database, config);
+            AssertQueueSinkDoneAsync(queueSinkDone, TimeSpan.FromMinutes(1), store.Database, config).GetAwaiter().GetResult();
 
             using var session = store.OpenSession();
 
@@ -174,7 +174,7 @@ namespace SlowTests.Server.Documents.QueueSink
             var config = SetupKafkaQueueSink(store, "this['@metadata']['@collection'] = 'Users'; put(this.Id, this)", new List<string>() { UsersQueueName });
 
             var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= numberOfUsers);
-            AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config).GetAwaiter().GetResult();
 
             using var session = store.OpenSession();
 
@@ -210,7 +210,7 @@ namespace SlowTests.Server.Documents.QueueSink
             var config = SetupKafkaQueueSink(store, "this['@metadata']['@collection'] = 'Users'; put(this.Id, this)", new List<string>() { UsersQueueName });
 
             var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= numberOfUsers);
-            AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config).GetAwaiter().GetResult();
 
             using var session = store.OpenSession();
 
@@ -236,7 +236,7 @@ namespace SlowTests.Server.Documents.QueueSink
                 producer.Produce(UsersQueueName, kafkaMessage);
             }
 
-            etlDone.Wait();
+            etlDone.Wait(TimeSpan.FromSeconds(60));
             
             var users2 = session.Query<User>().ToList();
             Assert.Equal(20, users2.Count);

--- a/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
@@ -14,6 +14,8 @@ using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
+using Sparrow.Server;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using QueueSinkConfiguration = Raven.Client.Documents.Operations.QueueSink.QueueSinkConfiguration;
@@ -87,25 +89,25 @@ namespace SlowTests.Server.Documents.QueueSink
             return null;
         }
         
-        protected ManualResetEventSlim WaitForQueueSinkBatch(DocumentStore store,
+        protected AsyncManualResetEvent WaitForQueueSinkBatch(DocumentStore store,
             Func<string, QueueSinkProcessStatistics, bool> predicate)
         {
             var database = AsyncHelpers.RunSync(() => GetDatabase(store.Database));
 
-            var mre = new ManualResetEventSlim();
+            var amre = new AsyncManualResetEvent();
 
             database.QueueSinkLoader.BatchCompleted += x =>
             {
                 if (predicate($"{x.ConfigurationName}/{x.ScriptName}", x.Statistics))
-                    mre.Set();
+                    amre.Set();
             };
 
-            return mre;
+            return amre;
         }
 
-        protected void AssertQueueSinkDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueSinkConfiguration config)
+        protected async Task AssertQueueSinkDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, QueueSinkConfiguration config)
         {
-            if (etlDone.Wait(timeout) == false)
+            if (await etlDone.WaitAsync(timeout) == false)
             {
                 var error = AsyncHelpers.RunSync(() => TryErrorFromAlertAsync(databaseName, config));
 

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
@@ -42,7 +42,7 @@ public class RabbitMqSinkTests : RabbitMqQueueSinkTestBase
             new List<string>() { UsersQueueName });
 
         var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 2);
-        AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var session = store.OpenSession();
 
@@ -90,7 +90,7 @@ public class RabbitMqSinkTests : RabbitMqQueueSinkTestBase
             new List<string>() { UsersQueueName, developersQueueName });
 
         var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses ! >= 4);
-        AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var session = store.OpenSession();
 
@@ -144,7 +144,7 @@ public class RabbitMqSinkTests : RabbitMqQueueSinkTestBase
         var config = SetupRabbitMqQueueSink(store, script, new List<string>() { UsersQueueName });
 
         var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 2);
-        AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var session = store.OpenSession();
 
@@ -182,7 +182,7 @@ public class RabbitMqSinkTests : RabbitMqQueueSinkTestBase
             new List<string>() { UsersQueueName });
 
         var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= numberOfUsers);
-        AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertQueueSinkDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var session = store.OpenSession();
 

--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -580,7 +580,7 @@ namespace SlowTests.Sharding.Cluster
                              MaxDocsPerBatch = 5, TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(250),
                          }))
             {
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var t = subscription.Run(batch =>
                 {
                     foreach (var item in batch.Items)
@@ -592,7 +592,7 @@ namespace SlowTests.Sharding.Cluster
 
                         if (users.Count == numberOfDocs + 1)
                         {
-                            mre.Set();
+                            amre.Set();
                         }
                     }
                 });
@@ -615,7 +615,7 @@ namespace SlowTests.Sharding.Cluster
                     // expected, means the worker is still alive  
                 }
 
-                if (await mre.WaitAsync(TimeSpan.FromSeconds(3)) == false)
+                if (await amre.WaitAsync(TimeSpan.FromSeconds(3)) == false)
                 {
                     await subscription.DisposeAsync(true);
                 }

--- a/test/SlowTests/Sharding/ETL/ShardedEtlFailoverTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlFailoverTests.cs
@@ -24,8 +24,10 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Server.Documents.ETL.Olap;
+using Sparrow.Server;
 using Sparrow.Utils;
 using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -348,7 +350,7 @@ namespace SlowTests.Sharding.ETL
 
                 var databases = Sharding.GetShardsDocumentDatabaseInstancesFor(srcDb, srcNodes.Servers);
 
-                var etlDone = new ManualResetEventSlim();
+                var etlDone = new AsyncManualResetEvent();
                 await foreach (var db in databases)
                 {
                     db.EtlLoader.BatchCompleted += x =>
@@ -367,7 +369,7 @@ namespace SlowTests.Sharding.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
                 Assert.True(WaitForDocument<User>(dest, "users/1", u => u.Name == "Joe Doe", 30_000));
 
                 // BEFORE THE FIX: this will change the database record and restart the ETL, which would fail the test.
@@ -402,7 +404,7 @@ namespace SlowTests.Sharding.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
                 Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", 30_000));
             }
         }
@@ -792,6 +794,7 @@ loadToOrders(partitionBy(key),
 
             var timeout = TimeSpan.FromMinutes(2);
             var waitHandles = etlsDone.Select(mre => mre.WaitHandle).ToArray();
+
             Assert.True(WaitHandle.WaitAll(waitHandles, timeout), await Etl.GetEtlDebugInfo(store.Database, timeout, RavenDatabaseMode.Sharded));
 
             var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -1181,7 +1181,7 @@ person.addCounter(loadCounter('down'));
 
                     SetupSqlEtl(store, connectionString, DefaultScript);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     using (var con = new SqlConnection())
                     {
@@ -1235,7 +1235,7 @@ person.addCounter(loadCounter('down'));
 
                     SetupSqlEtl(store, connectionString, DefaultScript);
 
-                    etlDone.Wait(TimeSpan.FromMinutes(5));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                     Assert.Equal(testCount, SqlEtlTests.GetOrdersCount(connectionString));
                 }
@@ -1566,7 +1566,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 await EnsureNonStaleElasticResultsAsync(client);
 
@@ -1585,7 +1585,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 await EnsureNonStaleElasticResultsAsync(client);
 
@@ -1700,7 +1700,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1725,7 +1725,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
 
                 Assert.NotEqual(originalLocation, newLocation);
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1751,7 +1751,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1847,7 +1847,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
                     }
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(90)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(90)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Sharding.Subscriptions
                     session.SaveChanges();
                 }
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)))
                 {
                     var c = 0;
@@ -61,12 +61,12 @@ namespace SlowTests.Sharding.Subscriptions
                             names.Remove(item.Result.Name);
                             if (++c == 3)
                             {
-                                mre.Set();
+                                amre.Set();
                             }
                         }
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                     Assert.Empty(names);
                 }
             }
@@ -170,7 +170,7 @@ namespace SlowTests.Sharding.Subscriptions
                 Assert.NotEmpty(expectedIds);
                 Assert.NotEmpty(expectedIds2);
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var mre2 = new AsyncManualResetEvent();
                 ConcurrentSet<string> results = new ConcurrentSet<string>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)))
@@ -183,13 +183,13 @@ namespace SlowTests.Sharding.Subscriptions
                         }
 
                         if (results.Count == expectedIds.Count)
-                            mre.Set();
+                            amre.Set();
 
                         if (results.Count == expectedIds.Count + expectedIds2.Count)
                             mre2.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime),$"error: {t.Exception}");
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime),$"error: {t.Exception}");
 
                     Assert.All(expectedIds, s => Assert.Contains(s, results));
 
@@ -260,7 +260,7 @@ namespace SlowTests.Sharding.Subscriptions
                 }
 
                 int docs = 3;
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 List<string> results = new List<string>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)))
                 {
@@ -275,10 +275,10 @@ namespace SlowTests.Sharding.Subscriptions
                         }
 
                         if (c == docs)
-                            mre.Set();
+                            amre.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                     foreach (var item in nodesWithIds.SelectMany(kvp => kvp.Value))
                     {

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -214,7 +214,7 @@ namespace SlowTests.Sharding.Subscriptions
 
                     using var first = new CountdownEvent(count);
                     using var second = new CountdownEvent(count / 2);
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var mre2 = new ManualResetEventSlim();
                     var t = subscription.Run(async x =>
                     {
@@ -227,7 +227,7 @@ namespace SlowTests.Sharding.Subscriptions
                             first.Signal(x.NumberOfItemsInBatch);
                             if (first.IsSet)
                             {
-                                await mre.WaitAsync();
+                                await amre.WaitAsync();
                             }
                         }
                     });
@@ -276,7 +276,7 @@ namespace SlowTests.Sharding.Subscriptions
                     try
                     {
                         // advance subscription worker
-                        mre.Set();
+                        amre.Set();
 
                         await store.Subscriptions.UpdateAsync(new SubscriptionUpdateOptions
                         {
@@ -442,7 +442,7 @@ namespace SlowTests.Sharding.Subscriptions
                 });
 
                 var ackDocs = new List<string>();
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var mre2 = new AsyncManualResetEvent();
                 var f = true;
                 subscription.AfterAcknowledgment += async batch =>
@@ -460,7 +460,7 @@ namespace SlowTests.Sharding.Subscriptions
 
                     if (f)
                     {
-                        mre.Set();
+                        amre.Set();
                         Assert.True(await mre2.WaitAsync(_reasonableWaitTime));
                     }
                 };
@@ -506,7 +506,7 @@ namespace SlowTests.Sharding.Subscriptions
                     session.SaveChanges();
                 }
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime));
 
                 var f1 = addedDocs.First();
                 var f2 = ackDocs.First();
@@ -858,7 +858,7 @@ namespace SlowTests.Sharding.Subscriptions
                 });
                 using (var sub = store.Subscriptions.GetSubscriptionWorker<Dog>(id))
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     var r = sub.Run(batch =>
                     {
                         Assert.NotEmpty(batch.Items);
@@ -872,9 +872,9 @@ namespace SlowTests.Sharding.Subscriptions
                             }
                             Assert.Equal(0, s.Advanced.NumberOfRequests);
                         }
-                        mre.Set();
+                        amre.Set();
                     });
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(60)));
                     await sub.DisposeAsync();
                     await r;// no error
                 }
@@ -1424,7 +1424,7 @@ namespace SlowTests.Sharding.Subscriptions
                         await session.SaveChangesAsync();
                     }
 
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     using (var worker = store2.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("sub1")
                     {
                         MaxDocsPerBatch = 5,
@@ -1433,10 +1433,10 @@ namespace SlowTests.Sharding.Subscriptions
                     {
                         var t = worker.Run(_ =>
                         {
-                            mre.Set();
+                            amre.Set();
                         });
 
-                        Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                        Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                     }
                 }
             }
@@ -1527,7 +1527,7 @@ namespace SlowTests.Sharding.Subscriptions
                 Assert.True(states.Any(x => x.SubscriptionName.Equals("sub1")));
                 Assert.True(states.Any(x => x.SubscriptionName.Equals("sub2")));
 
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 using (var worker = store2.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("sub1")
                 {
                     MaxDocsPerBatch = 5,
@@ -1536,10 +1536,10 @@ namespace SlowTests.Sharding.Subscriptions
                 {
                     var t = worker.Run(_ =>
                     {
-                        mre.Set();
+                        amre.Set();
                     });
 
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime));
                 }
             }
         }
@@ -1712,7 +1712,7 @@ namespace SlowTests.Sharding.Subscriptions
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(16)
                 });
-                var mre = new AsyncManualResetEvent();
+                var amre = new AsyncManualResetEvent();
                 var mre2 = new AsyncManualResetEvent();
                 var exceptions = new List<Exception>();
                 subscription.OnUnexpectedSubscriptionError += exception =>
@@ -1721,12 +1721,12 @@ namespace SlowTests.Sharding.Subscriptions
                 };
                 var t = subscription.Run(async x =>
                 {
-                    mre.Set();
+                    amre.Set();
                     Assert.True(await mre2.WaitAsync(_reasonableWaitTime), "await mre2.WaitAsync(_reasonableWaitTime)");
                 });
 
 
-                Assert.True(await mre.WaitAsync(_reasonableWaitTime), "await mre.WaitAsync(_reasonableWaitTime)");
+                Assert.True(await amre.WaitAsync(_reasonableWaitTime), "await amre.WaitAsync(_reasonableWaitTime)");
                 await subscription.DisposeAsync(false);
                 try
                 {
@@ -1813,7 +1813,7 @@ namespace SlowTests.Sharding.Subscriptions
                 });
                 try
                 {
-                    var mre = new AsyncManualResetEvent();
+                    var amre = new AsyncManualResetEvent();
                     worker1.AfterAcknowledgment += batch =>
                     {
                         foreach (var x in batch.Items)
@@ -1839,13 +1839,13 @@ namespace SlowTests.Sharding.Subscriptions
                     {
                         if (ids.Count == 3)
                         {
-                            mre.Set();
+                            amre.Set();
                             Assert.True(await mre2.WaitAsync(_reasonableWaitTime), "mre2");
                         }
 
                         await Task.Delay(16);
                     });
-                    Assert.True(await mre.WaitAsync(_reasonableWaitTime), "mre" + Environment.NewLine +
+                    Assert.True(await amre.WaitAsync(_reasonableWaitTime), "mre" + Environment.NewLine +
                                                                           PrintException(exceptions1));
                 }
                 finally

--- a/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
+++ b/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
@@ -20,6 +20,7 @@ using Raven.Server.Documents.ETL.Providers.OLAP;
 using Tests.Infrastructure;
 using SlowTests.Server.Documents.ETL;
 using Sparrow.Server;
+using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -78,7 +79,7 @@ loadToOrders(partitionBy(key), o);
                 SetupLocalOlapEtl(store, script, path, frequency: DefaultFrequency);
                 var firstBatchTime = DateTime.UtcNow;
                 var firstBatchTimeMinutes = firstBatchTime.Minute;
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(10)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(10)));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -143,7 +144,7 @@ loadToOrders(partitionBy(key), o);
                 }
 
                 etlDone = Etl.WaitForEtlToComplete(store);
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(60)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)));
 
                 var secondBatchTime = DateTime.UtcNow;
                 var secondBatchTimeMinutes = secondBatchTime.Minute;
@@ -208,7 +209,7 @@ loadToOrders(partitionBy(key), o);
                 var sw = new Stopwatch();
                 sw.Start();
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
                 Assert.Equal(1, files.Length);
@@ -266,15 +267,15 @@ loadToOrders(partitionBy(key), o);
 
         private static AsyncManualResetEvent WaitForEtl(DocumentDatabase database, Func<string, EtlProcessStatistics, bool> predicate)
         {
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             database.EtlLoader.BatchCompleted += x =>
             {
                 if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
-                    mre.Set();
+                    amre.Set();
             };
 
-            return mre;
+            return amre;
         }
 
         private async Task<DocumentDatabase> WaitForDatabaseToUnlockAsync(IDocumentStore store, TimeSpan timeout)

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -38,6 +38,7 @@ using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.Snowflake;
 using Raven.Server.Documents.ETL.Providers.RelationalDatabase.SQL;
+using Sparrow.Server;
 using Tests.Infrastructure;
 
 namespace FastTests
@@ -141,7 +142,7 @@ namespace FastTests
                 return (_src, _dest, result);
             }
 
-            public ManualResetEventSlim WaitForEtlToComplete(DocumentStore store, Func<string, EtlProcessStatistics, bool> predicate = null, int numOfProcessesToWaitFor = 1)
+            public AsyncManualResetEvent WaitForEtlToComplete(DocumentStore store, Func<string, EtlProcessStatistics, bool> predicate = null, int numOfProcessesToWaitFor = 1)
             {
                 predicate ??= (n, statistics) => statistics.LoadSuccesses > 0;
                 var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
@@ -159,19 +160,19 @@ namespace FastTests
                 }, timeout, interval);
             }
 
-            private ManualResetEventSlim WaitForEtl(DocumentStore store, Func<string, EtlProcessStatistics, bool> predicate)
+            private AsyncManualResetEvent WaitForEtl(DocumentStore store, Func<string, EtlProcessStatistics, bool> predicate)
             {
                 var database = AsyncHelpers.RunSync(() => _parent.GetDatabase(store.Database));
 
-                var mre = new ManualResetEventSlim();
+                var amre = new AsyncManualResetEvent();
 
                 database.EtlLoader.BatchCompleted += x =>
                 {
                     if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics))
-                        mre.Set();
+                        amre.Set();
                 };
                 
-                return mre;
+                return amre;
             }
 
             public async Task<(string, string, EtlProcessStatistics)> WaitForEtlAsync(DocumentStore store, Func<string, EtlProcessStatistics, bool> predicate, TimeSpan timeout)

--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -351,15 +351,15 @@ public partial class RavenTestBase
         {
             var database = await _parent.GetDatabase(store.Database);
 
-            var mre = new AsyncManualResetEvent();
+            var amre = new AsyncManualResetEvent();
 
             database.IndexStore.IndexBatchCompleted += x =>
             {
                 if (predicate(x))
-                    mre.Set();
+                    amre.Set();
             };
 
-            return mre;
+            return amre;
         }
         
         public async Task<Index> WaitForRollingIndexAsync(string database, string name, RavenServer server)

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedEtlTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedEtlTestBase.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Util;
 using Raven.Server.Documents.ETL;
+using Sparrow.Server;
 
 namespace FastTests;
 
@@ -22,14 +23,14 @@ public partial class RavenTestBase
         }
 
 
-        public Task<ManualResetEventSlim> WaitForEtlAsync(IDocumentStore store, Func<string, EtlProcessStatistics, bool> predicate, int count) => WaitForEtlAsync(store.Database, predicate, count);
+        public Task<AsyncManualResetEvent> WaitForEtlAsync(IDocumentStore store, Func<string, EtlProcessStatistics, bool> predicate, int count) => WaitForEtlAsync(store.Database, predicate, count);
 
-        public async Task<ManualResetEventSlim> WaitForEtlAsync(string database, Func<string, EtlProcessStatistics, bool> predicate, int count)
+        public async Task<AsyncManualResetEvent> WaitForEtlAsync(string database, Func<string, EtlProcessStatistics, bool> predicate, int count)
         {
             if (count < 1)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            var mre = new ManualResetEventSlim();
+            var amre = new AsyncManualResetEvent();
             var confirmations = new ConcurrentDictionary<int, byte>();
             var size = 0;
             var numberOfShards = 0;
@@ -46,7 +47,7 @@ public partial class RavenTestBase
                         {
                             confirmations.Clear();
                             size = 0;
-                            mre.Set();
+                            amre.Set();
                         }
                     }
                 };
@@ -54,11 +55,11 @@ public partial class RavenTestBase
 
             if (numberOfShards < count)
             {
-                mre.Set();
+                amre.Set();
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            return mre;
+            return amre;
         }
 
         public IEnumerable<ManualResetEventSlim> WaitForEtlOnAllShards(IDocumentStore store, Func<string, EtlProcessStatistics, bool> predicate)
@@ -107,7 +108,7 @@ public partial class RavenTestBase
             return mresPerShard.Values;
         }
 
-        public ManualResetEventSlim WaitForEtl(IDocumentStore store, Func<string, EtlProcessStatistics, bool> predicate)
+        public AsyncManualResetEvent WaitForEtl(IDocumentStore store, Func<string, EtlProcessStatistics, bool> predicate)
         {
             return AsyncHelpers.RunSync(() => WaitForEtlAsync(store, predicate, count: 1));
         }

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -836,12 +836,12 @@ namespace FastTests
             var timeout = TimeSpan.FromMilliseconds(timeoutInMs);
 
             using (await DebugHelper.GatherVerboseDatabaseDisposeInformationAsync(server, timeoutInMs))
-            using (var mre = new AsyncManualResetEvent())
+            using (var amre = new AsyncManualResetEvent())
             {
-                server.AfterDisposal += () => mre.Set();
+                server.AfterDisposal += () => amre.Set();
                 var task = Task.Run(server.Dispose);
 
-                if (await mre.WaitAsync(timeout) == false)
+                if (await amre.WaitAsync(timeout) == false)
                     await ThrowCouldNotDisposeServerExceptionAsync(url, debugTag, timeout);
 
                 await task;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23231

### Additional description

When an async method blocks current thread with `etlDone.Wait` it can fail other tests that use the same thread.
~~So we use the `ThreadPool.RegisterWaitForSingleObject` to signal the MRE and await for it in an async manner with the help of `TaskCompletionSource`.~~


### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
