### PR TITLE
RavenDB-24905 : AI Agent: Strip Query Tool Metadata

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -396,6 +396,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         using (var reqsBlittable = context.ReadObject(new DynamicJsonValue { ["Requests"] = reqs }, "ai-agent/multi-query"))
         using (var handler = new MultiGetHandlerProcessorForPost(multiGetHandler))
         using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
+        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext clone))
         {
             await handler.ExecuteMultiGetAsync(context, reqsBlittable, memoryStream);
             memoryStream.Position = 0;
@@ -417,16 +418,39 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 if (queryResponseResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
                     throw new InvalidOperationException("Missing Results from query output");
 
+                RemoveNonEssentialFieldsFromMetadata(queryResult);
+
                 _document.AddMessage(context, context.ReadObject(
                     new DynamicJsonValue
                     {
                         ["tool_call_id"] = toolCallsIds[i],
                         ["role"] = "tool",
-                        ["content"] = queryResult.ToString()
+                        ["content"] = queryResult.Clone(clone).ToString()
                     }, "tool-call/response"), usage: null);
             }
         }
     }
+
+    private static void RemoveNonEssentialFieldsFromMetadata(BlittableJsonReaderArray queryResult)
+    {
+        foreach (BlittableJsonReaderObject doc in queryResult)
+        {
+            if (doc.TryGet(Client.Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))
+            {
+                var modifications = metadata.Modifications = new DynamicJsonValue(metadata);
+                modifications.Remove(Client.Constants.Documents.Metadata.ChangeVector);
+                modifications.Remove(Client.Constants.Documents.Metadata.IndexScore);
+                modifications.Remove(Client.Constants.Documents.Metadata.Counters);
+                modifications.Remove(Client.Constants.Documents.Metadata.TimeSeries);
+                modifications.Remove(Client.Constants.Documents.Metadata.Attachments);
+                modifications.Remove(Client.Constants.Documents.Metadata.Flags);
+                modifications.Remove(Client.Constants.Documents.Metadata.Projection);
+                modifications.Remove(Client.Constants.Documents.Metadata.RavenClrType);
+                modifications.Remove(Client.Constants.Documents.Metadata.Collection);
+            }
+        }
+    }
+
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
         if (_conversationId[^1] == '|')
@@ -441,6 +465,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         _document.ChangeVector = cmd.PutResult.ChangeVector;
         return cmd.PutResult.Id;
     }
+
 
     private async Task<bool> TryHandleActionResponses(JsonOperationContext context)
     {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24905.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24905.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_24905 : RavenTestBase
+    {
+        public RavenDB_24905(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldStripQueryToolMetadataToEssentialFieldsWithProjection(Options options, GenAiConfiguration config)
+        {
+            var store = GetDocumentStore(options);
+            var conversation = await SetupTestAgentAsync(store, config, "from Products as p where search(p.Name, \"Product/1\") order by score() desc select p.Name");
+            using (var session = store.OpenAsyncSession())
+            {
+
+                var product = new Product { Name = "Product/1" };
+                await session.StoreAsync(product, "products/1-a");
+
+                await session.SaveChangesAsync();
+            }
+
+            await conversation.RunAsync<object>();
+
+            JObject conversationDoc;
+            using (var session = store.OpenAsyncSession())
+            {
+                conversationDoc = await session.LoadAsync<JObject>(conversation.Id);
+            }
+            Assert.NotNull(conversationDoc);
+
+            var toolContent = conversationDoc["Messages"]
+                ?.LastOrDefault(m => m["role"]?.Value<string>() == "tool")
+                ?["content"]?.Value<string>();
+
+            Assert.False(string.IsNullOrEmpty(toolContent), "content of tool msg should not be null");
+
+            var documentsArray = JArray.Parse(toolContent);
+            Assert.True(documentsArray.Count > 0, "The tool should have returned documents.");
+
+            foreach (var docToken in documentsArray)
+            {
+                AssertMetadataIsStripped(docToken as JObject, false);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldStripQueryToolMetadataToEssentialFields(Options options, GenAiConfiguration config)
+        {
+            var store = GetDocumentStore(options);
+            var conversation = await SetupTestAgentAsync(store, config, "from Products");
+            using (var session = store.OpenAsyncSession())
+            {
+                var product = new Product { Name = "Product/1" };
+                await session.StoreAsync(product, "products/1-a");
+                await session.SaveChangesAsync();
+
+                var metadata = session.Advanced.GetMetadataFor(product);
+                metadata["My-Custom-field"] = "Some value";
+                session.TimeSeriesFor(product, "StockPrices").Append(DateTime.UtcNow, 100);
+
+                await session.SaveChangesAsync();
+            }
+
+            await conversation.RunAsync<object>();
+
+            JObject conversationDoc;
+            using (var session = store.OpenAsyncSession())
+            {
+                conversationDoc = await session.LoadAsync<JObject>(conversation.Id);
+            }
+            Assert.NotNull(conversationDoc);
+
+            var toolContent = conversationDoc["Messages"]
+                ?.LastOrDefault(m => m["role"]?.Value<string>() == "tool")
+                ?["content"]?.Value<string>();
+
+            Assert.False(string.IsNullOrEmpty(toolContent), "content of tool msg should not be null");
+
+            var documentsArray = JArray.Parse(toolContent);
+            Assert.True(documentsArray.Count > 0, "The tool should have returned documents.");
+
+            foreach (var docToken in documentsArray)
+            {
+                AssertMetadataIsStripped(docToken as JObject, true);
+            }
+        }
+
+        private async Task<IAiConversationOperations> SetupTestAgentAsync(IDocumentStore store, GenAiConfiguration config, string query)
+        {
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentConfig = new AiAgentConfiguration("metadata-stripping-tester", config.ConnectionStringName,
+                "You are a test agent. Your only purpose is to run the 'get_all_products' tool, no matter what the user says.")
+            {
+                Queries =
+                [
+                    new AiAgentToolQuery { Name = "get_all_products", Query = query , Description = "A tool that gets all products", ParametersSampleObject = "{}"}
+                ],
+                SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+            };
+            var agent = await store.AI.CreateAgentAsync(agentConfig);
+
+            var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+            conversation.SetUserPrompt("Please run the tool.");
+            return conversation;
+        }
+
+        public static void AssertMetadataIsStripped(JObject doc, bool withCustomField)
+        {
+            var metadata = doc["@metadata"] as JObject;
+
+            Assert.NotNull(metadata);
+
+            Assert.True(metadata.ContainsKey(Constants.Documents.Metadata.Id));
+            Assert.True(metadata.ContainsKey(Constants.Documents.Metadata.LastModified));
+            if(withCustomField)
+                Assert.True(metadata.ContainsKey("My-Custom-field"));
+
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.ChangeVector));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.IndexScore));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Counters));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.TimeSeries));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Attachments));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Flags));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Projection));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.RavenClrType));
+            Assert.False(metadata.ContainsKey(Constants.Documents.Metadata.Collection));
+
+            var numOfProperties = withCustomField ? 3 : 2;
+
+            Assert.Equal(numOfProperties, metadata.Count);
+        }
+
+        private class Product
+        {
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24905/AI-Agent-Strip-Query-Tool-Metadata-by-Default-to-Essential-Fields

### Additional description

When an AI Agent uses a query tool (e.g., from Products), the full document is returned as the result, including the entire `@metadata` object. This PR intend to remove fields that irrelevant to the LLM in order to reduce the number of tokens we use.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
