### PR TITLE
RavenDB-24855 : Chat summary should also be applied mid agent operation

### DIFF
--- a/src/Raven.Server/Config/Categories/AiConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/AiConfiguration.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
-using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
 
 namespace Raven.Server.Config.Categories;
 
@@ -21,7 +20,6 @@ public sealed class AiConfiguration : ConfigurationCategory
     [ConfigurationEntry("Ai.Embeddings.MaxFallbackTimeInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public TimeSetting EmbeddingsGenerationMaxFallbackTime { get; set; }
     
-    
     [Description("Maximum number of query embedding batches that can be processed concurrently. Controls the degree of parallelism when sending query embedding requests to AI providers. " +
                  "Higher values improve throughput but increase resource usage and may trigger rate limits.")]
     [DefaultValue(4)]
@@ -36,21 +34,21 @@ public sealed class AiConfiguration : ConfigurationCategory
 - Reflects decisions made, suggestions given, preferences expressed, and any changes in direction
 - Captures tone when relevant (e.g., sarcastic, formal, humorous, concerned)
 - Omits general filler or small talk unless it contributes to context or tone Format the output in a structured manner (such as bullet points or labeled sections) suitable for fitting into a limited context window. Do not discard any information that contributes to understanding the conversation's flow and outcome.
-- When tool output appears at the end, extract the key facts (IDs, names, prices, dates, etc.) and include them in a Results Cache block inside your summary, so they are preserved for the next turns.")]
+- If the transcript ends with tool output, your summary must explicitly include the key results from those tool calls - extract the key facts (IDs, names, prices, dates, etc.) and include them in a Results Cache block inside your summary, so they are preserved for the next turns and the conversation can continue without re-running the same tools.")]
     [ConfigurationEntry("Ai.Agent.Trimming.Summarization.SummarizationTaskBeginningPrompt", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public string SummarizationTaskBeginningPrompt { get; set; }
 
     [Description("The user-role message that triggers the conversation summarization process.")]
-    [DefaultValue("Reminder - go over the entire previous conversation and summarize that according to the original instructions")]
+    [DefaultValue(@"Reminder:
+- Go over the entire previous conversation and summarize that according to the original instructions.
+- Make sure the final summary message contains the essential tool results already obtained, so they are available for future turns.")]
     [ConfigurationEntry("Ai.Agent.Trimming.Summarization.SummarizationTaskEndPrompt", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public string SummarizationTaskEndPrompt { get; set; }
-
 
     [Description("The text prefix that appears before the generated summary of the previous conversation.")]
     [DefaultValue("Summary of previous conversation: ")]
     [ConfigurationEntry("Ai.Agent.Trimming.Summarization.SummarizationResultPrefix", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public string SummarizationResultPrefix { get; set; }
-
 
     [Description("The recommanded token threshold for a tool response to the LLM. If the response exceeds this threshold, a notification will be raised.")]
     [DefaultValue(10_000)]

--- a/src/Raven.Server/Config/Categories/AiConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/AiConfiguration.cs
@@ -35,7 +35,8 @@ public sealed class AiConfiguration : ConfigurationCategory
 - Preserves the original intent of both the user and the assistant in each exchange
 - Reflects decisions made, suggestions given, preferences expressed, and any changes in direction
 - Captures tone when relevant (e.g., sarcastic, formal, humorous, concerned)
-- Omits general filler or small talk unless it contributes to context or tone Format the output in a structured manner (such as bullet points or labeled sections) suitable for fitting into a limited context window. Do not discard any information that contributes to understanding the conversation's flow and outcome.")]
+- Omits general filler or small talk unless it contributes to context or tone Format the output in a structured manner (such as bullet points or labeled sections) suitable for fitting into a limited context window. Do not discard any information that contributes to understanding the conversation's flow and outcome.
+- When tool output appears at the end, extract the key facts (IDs, names, prices, dates, etc.) and include them in a Results Cache block inside your summary, so they are preserved for the next turns.")]
     [ConfigurationEntry("Ai.Agent.Trimming.Summarization.SummarizationTaskBeginningPrompt", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public string SummarizationTaskBeginningPrompt { get; set; }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http.Features;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Handlers.Processors;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
@@ -37,7 +38,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
 
     public class TestConversationHandler(ServerStore server, DocumentDatabase database, BlittableJsonReaderObject document) : ConversationHandler(server, database)
     {
-        protected override Task<string> TryPersistAsync(JsonOperationContext context, BlittableJsonReaderObject history)
+        protected override Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
         {
             // In test mode, we don't persist the conversation document
             return Task.FromResult("test");

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -149,8 +149,11 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
     {
         talker.Init();
 
-        AiResponse r;
-        while (true)
+        AiResponse r = default;
+        List<BlittableJsonReaderObject> historyDocs = default;
+        bool shouldContinueConversation = true;
+
+        while (shouldContinueConversation)
         {
             using var request = talker.CreateCompletionRequest(_request.Attachments);
 
@@ -177,18 +180,27 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             }
 
             if (r.Type is AiResponseType.Result)
-                break;
+            {
+                shouldContinueConversation = false;
+            }
+            else
+            {
+                await HandleQueryToolCallsAsync(context, r.ToolCalls);
+                shouldContinueConversation = TryGetUserTools(context, r.ToolCalls) == false;
+            }
 
-            await HandleQueryToolCallsAsync(context, r.ToolCalls);
+            _document.CurrentUsage = talker.AiUsage;
 
-            if (TryGetUserTools(context, r.ToolCalls))
-                break; // we need to return the user tool requests to the client, so we can continue the conversation
+            // check if we should summarize or truncate the chat history
+            var reductionResult = await TryReduceChatSizeAsync(context, talker.Client, talker.AiUsage, token);
+            if (reductionResult != null)
+            {
+                historyDocs ??= [];
+                historyDocs.Add(reductionResult);
+            }
         }
 
-        var history = await TryReduceChatSizeAsync(context, talker.Client, talker.AiUsage, token);
-        _document.CurrentUsage = talker.AiUsage;
-
-        _conversationId = await TryPersistAsync(context, history);
+        _conversationId = await TryPersistAsync(context, historyDocs);
 
         return (r.Result, talker.AiUsage);
     }
@@ -250,6 +262,23 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             : summarization.SummarizationTaskBeginningPrompt;
         beginningPrompt += $" The original system prompt was: {systemPrompt}, the rest of follows";
 
+        var endPrompt = string.IsNullOrEmpty(summarization.SummarizationTaskEndPrompt)
+            ? database.Configuration.Ai.SummarizationTaskEndPrompt
+            : summarization.SummarizationTaskEndPrompt;
+
+        if (EndsWithTool(oldChat))
+        {
+            // Add a small nudge when the transcript ends with tool output, in order to avoid running the same tool again
+
+            beginningPrompt +=
+                " The transcript ends with tool output. Your summary must explicitly include the key results from those tool calls. " +
+                "These results must appear in the assistant’s summary message so that the conversation can continue without re-running the same tools.";
+
+            endPrompt +=
+                " Make sure the final summary message contains the essential tool results already obtained, so they are available for future turns. " +
+                "Do not suggest re-running the same tools unless the user explicitly asks for new data.";
+        }
+
         var messages = new List<BlittableJsonReaderObject>()
         {
             context.ReadObject(
@@ -261,9 +290,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         };
         messages.AddRange(oldChat.Messages.Skip(1));
 
-        var endPrompt = string.IsNullOrEmpty(summarization.SummarizationTaskEndPrompt)
-            ? database.Configuration.Ai.SummarizationTaskEndPrompt
-            : summarization.SummarizationTaskEndPrompt;
         messages.Add(context.ReadObject(
             new DynamicJsonValue
             {
@@ -295,6 +321,15 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
         oldChat.UpdateUsage(usage);
         oldChat.CurrentUsage = new AiUsage();
+    }
+
+    private bool EndsWithTool(ConversationDocument doc)
+    {
+        if (doc.Messages.Count < 2)
+            return false;
+
+        return doc.Messages[^1].TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string role) &&
+                          role.Equals("tool", StringComparison.OrdinalIgnoreCase);
     }
 
     private bool TryGetUserTools(JsonOperationContext context, List<AiToolCall> toolCalls)
@@ -343,6 +378,9 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
     public async Task HandleQueryToolCallsAsync(JsonOperationContext context, List<AiToolCall> toolCalls)
     {
+        if (toolCalls == null || toolCalls.Count == 0)
+            return;
+
         DynamicJsonArray reqs = [];
         List<string> toolCallsIds = [];
         var queryUrl = $"/databases/{database.Name}/queries";
@@ -365,6 +403,9 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 }
             });
         }
+
+        if (reqs.Count == 0)
+            return;
 
         var multiGetHandler = new MultiGetHandler();
         multiGetHandler.Init(new RequestHandlerContext
@@ -408,7 +449,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             }
         }
     }
-    protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, BlittableJsonReaderObject history)
+    protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
         if (_conversationId[^1] == '|')
         {
@@ -417,7 +458,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         }
 
         var changeVectorLsv = context.GetLazyString(_document.ChangeVector);
-        var cmd = new PutConversationCommand(_conversationId, _document, history, changeVectorLsv, _configuration, database);
+        var cmd = new PutConversationCommand(_conversationId, _document, historyDocs, changeVectorLsv, _configuration, database);
         await database.TxMerger.Enqueue(cmd);
         _document.ChangeVector = cmd.PutResult.Conversation.ChangeVector;
         return cmd.PutResult.Conversation.Id;
@@ -455,7 +496,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             // We have pending tool-call results from the user;
             // skip reduction - persist the document now without history,
             // ensuring we can recover if TalkAsync fails.
-            await TryPersistAsync(context, history: null);
+            await TryPersistAsync(context, historyDocs: null);
             return false;
         }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -262,22 +262,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             : summarization.SummarizationTaskBeginningPrompt;
         beginningPrompt += $" The original system prompt was: {systemPrompt}, the rest of follows";
 
-        var endPrompt = string.IsNullOrEmpty(summarization.SummarizationTaskEndPrompt)
-            ? database.Configuration.Ai.SummarizationTaskEndPrompt
-            : summarization.SummarizationTaskEndPrompt;
-
-        if (EndsWithTool(oldChat))
-        {
-            // Add a small nudge when the transcript ends with tool output, in order to avoid running the same tool again
-
-            beginningPrompt +=
-                " The transcript ends with tool output. Your summary must explicitly include the key results from those tool calls. " +
-                "These results must appear in the assistant’s summary message so that the conversation can continue without re-running the same tools.";
-
-            endPrompt +=
-                " Make sure the final summary message contains the essential tool results already obtained, so they are available for future turns. " +
-                "Do not suggest re-running the same tools unless the user explicitly asks for new data.";
-        }
 
         var messages = new List<BlittableJsonReaderObject>()
         {
@@ -290,6 +274,10 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         };
         messages.AddRange(oldChat.Messages.Skip(1));
 
+        var endPrompt = string.IsNullOrEmpty(summarization.SummarizationTaskEndPrompt)
+            ? database.Configuration.Ai.SummarizationTaskEndPrompt
+            : summarization.SummarizationTaskEndPrompt;
+
         messages.Add(context.ReadObject(
             new DynamicJsonValue
             {
@@ -297,7 +285,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 [ChatCompletionClient.Constants.RequestFields.Content] = endPrompt,
                 [ChatCompletionClient.Constants.RequestFields.MaxCompletionToken] = summarization.MaxTokensAfterSummarization
             }, "system/summary/final/msg"));
-
 
         var usage = new AiUsage();
         var tools = ConversationDocument.GenerateTools(context, configuration);
@@ -321,15 +308,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
         oldChat.UpdateUsage(usage);
         oldChat.CurrentUsage = new AiUsage();
-    }
-
-    private bool EndsWithTool(ConversationDocument doc)
-    {
-        if (doc.Messages.Count < 2)
-            return false;
-
-        return doc.Messages[^1].TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string role) &&
-                          role.Equals("tool", StringComparison.OrdinalIgnoreCase);
     }
 
     private bool TryGetUserTools(JsonOperationContext context, List<AiToolCall> toolCalls)
@@ -460,8 +438,8 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         var changeVectorLsv = context.GetLazyString(_document.ChangeVector);
         var cmd = new PutConversationCommand(_conversationId, _document, historyDocs, changeVectorLsv, _configuration, database);
         await database.TxMerger.Enqueue(cmd);
-        _document.ChangeVector = cmd.PutResult.Conversation.ChangeVector;
-        return cmd.PutResult.Conversation.Id;
+        _document.ChangeVector = cmd.PutResult.ChangeVector;
+        return cmd.PutResult.Id;
     }
 
     private async Task<bool> TryHandleActionResponses(JsonOperationContext context)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/GenAiConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/GenAiConversationHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
 
@@ -6,7 +7,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents;
 
 internal class GenAiConversationHandler(ServerStore server, DocumentDatabase database) : ConversationHandler(server, database)
 {
-    protected override Task<string> TryPersistAsync(JsonOperationContext context, BlittableJsonReaderObject history)
+    protected override Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
         // In GenAI mode, we don't persist the conversation document
         return Task.FromResult(_document.Id);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Raven.Client;
+﻿using System.Collections.Generic;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
@@ -10,22 +9,23 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 {
     internal class PutConversationCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
+        public (PutOperationResults Conversation, List<PutOperationResults> History) PutResult;
+
         private string _id;
-        private ConversationDocument _conversation;
         private BlittableJsonReaderObject _conversationDoc;
-        private BlittableJsonReaderObject _historyDoc;
+        private readonly ConversationDocument _conversation;
+        private readonly List<BlittableJsonReaderObject> _historyDocs;
         private readonly LazyStringValue _expectedChangeVector;
-        private DocumentDatabase _database;
-        private AiAgentConfiguration _configuration;
-        public (PutOperationResults Conversation, PutOperationResults History) PutResult;
+        private readonly DocumentDatabase _database;
+        private readonly AiAgentConfiguration _configuration;
 
         private const string AiAgentConversationHistoryIdPrefix = "ConversationHistory";
 
-        public PutConversationCommand(string conversationId, ConversationDocument conversation, BlittableJsonReaderObject history, LazyStringValue changeVector, AiAgentConfiguration configuration, DocumentDatabase database)
+        public PutConversationCommand(string conversationId, ConversationDocument conversation, List<BlittableJsonReaderObject> history, LazyStringValue changeVector, AiAgentConfiguration configuration, DocumentDatabase database)
         {
             _id = conversationId;
             _conversation = conversation;
-            _historyDoc = history;
+            _historyDocs = history;
             _expectedChangeVector = changeVector;
             _database = database;
             _configuration = configuration;
@@ -35,42 +35,47 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         {
             _id = _database.DocumentsStorage.DocumentPut.BuildDocumentId(_id, _database.DocumentsStorage.GenerateNextEtag(), out _);
 
-            PutOperationResults putHistoryResult = default;
-            if (_historyDoc != null)
+            List<PutOperationResults> putHistoryResults = default;
+            if (_historyDocs != null)
             {
-                var historyId = _database.DocumentsStorage.DocumentPut.BuildDocumentId($"{AiAgentConversationHistoryIdPrefix}{_database.IdentityPartsSeparator}", _database.DocumentsStorage.GenerateNextEtag(), out _);
-                historyId = $"{historyId}${_id}";
-                
-                putHistoryResult = _database.DocumentsStorage.Put(context, historyId, null, _historyDoc);
-                _conversation.LinkedConversations.Add(putHistoryResult.Id);
+                putHistoryResults = new List<PutOperationResults>(_historyDocs.Count);
+                foreach (var historyDoc in _historyDocs)
+                {
+                    var historyId = _database.DocumentsStorage.DocumentPut.BuildDocumentId($"{AiAgentConversationHistoryIdPrefix}{_database.IdentityPartsSeparator}", _database.DocumentsStorage.GenerateNextEtag(), out _);
+                    historyId = $"{historyId}${_id}";
+
+                    var putHistoryResult = _database.DocumentsStorage.Put(context, historyId, null, historyDoc);
+                    putHistoryResults.Add(putHistoryResult);
+                    _conversation.LinkedConversations.Add(putHistoryResult.Id);
+                }
             }
 
             _conversationDoc = _conversation.ToBlittable(context);
             var putResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _conversationDoc);
-            PutResult = (putResult, putHistoryResult);
+            PutResult = (putResult, putHistoryResults);
 
             return 1;
         }
 
         public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
-            return new PutChatCommandDto(_id, _conversation, _historyDoc, _expectedChangeVector, _configuration, _database);
+            return new PutChatCommandDto(_id, _conversation, _historyDocs, _expectedChangeVector, _configuration, _database);
         }
 
         public class PutChatCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, PutConversationCommand>
         {
             private string _id;
             private ConversationDocument _conversation;
-            private BlittableJsonReaderObject _historyDoc;
+            private List<BlittableJsonReaderObject> _historyDocs;
             private readonly LazyStringValue _expectedChangeVector;
             private DocumentDatabase _database;
             private AiAgentConfiguration _configuration;
 
-            public PutChatCommandDto(string conversationId, ConversationDocument conversation, BlittableJsonReaderObject history, LazyStringValue changeVector, AiAgentConfiguration configuration, DocumentDatabase database)
+            public PutChatCommandDto(string conversationId, ConversationDocument conversation, List<BlittableJsonReaderObject> history, LazyStringValue changeVector, AiAgentConfiguration configuration, DocumentDatabase database)
             {
                 _id = conversationId;
                 _conversation = conversation;
-                _historyDoc = history;
+                _historyDocs = history;
                 _expectedChangeVector = changeVector;
                 _database = database;
                 _configuration = configuration;
@@ -78,7 +83,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             public PutConversationCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                return new PutConversationCommand(_id, _conversation, _historyDoc, _expectedChangeVector, _configuration, _database);
+                return new PutConversationCommand(_id, _conversation, _historyDocs, _expectedChangeVector, _configuration, _database);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 {
     internal class PutConversationCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
-        public (PutOperationResults Conversation, List<PutOperationResults> History) PutResult;
+        public PutOperationResults PutResult;
 
         private string _id;
         private BlittableJsonReaderObject _conversationDoc;
@@ -35,24 +35,20 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         {
             _id = _database.DocumentsStorage.DocumentPut.BuildDocumentId(_id, _database.DocumentsStorage.GenerateNextEtag(), out _);
 
-            List<PutOperationResults> putHistoryResults = default;
             if (_historyDocs != null)
             {
-                putHistoryResults = new List<PutOperationResults>(_historyDocs.Count);
                 foreach (var historyDoc in _historyDocs)
                 {
                     var historyId = _database.DocumentsStorage.DocumentPut.BuildDocumentId($"{AiAgentConversationHistoryIdPrefix}{_database.IdentityPartsSeparator}", _database.DocumentsStorage.GenerateNextEtag(), out _);
                     historyId = $"{historyId}${_id}";
 
                     var putHistoryResult = _database.DocumentsStorage.Put(context, historyId, null, historyDoc);
-                    putHistoryResults.Add(putHistoryResult);
                     _conversation.LinkedConversations.Add(putHistoryResult.Id);
                 }
             }
 
             _conversationDoc = _conversation.ToBlittable(context);
-            var putResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _conversationDoc);
-            PutResult = (putResult, putHistoryResults);
+            PutResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _conversationDoc);
 
             return 1;
         }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -49,12 +49,11 @@ public class RavenDB_24407 : RavenTestBase
         public string Content { get; set; }
     }
 
-    // skip the Truncate test cases 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true, true })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true, false })]
-    //[RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false, true })]
-    //[RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false, false })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true], Skip = "RavenDB-24806")]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false], Skip = "RavenDB-24806")]
     public async Task CanResumeConversationWithSummarization(Options options, GenAiConfiguration config, bool summarization, bool withHistory)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
@@ -49,11 +49,12 @@ public class RavenDB_24407 : RavenTestBase
         public string Content { get; set; }
     }
 
+    // skip the Truncate test cases 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true, true })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false, true })]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true, false })]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false, false })]
+    //[RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false, true })]
+    //[RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false, false })]
     public async Task CanResumeConversationWithSummarization(Options options, GenAiConfiguration config, bool summarization, bool withHistory)
     {
         using var store = GetDocumentStore(options);
@@ -132,6 +133,8 @@ public class RavenDB_24407 : RavenTestBase
         }
         if (withHistory)
             agent.ChatTrimming.History = new();
+        
+        agent.MaxModelIterationsPerCall = 5;
 
         await store.AI.CreateAgentAsync(agent, OutputSampleObject.Instance);
 
@@ -143,7 +146,20 @@ public class RavenDB_24407 : RavenTestBase
         chatDoc = await GetChat(store, chat.Id);
         Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
-        Assert.Equal(withHistory ? 1 : 0, chatDoc.LinkedConversations.Count);
+
+        if (withHistory)
+        {
+            Assert.True(chatDoc.LinkedConversations.Count > 0);
+
+            // assert that the summarization happened during mid-chat (after a tool call)
+            var historyChat = await GetChat(store, chatDoc.LinkedConversations.First());
+            var lastMsg = historyChat.Messages.Last();
+            Assert.Equal("tool", lastMsg.Role);
+        }
+        else
+        {
+            Assert.Equal(0, chatDoc.LinkedConversations.Count);
+        }
 
         // resume - still with summarization
 
@@ -155,7 +171,6 @@ public class RavenDB_24407 : RavenTestBase
         chatDoc = await GetChat(store, chat.Id);
         Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
-        Assert.Equal(withHistory ? 2 : 0, chatDoc.LinkedConversations.Count);
 
         // resume
         agent.ChatTrimming = null;
@@ -168,7 +183,6 @@ public class RavenDB_24407 : RavenTestBase
 
         chatDoc = await GetChat(store, chat.Id);
         Assert.True(chatDoc.Messages.Count > 2, "messages count: " + chatDoc.Messages.Count);
-        Assert.Equal(withHistory ? 2 : 0, chatDoc.LinkedConversations.Count);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -209,7 +223,7 @@ public class RavenDB_24407 : RavenTestBase
                 }
             };
         }
-        if(withHistory)
+        if (withHistory)
             agent.ChatTrimming.History = new();
 
         agent.Actions =


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24855/Chat-summary-should-also-be-applied-mid-agent-operation

### Additional description

Add support for performing chat summarization _during_ an agent conversation, not only at the end.

- Prevents context from exploding when multiple tool calls or long interactions occur.
- Summarization now runs transparently in the middle of the conversation loop.
- Ensures tool outputs are incorporated into summaries (to help the model continue more smoothly and reduce repeated tool calls after summarization).
- Modified `PutConversationCommand` to be able to handle multiple "history docs" when persisting the chat and history, as we can have more than one history doc now in each conversation loop (if we summarize multiple times)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
