### PR TITLE
RavenDB-25118 Validate blittable before reading it in Voron.Recovery

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1579,9 +1579,11 @@ namespace Raven.Server.Documents
 
         public static Document ParseRawDataSectionDocumentWithValidation(JsonOperationContext context, ref TableValueReader tvr, int expectedSize)
         {
-            tvr.Read((int)DocumentsTable.Data, out int size);
+            var datPtr = tvr.Read((int)DocumentsTable.Data, out int size);
             if (size > expectedSize || size <= 0)
                 throw new ArgumentException("Data size is invalid, possible corruption when parsing BlittableJsonReaderObject", nameof(size));
+            
+            BlittableJsonReaderObject.BlittableValidation(context, datPtr, size);
             
             var doc = new Document();
             return InitializeDocument(context, doc, ref tvr);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2870,6 +2870,8 @@ namespace Raven.Server.Documents.Revisions
             if (size > expectedSize || size <= 0)
                 throw new ArgumentException("Data size is invalid, possible corruption when parsing BlittableJsonReaderObject", nameof(size));
 
+            BlittableJsonReaderObject.BlittableValidation(context, ptr, size);
+            
             var result = new Document
             {
                 StorageId = tvr.Id,

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -57,6 +57,24 @@ namespace Sparrow.Json
 
             return _context.WriteAsync(stream, this, token);
         }
+
+        public static void BlittableValidation(JsonOperationContext context, byte* mem, int size)
+        {
+            var bllitable = new BlittableJsonReaderObject(context, mem, size);
+            bllitable.BlittableValidation();
+        }
+        
+        //Only initiate directly for validation in Recovery tool
+        private BlittableJsonReaderObject(JsonOperationContext context, byte* mem, int size)
+            : base(context)
+        {
+            if (size == 0)
+                ThrowOnZeroSize(size);
+
+            _isRoot = true;
+            _mem = mem; // get beginning of memory pointer
+            _size = size; // get document size
+        }
         
         public BlittableJsonReaderObject(byte* mem, int size, JsonOperationContext context, UnmanagedWriteBuffer buffer = default(UnmanagedWriteBuffer))
             : this(mem, size, context)
@@ -71,15 +89,8 @@ namespace Sparrow.Json
         }
 
         private BlittableJsonReaderObject(byte* mem, int size, JsonOperationContext context)
-            : base(context)
+            : this(context, mem, size)
         {
-            if (size == 0)
-                ThrowOnZeroSize(size);
-
-            _isRoot = true;
-            _mem = mem; // get beginning of memory pointer
-            _size = size; // get document size
-
             NoCache = NoCache;
 
             var propOffsetStart = _size - 2;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25118
### Additional description
One simple option to implement is to add a flag to `BlittableJsonReaderObject` that defines if there should be a check before reading the blittable.  
This would be a very clean solution with minimal changes.  
But I don't like the idea of adding a condition in the main code that is only relevant for a tool that is rarely used.  

I prefer to extract the memory validation out of the `BlittableJsonReaderObject` class and then validate the memory before we construct the object.  
For that, the validation method should be static (and all the methods it calls).  
The better implementation is to move those methods to a static helper.  
In the implementation here, I didn’t do that so it will be easier to see what the changes are.  
If this approach is acceptable, I will do the further refactoring.  

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
