### PR TITLE
RavenDB-25113 Removes wrong assertions.

### DIFF
--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -325,8 +325,6 @@ public sealed partial class CompactTree : IPrepareForCommit
     public long Add(CompactKey key, long value)
     {
         key.ChangeDictionary(_inner.State.DictionaryId);
-        AssertValueAndKeySize(key, value);
-
         var lookup = new CompactKeyLookup(key);
         CompactTreeDumper.WriteAddition(this, ref lookup, value);
         _inner.Add(ref lookup, value);
@@ -337,8 +335,6 @@ public sealed partial class CompactTree : IPrepareForCommit
     public long Add(CompactKeyLookup key, long value)
     {
         Debug.Assert(key.Key.Dictionary == _inner.State.DictionaryId);
-        AssertValueAndKeySize(key.Key, value);
-        
         CompactTreeDumper.WriteAddition(this, ref key, value);
         _inner.Add(ref key, value);
         return key.ContainerId;
@@ -349,16 +345,6 @@ public sealed partial class CompactTree : IPrepareForCommit
         _inner.PrepareForCommit();
         CompactTreeDumper.WriteCommit(this);
     }
-
-    private void AssertValueAndKeySize(CompactKey key, long value)
-    {
-        if (value < 0)
-            throw new ArgumentOutOfRangeException(nameof(value), value, "Only positive values are allowed");
-        if (key.MaxLength > Constants.CompactTree.MaximumKeySize)
-            throw new ArgumentOutOfRangeException(nameof(key), Encoding.UTF8.GetString(key.Decoded()),
-                $"key must be less than {Constants.CompactTree.MaximumKeySize} bytes in size");
-    }
-
 
     public static unsafe CompactTree InternalCreate(Tree parent, Slice name)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25113

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
