### PR TITLE
RavenDB-24485 Allow to get schema validation report

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -99,7 +99,7 @@ namespace Raven.Client.Documents.Indexes
 
         public virtual ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
         
-        public SchemaValidationConfiguration SchemaValidationConfiguration { get; set; }
+        public string SchemaValidation { get; set; }
 
         public IndexDefinitionCompareDifferences Compare(IndexDefinition other)
         {
@@ -226,7 +226,9 @@ namespace Raven.Client.Documents.Indexes
                     }
                 }
             }
-            
+
+            if (string.Equals(SchemaValidation, other.SchemaValidation) == false)
+                result |= IndexDefinitionCompareDifferences.SchemaValidationConfiguration;
             
             if (DictionaryExtensions.ContentEquals(AdditionalSources, other.AdditionalSources) == false)
             {
@@ -554,7 +556,7 @@ namespace Raven.Client.Documents.Indexes
 
             definition.LockMode = LockMode;
             definition.ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior;
-            definition.SchemaValidationConfiguration = SchemaValidationConfiguration;
+            definition.SchemaValidation = SchemaValidation;
             definition.Fields = fields;
             definition.Name = Name;
             definition.Priority = Priority;
@@ -641,7 +643,8 @@ namespace Raven.Client.Documents.Indexes
         DeploymentMode = 1 << 12,
         CompoundFields = 1 << 13,
         ArchivedDataProcessingBehavior = 1 << 14,
+        SchemaValidationConfiguration = 1 << 15,
 
-        All = Maps | Reduce | Fields | Configuration | LockMode | Priority | State | AdditionalSources | AdditionalAssemblies | DeploymentMode | CompoundFields | ArchivedDataProcessingBehavior,
+        All = Maps | Reduce | Fields | Configuration | LockMode | Priority | State | AdditionalSources | AdditionalAssemblies | DeploymentMode | CompoundFields | ArchivedDataProcessingBehavior | SchemaValidationConfiguration,
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Raven.Client.Documents.DataArchival;
-using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes
@@ -81,6 +80,8 @@ namespace Raven.Client.Documents.Indexes
             set => _configuration = value;
         }
 
+        public IndexSchemaDefinitions SchemaDefinitions { get; set; }
+        
         private IndexSourceType? _indexSourceType;
 
         public virtual IndexSourceType SourceType
@@ -98,8 +99,6 @@ namespace Raven.Client.Documents.Indexes
         }
 
         public virtual ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
-        
-        public string SchemaValidation { get; set; }
 
         public IndexDefinitionCompareDifferences Compare(IndexDefinition other)
         {
@@ -227,7 +226,7 @@ namespace Raven.Client.Documents.Indexes
                 }
             }
 
-            if (string.Equals(SchemaValidation, other.SchemaValidation) == false)
+            if (DictionaryExtensions.ContentEquals(SchemaDefinitions, other.SchemaDefinitions) == false)
                 result |= IndexDefinitionCompareDifferences.SchemaValidationConfiguration;
             
             if (DictionaryExtensions.ContentEquals(AdditionalSources, other.AdditionalSources) == false)
@@ -556,7 +555,7 @@ namespace Raven.Client.Documents.Indexes
 
             definition.LockMode = LockMode;
             definition.ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior;
-            definition.SchemaValidation = SchemaValidation;
+            definition.SchemaDefinitions = SchemaDefinitions;
             definition.Fields = fields;
             definition.Name = Name;
             definition.Priority = Priority;

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Raven.Client.Documents.DataArchival;
-using Raven.Client.Documents.Operations.DataArchival;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Extensions;
 
 namespace Raven.Client.Documents.Indexes
@@ -98,6 +98,8 @@ namespace Raven.Client.Documents.Indexes
         }
 
         public virtual ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
+        
+        public SchemaValidationConfiguration SchemaValidationConfiguration { get; set; }
 
         public IndexDefinitionCompareDifferences Compare(IndexDefinition other)
         {
@@ -552,6 +554,7 @@ namespace Raven.Client.Documents.Indexes
 
             definition.LockMode = LockMode;
             definition.ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior;
+            definition.SchemaValidationConfiguration = SchemaValidationConfiguration;
             definition.Fields = fields;
             definition.Name = Name;
             definition.Priority = Priority;

--- a/src/Raven.Client/Documents/Indexes/IndexSchemaDefinitions.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexSchemaDefinitions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Raven.Client.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Indexes
+{
+    public sealed class IndexSchemaDefinitions : Dictionary<string, string>, IFillFromBlittableJson
+    {
+        public new void Add(string key, string value)
+        {
+            base[key] = value;
+        }
+
+        public new string this[string key]
+        {
+            get => base[key];
+            set => Add(key, value);
+        }
+        
+        private bool Equals(IndexSchemaDefinitions other)
+        {
+            return DictionaryExtensions.ContentEquals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((IndexSchemaDefinitions)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Count;
+        }
+
+        public void FillFromBlittableJson(BlittableJsonReaderObject json)
+        {
+            if (json == null)
+                return;
+
+            foreach (var propertyName in json.GetPropertyNames())
+                this[propertyName] = json[propertyName].ToString();
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/StartSchemaValidationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/StartSchemaValidationOperation.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Documents.Operations.SchemaValidation;
 /// Optional limits (if omitted server defaults are used): MaxErrorMessages=1024, MaxDocumentsToValidate=unlimited.
 /// You may also provide a starting Etag to continue validation from a point in the collection; by default validation starts from the first document.
 /// </summary>
-public sealed class ValidateSchemaOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaOperationResult>>
+public sealed class StartSchemaValidationOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaOperationResult>>
 {
     private readonly Parameters _parameters;
 
@@ -42,7 +42,7 @@ public sealed class ValidateSchemaOperation : IMaintenanceOperation<OperationIdR
     /// <summary>
     /// Create the operation.
     /// </summary>
-    public ValidateSchemaOperation(Parameters parameters)
+    public StartSchemaValidationOperation(Parameters parameters)
     {
         _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
 
@@ -59,16 +59,16 @@ public sealed class ValidateSchemaOperation : IMaintenanceOperation<OperationIdR
 
     public RavenCommand<OperationIdResult<StartValidateSchemaOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
     {
-        return new ValidateSchemaCommand(conventions, _parameters);
+        return new StartSchemaValidationCommand(conventions, _parameters);
     }
 
-    internal class ValidateSchemaCommand : RavenCommand<OperationIdResult<StartValidateSchemaOperationResult>>, IRaftCommand
+    internal class StartSchemaValidationCommand : RavenCommand<OperationIdResult<StartValidateSchemaOperationResult>>, IRaftCommand
     {
         private readonly DocumentConventions _conventions;
         private readonly Parameters _parameters;
         private readonly long? _operationId;
 
-        public ValidateSchemaCommand(DocumentConventions conventions, Parameters parameters, long? operationId = null)
+        public StartSchemaValidationCommand(DocumentConventions conventions, Parameters parameters, long? operationId = null)
         {
             _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaOperation.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaOperation.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.Documents.Operations.SchemaValidation;
 /// Optional limits (if omitted server defaults are used): MaxErrorMessages=1024, MaxDocumentsToValidate=unlimited.
 /// You may also provide a starting Etag to continue validation from a point in the collection; by default validation starts from the first document.
 /// </summary>
-public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>>
+public sealed class ValidateSchemaOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaOperationResult>>
 {
     private readonly Parameters _parameters;
 
@@ -32,17 +32,17 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
         /// <summary>Maximum collected validation error messages. (Optional, default 1024, must be >= 0 when specified)</summary>
         public int? MaxErrorMessages { get; set; }
 
-        /// <summary>Maximum collected validation error messages. (Optional, default 'unlimited', must be >= 0 when specified)</summary>
+        /// <summary>Maximum number of documents to validate (Optional, default: unlimited, must be > 0 when specified).</summary>
         public long? MaxDocumentsToValidate { get; set; }
         
         /// <summary>Starting document etag to begin validation from. (Optional, default: start from the first document)</summary>
-        public long? Etag { get; set; }
+        public long? StartEtag { get; set; }
     }
 
     /// <summary>
     /// Create the operation.
     /// </summary>
-    public ValidateSchemaValidationOperation(Parameters parameters)
+    public ValidateSchemaOperation(Parameters parameters)
     {
         _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
 
@@ -57,18 +57,18 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
             throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxDocumentsToValidate)} must be > 0.");
     }
 
-    public RavenCommand<OperationIdResult<StartValidateSchemaValidationOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+    public RavenCommand<OperationIdResult<StartValidateSchemaOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
     {
-        return new ValidateSchemaValidationCommand(conventions, _parameters);
+        return new ValidateSchemaCommand(conventions, _parameters);
     }
 
-    internal class ValidateSchemaValidationCommand : RavenCommand<OperationIdResult<StartValidateSchemaValidationOperationResult>>, IRaftCommand
+    internal class ValidateSchemaCommand : RavenCommand<OperationIdResult<StartValidateSchemaOperationResult>>, IRaftCommand
     {
         private readonly DocumentConventions _conventions;
         private readonly Parameters _parameters;
         private readonly long? _operationId;
 
-        public ValidateSchemaValidationCommand(DocumentConventions conventions, Parameters parameters, long? operationId = null)
+        public ValidateSchemaCommand(DocumentConventions conventions, Parameters parameters, long? operationId = null)
         {
             _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
@@ -98,11 +98,9 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
             if (response == null)
                 ThrowInvalidResponse();
 
-            var result = JsonDeserializationClient.StartValidateSchemaValidationOperationResult(response);
+            var result = JsonDeserializationClient.StartValidateSchemaOperationResult(response);
             var operationIdResult = JsonDeserializationClient.OperationIdResult(response);
 
-            // OperationNodeTag used to fetch operation status
-            operationIdResult.OperationNodeTag ??= result.ResponsibleNode;
             Result = operationIdResult.ForResult(result);
         }
 
@@ -110,7 +108,7 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
     }
 }
 
-public sealed class StartValidateSchemaValidationOperationResult
+public sealed class StartValidateSchemaOperationResult
 {
     public string ResponsibleNode { get; set; }
 

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaResult.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaResult.cs
@@ -37,7 +37,7 @@ public class ValidateSchemaValidationProgress : IOperationProgress
     }
 }
 
-public sealed class ValidateSchemaValidationResult : ValidateSchemaValidationProgress, IOperationResult
+public sealed class ValidateSchemaResult : ValidateSchemaValidationProgress, IOperationResult
 {
     public Dictionary<string, string> Errors { get; set; }
     
@@ -65,7 +65,7 @@ public sealed class ValidateSchemaValidationResult : ValidateSchemaValidationPro
 
     void IOperationResult.MergeWith(IOperationResult result)
     {
-        if (result is not ValidateSchemaValidationResult r)
+        if (result is not ValidateSchemaResult r)
             return;
         ErrorCount += r.ErrorCount;
         ValidatedCount += r.ValidatedCount;

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaResult.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaResult.cs
@@ -3,7 +3,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.SchemaValidation;
 
-public class ValidateSchemaValidationProgress : IOperationProgress
+public class ValidateSchemaProgress : IOperationProgress
 {
     public long ErrorCount { get; set; }
     public long ValidatedCount { get; set; }
@@ -19,7 +19,7 @@ public class ValidateSchemaValidationProgress : IOperationProgress
 
     public IOperationProgress Clone()
     {
-        return new ValidateSchemaValidationProgress
+        return new ValidateSchemaProgress
         {
             ErrorCount = ErrorCount,
             ValidatedCount = ValidatedCount,
@@ -29,7 +29,7 @@ public class ValidateSchemaValidationProgress : IOperationProgress
     public bool CanMerge => true;
     public void MergeWith(IOperationProgress progress)
     {
-        if (progress is not ValidateSchemaValidationProgress p)
+        if (progress is not ValidateSchemaProgress p)
             return;
         
         ErrorCount += p.ErrorCount;
@@ -37,7 +37,7 @@ public class ValidateSchemaValidationProgress : IOperationProgress
     }
 }
 
-public sealed class ValidateSchemaResult : ValidateSchemaValidationProgress, IOperationResult
+public sealed class ValidateSchemaResult : ValidateSchemaProgress, IOperationResult
 {
     public Dictionary<string, string> Errors { get; set; }
     

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
@@ -10,8 +10,9 @@ using Sparrow.Json;
 namespace Raven.Client.Documents.Operations.SchemaValidation;
 
 /// <summary>
-/// Starts a background operation that validates documents in the specified collection against the given JSON schema.
-/// Server defaults when optional limits are omitted: MaxErrorMessages=1024, MaxDurationInMinutes=16, MaxReadBatchDurationInSeconds=960.
+/// Starts a background operation that validates documents in the specified collection against the provided JSON schema.
+/// Optional limits (if omitted server defaults are used): MaxErrorMessages=1024, MaxDocumentsToValidate=unlimited.
+/// You may also provide a starting Etag to continue validation from a point in the collection; by default validation starts from the first document.
 /// </summary>
 public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>>
 {
@@ -25,17 +26,17 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
         /// <summary>JSON schema definition. (Required)</summary>
         public string SchemaDefinition { get; set; }
 
+        /// <summary>Target collection to validate. (Required)</summary>
+        public string Collection { get; set; }
+        
         /// <summary>Maximum collected validation error messages. (Optional, default 1024, must be >= 0 when specified)</summary>
         public int? MaxErrorMessages { get; set; }
 
-        /// <summary>Target collection to validate. (Required)</summary>
-        public string Collection { get; set; }
-
-        /// <summary>Total time limit in minutes. (Optional, default 16, must be > 0 when specified)</summary>
-        public int? MaxDurationInMinutes { get; set; }
-
-        /// <summary>Maximum duration per read batch in seconds. (Optional, default 960, must be > 0 when specified)</summary>
-        public int? MaxReadBatchDurationInSeconds { get; set; }
+        /// <summary>Maximum collected validation error messages. (Optional, default 'unlimited', must be >= 0 when specified)</summary>
+        public long? MaxDocumentsToValidate { get; set; }
+        
+        /// <summary>Starting document etag to begin validation from. (Optional, default: start from the first document)</summary>
+        public long? Etag { get; set; }
     }
 
     /// <summary>
@@ -52,10 +53,8 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
 
         if (_parameters.MaxErrorMessages is < 0)
             throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxErrorMessages)} must be >= 0.");
-        if (_parameters.MaxDurationInMinutes is <= 0)
-            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxDurationInMinutes)} must be > 0.");
-        if (_parameters.MaxReadBatchDurationInSeconds is <= 0)
-            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxReadBatchDurationInSeconds)} must be > 0.");
+        if (_parameters.MaxDocumentsToValidate is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxDocumentsToValidate)} must be > 0.");
     }
 
     public RavenCommand<OperationIdResult<StartValidateSchemaValidationOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
@@ -10,10 +10,8 @@ using Sparrow.Json;
 namespace Raven.Client.Documents.Operations.SchemaValidation;
 
 /// <summary>
-/// Starts a server-side background operation that validates documents of the specified collection
-/// against the provided JSON schema. Returns an operation id for status tracking.
-/// When optional limits are not supplied the server applies defaults:
-/// MaxErrorsMsg = 1024, MaxTimeInMinutes = 16, MaxReadTrxTimeInSeconds = 960.
+/// Starts a background operation that validates documents in the specified collection against the given JSON schema.
+/// Server defaults when optional limits are omitted: MaxErrorMessages=1024, MaxDurationInMinutes=16, MaxReadBatchDurationInSeconds=960.
 /// </summary>
 public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>>
 {
@@ -27,17 +25,17 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
         /// <summary>JSON schema definition text. (Required)</summary>
         public string Schema { get; set; }
 
-        /// <summary> Maximum collected validation error messages. (Optional, default 1024, must be > 0 when specified) </summary>
-        public int? MaxErrorsMsg { get; set; }
+        /// <summary>Maximum collected validation error messages. (Optional, default 1024, must be >= 0 when specified)</summary>
+        public int? MaxErrorMessages { get; set; }
 
         /// <summary>Target collection to validate. (Required)</summary>
         public string Collection { get; set; }
 
         /// <summary>Total time limit in minutes. (Optional, default 16, must be > 0 when specified)</summary>
-        public int? MaxTimeInMinutes { get; set; }
+        public int? MaxDurationInMinutes { get; set; }
 
-        /// <summary>Per read transaction time limit in seconds. (Optional, default 960, must be > 0 when specified)</summary>
-        public int? MaxReadTrxTimeInSeconds { get; set; }
+        /// <summary>Maximum duration per read batch in seconds. (Optional, default 960, must be > 0 when specified)</summary>
+        public int? MaxReadBatchDurationInSeconds { get; set; }
     }
 
     /// <summary>
@@ -52,12 +50,12 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
         if (string.IsNullOrWhiteSpace(_parameters.Collection))
             throw new ArgumentException("Collection must be provided.", nameof(parameters));
 
-        if (_parameters.MaxErrorsMsg is < 0)
-            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxErrorsMsg)} must be >= 0.");
-        if (_parameters.MaxTimeInMinutes is <= 0)
-            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxTimeInMinutes)} must be > 0.");
-        if (_parameters.MaxReadTrxTimeInSeconds is <= 0)
-            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxReadTrxTimeInSeconds)} must be > 0.");
+        if (_parameters.MaxErrorMessages is < 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxErrorMessages)} must be >= 0.");
+        if (_parameters.MaxDurationInMinutes is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxDurationInMinutes)} must be > 0.");
+        if (_parameters.MaxReadBatchDurationInSeconds is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxReadBatchDurationInSeconds)} must be > 0.");
     }
 
     public RavenCommand<OperationIdResult<StartValidateSchemaValidationOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.SchemaValidation;
+
+/// <summary>
+/// Starts a server-side background operation that validates documents of the specified collection
+/// against the provided JSON schema. Returns an operation id for status tracking.
+/// When optional limits are not supplied the server applies defaults:
+/// MaxErrorsMsg = 1024, MaxTimeInMinutes = 16, MaxReadTrxTimeInSeconds = 960.
+/// </summary>
+public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>>
+{
+    private readonly Parameters _parameters;
+
+    /// <summary>
+    /// Parameters for schema validation. Schema and Collection are required; other values are optional.
+    /// </summary>
+    public sealed class Parameters
+    {
+        /// <summary>JSON schema definition text. (Required)</summary>
+        public string Schema { get; set; }
+
+        /// <summary> Maximum collected validation error messages. (Optional, default 1024, must be > 0 when specified) </summary>
+        public int? MaxErrorsMsg { get; set; }
+
+        /// <summary>Target collection to validate. (Required)</summary>
+        public string Collection { get; set; }
+
+        /// <summary>Total time limit in minutes. (Optional, default 16, must be > 0 when specified)</summary>
+        public int? MaxTimeInMinutes { get; set; }
+
+        /// <summary>Per read transaction time limit in seconds. (Optional, default 960, must be > 0 when specified)</summary>
+        public int? MaxReadTrxTimeInSeconds { get; set; }
+    }
+
+    /// <summary>
+    /// Create the operation.
+    /// </summary>
+    public ValidateSchemaValidationOperation(Parameters parameters)
+    {
+        _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+
+        if (string.IsNullOrWhiteSpace(_parameters.Schema))
+            throw new ArgumentException("Schema must be provided.", nameof(parameters));
+        if (string.IsNullOrWhiteSpace(_parameters.Collection))
+            throw new ArgumentException("Collection must be provided.", nameof(parameters));
+
+        if (_parameters.MaxErrorsMsg is < 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxErrorsMsg)} must be >= 0.");
+        if (_parameters.MaxTimeInMinutes is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxTimeInMinutes)} must be > 0.");
+        if (_parameters.MaxReadTrxTimeInSeconds is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(parameters), $"Property {nameof(parameters.MaxReadTrxTimeInSeconds)} must be > 0.");
+    }
+
+    public RavenCommand<OperationIdResult<StartValidateSchemaValidationOperationResult>> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+    {
+        return new ValidateSchemaValidationCommand(conventions, _parameters);
+    }
+
+    internal class ValidateSchemaValidationCommand : RavenCommand<OperationIdResult<StartValidateSchemaValidationOperationResult>>, IRaftCommand
+    {
+        private readonly DocumentConventions _conventions;
+        private readonly Parameters _parameters;
+        private readonly long? _operationId;
+
+        public ValidateSchemaValidationCommand(DocumentConventions conventions, Parameters parameters, long? operationId = null)
+        {
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+            _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            _operationId = operationId;
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/schema-validation/validate";
+
+            if (_operationId.HasValue)
+                url += $"?operationId={_operationId}";
+            
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx)).ConfigureAwait(false), _conventions)
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            var result = JsonDeserializationClient.StartValidateSchemaValidationOperationResult(response);
+            var operationIdResult = JsonDeserializationClient.OperationIdResult(response);
+
+            // OperationNodeTag used to fetch operation status
+            operationIdResult.OperationNodeTag ??= result.ResponsibleNode;
+            Result = operationIdResult.ForResult(result);
+        }
+
+        public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+    }
+}
+
+public sealed class StartValidateSchemaValidationOperationResult
+{
+    public string ResponsibleNode { get; set; }
+
+    public long OperationId { get; set; }
+}

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationOperation.cs
@@ -22,8 +22,8 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
     /// </summary>
     public sealed class Parameters
     {
-        /// <summary>JSON schema definition text. (Required)</summary>
-        public string Schema { get; set; }
+        /// <summary>JSON schema definition. (Required)</summary>
+        public string SchemaDefinition { get; set; }
 
         /// <summary>Maximum collected validation error messages. (Optional, default 1024, must be >= 0 when specified)</summary>
         public int? MaxErrorMessages { get; set; }
@@ -45,7 +45,7 @@ public sealed class ValidateSchemaValidationOperation : IMaintenanceOperation<Op
     {
         _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
 
-        if (string.IsNullOrWhiteSpace(_parameters.Schema))
+        if (string.IsNullOrWhiteSpace(_parameters.SchemaDefinition))
             throw new ArgumentException("Schema must be provided.", nameof(parameters));
         if (string.IsNullOrWhiteSpace(_parameters.Collection))
             throw new ArgumentException("Collection must be provided.", nameof(parameters));

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationResult.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationResult.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.SchemaValidation;
+
+public class ValidateSchemaValidationProgress : IOperationProgress
+{
+    public int ErrorCount { get; set; }
+    public int ScannedCount { get; set; }
+
+    public virtual DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue(GetType())
+        {
+            [nameof(ErrorCount)] = ErrorCount,
+            [nameof(ScannedCount)] = ScannedCount,
+        };
+    }
+
+    public IOperationProgress Clone()
+    {
+        return new ValidateSchemaValidationProgress
+        {
+            ErrorCount = ErrorCount,
+            ScannedCount = ScannedCount,
+        };
+    }
+
+    public bool CanMerge => true;
+    public void MergeWith(IOperationProgress progress)
+    {
+        if (progress is not ValidateSchemaValidationProgress p)
+            return;
+        
+        ErrorCount += p.ErrorCount;
+        ScannedCount += p.ScannedCount;
+    }
+}
+
+public sealed class ValidateSchemaValidationResult : ValidateSchemaValidationProgress, IOperationResult
+{
+    public Dictionary<string, string> Errors { get; set; }
+    
+    public override DynamicJsonValue ToJson()
+    {
+        var errors = new DynamicJsonValue();
+        foreach (var keyValue in Errors)
+        {
+            errors[keyValue.Key] = keyValue.Value;
+        }
+
+        var result = base.ToJson();
+        result[nameof(Errors)] = errors;
+        return  result;
+    }
+    
+    string IOperationResult.Message { get; }
+    
+    public bool ShouldPersist => false;
+
+    bool IOperationResult.CanMerge => true;
+
+    void IOperationResult.MergeWith(IOperationResult result)
+    {
+        if (result is not ValidateSchemaValidationResult r)
+            return;
+        ErrorCount += r.ErrorCount;
+        ScannedCount += r.ScannedCount;
+
+        Errors ??= new Dictionary<string, string>();
+        foreach (var keyValue in r.Errors)
+        {
+            Errors[keyValue.Key] = keyValue.Value;
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationResult.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/ValidateSchemaValidationResult.cs
@@ -5,15 +5,15 @@ namespace Raven.Client.Documents.Operations.SchemaValidation;
 
 public class ValidateSchemaValidationProgress : IOperationProgress
 {
-    public int ErrorCount { get; set; }
-    public int ScannedCount { get; set; }
+    public long ErrorCount { get; set; }
+    public long ValidatedCount { get; set; }
 
     public virtual DynamicJsonValue ToJson()
     {
         return new DynamicJsonValue(GetType())
         {
             [nameof(ErrorCount)] = ErrorCount,
-            [nameof(ScannedCount)] = ScannedCount,
+            [nameof(ValidatedCount)] = ValidatedCount,
         };
     }
 
@@ -22,7 +22,7 @@ public class ValidateSchemaValidationProgress : IOperationProgress
         return new ValidateSchemaValidationProgress
         {
             ErrorCount = ErrorCount,
-            ScannedCount = ScannedCount,
+            ValidatedCount = ValidatedCount,
         };
     }
 
@@ -33,13 +33,15 @@ public class ValidateSchemaValidationProgress : IOperationProgress
             return;
         
         ErrorCount += p.ErrorCount;
-        ScannedCount += p.ScannedCount;
+        ValidatedCount += p.ValidatedCount;
     }
 }
 
 public sealed class ValidateSchemaValidationResult : ValidateSchemaValidationProgress, IOperationResult
 {
     public Dictionary<string, string> Errors { get; set; }
+    
+    public long LastEtag { get; set; }
     
     public override DynamicJsonValue ToJson()
     {
@@ -51,6 +53,7 @@ public sealed class ValidateSchemaValidationResult : ValidateSchemaValidationPro
 
         var result = base.ToJson();
         result[nameof(Errors)] = errors;
+        result[nameof(LastEtag)] = LastEtag;
         return  result;
     }
     
@@ -65,7 +68,7 @@ public sealed class ValidateSchemaValidationResult : ValidateSchemaValidationPro
         if (result is not ValidateSchemaValidationResult r)
             return;
         ErrorCount += r.ErrorCount;
-        ScannedCount += r.ScannedCount;
+        ValidatedCount += r.ValidatedCount;
 
         Errors ??= new Dictionary<string, string>();
         foreach (var keyValue in r.Errors)

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -201,6 +201,8 @@ namespace Raven.Client.Json.Serialization
         internal static readonly Func<BlittableJsonReaderObject, ConfigureDataArchivalOperationResult> ConfigureDataArchivalOperationResult = GenerateJsonDeserializationRoutine<ConfigureDataArchivalOperationResult>();
         
         internal static readonly Func<BlittableJsonReaderObject, ConfigureSchemaValidationOperationResult> ConfigureSchemaValidationOperationResult = GenerateJsonDeserializationRoutine<ConfigureSchemaValidationOperationResult>();
+        
+        internal static readonly Func<BlittableJsonReaderObject, StartValidateSchemaValidationOperationResult> StartValidateSchemaValidationOperationResult = GenerateJsonDeserializationRoutine<StartValidateSchemaValidationOperationResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, DocumentCompressionConfigurationResult> DocumentCompressionConfigurationOperationResult = GenerateJsonDeserializationRoutine<DocumentCompressionConfigurationResult>();
 

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -202,7 +202,7 @@ namespace Raven.Client.Json.Serialization
         
         internal static readonly Func<BlittableJsonReaderObject, ConfigureSchemaValidationOperationResult> ConfigureSchemaValidationOperationResult = GenerateJsonDeserializationRoutine<ConfigureSchemaValidationOperationResult>();
         
-        internal static readonly Func<BlittableJsonReaderObject, StartValidateSchemaValidationOperationResult> StartValidateSchemaValidationOperationResult = GenerateJsonDeserializationRoutine<StartValidateSchemaValidationOperationResult>();
+        internal static readonly Func<BlittableJsonReaderObject, StartValidateSchemaOperationResult> StartValidateSchemaOperationResult = GenerateJsonDeserializationRoutine<StartValidateSchemaOperationResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, DocumentCompressionConfigurationResult> DocumentCompressionConfigurationOperationResult = GenerateJsonDeserializationRoutine<DocumentCompressionConfigurationResult>();
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -446,7 +446,7 @@ namespace Raven.Server.Documents
 
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
-                SchemaValidatorCache = new SchemaValidatorCache(DocumentsStorage.ContextPool, Loggers.GetLogger<SchemaValidatorCache>());
+                SchemaValidatorCache = SchemaValidatorCache.Create(DocumentsStorage.ContextPool, Loggers.GetLogger<SchemaValidatorCache>());
 
                 _addToInitLog(LogLevel.Debug, "Initializing IndexStore (async)");
                 _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -446,7 +446,7 @@ namespace Raven.Server.Documents
 
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
-                SchemaValidatorCache = SchemaValidatorCache.Create(DocumentsStorage.ContextPool, Loggers.GetLogger<SchemaValidatorCache>());
+                SchemaValidatorCache = SchemaValidatorCache.Create(DocumentsStorage.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
 
                 _addToInitLog(LogLevel.Debug, "Initializing IndexStore (async)");
                 _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForRevertRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForRevertRevisions.cs
@@ -17,6 +17,12 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
         protected override void ScheduleRevertRevisions(long operationId, RevertRevisionsRequest configuration, OperationCancelToken token)
         {
             var collections = configuration.Collections?.Length > 0 ? new HashSet<string>(configuration.Collections, StringComparer.OrdinalIgnoreCase) : null;
+            
+            var schemaValidationCache = RequestHandler.Database.SchemaValidatorCache;
+            
+            if(schemaValidationCache.Disabled == false && collections == null
+                || schemaValidationCache.IsSchemaEnabledForAny(configuration.Collections))
+                throw new InvalidOperationException("Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.");
 
             var t = RequestHandler.Database.Operations.AddLocalOperation(
                 operationId,

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForRevertRevisionsForDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsHandlerProcessorForRevertRevisionsForDocument.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.ServerWide;
@@ -15,6 +15,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Revisions
 
         protected override Task RevertDocumentsAsync(Dictionary<string, string> idToChangeVector, OperationCancelToken token)
         {
+            if(RequestHandler.Database.SchemaValidatorCache.Disabled == false)
+                throw new InvalidOperationException("Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.");
+                
             return RequestHandler.Database.DocumentsStorage.RevisionsStorage.RevertDocumentsToRevisionsAsync(idToChangeVector, token);
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -44,7 +44,7 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
     private void ValidateParameters()
     {
         if (string.IsNullOrWhiteSpace(Parameters.Collection) == false 
-            && string.IsNullOrWhiteSpace(Parameters.Schema) == false 
+            && string.IsNullOrWhiteSpace(Parameters.SchemaDefinition) == false 
             && (Parameters.MaxErrorMessages.HasValue == false || Parameters.MaxErrorMessages.Value >= 0) 
             && (Parameters.MaxDurationInMinutes.HasValue == false || Parameters.MaxDurationInMinutes.Value > 0 )
             // Optional per-read-batch duration limit in seconds.
@@ -55,8 +55,8 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
 
         if (string.IsNullOrWhiteSpace(Parameters.Collection))
             errors.Add($"Missing required parameter '{nameof(Parameters.Collection)}'.");
-        if (string.IsNullOrWhiteSpace(Parameters.Schema))
-            errors.Add($"Missing required parameter '{nameof(Parameters.Schema)}'.");
+        if (string.IsNullOrWhiteSpace(Parameters.SchemaDefinition))
+            errors.Add($"Missing required parameter '{nameof(Parameters.SchemaDefinition)}'.");
 
         if (Parameters.MaxErrorMessages is < 0)
             errors.Add($"Parameter '{nameof(Parameters.MaxErrorMessages)}' must be non-negative.");

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -13,7 +13,7 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
     where TOperationContext : JsonOperationContext
     where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
 {
-    protected ValidateSchemaOperation.Parameters Parameters;
+    protected StartSchemaValidationOperation.Parameters Parameters;
 
     protected AbstractSchemaValidationHandlerProcessorForValidate([NotNull] TRequestHandler requestHandler) : base(requestHandler)
     {

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -46,9 +46,7 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
         if (string.IsNullOrWhiteSpace(Parameters.Collection) == false 
             && string.IsNullOrWhiteSpace(Parameters.SchemaDefinition) == false 
             && (Parameters.MaxErrorMessages.HasValue == false || Parameters.MaxErrorMessages.Value >= 0) 
-            && (Parameters.MaxDurationInMinutes.HasValue == false || Parameters.MaxDurationInMinutes.Value > 0 )
-            // Optional per-read-batch duration limit in seconds.
-            && (Parameters.MaxReadBatchDurationInSeconds.HasValue == false || Parameters.MaxReadBatchDurationInSeconds.Value > 0))
+            && (Parameters.MaxDocumentsToValidate.HasValue == false || Parameters.MaxDocumentsToValidate.Value > 0 ))
             return;
         
         var errors = new List<string>();
@@ -60,10 +58,8 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
 
         if (Parameters.MaxErrorMessages is < 0)
             errors.Add($"Parameter '{nameof(Parameters.MaxErrorMessages)}' must be non-negative.");
-        if (Parameters.MaxDurationInMinutes is <= 0)
-            errors.Add($"Parameter '{nameof(Parameters.MaxDurationInMinutes)}' must be greater than 0.");
-        if (Parameters.MaxReadBatchDurationInSeconds is <= 0)
-            errors.Add($"Parameter '{nameof(Parameters.MaxReadBatchDurationInSeconds)}' must be greater than 0.");
+        if (Parameters.MaxDocumentsToValidate is <= 0)
+            errors.Add($"Parameter '{nameof(Parameters.MaxDocumentsToValidate)}' must be greater than 0.");
 
         throw new BadRequestException("Invalid schema validation parameters:" + string.Join(", ", errors));
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -13,7 +13,7 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
     where TOperationContext : JsonOperationContext
     where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
 {
-    protected ValidateSchemaValidationOperation.Parameters Parameters;
+    protected ValidateSchemaOperation.Parameters Parameters;
 
     protected AbstractSchemaValidationHandlerProcessorForValidate([NotNull] TRequestHandler requestHandler) : base(requestHandler)
     {
@@ -61,7 +61,7 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
         if (Parameters.MaxDocumentsToValidate is <= 0)
             errors.Add($"Parameter '{nameof(Parameters.MaxDocumentsToValidate)}' must be greater than 0.");
 
-        throw new BadRequestException("Invalid schema validation parameters:" + string.Join(", ", errors));
+        throw new BadRequestException("Invalid schema validation parameters:\n" + string.Join("\n", errors));;
     }
 
     protected abstract void StartValidationOperation(long operationId, OperationCancelToken token);

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Client.Exceptions;
+using Raven.Server.Json;
+using Raven.Server.ServerWide;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.SchemaValidation;
+
+internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+    where TOperationContext : JsonOperationContext
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+{
+    protected ValidateSchemaValidationOperation.Parameters Parameters;
+
+    protected AbstractSchemaValidationHandlerProcessorForValidate([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        {
+            var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
+
+            var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "SchemaValidation/Validate");
+            Parameters = JsonDeserializationServer.Parameters.ValidateSchemaValidationOperationParameters(json);
+
+            ValidateParameters();
+
+            var token = RequestHandler.CreateBackgroundOperationToken();
+
+            StartValidationOperation(operationId, token);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteOperationIdAndNodeTag(context, operationId, RequestHandler.ServerStore.NodeTag);
+            }
+        }
+    }
+
+    private void ValidateParameters()
+    {
+        if (string.IsNullOrWhiteSpace(Parameters.Collection) == false &&
+            string.IsNullOrWhiteSpace(Parameters.Schema) == false &&
+            Parameters.MaxErrorsMsg is >= 0 &&
+            Parameters.MaxTimeInMinutes is > 0 &&
+            Parameters.MaxReadTrxTimeInSeconds is > 0) return;
+        
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(Parameters.Collection))
+            errors.Add($"Missing required parameter '{Parameters.Collection}'.");
+        if (string.IsNullOrWhiteSpace(Parameters.Schema))
+            errors.Add($"Missing required parameter '{Parameters.Schema}'.");
+
+        if (Parameters.MaxErrorsMsg is <= 0)
+            errors.Add($"Parameter '{Parameters.MaxErrorsMsg}' must be greater than 0.");
+        if (Parameters.MaxTimeInMinutes is <= 0)
+            errors.Add($"Parameter '{Parameters.MaxTimeInMinutes}' must be greater than 0.");
+        if (Parameters.MaxReadTrxTimeInSeconds is <= 0)
+            errors.Add($"Parameter '{Parameters.MaxReadTrxTimeInSeconds}' must be greater than 0.");
+
+        throw new BadRequestException("Invalid schema validation parameters:" + string.Join(", ", errors));
+    }
+
+    protected abstract void StartValidationOperation(long operationId, OperationCancelToken token);
+
+    protected abstract long GetNextOperationId();
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -43,25 +43,26 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
 
     private void ValidateParameters()
     {
-        if (string.IsNullOrWhiteSpace(Parameters.Collection) == false &&
-            string.IsNullOrWhiteSpace(Parameters.Schema) == false &&
-            Parameters.MaxErrorsMsg is >= 0 &&
-            Parameters.MaxTimeInMinutes is > 0 &&
-            Parameters.MaxReadTrxTimeInSeconds is > 0) return;
+        if (string.IsNullOrWhiteSpace(Parameters.Collection) == false 
+            && string.IsNullOrWhiteSpace(Parameters.Schema) == false 
+            && (Parameters.MaxErrorsMsg.HasValue == false || Parameters.MaxErrorsMsg.Value >= 0) 
+            && (Parameters.MaxTimeInMinutes.HasValue == false || Parameters.MaxTimeInMinutes.Value > 0 )
+            && (Parameters.MaxReadTrxTimeInSeconds.HasValue == false || Parameters.MaxReadTrxTimeInSeconds.Value > 0)) 
+            return;
         
         var errors = new List<string>();
 
         if (string.IsNullOrWhiteSpace(Parameters.Collection))
-            errors.Add($"Missing required parameter '{Parameters.Collection}'.");
+            errors.Add($"Missing required parameter '{nameof(Parameters.Collection)}'.");
         if (string.IsNullOrWhiteSpace(Parameters.Schema))
-            errors.Add($"Missing required parameter '{Parameters.Schema}'.");
+            errors.Add($"Missing required parameter '{nameof(Parameters.Schema)}'.");
 
-        if (Parameters.MaxErrorsMsg is <= 0)
-            errors.Add($"Parameter '{Parameters.MaxErrorsMsg}' must be greater than 0.");
+        if (Parameters.MaxErrorsMsg is < 0)
+            errors.Add($"Parameter '{nameof(Parameters.MaxErrorsMsg)}' must be non-negative.");
         if (Parameters.MaxTimeInMinutes is <= 0)
-            errors.Add($"Parameter '{Parameters.MaxTimeInMinutes}' must be greater than 0.");
+            errors.Add($"Parameter '{nameof(Parameters.MaxTimeInMinutes)}' must be greater than 0.");
         if (Parameters.MaxReadTrxTimeInSeconds is <= 0)
-            errors.Add($"Parameter '{Parameters.MaxReadTrxTimeInSeconds}' must be greater than 0.");
+            errors.Add($"Parameter '{nameof(Parameters.MaxReadTrxTimeInSeconds)}' must be greater than 0.");
 
         throw new BadRequestException("Invalid schema validation parameters:" + string.Join(", ", errors));
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -26,7 +26,7 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
 
             var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "SchemaValidation/Validate");
-            Parameters = JsonDeserializationServer.Parameters.ValidateSchemaValidationOperationParameters(json);
+            Parameters = JsonDeserializationServer.Parameters.ValidateSchemaOperationParameters(json);
 
             ValidateParameters();
 

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -45,9 +45,10 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
     {
         if (string.IsNullOrWhiteSpace(Parameters.Collection) == false 
             && string.IsNullOrWhiteSpace(Parameters.Schema) == false 
-            && (Parameters.MaxErrorsMsg.HasValue == false || Parameters.MaxErrorsMsg.Value >= 0) 
-            && (Parameters.MaxTimeInMinutes.HasValue == false || Parameters.MaxTimeInMinutes.Value > 0 )
-            && (Parameters.MaxReadTrxTimeInSeconds.HasValue == false || Parameters.MaxReadTrxTimeInSeconds.Value > 0)) 
+            && (Parameters.MaxErrorMessages.HasValue == false || Parameters.MaxErrorMessages.Value >= 0) 
+            && (Parameters.MaxDurationInMinutes.HasValue == false || Parameters.MaxDurationInMinutes.Value > 0 )
+            // Optional per-read-batch duration limit in seconds.
+            && (Parameters.MaxReadBatchDurationInSeconds.HasValue == false || Parameters.MaxReadBatchDurationInSeconds.Value > 0))
             return;
         
         var errors = new List<string>();
@@ -57,12 +58,12 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
         if (string.IsNullOrWhiteSpace(Parameters.Schema))
             errors.Add($"Missing required parameter '{nameof(Parameters.Schema)}'.");
 
-        if (Parameters.MaxErrorsMsg is < 0)
-            errors.Add($"Parameter '{nameof(Parameters.MaxErrorsMsg)}' must be non-negative.");
-        if (Parameters.MaxTimeInMinutes is <= 0)
-            errors.Add($"Parameter '{nameof(Parameters.MaxTimeInMinutes)}' must be greater than 0.");
-        if (Parameters.MaxReadTrxTimeInSeconds is <= 0)
-            errors.Add($"Parameter '{nameof(Parameters.MaxReadTrxTimeInSeconds)}' must be greater than 0.");
+        if (Parameters.MaxErrorMessages is < 0)
+            errors.Add($"Parameter '{nameof(Parameters.MaxErrorMessages)}' must be non-negative.");
+        if (Parameters.MaxDurationInMinutes is <= 0)
+            errors.Add($"Parameter '{nameof(Parameters.MaxDurationInMinutes)}' must be greater than 0.");
+        if (Parameters.MaxReadBatchDurationInSeconds is <= 0)
+            errors.Add($"Parameter '{nameof(Parameters.MaxReadBatchDurationInSeconds)}' must be greater than 0.");
 
         throw new BadRequestException("Invalid schema validation parameters:" + string.Join(", ", errors));
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations;
@@ -39,10 +40,12 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         {
             var errors = new Dictionary<string, string>();
+
+            var stop = Stopwatch.StartNew();
             
-            var stopTotalTime = DateTime.UtcNow + maxTime;
+            var stopTotalTime = maxTime;
             var progressReportRate = TimeSpan.FromMinutes(1);
-            var nextProgressReport = DateTime.UtcNow;
+            var nextProgressReport = TimeSpan.Zero;
             
             var etag = 0L;
             var actualErrorCount = 0;
@@ -55,11 +58,11 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
 
             using var errorBuilder = new ErrorBuilder(context);
             
-            while (DateTime.UtcNow < stopTotalTime)
+            while (stop.Elapsed < stopTotalTime)
             {
                 using (context.OpenReadTransaction())
                 {
-                    var stopTrxTime = DateTime.UtcNow + maxReadTrxTime;
+                    var stopTrxTime = stop.Elapsed + maxReadTrxTime;
                     var enumerable = context.DocumentDatabase.DocumentsStorage.GetDocumentsFrom(context, Parameters.Collection, etag, 0, long.MaxValue, DocumentFields.Id | DocumentFields.Data);
                     using var enumerator = enumerable.GetEnumerator();
 
@@ -70,14 +73,14 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
                         if(hasMore == false)
                             break;
                         
-                        if (DateTime.UtcNow > nextProgressReport)
+                        if (stop.Elapsed > nextProgressReport)
                         {
                             onProgress(new ValidateSchemaValidationProgress
                             {
                                 ScannedCount = totalScanned,
                                 ErrorCount = actualErrorCount
                             });
-                            nextProgressReport = DateTime.UtcNow + progressReportRate;
+                            nextProgressReport = stop.Elapsed + progressReportRate;
                         }
                         
                         using var document = enumerator.Current;
@@ -100,7 +103,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
 
                         ++totalScanned;
 
-                        var now = DateTime.UtcNow;
+                        var now = stop.Elapsed;
                         if(now > stopTotalTime || now > stopTrxTime)
                             break;
                     }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -32,9 +32,9 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
 
     private Task<IOperationResult> StartValidation(Action<IOperationProgress> onProgress)
     {
-        var maxErrorsMsg = Parameters.MaxErrorsMsg ?? 1024;
-        var maxTime = TimeSpan.FromMinutes(Parameters.MaxTimeInMinutes ?? 16);
-        var maxReadTrxTime = TimeSpan.FromSeconds(Parameters.MaxReadTrxTimeInSeconds ?? 16 * 60);
+        var maxErrorsMsg = Parameters.MaxErrorMessages ?? 1024;
+        var maxTime = TimeSpan.FromMinutes(Parameters.MaxDurationInMinutes ?? 16);
+        var maxReadTrxTime = TimeSpan.FromSeconds(Parameters.MaxReadBatchDurationInSeconds ?? 16 * 60);
         
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -101,8 +101,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
 
                         ++totalValidated;
 
-                        var now = stop.Elapsed;
-                        if(totalValidated >= maxToValidate || now > stopTrxTime)
+                        if(totalValidated >= maxToValidate || stop.Elapsed > stopTrxTime)
                             break;
                     }
                     if(hasMore == false)

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -51,9 +51,9 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
             var actualErrorCount = 0;
             var totalScanned = 0;
             
-            using var blittable = context.Sync.ReadForMemory(Parameters.Schema, "schema-validation");
+            using var blittable = context.Sync.ReadForMemory(Parameters.SchemaDefinition, "schema-validation");
             
-            var schemaValidator = new SchemaValidator { SchemaDefinition = Parameters.Schema };
+            var schemaValidator = new SchemaValidator { SchemaDefinition = Parameters.SchemaDefinition };
             schemaValidator.Init(blittable);
 
             using var errorBuilder = new ErrorBuilder(context);

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -34,8 +34,10 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
     private Task<IOperationResult> StartValidation(Action<IOperationProgress> onProgress)
     {
         var maxErrorsMsg = Parameters.MaxErrorMessages ?? 1024;
-        var maxTime = TimeSpan.FromMinutes(Parameters.MaxDurationInMinutes ?? 16);
-        var maxReadTrxTime = TimeSpan.FromSeconds(Parameters.MaxReadBatchDurationInSeconds ?? 16 * 60);
+        var maxToValidate = Parameters.MaxDocumentsToValidate ?? long.MaxValue;
+        var etag = Parameters.Etag ?? 0L;
+        
+        var maxReadTrxTime = TimeSpan.FromSeconds(16);
         
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         {
@@ -43,20 +45,18 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
 
             var stop = Stopwatch.StartNew();
             
-            var stopTotalTime = maxTime;
-            var progressReportRate = TimeSpan.FromMinutes(1);
+            var progressReportRate = TimeSpan.FromSeconds(5);
             var nextProgressReport = TimeSpan.Zero;
             
-            var etag = 0L;
-            var actualErrorCount = 0;
-            var totalScanned = 0;
+            var actualErrorCount = 0L;
+            var totalValidated = 0L;
             
             using var blittable = context.Sync.ReadForMemory(Parameters.SchemaDefinition, "schema-validation");
             var schemaValidator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Parameters.SchemaDefinition);
 
             using var errorBuilder = new ErrorBuilder(context);
             
-            while (stop.Elapsed < stopTotalTime)
+            while (totalValidated < maxToValidate)
             {
                 using (context.OpenReadTransaction())
                 {
@@ -75,7 +75,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
                         {
                             onProgress(new ValidateSchemaValidationProgress
                             {
-                                ScannedCount = totalScanned,
+                                ValidatedCount = totalValidated,
                                 ErrorCount = actualErrorCount
                             });
                             nextProgressReport = stop.Elapsed + progressReportRate;
@@ -99,10 +99,10 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
                                 ++actualErrorCount;
                         }
 
-                        ++totalScanned;
+                        ++totalValidated;
 
                         var now = stop.Elapsed;
-                        if(now > stopTotalTime || now > stopTrxTime)
+                        if(totalValidated >= maxToValidate || now > stopTrxTime)
                             break;
                     }
                     if(hasMore == false)
@@ -113,7 +113,8 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
             {
                 Errors = errors,
                 ErrorCount = actualErrorCount,
-                ScannedCount = totalScanned,
+                ValidatedCount = totalValidated,
+                LastEtag = etag
             });
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -52,9 +52,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
             var totalScanned = 0;
             
             using var blittable = context.Sync.ReadForMemory(Parameters.SchemaDefinition, "schema-validation");
-            
-            var schemaValidator = new SchemaValidator { SchemaDefinition = Parameters.SchemaDefinition };
-            schemaValidator.Init(blittable);
+            var schemaValidator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Parameters.SchemaDefinition);
 
             using var errorBuilder = new ErrorBuilder(context);
             

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -35,7 +35,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
     {
         var maxErrorsMsg = Parameters.MaxErrorMessages ?? 1024;
         var maxToValidate = Parameters.MaxDocumentsToValidate ?? long.MaxValue;
-        var etag = Parameters.Etag ?? 0L;
+        var etag = Parameters.StartEtag ?? 0L;
         
         var maxReadTrxTime = TimeSpan.FromSeconds(16);
         
@@ -108,7 +108,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
                         break;
                 }
             }
-            return Task.FromResult<IOperationResult>(new ValidateSchemaValidationResult
+            return Task.FromResult<IOperationResult>(new ValidateSchemaResult
             {
                 Errors = errors,
                 ErrorCount = actualErrorCount,

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Server.Documents.Operations;
+using Raven.Server.Documents.SchemaValidation;
+using Raven.Server.Documents.SchemaValidation.ErrorMessage;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Sync;
+
+namespace Raven.Server.Documents.Handlers.Processors.SchemaValidation;
+
+internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSchemaValidationHandlerProcessorForValidate<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public SchemaValidationHandlerProcessorForValidate([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+    
+    protected override void StartValidationOperation(long operationId, OperationCancelToken token)
+    {
+        _ = RequestHandler.Database.Operations.AddLocalOperation(
+            operationId,
+            OperationType.ValidateSchemaValidation,
+            $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.Database.Name}'",
+            detailedDescription: null,
+            StartValidation,
+            token: token).ContinueWith(_ => token.Dispose());
+    }
+
+    private Task<IOperationResult> StartValidation(Action<IOperationProgress> onProgress)
+    {
+        var maxErrorsMsg = Parameters.MaxErrorsMsg ?? 1024;
+        var maxTime = TimeSpan.FromMinutes(Parameters.MaxTimeInMinutes ?? 16);
+        var maxReadTrxTime = TimeSpan.FromSeconds(Parameters.MaxReadTrxTimeInSeconds ?? 16 * 60);
+        
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var errors = new Dictionary<string, string>();
+            
+            var stopTotalTime = DateTime.UtcNow + maxTime;
+            var progressReportRate = TimeSpan.FromMinutes(1);
+            var nextProgressReport = DateTime.UtcNow;
+            
+            var etag = 0L;
+            var actualErrorCount = 0;
+            var totalScanned = 0;
+            
+            using var blittable = context.Sync.ReadForMemory(Parameters.Schema, "schema-validation");
+            
+            var schemaValidator = new SchemaValidator { SchemaDefinition = Parameters.Schema };
+            schemaValidator.Init(blittable);
+
+            using var errorBuilder = new ErrorBuilder(context);
+            
+            while (DateTime.UtcNow < stopTotalTime)
+            {
+                using (context.OpenReadTransaction())
+                {
+                    var stopTrxTime = DateTime.UtcNow + maxReadTrxTime;
+                    var enumerable = context.DocumentDatabase.DocumentsStorage.GetDocumentsFrom(context, Parameters.Collection, etag, 0, long.MaxValue, DocumentFields.Id | DocumentFields.Data);
+                    using var enumerator = enumerable.GetEnumerator();
+
+                    bool hasMore;
+                    while (true)
+                    {
+                        hasMore = enumerator.MoveNext();
+                        if(hasMore == false)
+                            break;
+                        
+                        if (DateTime.UtcNow > nextProgressReport)
+                        {
+                            onProgress(new ValidateSchemaValidationProgress
+                            {
+                                ScannedCount = totalScanned,
+                                ErrorCount = actualErrorCount
+                            });
+                            nextProgressReport = DateTime.UtcNow + progressReportRate;
+                        }
+                        
+                        using var document = enumerator.Current;
+                        
+                        etag = document.Etag;
+                        if (actualErrorCount < maxErrorsMsg)
+                        {
+                            errorBuilder.Reset();
+                            if (schemaValidator.Validate(document.Data, errorBuilder) == false)
+                            {
+                                errors[document.Id] = errorBuilder.ToString();
+                                ++actualErrorCount;
+                            }
+                        }
+                        else
+                        {
+                            if (schemaValidator.Validate(document.Data, null) == false)
+                                ++actualErrorCount;
+                        }
+
+                        ++totalScanned;
+
+                        var now = DateTime.UtcNow;
+                        if(now > stopTotalTime || now > stopTrxTime)
+                            break;
+                    }
+                    if(hasMore == false)
+                        break;
+                }
+            }
+            return Task.FromResult<IOperationResult>(new ValidateSchemaValidationResult
+            {
+                Errors = errors,
+                ErrorCount = actualErrorCount,
+                ScannedCount = totalScanned,
+            });
+        }
+    }
+
+    protected override long GetNextOperationId() => RequestHandler.Database.Operations.GetNextOperationId();
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -24,7 +24,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
     {
         _ = RequestHandler.Database.Operations.AddLocalOperation(
             operationId,
-            OperationType.ValidateSchemaValidation,
+            OperationType.ValidateSchema,
             $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.Database.Name}'",
             detailedDescription: null,
             StartValidation,
@@ -73,7 +73,7 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
                         
                         if (stop.Elapsed > nextProgressReport)
                         {
-                            onProgress(new ValidateSchemaValidationProgress
+                            onProgress(new ValidateSchemaProgress
                             {
                                 ValidatedCount = totalValidated,
                                 ErrorCount = actualErrorCount

--- a/src/Raven.Server/Documents/Handlers/SchemaValidationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SchemaValidationHandler.cs
@@ -21,7 +21,7 @@ public sealed class SchemaValidationHandler : DatabaseRequestHandler
     }
 
     [RavenAction("/databases/*/schema-validation/validate", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
-    public async Task ValidateSchemaValidation()
+    public async Task ValidateSchema()
     {
         using (var processor = new SchemaValidationHandlerProcessorForValidate(this))
             await processor.ExecuteAsync();

--- a/src/Raven.Server/Documents/Handlers/SchemaValidationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SchemaValidationHandler.cs
@@ -19,4 +19,11 @@ public sealed class SchemaValidationHandler : DatabaseRequestHandler
         using (var processor = new SchemaValidationHandlerProcessorForPost(this))
             await processor.ExecuteAsync();
     }
+
+    [RavenAction("/databases/*/schema-validation/validate", "POST", AuthorizationStatus.DatabaseAdmin)]
+    public async Task ValidateSchemaValidation()
+    {
+        using (var processor = new SchemaValidationHandlerProcessorForValidate(this))
+            await processor.ExecuteAsync();
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/SchemaValidationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SchemaValidationHandler.cs
@@ -20,7 +20,7 @@ public sealed class SchemaValidationHandler : DatabaseRequestHandler
             await processor.ExecuteAsync();
     }
 
-    [RavenAction("/databases/*/schema-validation/validate", "POST", AuthorizationStatus.DatabaseAdmin)]
+    [RavenAction("/databases/*/schema-validation/validate", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
     public async Task ValidateSchemaValidation()
     {
         using (var processor = new SchemaValidationHandlerProcessorForValidate(this))

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -876,10 +876,9 @@ namespace Raven.Server.Documents.Indexes
                 if (Definition.SchemaValidation != null)
                 {
                     _schemaValidator.retrunCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
-                    _schemaValidator.validator = new SchemaValidator { SchemaDefinition = Definition.SchemaValidation };
                     var blittable = context.Sync.ReadForMemory(Definition.SchemaValidation, "schema-validation");
-                    SchemaValidationHelper.EnsureMetadataIsValid(context, ref blittable);
-                    _schemaValidator.validator.Init(blittable);
+                    
+                    _schemaValidator.validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Definition.SchemaValidation);
                 }
                 
                 OnInitialization();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -288,7 +288,7 @@ namespace Raven.Server.Documents.Indexes
         public bool IsOnBeforeExecuteIndexing { get; private set; }
 
         public TestIndexRun TestRun;
-        internal (SchemaValidator validator, IDisposable returnCtx) _schemaValidator;
+        internal (SchemaValidator Validator, IDisposable ReturnCtx) _schemaValidator;
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
@@ -408,7 +408,7 @@ namespace Raven.Server.Documents.Indexes
 
             exceptionAggregator.Execute(() => { _mre?.Dispose(); });
             
-            exceptionAggregator.Execute(() =>_schemaValidator.returnCtx?.Dispose());
+            exceptionAggregator.Execute(() =>_schemaValidator.ReturnCtx?.Dispose());
 
             exceptionAggregator.ThrowIfNeeded();
         }
@@ -875,10 +875,10 @@ namespace Raven.Server.Documents.Indexes
 
                 if (Definition.SchemaValidation != null)
                 {
-                    _schemaValidator.returnCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
+                    _schemaValidator.ReturnCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
                     var blittable = context.Sync.ReadForMemory(Definition.SchemaValidation, "schema-validation");
                     
-                    _schemaValidator.validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Definition.SchemaValidation);
+                    _schemaValidator.Validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Definition.SchemaValidation);
                 }
                 
                 OnInitialization();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -83,7 +83,7 @@ using Voron.Debugging;
 using Voron.Exceptions;
 using Voron.Impl;
 using Voron.Impl.Compaction;
-using static Raven.Server.Utils.MetricCacher.Keys;
+using Raven.Server.Documents.SchemaValidation;
 using AsyncManualResetEvent = Sparrow.Server.AsyncManualResetEvent;
 using Constants = Raven.Client.Constants;
 using FacetQuery = Raven.Server.Documents.Queries.Facets.FacetQuery;
@@ -287,6 +287,7 @@ namespace Raven.Server.Documents.Indexes
         public bool IsOnBeforeExecuteIndexing { get; private set; }
 
         public TestIndexRun TestRun;
+        internal SchemaValidatorCache _schemaValidatorCache;
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
@@ -405,6 +406,8 @@ namespace Raven.Server.Documents.Indexes
             exceptionAggregator.Execute(() => { _indexingProcessCancellationTokenSource?.Dispose(); });
 
             exceptionAggregator.Execute(() => { _mre?.Dispose(); });
+            
+            exceptionAggregator.Execute(() => { _schemaValidatorCache?.Dispose(); });
 
             exceptionAggregator.ThrowIfNeeded();
         }
@@ -869,6 +872,12 @@ namespace Raven.Server.Documents.Indexes
 
                 DocumentDatabase.Changes.OnIndexChange += HandleIndexChange;
 
+                if (Definition.SchemaValidationConfiguration != null)
+                {
+                    _schemaValidatorCache = SchemaValidatorCache.Create(_contextPool, _logger);
+                    _schemaValidatorCache.Update(Definition.SchemaValidationConfiguration);
+                }
+                
                 OnInitialization();
 
                 if (LastIndexingTime != null)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -84,6 +84,7 @@ using Voron.Exceptions;
 using Voron.Impl;
 using Voron.Impl.Compaction;
 using Raven.Server.Documents.SchemaValidation;
+using Sparrow.Json.Sync;
 using AsyncManualResetEvent = Sparrow.Server.AsyncManualResetEvent;
 using Constants = Raven.Client.Constants;
 using FacetQuery = Raven.Server.Documents.Queries.Facets.FacetQuery;
@@ -287,7 +288,7 @@ namespace Raven.Server.Documents.Indexes
         public bool IsOnBeforeExecuteIndexing { get; private set; }
 
         public TestIndexRun TestRun;
-        internal SchemaValidatorCache _schemaValidatorCache;
+        internal (SchemaValidator validator, IDisposable retrunCtx) _schemaValidator;
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
@@ -407,7 +408,7 @@ namespace Raven.Server.Documents.Indexes
 
             exceptionAggregator.Execute(() => { _mre?.Dispose(); });
             
-            exceptionAggregator.Execute(() => { _schemaValidatorCache?.Dispose(); });
+            exceptionAggregator.Execute(() =>_schemaValidator.retrunCtx?.Dispose());
 
             exceptionAggregator.ThrowIfNeeded();
         }
@@ -872,10 +873,13 @@ namespace Raven.Server.Documents.Indexes
 
                 DocumentDatabase.Changes.OnIndexChange += HandleIndexChange;
 
-                if (Definition.SchemaValidationConfiguration != null)
+                if (Definition.SchemaValidation != null)
                 {
-                    _schemaValidatorCache = SchemaValidatorCache.Create(_contextPool, _logger);
-                    _schemaValidatorCache.Update(Definition.SchemaValidationConfiguration);
+                    _schemaValidator.retrunCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
+                    _schemaValidator.validator = new SchemaValidator { SchemaDefinition = Definition.SchemaValidation };
+                    var blittable = context.Sync.ReadForMemory(Definition.SchemaValidation, "schema-validation");
+                    SchemaValidationHelper.EnsureMetadataIsValid(context, ref blittable);
+                    _schemaValidator.validator.Init(blittable);
                 }
                 
                 OnInitialization();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -288,7 +288,7 @@ namespace Raven.Server.Documents.Indexes
         public bool IsOnBeforeExecuteIndexing { get; private set; }
 
         public TestIndexRun TestRun;
-        internal (SchemaValidator validator, IDisposable retrunCtx) _schemaValidator;
+        internal (SchemaValidator validator, IDisposable returnCtx) _schemaValidator;
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
@@ -408,7 +408,7 @@ namespace Raven.Server.Documents.Indexes
 
             exceptionAggregator.Execute(() => { _mre?.Dispose(); });
             
-            exceptionAggregator.Execute(() =>_schemaValidator.retrunCtx?.Dispose());
+            exceptionAggregator.Execute(() =>_schemaValidator.returnCtx?.Dispose());
 
             exceptionAggregator.ThrowIfNeeded();
         }
@@ -875,7 +875,7 @@ namespace Raven.Server.Documents.Indexes
 
                 if (Definition.SchemaValidation != null)
                 {
-                    _schemaValidator.retrunCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
+                    _schemaValidator.returnCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
                     var blittable = context.Sync.ReadForMemory(Definition.SchemaValidation, "schema-validation");
                     
                     _schemaValidator.validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Definition.SchemaValidation);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -38,6 +38,7 @@ using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene;
+using Raven.Server.Documents.Indexes.SchemaValidation;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.Counters;
 using Raven.Server.Documents.Indexes.Static.Spatial;
@@ -288,7 +289,7 @@ namespace Raven.Server.Documents.Indexes
         public bool IsOnBeforeExecuteIndexing { get; private set; }
 
         public TestIndexRun TestRun;
-        internal (SchemaValidator Validator, IDisposable ReturnCtx) _schemaValidator;
+        internal IndexSchemaValidatorsByCollection _schemaValidators;
         
         private HashSet<string> _fieldsReportedAsComplex = new();
         private bool _newComplexFieldsToReport = false;
@@ -408,7 +409,7 @@ namespace Raven.Server.Documents.Indexes
 
             exceptionAggregator.Execute(() => { _mre?.Dispose(); });
             
-            exceptionAggregator.Execute(() =>_schemaValidator.ReturnCtx?.Dispose());
+            exceptionAggregator.Execute(() =>_schemaValidators?.Dispose());
 
             exceptionAggregator.ThrowIfNeeded();
         }
@@ -874,12 +875,7 @@ namespace Raven.Server.Documents.Indexes
                 DocumentDatabase.Changes.OnIndexChange += HandleIndexChange;
 
                 if (Definition.SchemaValidation != null)
-                {
-                    _schemaValidator.ReturnCtx = _contextPool.AllocateOperationContext(out TransactionOperationContext context);
-                    var blittable = context.Sync.ReadForMemory(Definition.SchemaValidation, "schema-validation");
-                    
-                    _schemaValidator.Validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Definition.SchemaValidation);
-                }
+                    _schemaValidators = IndexSchemaValidatorsByCollection.Create(_contextPool, Definition.SchemaValidation);
                 
                 OnInitialization();
 

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using Raven.Client.Documents.DataArchival;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Extensions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -51,6 +52,8 @@ namespace Raven.Server.Documents.Indexes
         // fieldName, string
         public Dictionary<string, string> VectorFieldToEmbeddingGenerationTask;
 
+        public SchemaValidationConfiguration SchemaValidationConfiguration { get; protected set; }
+        
         public void Rename(string name, TransactionOperationContext context, StorageEnvironmentOptions options)
         {
             Name = name;

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Indexes
         // fieldName, string
         public Dictionary<string, string> VectorFieldToEmbeddingGenerationTask;
 
-        public string SchemaValidation { get; protected set; }
+        public IndexSchemaDefinitions SchemaValidation { get; protected init; }
         
         public void Rename(string name, TransactionOperationContext context, StorageEnvironmentOptions options)
         {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Indexes
         // fieldName, string
         public Dictionary<string, string> VectorFieldToEmbeddingGenerationTask;
 
-        public SchemaValidationConfiguration SchemaValidationConfiguration { get; protected set; }
+        public string SchemaValidation { get; protected set; }
         
         public void Rename(string name, TransactionOperationContext context, StorageEnvironmentOptions options)
         {

--- a/src/Raven.Server/Documents/Indexes/SchemaValidation/IndexSchemaValidatorsByCollection.cs
+++ b/src/Raven.Server/Documents/Indexes/SchemaValidation/IndexSchemaValidatorsByCollection.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.SchemaValidation;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Sync;
+
+namespace Raven.Server.Documents.Indexes.SchemaValidation;
+
+public sealed class IndexSchemaValidatorsByCollection : IDisposable
+{
+    private readonly Dictionary<string, SchemaValidator> _validators;
+
+    private readonly IDisposable _returnContext; // holds allocated TransactionOperationContext lifetime
+
+    private IndexSchemaValidatorsByCollection(IDisposable returnContext, Dictionary<string, SchemaValidator> validators)
+    {
+        _returnContext = returnContext;
+        _validators = validators;
+    }
+
+    public static IndexSchemaValidatorsByCollection Create(TransactionContextPool ctxPool, IndexSchemaDefinitions definitions)
+    {
+        var returnContext = ctxPool.AllocateOperationContext(out TransactionOperationContext context);
+        var validators = new Dictionary<string, SchemaValidator>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            foreach (var (collection, definition) in definitions)
+            {
+                var blittable = context.Sync.ReadForMemory(definition, "schema-validation");
+                var validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, definition);
+                validators[collection] = validator;
+            }
+
+            return new IndexSchemaValidatorsByCollection(returnContext, validators);
+        }
+        catch
+        {
+            returnContext.Dispose();
+            throw;
+        }
+    }
+
+    public bool TryGet(string collection, out SchemaValidator validator) => _validators.TryGetValue(collection, out validator);
+
+    public void Dispose()
+    {
+        _returnContext?.Dispose();
+        _validators.Clear();
+    }
+}
+

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -301,9 +301,6 @@ namespace Raven.Server.Documents.Indexes.Static
             if (schemaValidator == null)
                 throw new InvalidOperationException("Schema validation was not configured for this index.");
 
-            if(Current.Source is not DynamicBlittableJson dynamicBlittableJson || !ReferenceEquals(dynamicBlittableJson.BlittableJson, doc))
-                throw new InvalidOperationException("Schema validation can only be performed on the source document.");
-            
             return schemaValidator.Validate(doc, errorBuilder);
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -291,8 +291,7 @@ namespace Raven.Server.Documents.Indexes.Static
             
             if (ValidateSchema(doc, _schemaValidationErrorBuilder))
                 return DynamicNullObject.Null;
-
-            //TODO Maybe worth to avoid allocation by creating a LazyStringValue
+            
             return _schemaValidationErrorBuilder.GetErrors().ToString();
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -279,12 +279,7 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
-        public dynamic SchemaValid(BlittableJsonReaderObject doc)
-        {
-            return ValidateSchema(doc, null);
-        }
-        
-        public dynamic SchemaError(BlittableJsonReaderObject doc)
+        public string SchemaValid(BlittableJsonReaderObject doc)
         {
             _schemaValidationErrorBuilder ??= new ErrorBuilder(Current.IndexContext);
             _schemaValidationErrorBuilder.Reset();
@@ -295,7 +290,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return _schemaValidationErrorBuilder.GetErrors().ToString();
         }
 
-        private bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
+        private static bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
         {
             var schemaValidator = Current.Index._schemaValidator.validator;
             if (schemaValidator == null)

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Raven.Client;
 using Raven.Client.Documents.Attachments;
@@ -279,24 +280,31 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
 
-        public string SchemaValid(BlittableJsonReaderObject doc)
+        public string[] SchemaGetErrorsFor(BlittableJsonReaderObject doc)
         {
             _schemaValidationErrorBuilder ??= new ErrorBuilder(Current.IndexContext);
             _schemaValidationErrorBuilder.Reset();
             
-            if (ValidateSchema(doc, _schemaValidationErrorBuilder))
-                return DynamicNullObject.Null;
+            var enumerable = ValidateSchema(doc, _schemaValidationErrorBuilder)
+                ? []
+                : _schemaValidationErrorBuilder.GetErrors().ToArray();
             
-            return _schemaValidationErrorBuilder.GetErrors().ToString();
+            return enumerable;
         }
 
-        private static bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
+        private bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
         {
-            var schemaValidator = Current.Index._schemaValidator.Validator;
-            if (schemaValidator == null)
-                throw new InvalidOperationException("Schema validation was not configured for this index.");
-
-            return schemaValidator.Validate(doc, errorBuilder);
+            var collection = CollectionName.GetCollectionName(doc);
+            
+            var validators = Current.Index._schemaValidators;
+            if (validators == null)
+            {
+                var validatorCache = QueryContext.Documents.DocumentDatabase.SchemaValidatorCache;
+                return validatorCache.Validate(collection, doc, errorBuilder);
+            }
+            
+            return validators.TryGet(collection, out var validator) == false
+                   || validator.Validate(doc, errorBuilder);
         }
 
         private Slice GetIdSlice(LazyStringValue id)

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -297,12 +297,14 @@ namespace Raven.Server.Documents.Indexes.Static
 
         private bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
         {
-            var schemaValidators = Current.Index._schemaValidatorCache;
-            if (schemaValidators == null)
+            var schemaValidator = Current.Index._schemaValidator.validator;
+            if (schemaValidator == null)
                 throw new InvalidOperationException("Schema validation was not configured for this index.");
 
-            var collection = _documentsStorage.ExtractCollectionName(QueryContext.Documents, doc);
-            return schemaValidators.Validate(QueryContext.Documents, collection.Name, doc, errorBuilder);
+            if(Current.Source is not DynamicBlittableJson dynamicBlittableJson || !ReferenceEquals(dynamicBlittableJson.BlittableJson, doc))
+                throw new InvalidOperationException("Schema validation can only be performed on the source document.");
+            
+            return schemaValidator.Validate(doc, errorBuilder);
         }
 
         private Slice GetIdSlice(LazyStringValue id)

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -292,7 +292,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
         private static bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
         {
-            var schemaValidator = Current.Index._schemaValidator.validator;
+            var schemaValidator = Current.Index._schemaValidator.Validator;
             if (schemaValidator == null)
                 throw new InvalidOperationException("Schema validation was not configured for this index.");
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -10,7 +10,7 @@ using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Patch;
-using Raven.Server.Extensions;
+using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -28,6 +28,7 @@ namespace Raven.Server.Documents.Indexes.Static
         private IndexingStatsScope _loadAttachmentStats;
         private IndexingStatsScope _loadCompareExchangeValueStats;
         private JavaScriptUtils _javaScriptUtils;
+        private ErrorBuilder _schemaValidationErrorBuilder;
         private readonly DocumentsStorage _documentsStorage;
         public readonly QueryOperationContext QueryContext;
 
@@ -276,6 +277,33 @@ namespace Raven.Server.Documents.Indexes.Static
                 // we can't share one DynamicBlittableJson instance among all documents because we can have multiple LoadDocuments in a single scope
                 return new DynamicBlittableJson(document);
             }
+        }
+
+        public dynamic SchemaValid(BlittableJsonReaderObject doc)
+        {
+            return ValidateSchema(doc, null);
+        }
+        
+        public dynamic SchemaError(BlittableJsonReaderObject doc)
+        {
+            _schemaValidationErrorBuilder ??= new ErrorBuilder(Current.IndexContext);
+            _schemaValidationErrorBuilder.Reset();
+            
+            if (ValidateSchema(doc, _schemaValidationErrorBuilder))
+                return DynamicNullObject.Null;
+
+            //TODO Maybe worth to avoid allocation by creating a LazyStringValue
+            return _schemaValidationErrorBuilder.GetErrors().ToString();
+        }
+
+        private bool ValidateSchema(BlittableJsonReaderObject doc, ErrorBuilder errorBuilder)
+        {
+            var schemaValidators = Current.Index._schemaValidatorCache;
+            if (schemaValidators == null)
+                throw new InvalidOperationException("Schema validation was not configured for this index.");
+
+            var collection = _documentsStorage.ExtractCollectionName(QueryContext.Documents, doc);
+            return schemaValidators.Validate(QueryContext.Documents, collection.Name, doc, errorBuilder);
         }
 
         private Slice GetIdSlice(LazyStringValue id)

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -64,7 +64,6 @@ function map(name, lambda) {
             engine.SetClrFunc("counterNamesFor", CounterNamesFor);
             engine.SetClrFunc("loadAttachment", LoadAttachment);
             engine.SetClrFunc("loadAttachments", LoadAttachments);
-            engine.SetClrFunc("schemaValidate", SchemaValidate);
             engine.SetClrFunc("id", GetDocumentId);
             
             var schemaValidatorObject = new JsObject(engine);
@@ -207,12 +206,12 @@ function map(name, lambda) {
             return _javaScriptUtils.LoadAttachments(self, args);
         }
         
-        private JsValue SchemaValidate(JsValue self, JsValue[] args)
+        private JsValue GetErrorsFor(JsValue self, JsValue[] args)
         {
             var scope = CurrentIndexingScope.Current;
             scope.RegisterJavaScriptUtils(_javaScriptUtils);
             
-            return _javaScriptUtils.SchemaValidate(self, args);
+            return _javaScriptUtils.GetErrorsFor(self, args);
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -67,7 +67,7 @@ function map(name, lambda) {
             engine.SetClrFunc("id", GetDocumentId);
             
             var schemaValidatorObject = new JsObject(engine);
-            schemaValidatorObject.SetClfFunc("validate", SchemaValidate);
+            schemaValidatorObject.SetClfFunc("getErrorsFor", GetErrorsFor);
             engine.SetValue("schema", schemaValidatorObject);
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -66,6 +66,10 @@ function map(name, lambda) {
             engine.SetClrFunc("loadAttachments", LoadAttachments);
             engine.SetClrFunc("schemaValidate", SchemaValidate);
             engine.SetClrFunc("id", GetDocumentId);
+            
+            var schemaValidatorObject = new JsObject(engine);
+            schemaValidatorObject.FastSetProperty("validate", new PropertyDescriptor(new ClrFunction(engine, "validate", SchemaValidate), false, false, false));
+            engine.SetValue("schema", schemaValidatorObject);
         }
 
         protected override void ProcessMaps(ObjectInstance definitions, JintPreventResolvingTasksReferenceResolver resolver, List<string> mapList, List<MapMetadata> mapReferencedCollections, out Dictionary<string, Dictionary<string, List<JavaScriptMapOperation>>> collectionFunctions)

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -68,7 +68,7 @@ function map(name, lambda) {
             engine.SetClrFunc("id", GetDocumentId);
             
             var schemaValidatorObject = new JsObject(engine);
-            schemaValidatorObject.FastSetProperty("validate", new PropertyDescriptor(new ClrFunction(engine, "validate", SchemaValidate), false, false, false));
+            schemaValidatorObject.SetClfFunc("validate", SchemaValidate);
             engine.SetValue("schema", schemaValidatorObject);
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -23,7 +23,6 @@ using Raven.Server.Documents.Indexes.Static.TimeSeries;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Extensions;
 using Raven.Server.ServerWide;
-using Sparrow;
 using Sparrow.Server;
 
 namespace Raven.Server.Documents.Indexes.Static
@@ -65,6 +64,7 @@ function map(name, lambda) {
             engine.SetClrFunc("counterNamesFor", CounterNamesFor);
             engine.SetClrFunc("loadAttachment", LoadAttachment);
             engine.SetClrFunc("loadAttachments", LoadAttachments);
+            engine.SetClrFunc("schemaValidate", SchemaValidate);
             engine.SetClrFunc("id", GetDocumentId);
         }
 
@@ -201,6 +201,14 @@ function map(name, lambda) {
             scope.RegisterJavaScriptUtils(_javaScriptUtils);
 
             return _javaScriptUtils.LoadAttachments(self, args);
+        }
+        
+        private JsValue SchemaValidate(JsValue self, JsValue[] args)
+        {
+            var scope = CurrentIndexingScope.Current;
+            scope.RegisterJavaScriptUtils(_javaScriptUtils);
+            
+            return _javaScriptUtils.SchemaValidate(self, args);
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -28,6 +28,7 @@ namespace Raven.Server.Documents.Indexes.Static
             _hasDynamicFields = hasDynamicFields;
             _hasCompareExchange = hasCompareExchange;
             IndexDefinition = definition;
+            SchemaValidationConfiguration = definition.SchemaValidationConfiguration;
         }
 
         public override bool HasDynamicFields => _hasDynamicFields;

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Indexes.Static
             _hasDynamicFields = hasDynamicFields;
             _hasCompareExchange = hasCompareExchange;
             IndexDefinition = definition;
-            SchemaValidation = definition.SchemaValidation;
+            SchemaValidation = definition.SchemaDefinitions;
         }
 
         public override bool HasDynamicFields => _hasDynamicFields;

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Indexes.Static
             _hasDynamicFields = hasDynamicFields;
             _hasCompareExchange = hasCompareExchange;
             IndexDefinition = definition;
-            SchemaValidationConfiguration = definition.SchemaValidationConfiguration;
+            SchemaValidation = definition.SchemaValidation;
         }
 
         public override bool HasDynamicFields => _hasDynamicFields;

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/MapFunctionProcessor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/MapFunctionProcessor.cs
@@ -48,6 +48,7 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn
                 NullRewriter.Instance,
                 IsRewriter.Instance,
                 NoTrackingRewriter.Instance,
+                SchemaValidatorRewriter.Instance,
                 _vectorFieldRewriter,
             })
             {

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/SchemaValidatorRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/SchemaValidatorRewriter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
+{
+    public sealed class SchemaValidatorRewriter : CSharpSyntaxRewriter
+    {
+        public static readonly SchemaValidatorRewriter Instance = new SchemaValidatorRewriter();
+
+        private SchemaValidatorRewriter()
+        {
+        }
+
+        public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            var expression = node.Expression.ToString();
+            if (TryRemoveSchema(expression, out var newExpression) == false)
+                return base.VisitInvocationExpression(node);
+
+            var newNode = SyntaxFactory.ParseExpression(node.ToString().Replace(expression, newExpression));
+            return Visit(newNode);
+        }
+
+        private static bool TryRemoveSchema(string expression, out string result)
+        {
+            const string thisRef = "this.";
+            const string toStrip = "Schema.GetErrorsFor";
+            const string generatedMethodName = "SchemaGetErrorsFor";
+            
+            ReadOnlySpan<char> span = expression.AsSpan(expression.StartsWith(thisRef) ? thisRef.Length : 0);
+            if (span.StartsWith(toStrip))
+            {
+                result = expression.Replace(toStrip, generatedMethodName);
+                return true;
+            }
+            
+            result = null;
+            return false;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -179,10 +179,10 @@ namespace Raven.Server.Documents.Indexes.Static
                 : new DynamicArray(Enumerable.Empty<object>());
         }
         
-        protected dynamic SchemaValid(dynamic doc)
+        protected dynamic SchemaGetErrorsFor(dynamic doc)
         {
-            var json = EnsureSourceDocumentOrThrow(doc, nameof(SchemaValid));
-            return CurrentIndexingScope.Current.SchemaValid(json);
+            var json = EnsureSourceDocumentOrThrow(doc, "Schema.GetErrorsFor");
+            return CurrentIndexingScope.Current.SchemaGetErrorsFor(json);
         }
 
         private static BlittableJsonReaderObject EnsureSourceDocumentOrThrow(dynamic doc, string funcName)

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -184,8 +184,6 @@ namespace Raven.Server.Documents.Indexes.Static
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
             
-            //TODO Maybe validate this is a document
-            
             if (doc is not DynamicBlittableJson json)
             {
                 if (doc is DynamicNullObject)
@@ -204,14 +202,12 @@ namespace Raven.Server.Documents.Indexes.Static
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
             
-            //TODO Maybe validate this is a document
-            
             if (doc is not DynamicBlittableJson json)
             {
                 if (doc is DynamicNullObject)
                     return doc;
                 
-                ThrowInvalidDocType(doc, nameof(SchemaValid));
+                ThrowInvalidDocType(doc, nameof(SchemaError));
                 // never hit
                 return null;
             }

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -21,6 +22,7 @@ using Raven.Server.Documents.Indexes.Static.JavaScript;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Logging;
 using Raven.Server.Documents.Indexes.VectorSearch;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.Rachis.Commands;
 using Sparrow;
@@ -143,7 +145,7 @@ namespace Raven.Server.Documents.Indexes.Static
             // never hit
             return null;
         }
-        
+
         public dynamic AttachmentsFor(dynamic doc)
         {
             var metadata = MetadataFor(doc);
@@ -176,7 +178,48 @@ namespace Raven.Server.Documents.Indexes.Static
                 ? timeSeries
                 : new DynamicArray(Enumerable.Empty<object>());
         }
+        
+        protected dynamic SchemaValid(dynamic doc)
+        {
+            if (CurrentIndexingScope.Current == null)
+                throw new InvalidOperationException("Indexing scope was not initialized.");
+            
+            //TODO Maybe validate this is a document
+            
+            if (doc is not DynamicBlittableJson json)
+            {
+                if (doc is DynamicNullObject)
+                    return doc;
+                
+                ThrowInvalidDocType(doc, nameof(SchemaValid));
+                // never hit
+                return null;
+            }
 
+            return CurrentIndexingScope.Current.SchemaValid(json.BlittableJson);
+        }
+        
+        protected dynamic SchemaError(dynamic doc)
+        {
+            if (CurrentIndexingScope.Current == null)
+                throw new InvalidOperationException("Indexing scope was not initialized.");
+            
+            //TODO Maybe validate this is a document
+            
+            if (doc is not DynamicBlittableJson json)
+            {
+                if (doc is DynamicNullObject)
+                    return doc;
+                
+                ThrowInvalidDocType(doc, nameof(SchemaValid));
+                // never hit
+                return null;
+            }
+
+            return CurrentIndexingScope.Current.SchemaError(json.BlittableJson);
+        }
+
+        
         [DoesNotReturn]
         private static void ThrowInvalidDocType(dynamic doc, string funcName)
         {

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -184,12 +184,6 @@ namespace Raven.Server.Documents.Indexes.Static
             var json = EnsureSourceDocumentOrThrow(doc, nameof(SchemaValid));
             return CurrentIndexingScope.Current.SchemaValid(json);
         }
-        
-        protected dynamic SchemaError(dynamic doc)
-        {
-            var json = EnsureSourceDocumentOrThrow(doc, nameof(SchemaError));
-            return CurrentIndexingScope.Current.SchemaError(json);
-        }
 
         private static BlittableJsonReaderObject EnsureSourceDocumentOrThrow(dynamic doc, string funcName)
         {
@@ -208,7 +202,6 @@ namespace Raven.Server.Documents.Indexes.Static
                 throw new InvalidOperationException($"'{funcName}' can only be performed on the source document.");
             return json.BlittableJson;
         }
-
 
         [DoesNotReturn]
         private static void ThrowInvalidDocType(dynamic doc, string funcName)

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -181,41 +181,35 @@ namespace Raven.Server.Documents.Indexes.Static
         
         protected dynamic SchemaValid(dynamic doc)
         {
-            if (CurrentIndexingScope.Current == null)
-                throw new InvalidOperationException("Indexing scope was not initialized.");
-            
-            if (doc is not DynamicBlittableJson json)
-            {
-                if (doc is DynamicNullObject)
-                    return doc;
-                
-                ThrowInvalidDocType(doc, nameof(SchemaValid));
-                // never hit
-                return null;
-            }
-
-            return CurrentIndexingScope.Current.SchemaValid(json.BlittableJson);
+            var json = EnsureSourceDocumentOrThrow(doc, nameof(SchemaValid));
+            return CurrentIndexingScope.Current.SchemaValid(json);
         }
         
         protected dynamic SchemaError(dynamic doc)
         {
+            var json = EnsureSourceDocumentOrThrow(doc, nameof(SchemaError));
+            return CurrentIndexingScope.Current.SchemaError(json);
+        }
+
+        private static BlittableJsonReaderObject EnsureSourceDocumentOrThrow(dynamic doc, string funcName)
+        {
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
-            
+
             if (doc is not DynamicBlittableJson json)
             {
-                if (doc is DynamicNullObject)
-                    return doc;
-                
-                ThrowInvalidDocType(doc, nameof(SchemaError));
+                ThrowInvalidDocType(doc, funcName);
                 // never hit
                 return null;
             }
-
-            return CurrentIndexingScope.Current.SchemaError(json.BlittableJson);
+            
+            if(CurrentIndexingScope.Current.Source is not DynamicBlittableJson srcDoc 
+               || ReferenceEquals(srcDoc.BlittableJson, json.BlittableJson) == false)
+                throw new InvalidOperationException($"'{funcName}' can only be performed on the source document.");
+            return json.BlittableJson;
         }
 
-        
+
         [DoesNotReturn]
         private static void ThrowInvalidDocType(dynamic doc, string funcName)
         {

--- a/src/Raven.Server/Documents/Operations/OperationType.cs
+++ b/src/Raven.Server/Documents/Operations/OperationType.cs
@@ -83,5 +83,5 @@ public enum OperationType
     AdoptOrphanedRevisions,
     
     [Description("Validate Schema Validation")]
-    ValidateSchemaValidation
+    ValidateSchema
 }

--- a/src/Raven.Server/Documents/Operations/OperationType.cs
+++ b/src/Raven.Server/Documents/Operations/OperationType.cs
@@ -80,5 +80,8 @@ public enum OperationType
     Resharding,
 
     [Description("Adopt Orphaned Revisions")]
-    AdoptOrphanedRevisions
+    AdoptOrphanedRevisions,
+    
+    [Description("Validate Schema Validation")]
+    ValidateSchemaValidation
 }

--- a/src/Raven.Server/Documents/Operations/OperationType.cs
+++ b/src/Raven.Server/Documents/Operations/OperationType.cs
@@ -82,6 +82,6 @@ public enum OperationType
     [Description("Adopt Orphaned Revisions")]
     AdoptOrphanedRevisions,
     
-    [Description("Validate Schema Validation")]
+    [Description("Validate JSON Schema")]
     ValidateSchema
 }

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -366,6 +366,24 @@ namespace Raven.Server.Documents.Patch
             return value;
         }
 
+        internal JsValue SchemaValidate(JsValue self, JsValue[] args)
+        {
+            if (args.Length != 1)
+                throw new InvalidOperationException($"'schemaValidate' may only be called with one argument, but '{args.Length}' were passed.");
+
+            if (args[0].IsObject() == false || args[0].AsObject() is BlittableObjectInstance blitDoc == false)
+                throw new InvalidOperationException($"'schemaValidate' may only be called with an object non-null entity as a parameter, but was called with a parameter of type {args[0].GetType().FullName}.");
+
+            if (CurrentIndexingScope.Current == null)
+                throw new InvalidOperationException("Indexing scope was not initialized.");
+            
+            if(CurrentIndexingScope.Current.Source is not DynamicBlittableJson srcDoc 
+               || ReferenceEquals(srcDoc.BlittableJson, blitDoc.Blittable) == false)
+                throw new InvalidOperationException("'schemaValidate' can only be performed on the source document.");
+
+            return CurrentIndexingScope.Current.SchemaValid(blitDoc.Blittable);
+        }
+
         internal JsValue TranslateToJs(Engine engine, JsonOperationContext context, object o, bool needsClone = true)
         {
             if (o is TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult tsrr)

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -366,22 +366,28 @@ namespace Raven.Server.Documents.Patch
             return value;
         }
 
-        internal JsValue SchemaValidate(JsValue self, JsValue[] args)
+        internal JsValue GetErrorsFor(JsValue self, JsValue[] args)
         {
             if (args.Length != 1)
-                throw new InvalidOperationException($"'schema.validate' may only be called with one argument, but '{args.Length}' were passed.");
+                throw new InvalidOperationException($"'schema.GetErrorsFor' may only be called with one argument, but '{args.Length}' were passed.");
 
             if (args[0].IsObject() == false || args[0].AsObject() is BlittableObjectInstance blitDoc == false)
-                throw new InvalidOperationException($"'schema.validate' may only be called with an object non-null entity as a parameter, but was called with a parameter of type {args[0].GetType().FullName}.");
+                throw new InvalidOperationException($"'schema.GetErrorsFor' may only be called with an object non-null entity as a parameter, but was called with a parameter of type {args[0].GetType().FullName}.");
 
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
             
             if(CurrentIndexingScope.Current.Source is not DynamicBlittableJson srcDoc 
                || ReferenceEquals(srcDoc.BlittableJson, blitDoc.Blittable) == false)
-                throw new InvalidOperationException("'schema.validate' can only be performed on the source document.");
+                throw new InvalidOperationException("'schema.GetErrorsFor' can only be performed on the source document.");
 
-            return CurrentIndexingScope.Current.SchemaValid(blitDoc.Blittable);
+            var errors = CurrentIndexingScope.Current.SchemaGetErrorsFor(blitDoc.Blittable);
+            var jsValues = new JsValue[errors.Length];
+            for (int i = 0; i < errors.Length; i++)
+            {
+                jsValues[i] = errors[i];
+            }
+            return new JsArray(_scriptEngine, jsValues);
         }
 
         internal JsValue TranslateToJs(Engine engine, JsonOperationContext context, object o, bool needsClone = true)

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -369,17 +369,17 @@ namespace Raven.Server.Documents.Patch
         internal JsValue SchemaValidate(JsValue self, JsValue[] args)
         {
             if (args.Length != 1)
-                throw new InvalidOperationException($"'schemaValidate' may only be called with one argument, but '{args.Length}' were passed.");
+                throw new InvalidOperationException($"'schema.validate' may only be called with one argument, but '{args.Length}' were passed.");
 
             if (args[0].IsObject() == false || args[0].AsObject() is BlittableObjectInstance blitDoc == false)
-                throw new InvalidOperationException($"'schemaValidate' may only be called with an object non-null entity as a parameter, but was called with a parameter of type {args[0].GetType().FullName}.");
+                throw new InvalidOperationException($"'schema.validate' may only be called with an object non-null entity as a parameter, but was called with a parameter of type {args[0].GetType().FullName}.");
 
             if (CurrentIndexingScope.Current == null)
                 throw new InvalidOperationException("Indexing scope was not initialized.");
             
             if(CurrentIndexingScope.Current.Source is not DynamicBlittableJson srcDoc 
                || ReferenceEquals(srcDoc.BlittableJson, blitDoc.Blittable) == false)
-                throw new InvalidOperationException("'schemaValidate' can only be performed on the source document.");
+                throw new InvalidOperationException("'schema.validate' can only be performed on the source document.");
 
             return CurrentIndexingScope.Current.SchemaValid(blitDoc.Blittable);
         }

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/AbstractBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/AbstractBuffer.cs
@@ -31,6 +31,12 @@ public abstract class AbstractBuffer<T> : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<T> AsSpan() => BufferAsSpan()[..Length];
 
+    public T this[int index]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => BufferAsSpan()[index];
+    }
+
     protected abstract Span<T> BufferAsSpan();
 
     public abstract void CheckAndGrow(int minRequired);

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/AbstractBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/AbstractBuffer.cs
@@ -35,5 +35,7 @@ public abstract class AbstractBuffer<T> : IDisposable
 
     public abstract void CheckAndGrow(int minRequired);
     
+    public void Reset() => Length = 0;
+    
     public abstract void Dispose();
 }

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuffer.cs
@@ -75,6 +75,8 @@ public class ErrorBuffer : IErrorBuffer
         return this;
     }
 
+    public void Reset() => _buffer.Reset();
+    
     public override string ToString() => new string(_buffer.AsSpan());
 
     public void Dispose() => _buffer.Dispose();

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuffer.cs
@@ -9,6 +9,8 @@ namespace Raven.Server.Documents.SchemaValidation.ErrorMessage;
 public class ErrorBuffer : IErrorBuffer
 {
     private readonly AbstractBuffer<char> _buffer;
+
+    public int Length => _buffer.Length;
     
     public ErrorBuffer(AbstractBuffer<char> buffer)
     {

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
@@ -148,6 +148,8 @@ public class ErrorBuilder : IDisposable
         return this;
     }
     
+    public void Reset() => _errorBuffer.Reset();
+    
     public override string ToString() => _errorBuffer?.ToString();
     
     [InterpolatedStringHandler]

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Sparrow.Json;
@@ -9,74 +10,98 @@ namespace Raven.Server.Documents.SchemaValidation.ErrorMessage;
 
 public class ErrorBuilder : IDisposable
 {
-    private readonly IErrorBuffer _errorBuffer;
-
+    private static readonly string NewErrorDelimiter = Environment.NewLine;
+    
+    private readonly AbstractBuffer<int> _errorOffsets;
+    public readonly IErrorBuffer ErrorBuffer;
+        
     public ValidationPath Path { get; }
 
-    public ErrorBuilder(RentedBuffer<char> innerBuffer)
-    {
-        _errorBuffer = new ErrorBuffer(innerBuffer);
-        Path = new ValidationPath();
-    }
-    
     public ErrorBuilder()
     {
         var innerBuffer = new RentedBuffer<char>();
-        _errorBuffer = new ErrorBuffer(innerBuffer);
+        ErrorBuffer = new ErrorBuffer(innerBuffer);
+        _errorOffsets = new RentedBuffer<int>();
         Path = new ValidationPath();
     }
     
     public ErrorBuilder(ByteStringContext allocator)
     {
         var innerBuffer = new ByteStringContextBuffer<char>(allocator);
-        _errorBuffer = new ErrorBuffer(innerBuffer);
+        ErrorBuffer = new ErrorBuffer(innerBuffer);
+        _errorOffsets = new ByteStringContextBuffer<int>(allocator);
         Path = new ValidationPath(allocator);
     }
     
     public ErrorBuilder(JsonOperationContext context)
     {
         var innerBuffer = new JsonOperationContextBuffer<char>(context);
-        _errorBuffer = new ErrorBuffer(innerBuffer);
+        ErrorBuffer = new ErrorBuffer(innerBuffer);
+        _errorOffsets = new JsonOperationContextBuffer<int>(context);
         Path = new ValidationPath(context);
     }
+
+    public ReadOnlySpan<char> GetError() => ErrorBuffer.AsSpan();
     
-    public ReadOnlySpan<char> GetErrors() => _errorBuffer.AsSpan();
-    
-    public void FinishErrorMessage() => Append(Environment.NewLine);
+    public IEnumerable<string> GetErrors()
+    {
+        var span = ErrorBuffer.AsSpan();
+        if (span.IsEmpty)
+            yield break;
+
+        var startIndex = 0;
+        for(var i = 0; i < _errorOffsets.Length; i++)
+        {
+            var offset = _errorOffsets[i];
+            Debug.Assert(offset < ErrorBuffer.Length);
+
+            yield return ErrorBuffer.AsSpan().Slice(startIndex, offset - startIndex).ToString();
+            startIndex = offset + NewErrorDelimiter.Length;
+        }
+        
+        if(startIndex < ErrorBuffer.Length)
+            yield return ErrorBuffer.AsSpan()[startIndex..].ToString();
+    }
+
+    public void FinishErrorMessage()
+    {
+        _errorOffsets.Append(ErrorBuffer.Length);
+        Append(NewErrorDelimiter);
+    }
 
     public ErrorBuilder Append(string value)
     {
-        _errorBuffer.Append(value);
+        ErrorBuffer.Append(value);
         return this;
     }
     public ErrorBuilder Append(BlittableJsonReaderObject value)
     {
-        _errorBuffer.Append(value);
+        ErrorBuffer.Append(value);
         return this;
     }
     public ErrorBuilder Append(LazyStringValue value)
     {
-        _errorBuffer.AppendUtf8(value.AsSpan());
+        ErrorBuffer.AppendUtf8(value.AsSpan());
         return this;
     }
     public ErrorBuilder Append(ValidationPath value)
     {
-        _errorBuffer.Append(value.AsSpan());
+        ErrorBuffer.Append(value.AsSpan());
         return this;
     }
     public ErrorBuilder Append(Regex value)
     {
-        _errorBuffer.Append(value.ToString());
+        ErrorBuffer.Append(value.ToString());
         return this;
     }
     public ErrorBuilder Append(bool value)
     {
-        _errorBuffer.Append(value.ToString());
+        ErrorBuffer.Append(value.ToString());
         return this;
     }
     public ErrorBuilder Append(ISpanFormattable value)
     {
-        _errorBuffer.Append(value);
+        ErrorBuffer.Append(value);
         return this;
     }
     public ErrorBuilder Append(IEnumerable<string> value, string format)
@@ -85,9 +110,9 @@ public class ErrorBuilder : IDisposable
         foreach (var v in value)
         {
             if (first == false)
-                _errorBuffer.Append(format);
+                ErrorBuffer.Append(format);
             first = false;
-            _errorBuffer.Append(v);
+            ErrorBuffer.Append(v);
         }
         return this;
     } 
@@ -97,7 +122,7 @@ public class ErrorBuilder : IDisposable
         foreach (var v in value)
         {
             if (first == false)
-                _errorBuffer.Append(format);
+                ErrorBuffer.Append(format);
             first = false;
             switch (v)
             {
@@ -138,21 +163,26 @@ public class ErrorBuilder : IDisposable
                 break;
             case string:
             case null:
-                _errorBuffer.Append((string)value);
+                ErrorBuffer.Append((string)value);
                 break;
             default:
-                _errorBuffer.Append(value);
+                ErrorBuffer.Append(value);
                 break;
         }
 
         return this;
     }
-    
-    public void Reset() => _errorBuffer.Reset();
 
-    public LazyStringValue ToLazyStringValue(JsonOperationContext context) => context.GetLazyString(GetErrors(), null, false);
+    public void Reset()
+    {
+        ErrorBuffer.Reset();
+        _errorOffsets.Reset();
+        Path.Reset();
+    }
+
+    public LazyStringValue ToLazyStringValue(JsonOperationContext context) => context.GetLazyString(GetError(), null, false);
     
-    public override string ToString() => _errorBuffer?.ToString();
+    public override string ToString() => ErrorBuffer?.ToString();
     
     [InterpolatedStringHandler]
     public readonly ref struct ErrorInterpolatedStringHandler
@@ -179,7 +209,8 @@ public class ErrorBuilder : IDisposable
 
     public void Dispose()
     {
-        _errorBuffer?.Dispose();
+        ErrorBuffer?.Dispose();
+        _errorOffsets.Dispose();
         Path.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
@@ -150,7 +150,7 @@ public class ErrorBuilder : IDisposable
     
     public void Reset() => _errorBuffer.Reset();
 
-    public LazyStringValue ToLazyStringValue(JsonOperationContext context) => context.GetLazyString(GetErrors(), false);
+    public LazyStringValue ToLazyStringValue(JsonOperationContext context) => context.GetLazyString(GetErrors(), null, false);
     
     public override string ToString() => _errorBuffer?.ToString();
     

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
@@ -149,6 +149,8 @@ public class ErrorBuilder : IDisposable
     }
     
     public void Reset() => _errorBuffer.Reset();
+
+    public LazyStringValue ToLazyStringValue(JsonOperationContext context) => context.GetLazyString(GetErrors(), false);
     
     public override string ToString() => _errorBuffer?.ToString();
     

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/IErrorBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/IErrorBuffer.cs
@@ -12,4 +12,5 @@ public interface IErrorBuffer : IDisposable
     IErrorBuffer Append(BlittableJsonReaderObject value);
     IErrorBuffer Append(ISpanFormattable value);
     IErrorBuffer Append(object value);
+    void Reset();
 }

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/IErrorBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/IErrorBuffer.cs
@@ -5,6 +5,7 @@ namespace Raven.Server.Documents.SchemaValidation.ErrorMessage;
 
 public interface IErrorBuffer : IDisposable
 {
+    public int Length { get; }
     ReadOnlySpan<char> AsSpan();
     IErrorBuffer Append(string value);
     IErrorBuffer AppendUtf8(ReadOnlySpan<byte> value);

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.SchemaValidation;
 
@@ -219,5 +220,37 @@ public static class SchemaValidationHelper
             throw new InvalidOperationException($"'{rule}' must to convertable to {nameof(T)} here. Should not happen");
 
         return true;
+    }
+    
+    public static void EnsureMetadataIsValid(JsonOperationContext context, ref BlittableJsonReaderObject blittable)
+    {
+        if (blittable.TryGet(SchemaValidatorConstants.AdditionalProperties, out object additionalProperties) == false 
+            || additionalProperties is true)
+            //If additional properties are allowed, no problematic restriction on metadata is can be.
+            return;
+
+        if (blittable.TryGet(SchemaValidatorConstants.Properties, out BlittableJsonReaderObject properties)
+            && properties.Contains(Client.Constants.Documents.Metadata.Key))
+            //If explicit restriction on metadata is configured we don't verify it in this point.
+            return;
+        
+        
+        object newProperties;
+        if (properties == null)
+        {
+            newProperties = new DynamicJsonValue { [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue() };
+        }
+        else
+        {
+            properties.Modifications = new DynamicJsonValue(properties) { [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue() };
+            newProperties = properties;
+        }
+        
+        blittable.Modifications = new DynamicJsonValue(blittable) { [SchemaValidatorConstants.Properties] = newProperties };
+
+        using (_ = blittable)
+        {
+            blittable = context.ReadObject(blittable, "modified-schema-validation");
+        }
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
@@ -234,9 +234,13 @@ public static class SchemaValidationHelper
     
     private static void ExcludeMetadata(JsonOperationContext context, ref BlittableJsonReaderObject blittable)
     {
+        object[] excludedProperties = [Constants.Documents.Metadata.Key];
+        if (blittable.TryGet(SchemaValidatorConstants.ExcludedProperties, out BlittableJsonReaderArray blitExcludedProperties))
+            excludedProperties = blitExcludedProperties.Select(x => x).Concat(excludedProperties).ToArray();
+        
         blittable.Modifications = new DynamicJsonValue(blittable)
         {
-            [SchemaValidatorConstants.ExcludedProperties] = new [] {Constants.Documents.Metadata.Id},
+            [SchemaValidatorConstants.ExcludedProperties] = excludedProperties,
         };
         
         using (_ = blittable)

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Raven.Client;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Sparrow;
 using Sparrow.Json;
@@ -221,36 +222,33 @@ public static class SchemaValidationHelper
 
         return true;
     }
-    
-    public static void EnsureMetadataIsValid(JsonOperationContext context, ref BlittableJsonReaderObject blittable)
+
+    public static SchemaValidator InitValidatorForDocument(JsonOperationContext context, BlittableJsonReaderObject definition, string strDefinition)
     {
-        if (blittable.TryGet(SchemaValidatorConstants.AdditionalProperties, out object additionalProperties) == false 
-            || additionalProperties is true)
-            //If additional properties are allowed, no problematic restriction on metadata is can be.
-            return;
-
-        if (blittable.TryGet(SchemaValidatorConstants.Properties, out BlittableJsonReaderObject properties)
-            && properties.Contains(Client.Constants.Documents.Metadata.Key))
-            //If explicit restriction on metadata is configured we don't verify it in this point.
-            return;
-        
-        
-        object newProperties;
-        if (properties == null)
+        var validator = new SchemaValidator { SchemaDefinition = strDefinition };
+        ValidateSchemaDefinitionForDocument(definition);
+        ExcludeMetadata(context, ref definition);
+        validator.Init(definition);
+        return validator;
+    }
+    
+    private static void ExcludeMetadata(JsonOperationContext context, ref BlittableJsonReaderObject blittable)
+    {
+        blittable.Modifications = new DynamicJsonValue(blittable)
         {
-            newProperties = new DynamicJsonValue { [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue() };
-        }
-        else
-        {
-            properties.Modifications = new DynamicJsonValue(properties) { [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue() };
-            newProperties = properties;
-        }
+            [SchemaValidatorConstants.ExcludedProperties] = new [] {Constants.Documents.Metadata.Id},
+        };
         
-        blittable.Modifications = new DynamicJsonValue(blittable) { [SchemaValidatorConstants.Properties] = newProperties };
-
         using (_ = blittable)
         {
-            blittable = context.ReadObject(blittable, "modified-schema-validation");
+            blittable = context.ReadObject(blittable, "schema-validation-metadata-excluded");
         }
+    }
+
+    public static void ValidateSchemaDefinitionForDocument(BlittableJsonReaderObject blittable)
+    {
+        if (blittable.TryGet(SchemaValidatorConstants.Properties, out BlittableJsonReaderObject properties)
+            && properties.Contains(Constants.Documents.Metadata.Key))
+            throw new InvalidOperationException("Define a schema validation on metadata is not allowed.");
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
@@ -13,9 +13,6 @@ public class SchemaValidator
     public readonly bool Disabled;
 
     private ElementSchemaRuleValidator _root;
-    //The context is only written during the initialization phase. During validation, it is used for reading only and can be used in parallel.
-    private readonly SingleUseFlag _disposing = new SingleUseFlag();
-    
     public string SchemaDefinition { get; set; }
 
     public SchemaValidator(bool disabled = false)
@@ -23,7 +20,7 @@ public class SchemaValidator
         Disabled = disabled;
     }
     
-    // TODO: add a comment about the blittable lifetime
+    // The caller (holder) is responsible for keeping the underlying Blittable / context alive (and disposing it) for as long as this SchemaValidator is used.
     public void Init(BlittableJsonReaderObject schemaDefinition)
     {
         var refSchemas = new RefSchemas();
@@ -34,8 +31,6 @@ public class SchemaValidator
 
     public bool Validate(BlittableJsonReaderObject obj, ErrorBuilder errorBuilder)
     {
-        ObjectDisposedException.ThrowIf(_disposing.IsRaised(), nameof(SchemaValidator));
-
         return _root.Validate(obj, errorBuilder);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -107,7 +107,7 @@ public class SchemaValidatorCache : IDisposable
             throw new SchemaValidationException(error);
     }
 
-    public bool Validate(JsonOperationContext context, string collection, BlittableJsonReaderObject document, out string error)
+    private bool Validate(JsonOperationContext context, string collection, BlittableJsonReaderObject document, out string error)
     {
         error = null;
         if (_schemaValidatorsPerCollection == null || _disabled)
@@ -124,12 +124,12 @@ public class SchemaValidatorCache : IDisposable
             if (validator.Validate(document, errorBuilder))
                 return true;
 
-            error = errorBuilder.GetErrors().ToString();
+            error = errorBuilder.GetError().ToString();
             return false;
         }
     }
 
-    public bool Validate(JsonOperationContext context, string collection, BlittableJsonReaderObject document, ErrorBuilder errorBuilder)
+    public bool Validate(string collection, BlittableJsonReaderObject document, ErrorBuilder errorBuilder)
     {
         if (_schemaValidatorsPerCollection == null || _disabled)
             return true;

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -21,9 +21,17 @@ public class SchemaValidatorCache : IDisposable
     private FrozenDictionary<string, SchemaValidator> _schemaValidatorsPerCollection = EmptyCache;
     private bool _disabled;
 
-    public SchemaValidatorCache(DocumentsContextPool contextPool, RavenLogger logger)
+    public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, RavenLogger logger)
+        where T : JsonOperationContext
     {
-        _context.Return = contextPool.AllocateOperationContext(out _context.Value);
+        var returnContext = contextPool.AllocateOperationContext(out JsonOperationContext context);
+        return new SchemaValidatorCache(returnContext, context, logger);
+    }
+    
+    private SchemaValidatorCache(IDisposable returnCtx, JsonOperationContext ctx, RavenLogger logger)
+    {
+        _context.Return = returnCtx;
+        _context.Value = ctx;
         _logger = logger;
     }
 
@@ -111,29 +119,51 @@ public class SchemaValidatorCache : IDisposable
             blittable = _context.Value.ReadObject(blittable, "modified-schema-validation");
     }
 
-    public void Validate(string collection, BlittableJsonReaderObject document, NonPersistentDocumentFlags nonPersistentFlags, DocumentsOperationContext context)
+    public void Validate(string collection, BlittableJsonReaderObject document, NonPersistentDocumentFlags nonPersistentFlags, JsonOperationContext context)
     {
         // TODO: check if we need to add more flags here
         if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) ||
             nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromResharding))
             return;
 
+        if (Validate(context, collection, document, out var error) == false)
+            throw new SchemaValidationException(error);
+    }
+
+    public bool Validate(JsonOperationContext context, string collection, BlittableJsonReaderObject document, out string error)
+    {
+        error = null;
         if (_schemaValidatorsPerCollection == null || _disabled)
-            return;
+            return true;
 
         if (_schemaValidatorsPerCollection.TryGetValue(collection, out var validator) == false)
-            return;
+            return true;
 
         if (validator.Disabled)
-            return;
+            return true;
 
         using (var errorBuilder = new ErrorBuilder(context))
         {
             if (validator.Validate(document, errorBuilder))
-                return;
+                return true;
 
-            throw new SchemaValidationException(errorBuilder.GetErrors().ToString());
+            error = errorBuilder.GetErrors().ToString();
+            return false;
         }
+    }
+
+    public bool Validate(JsonOperationContext context, string collection, BlittableJsonReaderObject document, ErrorBuilder errorBuilder)
+    {
+        if (_schemaValidatorsPerCollection == null || _disabled)
+            return true;
+
+        if (_schemaValidatorsPerCollection.TryGetValue(collection, out var validator) == false)
+            return true;
+
+        if (validator.Disabled)
+            return true;
+
+        return validator.Validate(document, errorBuilder);
     }
 
     public void Dispose()

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -21,7 +21,7 @@ public class SchemaValidatorCache : IDisposable
     private readonly RavenLogger _logger;
     private readonly (IDisposable Return, JsonOperationContext Value) _context;
     private FrozenDictionary<string, SchemaValidator> _schemaValidatorsPerCollection = EmptyCache;
-    private bool _disabled;
+    public bool Disabled { get; private set; } = true;
 
     public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, DatabaseNotificationCenter notificationCenter, RavenLogger logger)
         where T : JsonOperationContext
@@ -43,7 +43,7 @@ public class SchemaValidatorCache : IDisposable
         if (configuration == null)
             return;
 
-        _disabled = configuration.Disabled;
+        Disabled = configuration.Disabled;
 
         if (configuration.ValidatorsPerCollection == null || configuration.ValidatorsPerCollection.Count == 0)
         {
@@ -110,7 +110,7 @@ public class SchemaValidatorCache : IDisposable
     private bool Validate(JsonOperationContext context, string collection, BlittableJsonReaderObject document, out string error)
     {
         error = null;
-        if (_schemaValidatorsPerCollection == null || _disabled)
+        if (_schemaValidatorsPerCollection == null || Disabled)
             return true;
 
         if (_schemaValidatorsPerCollection.TryGetValue(collection, out var validator) == false)
@@ -131,7 +131,7 @@ public class SchemaValidatorCache : IDisposable
 
     public bool Validate(string collection, BlittableJsonReaderObject document, ErrorBuilder errorBuilder)
     {
-        if (_schemaValidatorsPerCollection == null || _disabled)
+        if (_schemaValidatorsPerCollection == null || Disabled)
             return true;
 
         if (_schemaValidatorsPerCollection.TryGetValue(collection, out var validator) == false)
@@ -141,6 +141,20 @@ public class SchemaValidatorCache : IDisposable
             return true;
 
         return validator.Validate(document, errorBuilder);
+    }
+    
+    public bool IsSchemaEnabledForAny(string[] collections)
+    {
+        if (Disabled)
+            return false;
+
+        foreach (var collection in collections)
+        {
+            if (_schemaValidatorsPerCollection.TryGetValue(collection, out var validator) && validator.Disabled == false)
+                return true;
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -73,7 +73,7 @@ public class SchemaValidatorCache : IDisposable
                     _logger.Error(errorMessage, e);
 
                 const string title = "Schema Validation Configuration";
-                var alert = AlertRaised.Create(_notificationCenter.Database, title, errorMessage, AlertType.SchemaValidationConfiguration_Error, NotificationSeverity.Error, details:new ExceptionDetails(e));
+                var alert = AlertRaised.Create(_notificationCenter.Database, title, errorMessage, AlertReason.SchemaValidationConfiguration_Error, NotificationSeverity.Error, details:new ExceptionDetails(e));
                 _notificationCenter.Add(alert);
                 
                 continue;

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -61,7 +61,7 @@ public class SchemaValidatorCache : IDisposable
             try
             {
                 var blittable = _context.Value.Sync.ReadForMemory(validator.Schema, "schema-validation");
-                EnsureMetadataIsValid(ref blittable);
+                SchemaValidationHelper.EnsureMetadataIsValid(_context.Value, ref blittable);
                 schemaValidator.Init(blittable);
             }
             catch (Exception e)
@@ -87,36 +87,6 @@ public class SchemaValidatorCache : IDisposable
 
         if (newSchemaValidators != null)
             _schemaValidatorsPerCollection = newSchemaValidators.ToFrozenDictionary();
-    }
-
-    private void EnsureMetadataIsValid(ref BlittableJsonReaderObject blittable)
-    {
-        if (blittable.TryGet(SchemaValidatorConstants.AdditionalProperties, out object additionalProperties) == false 
-            || additionalProperties is true)
-            //If additional properties are allowed, no problematic restriction on metadata is can be.
-            return;
-
-        if (blittable.TryGet(SchemaValidatorConstants.Properties, out BlittableJsonReaderObject properties)
-            && properties.Contains(Client.Constants.Documents.Metadata.Key))
-            //If explicit restriction on metadata is configured we don't verify it in this point.
-            return;
-        
-        
-        object newProperties;
-        if (properties == null)
-        {
-            newProperties = new DynamicJsonValue { [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue() };
-        }
-        else
-        {
-            properties.Modifications = new DynamicJsonValue(properties) { [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue() };
-            newProperties = properties;
-        }
-        
-        blittable.Modifications = new DynamicJsonValue(blittable) { [SchemaValidatorConstants.Properties] = newProperties };
-
-        using (_ = blittable)
-            blittable = _context.Value.ReadObject(blittable, "modified-schema-validation");
     }
 
     public void Validate(string collection, BlittableJsonReaderObject document, NonPersistentDocumentFlags nonPersistentFlags, JsonOperationContext context)

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -4,9 +4,10 @@ using System.Collections.Generic;
 using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Exceptions.SchemaValidation;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
-using Raven.Server.ServerWide.Context;
+using Raven.Server.NotificationCenter;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Server.Logging;
 
@@ -15,23 +16,25 @@ namespace Raven.Server.Documents.SchemaValidation;
 public class SchemaValidatorCache : IDisposable
 {
     private static readonly FrozenDictionary<string, SchemaValidator> EmptyCache = Array.Empty<KeyValuePair<string, SchemaValidator>>().ToFrozenDictionary();
-    
+
+    private readonly DatabaseNotificationCenter _notificationCenter;
     private readonly RavenLogger _logger;
     private readonly (IDisposable Return, JsonOperationContext Value) _context;
     private FrozenDictionary<string, SchemaValidator> _schemaValidatorsPerCollection = EmptyCache;
     private bool _disabled;
 
-    public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, RavenLogger logger)
+    public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, DatabaseNotificationCenter notificationCenter, RavenLogger logger)
         where T : JsonOperationContext
     {
         var returnContext = contextPool.AllocateOperationContext(out JsonOperationContext context);
-        return new SchemaValidatorCache(returnContext, context, logger);
+        return new SchemaValidatorCache(returnContext, context, notificationCenter, logger);
     }
     
-    private SchemaValidatorCache(IDisposable returnCtx, JsonOperationContext ctx, RavenLogger logger)
+    private SchemaValidatorCache(IDisposable returnCtx, JsonOperationContext ctx, DatabaseNotificationCenter notificationCenter, RavenLogger logger)
     {
         _context.Return = returnCtx;
         _context.Value = ctx;
+        _notificationCenter = notificationCenter;
         _logger = logger;
     }
 
@@ -50,25 +53,29 @@ public class SchemaValidatorCache : IDisposable
 
         Dictionary<string, SchemaValidator> newSchemaValidators = null;
         
-        foreach ((string collection, Client.Documents.Operations.SchemaValidation.SchemaDefinition validator) in configuration.ValidatorsPerCollection)
+        foreach ((string collection, SchemaDefinition validator) in configuration.ValidatorsPerCollection)
         {
             if (_schemaValidatorsPerCollection.TryGetValue(collection, out var existingValidator)
                 && validator.Schema.Equals(existingValidator.SchemaDefinition))
                 continue;
 
-            var schemaValidator = new SchemaValidator(validator.Disabled) { SchemaDefinition = validator.Schema };
-
+            SchemaValidator schemaValidator;
             try
             {
                 var blittable = _context.Value.Sync.ReadForMemory(validator.Schema, "schema-validation");
-                SchemaValidationHelper.EnsureMetadataIsValid(_context.Value, ref blittable);
-                schemaValidator.Init(blittable);
+                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context.Value, blittable, validator.Schema);
             }
             catch (Exception e)
             {
+                var errorMessage = $"Failed to parse the schema validator for collection {collection}";
+                
                 if (_logger.IsErrorEnabled)
-                    _logger.Error($"Failed to parse the schema validator for collection {collection}", e);
+                    _logger.Error(errorMessage, e);
 
+                const string title = "Schema Validation Configuration";
+                var alert = AlertRaised.Create(_notificationCenter.Database, title, errorMessage, AlertType.SchemaValidationConfiguration_Error, NotificationSeverity.Error, details:new ExceptionDetails(e));
+                _notificationCenter.Add(alert);
+                
                 continue;
             }
 

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorConstants.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorConstants.cs
@@ -31,6 +31,7 @@ internal static class SchemaValidatorConstants
     public const string MinProperties = "minProperties";
     public const string PropertyNames = "propertyNames";
     public const string Required = "required";
+    public const string ExcludedProperties = "x-excludedProperties";
     #endregion
     
     #region Array

--- a/src/Raven.Server/Documents/SchemaValidation/ValidationPath.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ValidationPath.cs
@@ -61,6 +61,13 @@ public class ValidationPath :IDisposable
         _path.Trim(toRemove);
     }
 
+    public void Reset()
+    {
+        _toString = null;
+        _sizes.Reset();
+        _path.Reset();
+    }
+    
     public ReadOnlySpan<char> AsSpan() => _path.AsSpan();
     public override string ToString() => _toString ??= _path.ToString();
 

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
@@ -27,7 +27,7 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
         _schemaPath = schemaPath;
         _exclude = exclude?.ToHashSet();
 
-        if (exclude != null)
+        if (exclude != null && _namedPropertyValidators != null)
         {
             foreach (var lazyStringValue in exclude)
             {

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
@@ -13,7 +13,7 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Object;
 public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderObject>
 {
     private readonly SchemaPath _schemaPath;
-    private readonly LazyStringValue[] _exclude;
+    private readonly HashSet<LazyStringValue> _exclude;
     private readonly Dictionary<LazyStringValue, ElementSchemaRuleValidator> _namedPropertyValidators;
     private readonly (Regex Regex, ElementSchemaRuleValidator Validator)[] _patternPropertiesValidators;
     private readonly (bool Allowed, ElementSchemaRuleValidator Validator) _additionalPropertiesValidator;
@@ -25,7 +25,7 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
         _patternPropertiesValidators = pattern;
         _additionalPropertiesValidator = additional;
         _schemaPath = schemaPath;
-        _exclude = exclude;
+        _exclude = exclude?.ToHashSet();
 
         if (exclude != null)
         {
@@ -106,24 +106,6 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
         }
 
         return isValid;
-    }
-
-    private bool ShouldExclude(LazyStringValue prop)
-    {
-        if(_exclude != null)
-            return true;
-
-        var ret = false;
-        foreach (var ex in _exclude)
-        {
-            if(prop.Equals(ex))
-            if (string.Equals(ex, prop, StringComparison.Ordinal))
-            {
-                ret = true;
-                break;
-            }
-        }
-        return false;
     }
 
     private static bool ValidateProperty(ElementSchemaRuleValidator validator, BlittableJsonReaderObject value, LazyStringValue prop,

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
@@ -13,17 +13,27 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Object;
 public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderObject>
 {
     private readonly SchemaPath _schemaPath;
+    private readonly LazyStringValue[] _exclude;
     private readonly Dictionary<LazyStringValue, ElementSchemaRuleValidator> _namedPropertyValidators;
     private readonly (Regex Regex, ElementSchemaRuleValidator Validator)[] _patternPropertiesValidators;
     private readonly (bool Allowed, ElementSchemaRuleValidator Validator) _additionalPropertiesValidator;
 
     // ReSharper disable once ConvertToPrimaryConstructor
-    public ObjectSchemaRuleValidator(Dictionary<LazyStringValue, ElementSchemaRuleValidator> named, (Regex, ElementSchemaRuleValidator x)[] pattern, (bool IsAllowed, ElementSchemaRuleValidator Validator) additional, SchemaPath schemaPath)
+    public ObjectSchemaRuleValidator(Dictionary<LazyStringValue, ElementSchemaRuleValidator> named, (Regex, ElementSchemaRuleValidator x)[] pattern, (bool IsAllowed, ElementSchemaRuleValidator Validator) additional, SchemaPath schemaPath, LazyStringValue[] exclude)
     {
         _namedPropertyValidators = named;
         _patternPropertiesValidators = pattern;
         _additionalPropertiesValidator = additional;
         _schemaPath = schemaPath;
+        _exclude = exclude;
+
+        if (exclude != null)
+        {
+            foreach (var lazyStringValue in exclude)
+            {
+                _namedPropertyValidators.Remove(lazyStringValue);
+            }
+        }
     }
 
     public override bool Validate(BlittableJsonReaderObject value, ErrorBuilder errorBuilder)
@@ -45,6 +55,8 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
             for (int i = 0; i < value.Count; i++)
             {
                 var propName = value.GetPropertyNameByIndex(i);
+                if (_exclude?.Contains(propName) == true) 
+                    continue;
                 
                 var hasValidator = _namedPropertyValidators != null && _namedPropertyValidators.ContainsKey(propName);
                 if (_patternPropertiesValidators != null)
@@ -96,6 +108,24 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
         return isValid;
     }
 
+    private bool ShouldExclude(LazyStringValue prop)
+    {
+        if(_exclude != null)
+            return true;
+
+        var ret = false;
+        foreach (var ex in _exclude)
+        {
+            if(prop.Equals(ex))
+            if (string.Equals(ex, prop, StringComparison.Ordinal))
+            {
+                ret = true;
+                break;
+            }
+        }
+        return false;
+    }
+
     private static bool ValidateProperty(ElementSchemaRuleValidator validator, BlittableJsonReaderObject value, LazyStringValue prop,
         ErrorBuilder errorBuilder)
     {
@@ -124,8 +154,10 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
 
         if (named == null && pattern == null && additional is { IsAllowed: true, Validator: null })
             return null;
+
+        var exclude = ReadExcludeProperties(schemaDefinition, schemaPath);
         
-        return new ObjectSchemaRuleValidator(named, pattern, additional, schemaPath);
+        return new ObjectSchemaRuleValidator(named, pattern, additional, schemaPath, exclude);
     }
     
     private static (bool IsAllowed, ElementSchemaRuleValidator Validator) ReadAdditionalProperties(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
@@ -152,6 +184,29 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
                 SchemaValidationHelper.ThrowRuleTypeError(additionalProperties, expectedTypes.ToHashSet(), schemaPath);
                 return (false, null);
         }
+    }
+    
+    private static LazyStringValue[] ReadExcludeProperties(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
+    {
+        const string rule = SchemaValidatorConstants.ExcludedProperties;
+        schemaPath += rule;
+        if(SchemaValidationHelper.TryGetArray(schemaDefinition, rule, schemaPath, out var excludeProperties) == false)
+            return null;
+
+        var excluded = new LazyStringValue[excludeProperties.Length];
+        for (var i = 0; i < excludeProperties.Length; i++)
+        {
+            var item = excludeProperties[i];
+            if (item is LazyStringValue str == false)
+            {
+                SchemaValidationHelper.ThrowRuleTypeError(item, typeof(LazyStringValue), schemaPath + $"[{i}]");
+                return null; // never hit
+            }
+            
+            excluded[i] = str;
+        }
+
+        return excluded;
     }
 
     private static List<(LazyStringValue property, ElementSchemaRuleValidator validator)> ReadPropertyValidators(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
@@ -17,8 +17,8 @@ internal sealed class ShardedSchemaValidationHandlerProcessorForValidate : Abstr
 
     protected override void StartValidationOperation(long operationId, OperationCancelToken token)
     {
-        Parameters.MaxErrorsMsg = Parameters.MaxErrorsMsg.HasValue 
-            ? Math.Max(1, Parameters.MaxErrorsMsg.Value / RequestHandler.DatabaseContext.ShardCount) 
+        Parameters.MaxErrorMessages = Parameters.MaxErrorMessages.HasValue 
+            ? Math.Max(1, Parameters.MaxErrorMessages.Value / RequestHandler.DatabaseContext.ShardCount) 
             : null;
         
         _ = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>, ValidateSchemaValidationResult, ValidateSchemaValidationProgress>(

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
@@ -30,7 +30,7 @@ internal sealed class ShardedSchemaValidationHandlerProcessorForValidate : Abstr
                 OperationType.ValidateSchema,
                 $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.DatabaseName}'",
                 detailedDescription: null,
-                commandFactory: (_, _) => new ValidateSchemaOperation.ValidateSchemaCommand(RequestHandler.ShardExecutor.Conventions, Parameters, operationId),
+                commandFactory: (_, _) => new StartSchemaValidationOperation.StartSchemaValidationCommand(RequestHandler.ShardExecutor.Conventions, Parameters, operationId),
                 token)
             .ContinueWith(_ => { token.Dispose(); });
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
@@ -2,6 +2,7 @@
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Client.Exceptions;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.ServerWide;
@@ -17,6 +18,9 @@ internal sealed class ShardedSchemaValidationHandlerProcessorForValidate : Abstr
 
     protected override void StartValidationOperation(long operationId, OperationCancelToken token)
     {
+        if (Parameters.Etag != null)
+            throw new BadRequestException($"Parameter '{nameof(Parameters.Etag)}' is not supported for schema validation on a sharded database.");
+        
         Parameters.MaxErrorMessages = Parameters.MaxErrorMessages.HasValue 
             ? Math.Max(1, Parameters.MaxErrorMessages.Value / RequestHandler.DatabaseContext.ShardCount) 
             : null;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Server.Documents.Operations;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.Processors.SchemaValidation;
+
+internal sealed class ShardedSchemaValidationHandlerProcessorForValidate : AbstractSchemaValidationHandlerProcessorForValidate<ShardedDatabaseRequestHandler, TransactionOperationContext>
+{
+    public ShardedSchemaValidationHandlerProcessorForValidate([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override void StartValidationOperation(long operationId, OperationCancelToken token)
+    {
+        Parameters.MaxErrorsMsg = Parameters.MaxErrorsMsg.HasValue 
+            ? Math.Max(1, Parameters.MaxErrorsMsg.Value / RequestHandler.DatabaseContext.ShardCount) 
+            : null;
+        
+        _ = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>, ValidateSchemaValidationResult, ValidateSchemaValidationProgress>(
+                operationId,
+                OperationType.ValidateSchemaValidation,
+                $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.DatabaseName}'",
+                detailedDescription: null,
+                commandFactory: (_, _) => new ValidateSchemaValidationOperation.ValidateSchemaValidationCommand(RequestHandler.ShardExecutor.Conventions, Parameters, operationId),
+                token)
+            .ContinueWith(_ => { token.Dispose(); });
+    }
+
+    protected override long GetNextOperationId() => RequestHandler.DatabaseContext.Operations.GetNextOperationId();
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
@@ -18,19 +18,19 @@ internal sealed class ShardedSchemaValidationHandlerProcessorForValidate : Abstr
 
     protected override void StartValidationOperation(long operationId, OperationCancelToken token)
     {
-        if (Parameters.Etag != null)
-            throw new BadRequestException($"Parameter '{nameof(Parameters.Etag)}' is not supported for schema validation on a sharded database.");
+        if (Parameters.StartEtag != null)
+            throw new BadRequestException($"Parameter '{nameof(Parameters.StartEtag)}' is not supported for schema validation on a sharded database.");
         
         Parameters.MaxErrorMessages = Parameters.MaxErrorMessages.HasValue 
             ? Math.Max(1, Parameters.MaxErrorMessages.Value / RequestHandler.DatabaseContext.ShardCount) 
             : null;
         
-        _ = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartValidateSchemaValidationOperationResult>, ValidateSchemaValidationResult, ValidateSchemaValidationProgress>(
+        _ = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartValidateSchemaOperationResult>, ValidateSchemaResult, ValidateSchemaValidationProgress>(
                 operationId,
                 OperationType.ValidateSchemaValidation,
                 $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.DatabaseName}'",
                 detailedDescription: null,
-                commandFactory: (_, _) => new ValidateSchemaValidationOperation.ValidateSchemaValidationCommand(RequestHandler.ShardExecutor.Conventions, Parameters, operationId),
+                commandFactory: (_, _) => new ValidateSchemaOperation.ValidateSchemaCommand(RequestHandler.ShardExecutor.Conventions, Parameters, operationId),
                 token)
             .ContinueWith(_ => { token.Dispose(); });
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SchemaValidation/ShardedSchemaValidationHandlerProcessorForValidate.cs
@@ -25,9 +25,9 @@ internal sealed class ShardedSchemaValidationHandlerProcessorForValidate : Abstr
             ? Math.Max(1, Parameters.MaxErrorMessages.Value / RequestHandler.DatabaseContext.ShardCount) 
             : null;
         
-        _ = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartValidateSchemaOperationResult>, ValidateSchemaResult, ValidateSchemaValidationProgress>(
+        _ = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartValidateSchemaOperationResult>, ValidateSchemaResult, ValidateSchemaProgress>(
                 operationId,
-                OperationType.ValidateSchemaValidation,
+                OperationType.ValidateSchema,
                 $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.DatabaseName}'",
                 detailedDescription: null,
                 commandFactory: (_, _) => new ValidateSchemaOperation.ValidateSchemaCommand(RequestHandler.ShardExecutor.Conventions, Parameters, operationId),

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSchemaValidationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSchemaValidationHandler.cs
@@ -22,7 +22,7 @@ public sealed class ShardedSchemaValidationHandler : ShardedDatabaseRequestHandl
     }
     
     [RavenShardedAction("/databases/*/schema-validation/validate", "POST")]
-    public async Task ValidateSchemaValidation()
+    public async Task ValidateSchema()
     {
         using (var processor = new ShardedSchemaValidationHandlerProcessorForValidate(this))
             await processor.ExecuteAsync();

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSchemaValidationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSchemaValidationHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Processors.SchemaValidation;
 using Raven.Server.Documents.Sharding.Handlers.Processors.SchemaValidation;
 using Raven.Server.Routing;
 
@@ -17,6 +18,13 @@ public sealed class ShardedSchemaValidationHandler : ShardedDatabaseRequestHandl
     public async Task ConfigSchemaValidation()
     {
         using (var processor = new ShardedSchemaValidationHandlerProcessorForPost(this))
+            await processor.ExecuteAsync();
+    }
+    
+    [RavenShardedAction("/databases/*/schema-validation/validate", "POST")]
+    public async Task ValidateSchemaValidation()
+    {
+        using (var processor = new ShardedSchemaValidationHandlerProcessorForValidate(this))
             await processor.ExecuteAsync();
     }
 }

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -38,6 +38,7 @@ namespace Raven.Server.Extensions
             result[nameof(IndexDefinition.SourceType)] = definition.SourceType.ToString();
             result[nameof(IndexDefinition.LockMode)] = definition.LockMode?.ToString();
             result[nameof(IndexDefinition.ArchivedDataProcessingBehavior)] = definition.ArchivedDataProcessingBehavior?.ToString();
+            result[nameof(IndexDefinition.SchemaValidationConfiguration)] = definition.SchemaValidationConfiguration?.ToJson();
             result[nameof(IndexDefinition.Priority)] = definition.Priority?.ToString();
             result[nameof(IndexDefinition.State)] = definition.State?.ToString();
             result[nameof(IndexDefinition.OutputReduceToCollection)] = definition.OutputReduceToCollection;

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Extensions
             result[nameof(IndexDefinition.SourceType)] = definition.SourceType.ToString();
             result[nameof(IndexDefinition.LockMode)] = definition.LockMode?.ToString();
             result[nameof(IndexDefinition.ArchivedDataProcessingBehavior)] = definition.ArchivedDataProcessingBehavior?.ToString();
-            result[nameof(IndexDefinition.SchemaValidationConfiguration)] = definition.SchemaValidationConfiguration?.ToJson();
+            result[nameof(IndexDefinition.SchemaValidation)] = definition.SchemaValidation;
             result[nameof(IndexDefinition.Priority)] = definition.Priority?.ToString();
             result[nameof(IndexDefinition.State)] = definition.State?.ToString();
             result[nameof(IndexDefinition.OutputReduceToCollection)] = definition.OutputReduceToCollection;

--- a/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
+++ b/src/Raven.Server/Extensions/JsonSerializationExtensions.cs
@@ -38,7 +38,6 @@ namespace Raven.Server.Extensions
             result[nameof(IndexDefinition.SourceType)] = definition.SourceType.ToString();
             result[nameof(IndexDefinition.LockMode)] = definition.LockMode?.ToString();
             result[nameof(IndexDefinition.ArchivedDataProcessingBehavior)] = definition.ArchivedDataProcessingBehavior?.ToString();
-            result[nameof(IndexDefinition.SchemaValidation)] = definition.SchemaValidation;
             result[nameof(IndexDefinition.Priority)] = definition.Priority?.ToString();
             result[nameof(IndexDefinition.State)] = definition.State?.ToString();
             result[nameof(IndexDefinition.OutputReduceToCollection)] = definition.OutputReduceToCollection;
@@ -102,9 +101,16 @@ namespace Raven.Server.Extensions
             var settings = new DynamicJsonValue();
             foreach (var kvp in definition.Configuration)
                 settings[kvp.Key] = kvp.Value;
-
             result[nameof(IndexDefinition.Configuration)] = settings;
 
+            if (definition.SchemaDefinitions != null)
+            {
+                var schemaDefinitions = new DynamicJsonValue();
+                foreach (var kvp in definition.SchemaDefinitions)
+                    schemaDefinitions[kvp.Key] = kvp.Value;
+                result[nameof(IndexDefinition.SchemaDefinitions)] = schemaDefinitions;
+            }
+            
             var additionalSources = new DynamicJsonValue();
             foreach (var kvp in definition.AdditionalSources)
                 additionalSources[kvp.Key] = kvp.Value;

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -32,7 +32,6 @@ using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.Documents.Sharding.Queries.Suggestions;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions.Stats;
-using Raven.Server.Json.Sync;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Extensions;
@@ -1500,8 +1499,8 @@ namespace Raven.Server.Json
                 writer.WriteNull();
             writer.WriteComma();
             
-            writer.WritePropertyName(nameof(indexDefinition.SchemaValidation));
-            writer.WriteString(indexDefinition.SchemaValidation);
+            writer.WritePropertyName(nameof(indexDefinition.SchemaDefinitions));
+            writer.WriteIndexSchemaDefinitions(indexDefinition.SchemaDefinitions);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(indexDefinition.Priority));
@@ -2760,6 +2759,28 @@ namespace Raven.Server.Json
             writer.WriteComma();
             writer.WritePropertyName("NodeTag");
             writer.WriteString(nodeTag);
+            writer.WriteEndObject();
+        }
+        
+        public static void WriteIndexSchemaDefinitions(this AbstractBlittableJsonTextWriter writer, IndexSchemaDefinitions indexDefinitionSchemaDefinitions)
+        {
+            if(indexDefinitionSchemaDefinitions == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            
+            var first = true;
+            writer.WriteStartObject();
+            foreach (var (collection, definition) in indexDefinitionSchemaDefinitions)
+            {
+                if (first == false)
+                    writer.WriteComma();
+
+                first = false;
+                writer.WritePropertyName(collection);
+                writer.WriteString(definition);
+            }
             writer.WriteEndObject();
         }
     }

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1500,8 +1500,8 @@ namespace Raven.Server.Json
                 writer.WriteNull();
             writer.WriteComma();
             
-            writer.WritePropertyName(nameof(indexDefinition.SchemaValidationConfiguration));
-            writer.WriteSchemaValidationConfiguration(indexDefinition.SchemaValidationConfiguration);
+            writer.WritePropertyName(nameof(indexDefinition.SchemaValidation));
+            writer.WriteString(indexDefinition.SchemaValidation);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(indexDefinition.Priority));

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -32,6 +32,7 @@ using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.Documents.Sharding.Queries.Suggestions;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions.Stats;
+using Raven.Server.Json.Sync;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Extensions;
@@ -1497,6 +1498,10 @@ namespace Raven.Server.Json
                 writer.WriteString(indexDefinition.ArchivedDataProcessingBehavior?.ToString());
             else
                 writer.WriteNull();
+            writer.WriteComma();
+            
+            writer.WritePropertyName(nameof(indexDefinition.SchemaValidationConfiguration));
+            writer.WriteSchemaValidationConfiguration(indexDefinition.SchemaValidationConfiguration);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(indexDefinition.Priority));

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Json
 
             public static readonly Func<BlittableJsonReaderObject, AdoptOrphanedRevisionsOperation.Parameters> AdoptOrphanedRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<AdoptOrphanedRevisionsOperation.Parameters>();
             
-            public static readonly Func<BlittableJsonReaderObject, ValidateSchemaOperation.Parameters> ValidateSchemaOperationParameters = GenerateJsonDeserializationRoutine<ValidateSchemaOperation.Parameters>();
+            public static readonly Func<BlittableJsonReaderObject, StartSchemaValidationOperation.Parameters> ValidateSchemaOperationParameters = GenerateJsonDeserializationRoutine<StartSchemaValidationOperation.Parameters>();
         }
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Json
 
             public static readonly Func<BlittableJsonReaderObject, AdoptOrphanedRevisionsOperation.Parameters> AdoptOrphanedRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<AdoptOrphanedRevisionsOperation.Parameters>();
             
-            public static readonly Func<BlittableJsonReaderObject, ValidateSchemaValidationOperation.Parameters> ValidateSchemaValidationOperationParameters = GenerateJsonDeserializationRoutine<ValidateSchemaValidationOperation.Parameters>();
+            public static readonly Func<BlittableJsonReaderObject, ValidateSchemaOperation.Parameters> ValidateSchemaValidationOperationParameters = GenerateJsonDeserializationRoutine<ValidateSchemaOperation.Parameters>();
         }
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Json
 
             public static readonly Func<BlittableJsonReaderObject, AdoptOrphanedRevisionsOperation.Parameters> AdoptOrphanedRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<AdoptOrphanedRevisionsOperation.Parameters>();
             
-            public static readonly Func<BlittableJsonReaderObject, ValidateSchemaOperation.Parameters> ValidateSchemaValidationOperationParameters = GenerateJsonDeserializationRoutine<ValidateSchemaOperation.Parameters>();
+            public static readonly Func<BlittableJsonReaderObject, ValidateSchemaOperation.Parameters> ValidateSchemaOperationParameters = GenerateJsonDeserializationRoutine<ValidateSchemaOperation.Parameters>();
         }
     }
 }

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Operations.TransactionsRecording;
 using Raven.Client.Documents.Queries.Facets;
@@ -394,7 +395,8 @@ namespace Raven.Server.Json
             public static readonly Func<BlittableJsonReaderObject, EnforceRevisionsConfigurationOperation.Parameters> EnforceRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<EnforceRevisionsConfigurationOperation.Parameters>();
 
             public static readonly Func<BlittableJsonReaderObject, AdoptOrphanedRevisionsOperation.Parameters> AdoptOrphanedRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<AdoptOrphanedRevisionsOperation.Parameters>();
-
+            
+            public static readonly Func<BlittableJsonReaderObject, ValidateSchemaValidationOperation.Parameters> ValidateSchemaValidationOperationParameters = GenerateJsonDeserializationRoutine<ValidateSchemaValidationOperation.Parameters>();
         }
     }
 }

--- a/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
@@ -34,8 +34,8 @@ namespace Raven.Server.Json.Sync
                 writer.WriteNull();
             writer.WriteComma();
             
-            writer.WritePropertyName(nameof(indexDefinition.SchemaValidationConfiguration));
-            writer.WriteSchemaValidationConfiguration(indexDefinition.SchemaValidationConfiguration);
+            writer.WritePropertyName(nameof(indexDefinition.SchemaValidation));
+            writer.WriteString(indexDefinition.SchemaValidation);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(indexDefinition.LockMode));
@@ -440,47 +440,5 @@ namespace Raven.Server.Json.Sync
             }
             writer.WriteEndObject();
         }
-        
-        public static void WriteSchemaValidationConfiguration(this AbstractBlittableJsonTextWriter writer, SchemaValidationConfiguration configuration)
-        {
-            if (configuration == null)
-            {
-                writer.WriteNull();
-                return;
-            }
-            
-            writer.WriteStartObject();
-            {
-                writer.WritePropertyName(nameof(SchemaValidationConfiguration.ValidatorsPerCollection));
-                writer.WriteStartArray();
-                {
-                    var isFirst = true;
-                    foreach (var keyValue in configuration.ValidatorsPerCollection)
-                    {
-                        if(isFirst == false)
-                            writer.WriteComma();
-
-                        isFirst = false;
-                        writer.WriteStartObject();
-                        {
-                            writer.WritePropertyName(nameof(keyValue.Key));
-                            writer.WriteString(keyValue.Key);
-                            writer.WriteComma();
-                            writer.WritePropertyName(nameof(keyValue.Value));
-                            writer.WriteStartObject();
-                            {
-                                writer.WritePropertyName(nameof(keyValue.Value.Schema));
-                                writer.WriteString(keyValue.Value.Schema);
-                            }
-                            writer.WriteEndObject();
-                        }
-                        writer.WriteEndObject();
-                    }
-                }
-                writer.WriteEndArray();
-            }
-            writer.WriteEndObject();
-        }
-
     }
 }

--- a/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Extensions;
 using Raven.Server.Documents;
 using Sparrow.Json;
@@ -34,8 +33,8 @@ namespace Raven.Server.Json.Sync
                 writer.WriteNull();
             writer.WriteComma();
             
-            writer.WritePropertyName(nameof(indexDefinition.SchemaValidation));
-            writer.WriteString(indexDefinition.SchemaValidation);
+            writer.WritePropertyName(nameof(indexDefinition.SchemaDefinitions));
+            writer.WriteIndexSchemaDefinitions(indexDefinition.SchemaDefinitions);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(indexDefinition.LockMode));

--- a/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
@@ -469,8 +469,8 @@ namespace Raven.Server.Json.Sync
                             writer.WritePropertyName(nameof(keyValue.Value));
                             writer.WriteStartObject();
                             {
-                                writer.WritePropertyName(nameof(keyValue.Value.SchemaDefinition));
-                                writer.WriteString(keyValue.Value.SchemaDefinition);
+                                writer.WritePropertyName(nameof(keyValue.Value.Schema));
+                                writer.WriteString(keyValue.Value.Schema);
                             }
                             writer.WriteEndObject();
                         }

--- a/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/Sync/BlittableJsonTextWriterExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Extensions;
 using Raven.Server.Documents;
 using Sparrow.Json;
@@ -31,6 +32,10 @@ namespace Raven.Server.Json.Sync
                 writer.WriteString(indexDefinition.ArchivedDataProcessingBehavior.ToString());
             else
                 writer.WriteNull();
+            writer.WriteComma();
+            
+            writer.WritePropertyName(nameof(indexDefinition.SchemaValidationConfiguration));
+            writer.WriteSchemaValidationConfiguration(indexDefinition.SchemaValidationConfiguration);
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(indexDefinition.LockMode));
@@ -435,5 +440,47 @@ namespace Raven.Server.Json.Sync
             }
             writer.WriteEndObject();
         }
+        
+        public static void WriteSchemaValidationConfiguration(this AbstractBlittableJsonTextWriter writer, SchemaValidationConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            
+            writer.WriteStartObject();
+            {
+                writer.WritePropertyName(nameof(SchemaValidationConfiguration.ValidatorsPerCollection));
+                writer.WriteStartArray();
+                {
+                    var isFirst = true;
+                    foreach (var keyValue in configuration.ValidatorsPerCollection)
+                    {
+                        if(isFirst == false)
+                            writer.WriteComma();
+
+                        isFirst = false;
+                        writer.WriteStartObject();
+                        {
+                            writer.WritePropertyName(nameof(keyValue.Key));
+                            writer.WriteString(keyValue.Key);
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(keyValue.Value));
+                            writer.WriteStartObject();
+                            {
+                                writer.WritePropertyName(nameof(keyValue.Value.SchemaDefinition));
+                                writer.WriteString(keyValue.Value.SchemaDefinition);
+                            }
+                            writer.WriteEndObject();
+                        }
+                        writer.WriteEndObject();
+                    }
+                }
+                writer.WriteEndArray();
+            }
+            writer.WriteEndObject();
+        }
+
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
@@ -99,5 +99,7 @@ namespace Raven.Server.NotificationCenter.Notifications
         ConflictRevisionsExceeded,
         
         SqlConnectionString_DeprecatedFactoryReplaced,
+        
+        SchemaValidationConfiguration_Error,
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2091,7 +2091,7 @@ namespace Raven.Server.ServerWide
             foreach (var item in configurationJson.ValidatorsPerCollection)
             {
                 using var schema = context.Sync.ReadForMemory(item.Value.Schema, "schema-validation");
-                //TO make sure the schema is valid we run Init on an instance of SchemaValidator, but it is not used
+                //To make sure the schema is valid, we run Init on an instance of SchemaValidator, but it is not used
                 var validator = new SchemaValidator();
                 validator.Init(schema);
                 SchemaValidationHelper.ValidateSchemaDefinitionForDocument(schema);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2077,13 +2077,13 @@ namespace Raven.Server.ServerWide
         public Task<(long Index, object Result)> ModifySchemaValidation(TransactionOperationContext context, string databaseName, BlittableJsonReaderObject configurationJson, string raftRequestId)
         {
             var schemaValidationConfiguration = JsonDeserializationCluster.SchemaValidationConfiguration(configurationJson);
-            ValidateSchemaDefinition(context, schemaValidationConfiguration);            
+            ValidateSchemaConfiguration(context, schemaValidationConfiguration);            
             
             var editSchemaValidation = new EditSchemaValidationConfigurationCommand(schemaValidationConfiguration, databaseName, raftRequestId);
             return SendToLeaderAsync(editSchemaValidation);
         }
 
-        private static void ValidateSchemaDefinition(JsonOperationContext context, SchemaValidationConfiguration configurationJson)
+        private static void ValidateSchemaConfiguration(JsonOperationContext context, SchemaValidationConfiguration configurationJson)
         {
             if (configurationJson.ValidatorsPerCollection == null)
                 throw new InvalidOperationException($"'{nameof(SchemaValidationConfiguration.ValidatorsPerCollection)}' cannot be null");

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -24,6 +24,7 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
@@ -51,6 +52,7 @@ using Raven.Server.Documents.Indexes.Analysis;
 using Raven.Server.Documents.Indexes.Sorting;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Exceptions;
 using Raven.Server.Integrations.PostgreSQL.Commands;
@@ -82,6 +84,7 @@ using Raven.Server.Web.System;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Json.Sync;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
@@ -2074,9 +2077,25 @@ namespace Raven.Server.ServerWide
         public Task<(long Index, object Result)> ModifySchemaValidation(TransactionOperationContext context, string databaseName, BlittableJsonReaderObject configurationJson, string raftRequestId)
         {
             var schemaValidationConfiguration = JsonDeserializationCluster.SchemaValidationConfiguration(configurationJson);
-
+            ValidateSchemaDefinition(context, schemaValidationConfiguration);            
+            
             var editSchemaValidation = new EditSchemaValidationConfigurationCommand(schemaValidationConfiguration, databaseName, raftRequestId);
             return SendToLeaderAsync(editSchemaValidation);
+        }
+
+        private static void ValidateSchemaDefinition(JsonOperationContext context, SchemaValidationConfiguration configurationJson)
+        {
+            if (configurationJson.ValidatorsPerCollection == null)
+                throw new InvalidOperationException($"'{nameof(SchemaValidationConfiguration.ValidatorsPerCollection)}' cannot be null");
+
+            foreach (var item in configurationJson.ValidatorsPerCollection)
+            {
+                using var schema = context.Sync.ReadForMemory(item.Value.Schema, "schema-validation");
+                //TO make sure the schema is valid we run Init on an instance of SchemaValidator, but it is not used
+                var validator = new SchemaValidator();
+                validator.Init(schema);
+                SchemaValidationHelper.ValidateSchemaDefinitionForDocument(schema);
+            }
         }
 
         public Task<(long Index, object Result)> ModifyPostgreSqlConfiguration(TransactionOperationContext context, string databaseName, BlittableJsonReaderObject configurationJson, string raftRequestId)

--- a/src/Raven.Studio/typescript/commands/database/settings/validateSchemaCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/validateSchemaCommand.ts
@@ -3,14 +3,14 @@ import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
 class validateSchemaCommand extends commandBase {
-    constructor(private db: database | string, private validateSchemaRequestDto: ValidateSchemaRequestDto) {
+    constructor(private db: database | string, private dto: ValidateSchemaRequestDto) {
         super();
     }
 
     execute(): JQueryPromise<ValidateSchemaResponseDto> {
         const url = endpoints.databases.schemaValidation.schemaValidationValidate;
 
-        return this.post<ValidateSchemaResponseDto>(url, JSON.stringify(this.validateSchemaRequestDto), this.db)
+        return this.post<ValidateSchemaResponseDto>(url, JSON.stringify(this.dto), this.db)
             .fail((response: JQueryXHR) =>
                 this.reportError("Failed to validate schema configuration", response.responseText, response.statusText)
             )

--- a/src/Raven.Studio/typescript/commands/database/settings/validateSchemaCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/validateSchemaCommand.ts
@@ -1,0 +1,20 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+
+class validateSchemaCommand extends commandBase {
+    constructor(private db: database | string, private validateSchemaRequestDto: ValidateSchemaRequestDto) {
+        super();
+    }
+
+    execute(): JQueryPromise<ValidateSchemaResponseDto> {
+        const url = endpoints.databases.schemaValidation.schemaValidationValidate;
+
+        return this.post<ValidateSchemaResponseDto>(url, JSON.stringify(this.validateSchemaRequestDto), this.db)
+            .fail((response: JQueryXHR) =>
+                this.reportError("Failed to validate schema configuration", response.responseText, response.statusText)
+            )
+    }
+}
+
+export = validateSchemaCommand;

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -52,6 +52,7 @@ import licenseLimitDetails = require("viewmodels/common/notificationCenter/detai
 import requestLatencyDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/requestLatencyDetails");
 import transactionCommandsDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/transactionCommandsDetails");
 import dumpRawIndexDataDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/dumpRawIndexDataDetails");
+import validateSchemaDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/validateSchemaDetails");
 
 import studioSettings = require("common/settings/studioSettings");
 import optimizeIndexDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/optimizeIndexDetails");
@@ -65,6 +66,7 @@ import cpuCreditsBalanceDetails = require("viewmodels/common/notificationCenter/
 import groupedVirtualNotification = require("common/notifications/models/groupedVirtualNotification");
 import typeUtils = require("common/typeUtils");
 import aiAgentExceededTokenThreshold = require("viewmodels/common/notificationCenter/detailViewer/alerts/aiAgentExceededTokenThreshold");
+
 interface detailsProvider {
     supportsDetailsFor(notification: abstractNotification): boolean;
     showDetailsFor(notification: abstractNotification, notificationCenter: notificationCenter): JQueryPromise<void> | void;
@@ -162,6 +164,7 @@ class notificationCenter {
             transactionCommandsDetails,
             dumpRawIndexDataDetails,
             optimizeIndexDetails,
+            validateSchemaDetails,
             
             // virtual operations:
             virtualBulkInsertDetails,
@@ -413,9 +416,9 @@ class notificationCenter {
         return db ? this.databaseOperationsWatch : this.globalOperationsWatch;
     }
 
-    monitorOperation(db: database | string,
+    monitorOperation<T = unknown>(db: database | string,
         operationId: number,
-        onProgress: (progress: unknown) => void = null): JQueryPromise<unknown> {
+        onProgress: (progress: T) => void = null): JQueryPromise<T> {
 
         return this.getOperationsWatch(db).monitorOperation(operationId, onProgress);
     }

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenterOperationsWatch.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenterOperationsWatch.ts
@@ -13,7 +13,7 @@ class notificationCenterOperationsWatch {
         this.watchedProgresses.clear();
     }
 
-    monitorOperation(operationId: number, onProgress: (progress: unknown) => void = null): JQueryPromise<unknown> {
+    monitorOperation<T = unknown>(operationId: number, onProgress: (progress: unknown) => void = null): JQueryPromise<T> {
         if (onProgress) {
             let progresses = this.watchedProgresses.get(operationId);
             if (!progresses) {
@@ -24,14 +24,14 @@ class notificationCenterOperationsWatch {
             progresses.push(onProgress);
         }
 
-        return this.getOrCreateOperation(operationId).promise();
+        return this.getOrCreateOperation<T>(operationId).promise();
     }
 
-    private getOrCreateOperation(operationId: number): JQueryDeferred<unknown> {
+    private getOrCreateOperation<T = unknown>(operationId: number): JQueryDeferred<T> {
         if (this.operations.has(operationId)) {
-            return this.operations.get(operationId) as JQueryDeferred<unknown>;
+            return this.operations.get(operationId) as JQueryDeferred<T>;
         } else {
-            const task = $.Deferred<unknown>();
+            const task = $.Deferred<T>();
             this.operations.set(operationId, task);
             return task;
         }

--- a/src/Raven.Studio/typescript/common/shell/menu/items/settings.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/settings.ts
@@ -21,6 +21,7 @@ import Integrations = require("components/pages/database/settings/integrations/I
 import UnusedDatabaseIds = require("components/pages/database/settings/unusedDatabaseIds/UnusedDatabaseIds");
 import RevisionsBinCleaner = require("components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner");
 import DocumentSchema = require("components/pages/database/settings/documentSchema/DocumentSchema");
+import DocumentSchemaPlayground = require("components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground");
 
 export = getSettingsMenuItem;
 
@@ -168,16 +169,15 @@ function getSettingsMenuItem(appUrls: computedAppUrls) {
             css: 'icon-document-schema',
             dynamicHash: appUrls.documentSchema,
         }),
-        // TODO: For now schema playground is not available. https://issues.hibernatingrhinos.com/issue/RavenDB-22142/Schema-Validation
-        // new leafMenuItem({
-        //     route: 'databases/settings/documentSchema/playground',
-        //     moduleId: reactUtils.bridgeToReact(DocumentSchemaPlayground.default, "nonShardedView"),
-        //     title: 'Document Schema Playground',
-        //     nav: false,
-        //     css: 'icon-document',
-        //     dynamicHash: appUrls.documentSchemaPlayground,
-        //     itemRouteToHighlight: "databases/settings/documentSchema",
-        // }),
+        new leafMenuItem({
+            route: 'databases/settings/documentSchema/playground',
+            moduleId: reactUtils.bridgeToReact(DocumentSchemaPlayground.default, "nonShardedView"),
+            title: 'Document Schema Playground',
+            nav: false,
+            css: 'icon-document',
+            dynamicHash: appUrls.documentSchemaPlayground,
+            itemRouteToHighlight: "databases/settings/documentSchema",
+        }),
         new leafMenuItem({
             route: 'databases/settings/revisions',
             moduleId: reactUtils.bridgeToReact(DocumentRevisions.default, "nonShardedView"),

--- a/src/Raven.Studio/typescript/components/common/shell/collectionsTrackerSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/collectionsTrackerSlice.ts
@@ -51,7 +51,12 @@ const selectCollectionNames = createSelector(
     (collections) => collections.filter((name) => name !== collectionNames.allDocuments)
 );
 
+const selectUserCollectionNames = createSelector(selectCollectionNames, (collections) =>
+    collections.filter((name) => name !== collectionNames.empty && name !== collectionNames.hilo)
+);
+
 export const collectionsTrackerSelectors = {
     collections: (store: RootState) => collectionsSelectors.selectAll(store.collectionsTracker.collections),
     collectionNames: selectCollectionNames,
+    userCollectionNames: selectUserCollectionNames,
 };

--- a/src/Raven.Studio/typescript/components/common/virtualTable/utils/virtualTableConstants.ts
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/utils/virtualTableConstants.ts
@@ -4,4 +4,5 @@ export const virtualTableConstants = {
     paddingInPx: 14,
     scrollbarWidthInPx: 12,
     scrollbarHeightInPx: 12,
+    defaultTableHeightInPx: 300,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
@@ -17,7 +17,7 @@ import {
     RichPanelName,
     RichPanelSelect,
 } from "components/common/RichPanel";
-import { FormAceEditor, FormGroup, FormLabel, FormSelectCreatable } from "components/common/Form";
+import { FormAceEditor, FormGroup, FormLabel, FormSelectAutocomplete } from "components/common/Form";
 import AceEditor from "components/common/ace/AceEditor";
 import ReactAce from "react-ace/lib/ace";
 import useBoolean from "hooks/useBoolean";
@@ -25,6 +25,7 @@ import { useAppDispatch, useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import jsonUtil from "common/jsonUtil";
 import * as yup from "yup";
+import { TestContext } from "yup";
 import { FormProvider, useForm, useFormContext } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { collectionsTrackerSelectors } from "components/common/shell/collectionsTrackerSlice";
@@ -51,6 +52,11 @@ import Spinner from "react-bootstrap/Spinner";
 import Code from "components/common/Code";
 import DocumentSchemaFilter from "components/pages/database/settings/documentSchema/DocumentSchemaFilter";
 import Ajv from "ajv";
+import { useViewSheet } from "components/common/splitView/ViewSheet";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
+import {
+    ValidationSchemaViewSheetPanel
+} from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
 const ajv = new Ajv({
     allErrors: true,
@@ -82,59 +88,57 @@ export default function DocumentSchema() {
 
     return (
         <div className="content-margin">
-            <Col>
-                <Row className="gy-sm">
-                    <Col>
-                        <AboutViewHeading marginBottom={4} title="Document Schema" icon="document-schema" />
-                        {hasDatabaseAdminAccess && <DocumentSchemaSelectActions />}
+            <Row className="gy-sm">
+                <Col>
+                    <AboutViewHeading marginBottom={4} title="Document Schema" icon="document-schema" />
+                    {hasDatabaseAdminAccess && <DocumentSchemaSelectActions />}
 
-                        {hasAnyValidator && (
-                            <DocumentSchemaFilter
-                                selectedCollections={selectedCollections}
-                                setSelectedCollections={handleOnSelectCollection}
-                                collectionOptions={options}
-                                selectedStatuses={selectedStatuses}
-                                setSelectedStatuses={setSelectedStatuses}
-                                schemasCount={filteredValidators.length}
-                                isLoading={asyncLoadValidators.loading}
-                            />
-                        )}
+                    {hasAnyValidator && (
+                        <DocumentSchemaFilter
+                            selectedCollections={selectedCollections}
+                            setSelectedCollections={handleOnSelectCollection}
+                            collectionOptions={options}
+                            selectedStatuses={selectedStatuses}
+                            setSelectedStatuses={setSelectedStatuses}
+                            schemasCount={filteredValidators.length}
+                            isLoading={asyncLoadValidators.loading}
+                        />
+                    )}
 
-                        <div className="mt-4">
-                            <HrHeader
-                                count={filteredValidators.length}
-                                right={
-                                    hasDatabaseAdminAccess && (
-                                        <Button
-                                            size="xs"
-                                            variant="info"
-                                            className="rounded-pill"
-                                            onClick={handleAddNew}
-                                            title="Click to add a new schema for a collection"
-                                        >
-                                            <Icon icon="plus" />
-                                            Add new
-                                        </Button>
-                                    )
-                                }
-                            >
-                                <Icon icon="documents" />
-                                <span>Collection specific document schemas</span>
-                                <PopoverWithHoverWrapper message="Define and manage JSON Schemas for each collection">
-                                    <Icon icon="info-new" margin="ms-1" />
-                                </PopoverWithHoverWrapper>
-                            </HrHeader>
-                            <DocumentSchemaBody
-                                filteredValidators={filteredValidators}
-                                asyncLoadValidators={asyncLoadValidators}
-                            />
-                        </div>
-                    </Col>
-                    <Col sm={12} lg={4}>
-                        <DocumentSchemaAboutView />
-                    </Col>
-                </Row>
-            </Col>
+                    <div className="mt-4">
+                        <HrHeader
+                            count={filteredValidators.length}
+                            right={
+                                hasDatabaseAdminAccess && (
+                                    <Button
+                                        size="xs"
+                                        variant="info"
+                                        className="rounded-pill"
+                                        onClick={handleAddNew}
+                                        title="Click to add a new schema for a collection"
+                                    >
+                                        <Icon icon="plus" />
+                                        Add new
+                                    </Button>
+                                )
+                            }
+                        >
+                            <Icon icon="documents" />
+                            <span>Collection specific document schemas</span>
+                            <PopoverWithHoverWrapper message="Define and manage JSON Schemas for each collection">
+                                <Icon icon="info-new" margin="ms-1" />
+                            </PopoverWithHoverWrapper>
+                        </HrHeader>
+                        <DocumentSchemaBody
+                            filteredValidators={filteredValidators}
+                            asyncLoadValidators={asyncLoadValidators}
+                        />
+                    </div>
+                </Col>
+                <Col sm={12} lg={4}>
+                    <DocumentSchemaAboutView />
+                </Col>
+            </Row>
         </div>
     );
 }
@@ -246,6 +250,7 @@ const CollectionSchemaRichPanel = ({
 }: CollectionSchemaRichPanelProps) => {
     const { value: isEditingSchema, toggle: toggleEditingSchema } = useBoolean(false);
     const { value: isTogglingStatus, setTrue: setTogglingStatus, setFalse: unsetTogglingStatus } = useBoolean(false);
+    const { open } = useViewSheet();
     const [operationConfirm, setOperationConfirm] = React.useState<{
         type: DocumentSchemaOperationConfirmType;
         onConfirm: () => void;
@@ -275,6 +280,7 @@ const CollectionSchemaRichPanel = ({
             collection: validator.Name,
             schema,
         },
+        context: { schemaValidatorCollections },
     });
 
     const { handleSubmit, reset } = form;
@@ -303,11 +309,16 @@ const CollectionSchemaRichPanel = ({
 
     const handleStatusToggle = (disabled: boolean) => {
         const operationType: DocumentSchemaOperationConfirmType = disabled ? "disable" : "enable";
-
         setOperationConfirm({
             type: operationType,
             onConfirm: () => handleBulkStatusToggle(disabled),
             validators: [validator],
+        });
+    };
+
+    const handleOpenSheet = () => {
+        open({
+            component: <ValidationSchemaViewSheetPanel validators={[validator]} />,
         });
     };
 
@@ -339,6 +350,17 @@ const CollectionSchemaRichPanel = ({
                                     onStatusToggle={handleStatusToggle}
                                     isTogglingState={isTogglingStatus}
                                 />
+                                <ConditionalPopover
+                                    conditions={{
+                                        isActive: isEditingSchema,
+                                        message:
+                                            "The schema must be saved in order to test it against existing documents.",
+                                    }}
+                                >
+                                    <Button disabled={isEditingSchema} onClick={handleOpenSheet} variant="secondary">
+                                        <Icon icon="rocket" margin="m-0" />
+                                    </Button>
+                                </ConditionalPopover>
                                 <ButtonWithSpinner
                                     onClick={isEditingSchema ? handleSubmit(handleEditSchema) : toggleEditingSchema}
                                     variant={isEditingSchema ? "success" : "secondary"}
@@ -514,7 +536,7 @@ const RichPanelDetailsEditSchema = ({
             <FormGroup className="w-100 mt-2">
                 <FormGroup>
                     <FormLabel>Collection</FormLabel>
-                    <FormSelectCreatable
+                    <FormSelectAutocomplete
                         control={control}
                         name="collection"
                         placeholder="Select a collection (or enter a new one)"
@@ -574,6 +596,7 @@ const NewCollectionSchemaRichPanel = ({
 }: NewCollectionSchemaRichPanelProps) => {
     const form = useForm<DocumentSchemaFormData>({
         resolver: yupResolver(formSchema),
+        context: { schemaValidatorCollections },
     });
 
     const handleSubmit = async (data: DocumentSchemaFormData) => {
@@ -606,7 +629,22 @@ const NewCollectionSchemaRichPanel = ({
 };
 
 const formSchema = yup.object({
-    collection: yup.string().required(),
+    collection: yup
+        .string()
+        .required()
+        .test(
+            "is-unique-collection",
+            "A schema for this collection already exists",
+            function (value, ctx: TestContext<{ schemaValidatorCollections: string[] }>) {
+                if (!value) {
+                    return true;
+                }
+
+                return !ctx.options.context.schemaValidatorCollections
+                    .map((x) => x.toLowerCase())
+                    .includes(value.toLowerCase());
+            }
+        ),
     schema: yup
         .string()
         .required()

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
@@ -54,9 +54,7 @@ import DocumentSchemaFilter from "components/pages/database/settings/documentSch
 import Ajv from "ajv";
 import { useViewSheet } from "components/common/splitView/ViewSheet";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
-import {
-    ValidationSchemaViewSheetPanel
-} from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
+import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
 const ajv = new Ajv({
     allErrors: true,
@@ -280,7 +278,7 @@ const CollectionSchemaRichPanel = ({
             collection: validator.Name,
             schema,
         },
-        context: { schemaValidatorCollections },
+        context: { schemaValidatorCollections, originalCollectionName: validator.Name },
     });
 
     const { handleSubmit, reset } = form;
@@ -635,14 +633,20 @@ const formSchema = yup.object({
         .test(
             "is-unique-collection",
             "A schema for this collection already exists",
-            function (value, ctx: TestContext<{ schemaValidatorCollections: string[] }>) {
+            function (
+                value,
+                ctx: TestContext<{ schemaValidatorCollections: string[]; originalCollectionName?: string }>
+            ) {
                 if (!value) {
                     return true;
                 }
+                const { schemaValidatorCollections, originalCollectionName } = ctx.options.context;
 
-                return !ctx.options.context.schemaValidatorCollections
-                    .map((x) => x.toLowerCase())
-                    .includes(value.toLowerCase());
+                const collectionsToCheck = originalCollectionName
+                    ? schemaValidatorCollections.filter((x) => x.toLowerCase() !== originalCollectionName.toLowerCase())
+                    : schemaValidatorCollections;
+
+                return !collectionsToCheck.map((x) => x.toLowerCase()).includes(value.toLowerCase());
             }
         ),
     schema: yup

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
@@ -84,6 +84,8 @@ export default function DocumentSchema() {
         setSelectedStatuses,
     } = useDocumentSchema();
 
+    console.log("maxym hasDatabaseAdminAccess", hasDatabaseAdminAccess);
+
     return (
         <div className="content-margin">
             <Row className="gy-sm">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
@@ -84,8 +84,6 @@ export default function DocumentSchema() {
         setSelectedStatuses,
     } = useDocumentSchema();
 
-    console.log("maxym hasDatabaseAdminAccess", hasDatabaseAdminAccess);
-
     return (
         <div className="content-margin">
             <Row className="gy-sm">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/documentSchemaUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/documentSchemaUtils.ts
@@ -48,4 +48,8 @@ const mapToValidateSchemaRequestDto = (
     };
 };
 
-export const documentSchemaUtils = { mapToSchemaValidationConfigurationDto, mapToDocumentSchemaValidatorConfigDto, mapToValidateSchemaRequestDto };
+export const documentSchemaUtils = {
+    mapToSchemaValidationConfigurationDto,
+    mapToDocumentSchemaValidatorConfigDto,
+    mapToValidateSchemaRequestDto,
+};

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/documentSchemaUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/documentSchemaUtils.ts
@@ -2,6 +2,7 @@ import { DocumentSchemaValidatorConfig } from "components/pages/database/setting
 import { DocumentSchemaFormData } from "components/pages/database/settings/documentSchema/DocumentSchema";
 import SchemaValidationConfiguration = Raven.Client.Documents.Operations.SchemaValidation.SchemaValidationConfiguration;
 import genUtils from "common/generalUtils";
+import { ValidateSchemaFormData } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
 const mapToSchemaValidationConfigurationDto = (
     formData: DocumentSchemaValidatorConfig[],
@@ -31,4 +32,20 @@ const mapToDocumentSchemaValidatorConfigDto = (formData: DocumentSchemaFormData)
     };
 };
 
-export const documentSchemaUtils = { mapToSchemaValidationConfigurationDto, mapToDocumentSchemaValidatorConfigDto };
+const mapToValidateSchemaRequestDto = (
+    validator: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">,
+    formData: ValidateSchemaFormData
+) => {
+    if (!validator) {
+        return null;
+    }
+
+    return {
+        Collection: validator.Name,
+        SchemaDefinition: validator.Schema,
+        MaxDocumentsToValidate: formData.isTestSettingsEnabled ? formData.maxDocumentsToValidate : null,
+        MaxErrorMessages: formData.isTestSettingsEnabled ? formData.maxErrorMessages : null,
+    };
+};
+
+export const documentSchemaUtils = { mapToSchemaValidationConfigurationDto, mapToDocumentSchemaValidatorConfigDto, mapToValidateSchemaRequestDto };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -68,7 +68,7 @@ export default function DocumentSchemaPlayground() {
         <div className="content-margin">
             <Row className="gy-sm">
                 <Col>
-                    <form>
+                    <form onSubmit={handleSubmit(handleOpenSheet)}>
                         <AboutViewHeading marginBottom={4} title="Document Schema Playground" icon="rocket" />
                         <span>
                             Quickly create and test schemas against your documents without affecting your saved data.
@@ -80,7 +80,7 @@ export default function DocumentSchemaPlayground() {
                                 <Icon icon="close" />
                                 Cancel
                             </a>
-                            <Button type="submit" onClick={handleSubmit(handleOpenSheet)} className="rounded-pill">
+                            <Button type="submit" className="rounded-pill">
                                 <Icon icon="rocket" />
                                 Run test
                             </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -117,7 +117,8 @@ export default function DocumentSchemaPlayground() {
                     </form>
                 </Col>
                 <Col sm={12} lg={4}>
-                    <DocumentSchemaPlaygroundAboutView />
+                    {/*TODO: remove if about view is finished*/}
+                    {false && <DocumentSchemaPlaygroundAboutView />}
                 </Col>
             </Row>
         </div>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -31,9 +31,7 @@ import { collectionsTrackerSelectors } from "components/common/shell/collections
 import { SelectOption } from "components/common/select/Select";
 import { DocumentSchemaValidatorConfig } from "components/pages/database/settings/documentSchema/store/documentSchemaSlice";
 import DocumentSchemaPlaygroundAboutView from "components/pages/database/settings/documentSchema/partials/DocumentSchemaPlaygroundAboutView";
-import {
-    ValidationSchemaViewSheetPanel
-} from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
+import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
 export default function DocumentSchemaPlayground() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -14,24 +14,63 @@ import {
     RichPanelInfo,
     RichPanelName,
 } from "components/common/RichPanel";
-import { FormGroup, FormLabel } from "components/common/Form";
-import Select from "components/common/select/Select";
+import { FormAceEditor, FormGroup, FormLabel, FormSelect } from "components/common/Form";
 import AceEditor from "components/common/ace/AceEditor";
 import ReactAce from "react-ace/lib/ace";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppUrls } from "hooks/useAppUrls";
+import { FormProvider, useFieldArray, UseFieldArrayRemove, useForm, useFormContext } from "react-hook-form";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { FieldArrayWithId } from "react-hook-form/dist/types/fieldArray";
+import useBoolean from "hooks/useBoolean";
+import Collapse from "react-bootstrap/Collapse";
+import { useViewSheet } from "components/common/splitView/ViewSheet";
+import { collectionsTrackerSelectors } from "components/common/shell/collectionsTrackerSlice";
+import { SelectOption } from "components/common/select/Select";
+import { DocumentSchemaValidatorConfig } from "components/pages/database/settings/documentSchema/store/documentSchemaSlice";
+import DocumentSchemaPlaygroundAboutView from "components/pages/database/settings/documentSchema/partials/DocumentSchemaPlaygroundAboutView";
+import {
+    ValidationSchemaViewSheetPanel
+} from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
 export default function DocumentSchemaPlayground() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const aceRef = useRef<ReactAce>(null);
     const { appUrl } = useAppUrls();
+    const { open } = useViewSheet();
 
+    const form = useForm({
+        resolver: yupResolver(schema),
+        defaultValues: { documentSchemas: [{ collection: "", schema: "" }] },
+    });
+
+    const { control, handleSubmit } = form;
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: "documentSchemas",
+    });
+
+    const handleAppendTestField = () => {
+        append({ collection: "", schema: "" });
+    };
+
+    const handleOpenSheet = (formData: DocumentSchemaFormData) => {
+        const validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[] = formData.documentSchemas.map(
+            (ds) => ({
+                Name: ds.collection,
+                Schema: ds.schema,
+            })
+        );
+        open({
+            component: <ValidationSchemaViewSheetPanel validators={validators} />,
+        });
+    };
     return (
         <div className="content-margin">
-            <Col>
-                <Row>
-                    <Col>
+            <Row className="gy-sm">
+                <Col>
+                    <form>
                         <AboutViewHeading marginBottom={4} title="Document Schema Playground" icon="rocket" />
                         <span>
                             Quickly create and test schemas against your documents without affecting your saved data.
@@ -43,7 +82,7 @@ export default function DocumentSchemaPlayground() {
                                 <Icon icon="close" />
                                 Cancel
                             </a>
-                            <Button className="rounded-pill">
+                            <Button type="submit" onClick={handleSubmit(handleOpenSheet)} className="rounded-pill">
                                 <Icon icon="rocket" />
                                 Run test
                             </Button>
@@ -53,7 +92,12 @@ export default function DocumentSchemaPlayground() {
                             <HrHeader
                                 count={3}
                                 right={
-                                    <Button size="xs" variant="info" className="rounded-pill">
+                                    <Button
+                                        onClick={handleAppendTestField}
+                                        size="xs"
+                                        variant="info"
+                                        className="rounded-pill"
+                                    >
                                         <Icon icon="plus" />
                                         Add new
                                     </Button>
@@ -66,53 +110,109 @@ export default function DocumentSchemaPlayground() {
                                 </PopoverWithHoverWrapper>
                             </HrHeader>
 
-                            <RichPanel>
-                                <RichPanelHeader>
-                                    <RichPanelInfo>
-                                        <RichPanelName>Document schema</RichPanelName>
-                                    </RichPanelInfo>
-                                    <RichPanelActions>
-                                        <Button variant="danger">
-                                            <Icon margin="m-0" icon="trash" />
-                                        </Button>
-                                    </RichPanelActions>
-                                </RichPanelHeader>
-
-                                <RichPanelDetails>
-                                    <FormGroup className="w-100 mt-2">
-                                        <FormGroup>
-                                            <FormLabel>Collection</FormLabel>
-                                            <Select
-                                                placeholder="Select a collection (or enter a new one)"
-                                                options={[
-                                                    {
-                                                        label: "Orders",
-                                                        value: "orders",
-                                                    },
-                                                ]}
-                                            />
-                                        </FormGroup>
-                                        <FormLabel>
-                                            Document schema <Icon icon="info" color="info" margin="m-0" />
-                                        </FormLabel>
-                                        <AceEditor
-                                            height="500px"
-                                            aceRef={aceRef}
-                                            isFullScreenLabelHidden
-                                            actions={[
-                                                { component: <AceEditor.FullScreenAction /> },
-                                                { component: <AceEditor.FormatAction /> },
-                                                { component: <AceEditor.LoadFileAction onLoad={() => {}} /> },
-                                            ]}
-                                            mode="json"
-                                        />
-                                    </FormGroup>
-                                </RichPanelDetails>
-                            </RichPanel>
+                            <FormProvider {...form}>
+                                {fields.map((field, index) => (
+                                    <TestDocumentSchema remove={remove} key={field.id} {...field} index={index} />
+                                ))}
+                            </FormProvider>
                         </div>
-                    </Col>
-                </Row>
-            </Col>
+                    </form>
+                </Col>
+                <Col sm={12} lg={4}>
+                    <DocumentSchemaPlaygroundAboutView />
+                </Col>
+            </Row>
         </div>
     );
 }
+
+type ExtendedFieldArrayWithId = FieldArrayWithId<DocumentSchemaFormData["documentSchemas"]> & {
+    index: number;
+    remove: UseFieldArrayRemove;
+};
+
+function TestDocumentSchema({ index, remove }: ExtendedFieldArrayWithId) {
+    const { value: isPanelCollapsed, toggle: togglePanelCollapse } = useBoolean(false);
+    const { control, setValue } = useFormContext();
+    const aceRef = useRef<ReactAce>(null);
+
+    const allCollectionNames = useAppSelector(collectionsTrackerSelectors.userCollectionNames);
+
+    const collectionOptions: SelectOption[] = allCollectionNames.map((x) => ({
+        label: x,
+        value: x,
+    }));
+
+    return (
+        <RichPanel>
+            <RichPanelHeader>
+                <RichPanelInfo>
+                    <RichPanelName>Document schema {index + 1}</RichPanelName>
+                </RichPanelInfo>
+                <RichPanelActions>
+                    <Button onClick={() => remove(index)} variant="danger">
+                        <Icon margin="m-0" icon="trash" />
+                    </Button>
+                    <Button onClick={togglePanelCollapse} variant="secondary">
+                        <Icon margin="m-0" icon={isPanelCollapsed ? "expand-vertical" : "collapse-vertical"} />
+                    </Button>
+                </RichPanelActions>
+            </RichPanelHeader>
+
+            <Collapse in={!isPanelCollapsed} mountOnEnter unmountOnExit>
+                <div>
+                    <RichPanelDetails>
+                        <FormGroup className="w-100 mt-2">
+                            <FormGroup>
+                                <FormLabel>Collection</FormLabel>
+                                <FormSelect
+                                    control={control}
+                                    name={`documentSchemas.${index}.collection`}
+                                    placeholder="Select a collection (or enter a new one)"
+                                    options={collectionOptions}
+                                />
+                            </FormGroup>
+                            <FormLabel>
+                                Document schema <Icon icon="info" color="info" margin="m-0" />
+                            </FormLabel>
+                            <FormAceEditor
+                                control={control}
+                                name={`documentSchemas.${index}.schema`}
+                                height="500px"
+                                aceRef={aceRef}
+                                isFullScreenLabelHidden
+                                actions={[
+                                    { component: <AceEditor.FullScreenAction /> },
+                                    { component: <AceEditor.FormatAction /> },
+                                    {
+                                        component: (
+                                            <AceEditor.LoadFileAction
+                                                onLoad={(value) => {
+                                                    setValue("documentSchemas." + index + ".schema", value, {
+                                                        shouldValidate: true,
+                                                    });
+                                                }}
+                                            />
+                                        ),
+                                    },
+                                ]}
+                                mode="json"
+                            />
+                        </FormGroup>
+                    </RichPanelDetails>
+                </div>
+            </Collapse>
+        </RichPanel>
+    );
+}
+
+const schema = yup.object({
+    documentSchemas: yup.array().of(
+        yup.object({
+            collection: yup.string().required(),
+            schema: yup.string().required(),
+        })
+    ),
+});
+
+type DocumentSchemaFormData = yup.InferType<typeof schema>;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlaygroundAboutView.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlaygroundAboutView.tsx
@@ -1,0 +1,17 @@
+import { AboutViewAnchored, AccordionItemWrapper } from "components/common/AboutView";
+import React from "react";
+
+export default function DocumentSchemaPlaygroundAboutView() {
+    return (
+        <AboutViewAnchored>
+            <AccordionItemWrapper
+                icon="about"
+                color="info"
+                description="Get additional info on this feature"
+                heading="About this view"
+            >
+                todo
+            </AccordionItemWrapper>
+        </AboutViewAnchored>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaSelectActions.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import genUtils from "common/generalUtils";
 import { Icon } from "components/common/Icon";
 import { Checkbox } from "components/common/Checkbox";
@@ -28,6 +28,7 @@ import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { useAppUrls } from "hooks/useAppUrls";
 import { useViewSheet } from "components/common/splitView/ViewSheet";
 import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
+import classNames from "classnames";
 
 export interface OperationConfirm {
     type: DocumentSchemaOperationConfirmType;
@@ -47,7 +48,8 @@ export default function DocumentSchemaSelectActions() {
         setFalse: setIsTogglingGlobalStatusFalse,
     } = useBoolean(false);
     const confirm = useConfirm();
-    const [operationConfirm, setOperationConfirm] = React.useState<OperationConfirm>(null);
+    const { open } = useViewSheet();
+    const [operationConfirm, setOperationConfirm] = useState<OperationConfirm>(null);
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
@@ -55,8 +57,7 @@ export default function DocumentSchemaSelectActions() {
     const allCollectionNames = useAppSelector(documentSchemaSelectors.allCollectionNames);
     const selectedCollectionNames = useAppSelector(documentSchemaSelectors.selectedCollectionNames);
     const isGlobalDisabled = useAppSelector(documentSchemaSelectors.isGlobalDisabled);
-
-    const { open } = useViewSheet();
+    const selectionState = genUtils.getSelectionState(allCollectionNames, selectedCollectionNames);
 
     const handleOpenSheet = () => {
         const validators = allValidators.filter((v) => selectedCollectionNames.includes(v.Name));
@@ -65,12 +66,6 @@ export default function DocumentSchemaSelectActions() {
         });
         dispatch(documentSchemaActions.selectedCollectionNamesCleared());
     };
-
-    if (allCollectionNames.length === 0) {
-        return null;
-    }
-
-    const selectionState = genUtils.getSelectionState(allCollectionNames, selectedCollectionNames);
 
     const toggleAll = () => {
         reportEvent("document-schema", "toggle-select-all");
@@ -164,81 +159,96 @@ export default function DocumentSchemaSelectActions() {
 
     return (
         <>
-            <div className="position-relative d-flex w-100 justify-content-between align-items-center gap-2">
-                <div>
-                    <Checkbox
-                        selected={selectionState === "AllSelected"}
-                        indeterminate={selectionState === "SomeSelected"}
-                        toggleSelection={toggleAll}
-                        color="primary"
-                        title="Select all or none"
-                        size="lg"
-                    >
-                        <span className="small-label">Select All</span>
-                    </Checkbox>
-                    <SelectionActions active={selectionState !== "Empty"}>
-                        <div className="d-flex align-items-center justify-content-center flex-wrap gap-2">
-                            <div className="lead text-nowrap">
-                                <strong className="text-emphasis me-1">{selectedCollectionNames.length}</strong>{" "}
-                                selected
-                            </div>
-                            <ButtonGroup className="gap-2 flex-wrap justify-content-center">
-                                <Button onClick={handleOpenSheet} className="rounded-pill flex-grow-0">
-                                    <Icon icon="rocket" />
-                                    Run test
-                                </Button>
-                                <Dropdown>
-                                    <Dropdown.Toggle
-                                        variant="secondary"
-                                        disabled={selectionState === "Empty" || isTogglingStatus}
-                                        title="Set the status (enabled/disabled) of selected document schemas"
-                                        className="rounded-pill"
-                                    >
-                                        {isTogglingStatus ? <Spinner size="sm" /> : <Icon icon="play" />} Set state
-                                    </Dropdown.Toggle>
-                                    <Dropdown.Menu>
-                                        <Dropdown.Item title="Enable" onClick={() => handleStatusOperation("enable")}>
-                                            <Icon icon="play" color="success" />
-                                            <span>Enable</span>
-                                        </Dropdown.Item>
-                                        <Dropdown.Item title="Disable" onClick={() => handleStatusOperation("disable")}>
-                                            <Icon icon="stop" color="danger" />
-                                            <span>Disable</span>
-                                        </Dropdown.Item>
-                                    </Dropdown.Menu>
-                                </Dropdown>
+            <div
+                className={classNames(
+                    "position-relative d-flex w-100 align-items-center gap-2",
+                    allCollectionNames.length !== 0 ? "justify-content-between" : "justify-content-end"
+                )}
+            >
+                {allCollectionNames.length !== 0 && (
+                    <div>
+                        <Checkbox
+                            selected={selectionState === "AllSelected"}
+                            indeterminate={selectionState === "SomeSelected"}
+                            toggleSelection={toggleAll}
+                            color="primary"
+                            title="Select all or none"
+                            size="lg"
+                        >
+                            <span className="small-label">Select All</span>
+                        </Checkbox>
+                        <SelectionActions active={selectionState !== "Empty"}>
+                            <div className="d-flex align-items-center justify-content-center flex-wrap gap-2">
+                                <div className="lead text-nowrap">
+                                    <strong className="text-emphasis me-1">{selectedCollectionNames.length}</strong>{" "}
+                                    selected
+                                </div>
+                                <ButtonGroup className="gap-2 flex-wrap justify-content-center">
+                                    <Button onClick={handleOpenSheet} className="rounded-pill flex-grow-0">
+                                        <Icon icon="rocket" />
+                                        Run test
+                                    </Button>
+                                    <Dropdown>
+                                        <Dropdown.Toggle
+                                            variant="secondary"
+                                            disabled={selectionState === "Empty" || isTogglingStatus}
+                                            title="Set the status (enabled/disabled) of selected document schemas"
+                                            className="rounded-pill"
+                                        >
+                                            {isTogglingStatus ? <Spinner size="sm" /> : <Icon icon="play" />} Set state
+                                        </Dropdown.Toggle>
+                                        <Dropdown.Menu>
+                                            <Dropdown.Item
+                                                title="Enable"
+                                                onClick={() => handleStatusOperation("enable")}
+                                            >
+                                                <Icon icon="play" color="success" />
+                                                <span>Enable</span>
+                                            </Dropdown.Item>
+                                            <Dropdown.Item
+                                                title="Disable"
+                                                onClick={() => handleStatusOperation("disable")}
+                                            >
+                                                <Icon icon="stop" color="danger" />
+                                                <span>Disable</span>
+                                            </Dropdown.Item>
+                                        </Dropdown.Menu>
+                                    </Dropdown>
 
+                                    <Button
+                                        variant="danger"
+                                        onClick={toggleDeleteModal}
+                                        className="rounded-pill flex-grow-0"
+                                    >
+                                        <Icon icon="trash" /> Delete
+                                    </Button>
+                                </ButtonGroup>
                                 <Button
-                                    variant="danger"
-                                    onClick={toggleDeleteModal}
-                                    className="rounded-pill flex-grow-0"
+                                    onClick={() => dispatch(documentSchemaActions.allSelectedCollectionNamesToggled())}
+                                    variant="link"
                                 >
-                                    <Icon icon="trash" /> Delete
+                                    Cancel
                                 </Button>
-                            </ButtonGroup>
-                            <Button
-                                onClick={() => dispatch(documentSchemaActions.allSelectedCollectionNamesToggled())}
-                                variant="link"
-                            >
-                                Cancel
-                            </Button>
-                        </div>
-                    </SelectionActions>
-                </div>
+                            </div>
+                        </SelectionActions>
+                    </div>
+                )}
                 <div className="d-flex gap-2 align-items-center">
                     <a className="btn btn-secondary rounded-pill" href={urls.documentSchemaPlayground()}>
                         <Icon icon="rocket" />
                         Schema Playground
                     </a>
-                    <ButtonWithSpinner
-                        variant={isGlobalDisabled ? "success" : "secondary"}
-                        onClick={() => handleGlobalStatusOperation(!isGlobalDisabled)}
-                        isSpinning={isTogglingGlobalStatus}
-                        className="rounded-pill"
-                    >
-                        <Icon icon={isGlobalDisabled ? "play" : "stop"} />
-                        {isGlobalDisabled ? "Enable" : "Disable"} Schema Validation
-                    </ButtonWithSpinner>
+                    {allCollectionNames.length !== 0 && (
+                        <ButtonWithSpinner
+                            variant={isGlobalDisabled ? "success" : "secondary"}
+                            onClick={() => handleGlobalStatusOperation(!isGlobalDisabled)}
+                            isSpinning={isTogglingGlobalStatus}
+                            className="rounded-pill"
+                        >
+                            <Icon icon={isGlobalDisabled ? "play" : "stop"} />
+                            {isGlobalDisabled ? "Enable" : "Disable"} Schema Validation
+                        </ButtonWithSpinner>
+                    )}
                 </div>
             </div>
             {isDeleteModalOpen && (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaSelectActions.tsx
@@ -25,14 +25,18 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import { documentSchemaUtils } from "components/pages/database/settings/documentSchema/documentSchemaUtils";
 import useConfirm from "components/common/ConfirmDialog";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { useAppUrls } from "hooks/useAppUrls";
+import { useViewSheet } from "components/common/splitView/ViewSheet";
+import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
-interface OperationConfirm {
+export interface OperationConfirm {
     type: DocumentSchemaOperationConfirmType;
     onConfirm: () => void;
     validators: DocumentSchemaValidatorConfig[];
 }
 
 export default function DocumentSchemaSelectActions() {
+    const { forCurrentDatabase: urls } = useAppUrls();
     const dispatch = useDispatch();
     const { reportEvent } = useEventsCollector();
     const { value: isDeleteModalOpen, toggle: toggleDeleteModal } = useBoolean(false);
@@ -42,8 +46,8 @@ export default function DocumentSchemaSelectActions() {
         setTrue: setIsTogglingGlobalStatusTrue,
         setFalse: setIsTogglingGlobalStatusFalse,
     } = useBoolean(false);
-    const [operationConfirm, setOperationConfirm] = React.useState<OperationConfirm>(null);
     const confirm = useConfirm();
+    const [operationConfirm, setOperationConfirm] = React.useState<OperationConfirm>(null);
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
@@ -51,6 +55,16 @@ export default function DocumentSchemaSelectActions() {
     const allCollectionNames = useAppSelector(documentSchemaSelectors.allCollectionNames);
     const selectedCollectionNames = useAppSelector(documentSchemaSelectors.selectedCollectionNames);
     const isGlobalDisabled = useAppSelector(documentSchemaSelectors.isGlobalDisabled);
+
+    const { open } = useViewSheet();
+
+    const handleOpenSheet = () => {
+        const validators = allValidators.filter((v) => selectedCollectionNames.includes(v.Name));
+        open({
+            component: <ValidationSchemaViewSheetPanel validators={validators} />,
+        });
+        dispatch(documentSchemaActions.selectedCollectionNamesCleared());
+    };
 
     if (allCollectionNames.length === 0) {
         return null;
@@ -169,6 +183,10 @@ export default function DocumentSchemaSelectActions() {
                                 selected
                             </div>
                             <ButtonGroup className="gap-2 flex-wrap justify-content-center">
+                                <Button onClick={handleOpenSheet} className="rounded-pill flex-grow-0">
+                                    <Icon icon="rocket" />
+                                    Run test
+                                </Button>
                                 <Dropdown>
                                     <Dropdown.Toggle
                                         variant="secondary"
@@ -207,25 +225,21 @@ export default function DocumentSchemaSelectActions() {
                         </div>
                     </SelectionActions>
                 </div>
-                {isGlobalDisabled ? (
+                <div className="d-flex gap-2 align-items-center">
+                    <a className="btn btn-secondary rounded-pill" href={urls.documentSchemaPlayground()}>
+                        <Icon icon="rocket" />
+                        Schema Playground
+                    </a>
                     <ButtonWithSpinner
-                        variant="success"
-                        onClick={() => handleGlobalStatusOperation(false)}
+                        variant={isGlobalDisabled ? "success" : "secondary"}
+                        onClick={() => handleGlobalStatusOperation(!isGlobalDisabled)}
                         isSpinning={isTogglingGlobalStatus}
+                        className="rounded-pill"
                     >
-                        <Icon icon="play" />
-                        Enable Schema Validation
+                        <Icon icon={isGlobalDisabled ? "play" : "stop"} />
+                        {isGlobalDisabled ? "Enable" : "Disable"} Schema Validation
                     </ButtonWithSpinner>
-                ) : (
-                    <ButtonWithSpinner
-                        variant="secondary"
-                        onClick={() => handleGlobalStatusOperation(true)}
-                        isSpinning={isTogglingGlobalStatus}
-                    >
-                        <Icon icon="stop" />
-                        Disable Schema Validation
-                    </ButtonWithSpinner>
-                )}
+                </div>
             </div>
             {isDeleteModalOpen && (
                 <DocumentSchemaDeleteModal

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.scss
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.scss
@@ -3,7 +3,60 @@
 @use "Content/scss/sizes";
 
 .validation-schema-view-sheet-panel {
-    .hide-accordion-dropdown .accordion-button::after {
-        display: none;
+    .accordion {
+        border-radius: sizes.$gutter-xxs;
+
+        .accordion-item {
+            &:first-of-type {
+                border-top-left-radius: sizes.$gutter-xxs;
+                border-top-right-radius: sizes.$gutter-xxs;
+
+                .accordion-button,
+                .accordion-header {
+                    border-radius: sizes.$gutter-xxs sizes.$gutter-xxs 0 0;
+                }
+            }
+
+            &:last-of-type {
+                border-bottom-left-radius: sizes.$gutter-xxs;
+                border-bottom-right-radius: sizes.$gutter-xxs;
+
+                .accordion-collapse,
+                .accordion-button,
+                .accordion-header {
+                    border-bottom-left-radius: sizes.$gutter-xxs !important;
+                    border-bottom-right-radius: sizes.$gutter-xxs !important;
+                }
+            }
+
+            &:has(.accordion-collapse) {
+                .accordion-button,
+                .accordion-header {
+                    border-bottom: 0 !important;
+                    border-bottom-left-radius: 0 !important;
+                    border-bottom-right-radius: 0 !important;
+                }
+
+                .accordion-collapse {
+                    border-top: 0 !important;
+                }
+            }
+
+            &:not(:first-of-type) {
+                .accordion-button,
+                .accordion-header {
+                    border-top: 0 !important;
+                }
+            }
+        }
+
+        .accordion-button,
+        .accordion-collapse {
+            background-color: colors.$panel-bg-2-var;
+        }
+
+        .hide-accordion-dropdown .accordion-button::after {
+            display: none;
+        }
     }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.scss
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.scss
@@ -1,0 +1,9 @@
+@use "Content/scss/bs5variables";
+@use "Content/scss/colors";
+@use "Content/scss/sizes";
+
+.validation-schema-view-sheet-panel {
+    .hide-accordion-dropdown .accordion-button::after {
+        display: none;
+    }
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -32,17 +32,22 @@ import { isEmpty } from "common/typeUtils";
 import { documentSchemaUtils } from "components/pages/database/settings/documentSchema/documentSchemaUtils";
 import { CellWithCopyWrapper } from "components/common/virtualTable/cells/CellWithCopy";
 import CellDocumentValue from "components/common/virtualTable/cells/CellDocumentValue";
+import Code from "components/common/Code";
 
 interface ValidationSchemaViewSheetPanelProps {
     validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[];
 }
 
 interface ValidationOperationProgress extends ValidateSchemaResult {
-    completed?: boolean;
+    isCompleted?: boolean;
+    isErrored?: boolean;
+    isLoading?: boolean;
+    error?: unknown;
 }
 
 export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaViewSheetPanelProps) {
     // TODO: At the moment, when i close viewSheet, the entire state is deleted. I need to add the ability to persist this state if, for example, someone runs a test.
+    // In Phase 2 i will rewrite monitorOperationProgress logic into redux.
     const [monitorOperationProgress, setMonitorOperationProgress] = React.useState<
         Record<string, ValidationOperationProgress>
     >({});
@@ -71,34 +76,43 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
 
         const operationResults = await asyncGetOperationIds.execute(formData);
 
-        const monitorPromises = operationResults.map((result, idx) => {
+        operationResults.forEach((result, idx) => {
             const collectionName = dtos[idx].Collection;
 
-            return notificationCenter.instance.monitorOperation<ValidationOperationProgress>(
-                databaseName,
-                result.OperationId,
-                (progress) =>
+            setMonitorOperationProgress((prev) => ({
+                ...prev,
+                [collectionName]: {
+                    Errors: {},
+                    LastEtag: 0,
+                    ErrorCount: 0,
+                    ValidatedCount: 0,
+                    isLoading: true,
+                    isCompleted: false,
+                    isErrored: false,
+                },
+            }));
+
+            notificationCenter.instance
+                .monitorOperation<ValidationOperationProgress>(databaseName, result.OperationId, (progress) =>
                     setMonitorOperationProgress((prev) => ({
                         ...prev,
-                        [collectionName]: progress,
+                        [collectionName]: { ...progress, isLoading: true, isCompleted: false, isErrored: false },
                     }))
-            );
+                )
+                .then((finalResult) => {
+                    setMonitorOperationProgress((prev) => ({
+                        ...prev,
+                        [collectionName]: { ...finalResult, isCompleted: true, isLoading: false },
+                    }));
+                })
+                .catch((error) => {
+                    console.error(`Validation failed for ${collectionName}:`, error);
+                    setMonitorOperationProgress((prev) => ({
+                        ...prev,
+                        [collectionName]: { ...prev[collectionName], isErrored: true, error, isLoading: false },
+                    }));
+                });
         });
-
-        const finalResults = await Promise.all(monitorPromises);
-
-        setMonitorOperationProgress((prev) => {
-            const next = { ...prev };
-
-            finalResults.forEach((result, idx) => {
-                const collectionName = dtos[idx].Collection;
-                next[collectionName] = { ...next[collectionName], ...result, completed: true };
-            });
-
-            return next;
-        });
-
-        return finalResults;
     });
 
     const killOperation = useAsyncCallback(async () => {
@@ -118,7 +132,11 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
         control,
     });
 
-    const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || asyncTestSchema.loading;
+    const isValidating = useMemo(() => {
+        return validators.some((validator) => monitorOperationProgress[validator.Name]?.isLoading);
+    }, [monitorOperationProgress, validators]);
+
+    const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || isValidating;
 
     return (
         <FormProvider {...form}>
@@ -132,7 +150,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                     </ViewSheet.Header>
                     <ViewSheet.Body className="p-4">
                         <h4 className="w-100 text-center">
-                            {asyncTestSchema.loading ? (
+                            {isValidating ? (
                                 <ValidationProgressSummary
                                     validators={validators}
                                     monitorOperationProgress={monitorOperationProgress}
@@ -147,22 +165,21 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                                 />
                             )}
                         </h4>
-                        <Accordion alwaysOpen className="mt-1" defaultActiveKey={[]}>
+                        <Accordion alwaysOpen className="mt-1  panel-bg-2" defaultActiveKey={[]}>
                             {validators.map((validator) => (
                                 <ValidationCollectionAccordionItem
                                     key={validator.Name}
                                     validator={validator}
-                                    monitorOperationProgress={monitorOperationProgress}
+                                    monitorOperationProgress={monitorOperationProgress?.[validator.Name]}
                                     collections={collections}
                                     isTestSettingsEnabled={formValues.isTestSettingsEnabled}
                                     maxDocumentsToValidate={formValues.maxDocumentsToValidate}
-                                    isLoading={asyncTestSchema.loading}
                                 />
                             ))}
                         </Accordion>
                         <div
                             className={classNames("mt-4", {
-                                "item-disabled": asyncTestSchema.loading,
+                                "item-disabled": isValidating,
                             })}
                         >
                             <FormSwitch color="primary" control={control} name="isTestSettingsEnabled">
@@ -200,7 +217,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                         </div>
                     </ViewSheet.Body>
                     <ViewSheet.Footer className="d-flex justify-content-end">
-                        {asyncTestSchema.loading ? (
+                        {isValidating ? (
                             <ButtonWithSpinner
                                 isSpinning={killOperation.loading}
                                 icon="stop"
@@ -212,7 +229,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                             </ButtonWithSpinner>
                         ) : (
                             <ButtonWithSpinner
-                                isSpinning={asyncTestSchema.loading}
+                                isSpinning={isValidating}
                                 icon="start"
                                 variant="primary"
                                 type="submit"
@@ -388,7 +405,14 @@ interface ValidationStatusMessageProps {
 }
 
 function ValidationStatusMessage({ validators, monitorOperationProgress }: ValidationStatusMessageProps) {
-    console.log("maxym monitorOperationProgress", monitorOperationProgress);
+    if (validators.some((v) => monitorOperationProgress[v.Name]?.isErrored)) {
+        return (
+            <div>
+                <Icon icon="danger" color="danger" />
+                An unexpected error occurred during validation.
+            </div>
+        );
+    }
 
     if (isEmpty(monitorOperationProgress)) {
         return <div>You&#39;re about to run the validation schema test on these collections:</div>;
@@ -453,11 +477,10 @@ function ValidationDocumentCountDisplay({
 
 interface ValidationCollectionAccordionItemProps {
     validator: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">;
-    monitorOperationProgress: Record<string, ValidationOperationProgress>;
+    monitorOperationProgress: ValidationOperationProgress;
     collections: { name: string; documentCount: number }[];
     isTestSettingsEnabled: boolean;
     maxDocumentsToValidate: number | null;
-    isLoading: boolean;
 }
 
 function ValidationCollectionAccordionItem({
@@ -466,17 +489,35 @@ function ValidationCollectionAccordionItem({
     collections,
     isTestSettingsEnabled,
     maxDocumentsToValidate,
-    isLoading,
 }: ValidationCollectionAccordionItemProps) {
-    const validationResult = monitorOperationProgress?.[validator.Name];
-    const errorCount = validationResult?.ErrorCount ?? 0;
-    const isCompleted = validationResult?.completed;
+    const errorCount = monitorOperationProgress?.ErrorCount ?? 0;
+    const isCompleted = monitorOperationProgress?.isCompleted;
+    const isLoading = monitorOperationProgress?.isLoading;
+    const isErrored = monitorOperationProgress?.isErrored;
+
+    const errorMessage = isErrored
+        ? ((monitorOperationProgress.error as any)?.Message ?? String(monitorOperationProgress.error))
+        : null;
+    const fullError = isErrored
+        ? ((monitorOperationProgress.error as any)?.Error ?? JSON.stringify(monitorOperationProgress.error, null, 2))
+        : null;
 
     return (
-        <Accordion.Item className="border-light-var" eventKey={validator.Name}>
-            <Accordion.Header as="h5" className={classNames({ "hide-accordion-dropdown": isLoading })}>
+        <Accordion.Item eventKey={validator.Name}>
+            <Accordion.Header
+                as="h5"
+                className={classNames("border border-secondary", {
+                    "hide-accordion-dropdown": !isCompleted || (isCompleted && errorCount === 0 && !isErrored),
+                })}
+            >
                 <span>{validator.Name}</span>{" "}
-                <small className="ms-3 text-muted flex-grow-1">
+                <small className="ms-3 text-muted text-truncate flex-grow-1">
+                    {isErrored && (
+                        <b className="text-danger">
+                            <Icon icon="danger" color="danger" />
+                            {errorMessage}
+                        </b>
+                    )}
                     {isCompleted && errorCount === 0 && (
                         <b className="text-success">
                             <Icon icon="check" />
@@ -491,24 +532,47 @@ function ValidationCollectionAccordionItem({
                         </b>
                     )}
 
-                    <span>
-                        <ValidationDocumentCountDisplay
-                            collectionName={validator.Name}
-                            errorCount={errorCount}
-                            collections={collections}
-                            isTestSettingsEnabled={isTestSettingsEnabled}
-                            maxDocumentsToValidate={maxDocumentsToValidate}
-                        />
-                    </span>
+                    {!isErrored && (
+                        <span>
+                            <ValidationDocumentCountDisplay
+                                collectionName={validator.Name}
+                                errorCount={errorCount}
+                                collections={collections}
+                                isTestSettingsEnabled={isTestSettingsEnabled}
+                                maxDocumentsToValidate={maxDocumentsToValidate}
+                            />
+                        </span>
+                    )}
                 </small>
-                {isLoading && !isCompleted && <Spinner size="sm" className="spinner-gradient" />}
+                {isLoading && <Spinner size="sm" className="spinner-gradient" />}
             </Accordion.Header>
-            {!isLoading && (
-                <Accordion.Collapse unmountOnExit mountOnEnter eventKey={validator.Name}>
+            {isErrored && (
+                <Accordion.Collapse
+                    className="border border-secondary"
+                    unmountOnExit
+                    mountOnEnter
+                    eventKey={validator.Name}
+                >
+                    <Accordion.Body>
+                        <Code code={fullError} language="plaintext" />
+                    </Accordion.Body>
+                </Accordion.Collapse>
+            )}
+            {!isErrored && isCompleted && errorCount > 0 && (
+                <Accordion.Collapse
+                    className="border border-secondary"
+                    unmountOnExit
+                    mountOnEnter
+                    eventKey={validator.Name}
+                >
                     <Accordion.Body>
                         <SizeGetter
                             render={(props) => (
-                                <ValidatedDocumentsTable loading={isLoading} result={validationResult} {...props} />
+                                <ValidatedDocumentsTable
+                                    loading={isLoading}
+                                    result={monitorOperationProgress}
+                                    {...props}
+                                />
                             )}
                         />
                     </Accordion.Body>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -39,9 +39,7 @@ interface ValidationSchemaViewSheetPanelProps {
 }
 
 interface ValidationOperationProgress extends ValidateSchemaResult {
-    isCompleted?: boolean;
-    isErrored?: boolean;
-    isLoading?: boolean;
+    status?: "complete" | "loading" | "error";
     error?: unknown;
 }
 
@@ -88,9 +86,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                     LastEtag: 0,
                     ErrorCount: 0,
                     ValidatedCount: 0,
-                    isLoading: true,
-                    isCompleted: false,
-                    isErrored: false,
+                    status: "loading",
                 },
             }));
 
@@ -101,8 +97,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                     ...prev,
                     [collectionName]: {
                         ...prev[collectionName],
-                        isLoading: false,
-                        isErrored: true,
+                        status: "error",
                         error: result.reason,
                     },
                 }));
@@ -116,20 +111,20 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                 .monitorOperation<ValidationOperationProgress>(databaseName, operationId, (progress) =>
                     setMonitorOperationProgress((prev) => ({
                         ...prev,
-                        [collectionName]: { ...progress, isLoading: true, isCompleted: false, isErrored: false },
+                        [collectionName]: { ...progress, status: "loading" },
                     }))
                 )
                 .then((finalResult) => {
                     setMonitorOperationProgress((prev) => ({
                         ...prev,
-                        [collectionName]: { ...finalResult, isCompleted: true, isLoading: false },
+                        [collectionName]: { ...finalResult, status: "complete" },
                     }));
                 })
                 .catch((error) => {
                     console.error(`Validation failed for ${collectionName}:`, error);
                     setMonitorOperationProgress((prev) => ({
                         ...prev,
-                        [collectionName]: { ...prev[collectionName], isErrored: true, error, isLoading: false },
+                        [collectionName]: { ...prev[collectionName], status: "error", error },
                     }));
                 });
         });
@@ -157,7 +152,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
         control,
     });
 
-    const isValidating = validators.some((validator) => monitorOperationProgress[validator.Name]?.isLoading);
+    const isValidating = validators.some((validator) => monitorOperationProgress[validator.Name]?.status === "loading");
 
     const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || isValidating;
 
@@ -305,7 +300,10 @@ const ValidatedDocumentsTable = ({ width, loading, result }: ValidatedDocumentsT
 
 function useValidationInvalidDocumentsColumns(availableWidth: number): { columns: ColumnDef<TableProps>[] } {
     const bodyWidth = virtualTableUtils.getTableBodyWidth(availableWidth);
-    const getSize = virtualTableUtils.getCellSizeProvider(bodyWidth);
+    const getSize = React.useCallback(
+        (percentage: number) => virtualTableUtils.getCellSizeProvider(bodyWidth)(percentage),
+        [bodyWidth]
+    );
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const columns: ColumnDef<TableProps>[] = useMemo(() => {
         const cols: ColumnDef<TableProps>[] = [
@@ -428,7 +426,7 @@ interface ValidationStatusMessageProps {
 }
 
 function ValidationStatusMessage({ validators, monitorOperationProgress }: ValidationStatusMessageProps) {
-    if (validators.some((v) => monitorOperationProgress[v.Name]?.isErrored)) {
+    if (validators.some((v) => monitorOperationProgress[v.Name]?.status === "error")) {
         return (
             <div>
                 <Icon icon="danger" color="danger" />
@@ -514,9 +512,9 @@ function ValidationCollectionAccordionItem({
     maxDocumentsToValidate,
 }: ValidationCollectionAccordionItemProps) {
     const errorCount = monitorOperationProgress?.ErrorCount ?? 0;
-    const isCompleted = monitorOperationProgress?.isCompleted;
-    const isLoading = monitorOperationProgress?.isLoading;
-    const isErrored = monitorOperationProgress?.isErrored;
+    const isCompleted = monitorOperationProgress?.status === "complete";
+    const isLoading = monitorOperationProgress?.status === "loading";
+    const isErrored = monitorOperationProgress?.status === "error";
 
     const errorMessage = isErrored
         ? ((monitorOperationProgress.error as any)?.Message ?? String(monitorOperationProgress.error))

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -1,0 +1,519 @@
+import { ViewSheet } from "components/common/splitView/ViewSheet";
+import { Icon } from "components/common/Icon";
+import React, { useMemo } from "react";
+import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
+import {
+    ColumnDef,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from "@tanstack/react-table";
+import VirtualTable from "components/common/virtualTable/VirtualTable";
+import * as yup from "yup";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { FormGroup, FormInput, FormLabel, FormSwitch } from "components/common/Form";
+import classNames from "classnames";
+import { useAsyncCallback } from "react-async-hook";
+import { DocumentSchemaValidatorConfig } from "components/pages/database/settings/documentSchema/store/documentSchemaSlice";
+import { useServices } from "hooks/useServices";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import notificationCenter from "common/notifications/notificationCenter";
+import Accordion from "react-bootstrap/Accordion";
+import "./ValidationSchemaViewSheetPanel.scss";
+import Spinner from "react-bootstrap/Spinner";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import SizeGetter from "components/common/SizeGetter";
+import { collectionsTrackerSelectors } from "components/common/shell/collectionsTrackerSlice";
+import ProgressBar from "react-bootstrap/ProgressBar";
+import { isEmpty } from "common/typeUtils";
+import { documentSchemaUtils } from "components/pages/database/settings/documentSchema/documentSchemaUtils";
+import { CellWithCopyWrapper } from "components/common/virtualTable/cells/CellWithCopy";
+import CellDocumentValue from "components/common/virtualTable/cells/CellDocumentValue";
+
+interface ValidationSchemaViewSheetPanelProps {
+    validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[];
+}
+
+interface ValidationOperationProgress extends ValidateSchemaResult {
+    completed?: boolean;
+}
+
+export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaViewSheetPanelProps) {
+    // TODO: At the moment, when i close viewSheet, the entire state is deleted. I need to add the ability to persist this state if, for example, someone runs a test.
+    const [monitorOperationProgress, setMonitorOperationProgress] = React.useState<
+        Record<string, ValidationOperationProgress>
+    >({});
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { databasesService } = useServices();
+    const collections = useAppSelector(collectionsTrackerSelectors.collections);
+
+    const form = useForm<ValidateSchemaFormData>({
+        resolver: yupResolver(schema),
+    });
+
+    const asyncGetOperationIds = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
+        const dtos: ValidateSchemaRequestDto[] = validators.map((validator) =>
+            documentSchemaUtils.mapToValidateSchemaRequestDto(validator, formData)
+        );
+
+        return await Promise.all(dtos.map(async (dto) => await databasesService.validateSchema(databaseName, dto)));
+    });
+
+    const asyncTestSchema = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
+        setMonitorOperationProgress({});
+
+        const dtos: ValidateSchemaRequestDto[] = validators.map((validator) =>
+            documentSchemaUtils.mapToValidateSchemaRequestDto(validator, formData)
+        );
+
+        const operationResults = await asyncGetOperationIds.execute(formData);
+
+        const monitorPromises = operationResults.map((result, idx) => {
+            const collectionName = dtos[idx].Collection;
+
+            return notificationCenter.instance.monitorOperation<ValidationOperationProgress>(
+                databaseName,
+                result.OperationId,
+                (progress) =>
+                    setMonitorOperationProgress((prev) => ({
+                        ...prev,
+                        [collectionName]: progress,
+                    }))
+            );
+        });
+
+        const finalResults = await Promise.all(monitorPromises);
+
+        setMonitorOperationProgress((prev) => {
+            const next = { ...prev };
+
+            finalResults.forEach((result, idx) => {
+                const collectionName = dtos[idx].Collection;
+                next[collectionName] = { ...next[collectionName], ...result, completed: true };
+            });
+
+            return next;
+        });
+
+        return finalResults;
+    });
+
+    const killOperation = useAsyncCallback(async () => {
+        if (!asyncGetOperationIds.result) {
+            return [];
+        }
+
+        return Promise.all(
+            asyncGetOperationIds.result.map(async (result) =>
+                databasesService.killOperation(databaseName, result.OperationId)
+            )
+        );
+    });
+    const { control, handleSubmit } = form;
+
+    const formValues = useWatch({
+        control,
+    });
+
+    const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || asyncTestSchema.loading;
+
+    return (
+        <FormProvider {...form}>
+            <form className="h-100" onSubmit={handleSubmit(asyncTestSchema.execute)}>
+                <ViewSheet className="h-100 validation-schema-view-sheet-panel">
+                    <ViewSheet.Header>
+                        <div className="d-flex gap-2 align-items-center">
+                            <Icon icon="rocket" size="lg" className="text-primary" />
+                            <h3 className="mb-0">Validation schema test</h3>
+                        </div>
+                    </ViewSheet.Header>
+                    <ViewSheet.Body className="p-4">
+                        <h4 className="w-100 text-center">
+                            {asyncTestSchema.loading ? (
+                                <ValidationProgressSummary
+                                    validators={validators}
+                                    monitorOperationProgress={monitorOperationProgress}
+                                    collections={collections}
+                                    isTestSettingsEnabled={formValues.isTestSettingsEnabled}
+                                    maxDocumentsToValidate={formValues.maxDocumentsToValidate}
+                                />
+                            ) : (
+                                <ValidationStatusMessage
+                                    validators={validators}
+                                    monitorOperationProgress={monitorOperationProgress}
+                                />
+                            )}
+                        </h4>
+                        <Accordion alwaysOpen className="mt-1" defaultActiveKey={[]}>
+                            {validators.map((validator) => (
+                                <ValidationCollectionAccordionItem
+                                    key={validator.Name}
+                                    validator={validator}
+                                    monitorOperationProgress={monitorOperationProgress}
+                                    collections={collections}
+                                    isTestSettingsEnabled={formValues.isTestSettingsEnabled}
+                                    maxDocumentsToValidate={formValues.maxDocumentsToValidate}
+                                    isLoading={asyncTestSchema.loading}
+                                />
+                            ))}
+                        </Accordion>
+                        <div
+                            className={classNames("mt-4", {
+                                "item-disabled": asyncTestSchema.loading,
+                            })}
+                        >
+                            <FormSwitch color="primary" control={control} name="isTestSettingsEnabled">
+                                Test settings
+                            </FormSwitch>
+                            <div>Specify maximum documents and run time - leave unset for unlimited.</div>
+                            <div
+                                className={classNames("mt-2", {
+                                    "item-disabled": isTestSettingsDisabled,
+                                })}
+                            >
+                                <FormGroup>
+                                    <FormLabel>Max documents to scan (per collection)</FormLabel>
+                                    <FormInput
+                                        name="maxDocumentsToValidate"
+                                        control={control}
+                                        disabled={isTestSettingsDisabled}
+                                        addon="documents"
+                                        placeholder="e.g. 1000"
+                                        type="text"
+                                    />
+                                </FormGroup>
+                                <FormGroup>
+                                    <FormLabel>Max error messages to return</FormLabel>
+                                    <FormInput
+                                        name="maxErrorMessages"
+                                        control={control}
+                                        disabled={isTestSettingsDisabled}
+                                        placeholder="e.g. 1000"
+                                        addon="documents"
+                                        type="text"
+                                    />
+                                </FormGroup>
+                            </div>
+                        </div>
+                    </ViewSheet.Body>
+                    <ViewSheet.Footer className="d-flex justify-content-end">
+                        {asyncTestSchema.loading ? (
+                            <ButtonWithSpinner
+                                isSpinning={killOperation.loading}
+                                icon="stop"
+                                variant="danger"
+                                className="rounded-pill"
+                                onClick={killOperation.execute}
+                            >
+                                Abort operation
+                            </ButtonWithSpinner>
+                        ) : (
+                            <ButtonWithSpinner
+                                isSpinning={asyncTestSchema.loading}
+                                icon="start"
+                                variant="primary"
+                                type="submit"
+                                className="rounded-pill"
+                            >
+                                Run test
+                            </ButtonWithSpinner>
+                        )}
+                    </ViewSheet.Footer>
+                </ViewSheet>
+            </form>
+        </FormProvider>
+    );
+}
+
+interface ValidatedDocumentsTableProps {
+    width: number;
+    loading: boolean;
+    result?: ValidateSchemaResult;
+}
+
+interface TableProps {
+    documentId: string;
+    error: string;
+}
+
+const ValidatedDocumentsTable = ({ width, loading, result }: ValidatedDocumentsTableProps) => {
+    const { columns } = useValidationInvalidDocumentsColumns(width);
+
+    const data: TableProps[] = useMemo(() => {
+        if (!result?.Errors) {
+            return [];
+        }
+
+        return Object.entries(result.Errors).map(([key, value]) => ({
+            documentId: key,
+            error: value,
+        }));
+    }, [result]);
+
+    const table = useReactTable({
+        data,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+    });
+    return <VirtualTable className="panel-bg-1" isLoading={loading} table={table} heightInPx={400} />;
+};
+
+function useValidationInvalidDocumentsColumns(availableWidth: number): { columns: ColumnDef<TableProps>[] } {
+    const bodyWidth = virtualTableUtils.getTableBodyWidth(availableWidth);
+    const getSize = virtualTableUtils.getCellSizeProvider(bodyWidth);
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const columns: ColumnDef<TableProps>[] = useMemo(() => {
+        const cols: ColumnDef<TableProps>[] = [
+            {
+                header: "@id",
+                accessorKey: "documentId",
+                cell: ({ getValue }) => (
+                    <CellDocumentValue value={getValue()} databaseName={databaseName} hasHyperlinkForIds />
+                ),
+                size: getSize(25),
+            },
+            {
+                header: "Error message",
+                accessorKey: "error",
+                cell: CellWithCopyWrapper,
+                size: getSize(75),
+            },
+        ];
+
+        return cols;
+    }, []);
+
+    return { columns };
+}
+
+const schema = yup.object({
+    isTestSettingsEnabled: yup.boolean(),
+    maxDocumentsToValidate: yup.number().nullable().positive(),
+    maxErrorMessages: yup.number().nullable().positive(),
+});
+
+export type ValidateSchemaFormData = yup.InferType<typeof schema>;
+
+interface ValidationTotals {
+    totalValidated: number;
+    totalTarget: number;
+}
+
+function getCollectionDocumentCount(
+    collectionName: string,
+    collections: { name: string; documentCount: number }[]
+): number {
+    return collections.find((c) => c.name === collectionName)?.documentCount ?? 0;
+}
+
+function calculateTargetDocumentCount(
+    collectionName: string,
+    collections: { name: string; documentCount: number }[],
+    isTestSettingsEnabled: boolean,
+    maxDocumentsToValidate: number | null
+): number {
+    const docCount = getCollectionDocumentCount(collectionName, collections);
+    const maxDocs = isTestSettingsEnabled ? maxDocumentsToValidate : null;
+    return typeof maxDocs === "number" && maxDocs > 0 ? Math.min(docCount, maxDocs) : docCount;
+}
+
+function calculateValidationTotals(
+    validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[],
+    monitorOperationProgress: Record<string, ValidationOperationProgress>,
+    collections: { name: string; documentCount: number }[],
+    isTestSettingsEnabled: boolean,
+    maxDocumentsToValidate: number | null
+): ValidationTotals {
+    const totalValidated = validators.reduce((sum, v) => {
+        return sum + (monitorOperationProgress?.[v.Name]?.ValidatedCount ?? 0);
+    }, 0);
+
+    const totalTarget = validators.reduce((sum, v) => {
+        const targetForCol = calculateTargetDocumentCount(
+            v.Name,
+            collections,
+            isTestSettingsEnabled,
+            maxDocumentsToValidate
+        );
+        return sum + targetForCol;
+    }, 0);
+
+    return { totalValidated, totalTarget };
+}
+
+interface ValidationProgressSummaryProps {
+    validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[];
+    monitorOperationProgress: Record<string, ValidationOperationProgress>;
+    collections: { name: string; documentCount: number }[];
+    isTestSettingsEnabled: boolean;
+    maxDocumentsToValidate: number | null;
+}
+
+function ValidationProgressSummary({
+    validators,
+    monitorOperationProgress,
+    collections,
+    isTestSettingsEnabled,
+    maxDocumentsToValidate,
+}: ValidationProgressSummaryProps) {
+    const { totalValidated, totalTarget } = calculateValidationTotals(
+        validators,
+        monitorOperationProgress,
+        collections,
+        isTestSettingsEnabled,
+        maxDocumentsToValidate
+    );
+
+    return (
+        <div>
+            <div className="hstack justify-content-between mb-1">
+                <h4 className="mb-0">Running validation schema test...</h4>
+                <small className="text-muted text-nowrap">
+                    {totalValidated} / {totalTarget} documents tested
+                </small>
+            </div>
+            <ProgressBar max={totalTarget} min={0} now={totalValidated} />
+        </div>
+    );
+}
+
+interface ValidationStatusMessageProps {
+    validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[];
+    monitorOperationProgress: Record<string, ValidationOperationProgress>;
+}
+
+function ValidationStatusMessage({ validators, monitorOperationProgress }: ValidationStatusMessageProps) {
+    console.log("maxym monitorOperationProgress", monitorOperationProgress);
+
+    if (isEmpty(monitorOperationProgress)) {
+        return <div>You&#39;re about to run the validation schema test on these collections:</div>;
+    }
+
+    const totalErrors = validators.reduce((sum, v) => {
+        return sum + (monitorOperationProgress?.[v.Name]?.ErrorCount ?? 0);
+    }, 0);
+
+    if (totalErrors > 0) {
+        return (
+            <div>
+                <Icon icon="warning" className="text-warning" />
+                <b className="text-warning">
+                    {totalErrors} invalid document
+                    {totalErrors !== 1 ? "s " : " "}
+                </b>
+                <span>been found according to the defined document schemas.</span>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <span className="text-success">
+                <Icon icon="check" />
+                <b>All documents validated successfully </b>
+            </span>
+            <span>against the defined schemas with no errors found.</span>
+        </div>
+    );
+}
+
+interface ValidationDocumentCountDisplayProps {
+    collectionName: string;
+    errorCount: number;
+    collections: { name: string; documentCount: number }[];
+    isTestSettingsEnabled: boolean;
+    maxDocumentsToValidate: number | null;
+}
+
+function ValidationDocumentCountDisplay({
+    collectionName,
+    errorCount,
+    collections,
+    isTestSettingsEnabled,
+    maxDocumentsToValidate,
+}: ValidationDocumentCountDisplayProps) {
+    if (errorCount > 0) {
+        const targetCount = calculateTargetDocumentCount(
+            collectionName,
+            collections,
+            isTestSettingsEnabled,
+            maxDocumentsToValidate
+        );
+        return <span> (out of {targetCount} documents)</span>;
+    }
+
+    const docCount = getCollectionDocumentCount(collectionName, collections);
+    return <span> ({docCount}) documents</span>;
+}
+
+interface ValidationCollectionAccordionItemProps {
+    validator: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">;
+    monitorOperationProgress: Record<string, ValidationOperationProgress>;
+    collections: { name: string; documentCount: number }[];
+    isTestSettingsEnabled: boolean;
+    maxDocumentsToValidate: number | null;
+    isLoading: boolean;
+}
+
+function ValidationCollectionAccordionItem({
+    validator,
+    monitorOperationProgress,
+    collections,
+    isTestSettingsEnabled,
+    maxDocumentsToValidate,
+    isLoading,
+}: ValidationCollectionAccordionItemProps) {
+    const validationResult = monitorOperationProgress?.[validator.Name];
+    const errorCount = validationResult?.ErrorCount ?? 0;
+    const isCompleted = validationResult?.completed;
+
+    return (
+        <Accordion.Item className="border-light-var" eventKey={validator.Name}>
+            <Accordion.Header as="h5" className={classNames({ "hide-accordion-dropdown": isLoading })}>
+                <span>{validator.Name}</span>{" "}
+                <small className="ms-3 text-muted flex-grow-1">
+                    {isCompleted && errorCount === 0 && (
+                        <b className="text-success">
+                            <Icon icon="check" />
+                            <span>All valid</span>
+                        </b>
+                    )}
+
+                    {isCompleted && errorCount > 0 && (
+                        <b className="text-warning">
+                            <Icon icon="warning" />
+                            <span>{errorCount} invalid</span>
+                        </b>
+                    )}
+
+                    <span>
+                        <ValidationDocumentCountDisplay
+                            collectionName={validator.Name}
+                            errorCount={errorCount}
+                            collections={collections}
+                            isTestSettingsEnabled={isTestSettingsEnabled}
+                            maxDocumentsToValidate={maxDocumentsToValidate}
+                        />
+                    </span>
+                </small>
+                {isLoading && !isCompleted && <Spinner size="sm" className="spinner-gradient" />}
+            </Accordion.Header>
+            {!isLoading && (
+                <Accordion.Collapse unmountOnExit mountOnEnter eventKey={validator.Name}>
+                    <Accordion.Body>
+                        <SizeGetter
+                            render={(props) => (
+                                <ValidatedDocumentsTable loading={isLoading} result={validationResult} {...props} />
+                            )}
+                        />
+                    </Accordion.Body>
+                </Accordion.Collapse>
+            )}
+        </Accordion.Item>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -64,7 +64,9 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
             documentSchemaUtils.mapToValidateSchemaRequestDto(validator, formData)
         );
 
-        return await Promise.all(dtos.map(async (dto) => await databasesService.validateSchema(databaseName, dto)));
+        return await Promise.allSettled(
+            dtos.map(async (dto) => await databasesService.validateSchema(databaseName, dto))
+        );
     });
 
     const asyncTestSchema = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
@@ -92,8 +94,26 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                 },
             }));
 
+            if (result.status === "rejected") {
+                console.error(`Validation operation failed to start for ${collectionName}:`, result.reason);
+
+                setMonitorOperationProgress((prev) => ({
+                    ...prev,
+                    [collectionName]: {
+                        ...prev[collectionName],
+                        isLoading: false,
+                        isErrored: true,
+                        error: result.reason,
+                    },
+                }));
+
+                return;
+            }
+
+            const operationId = result.value.OperationId;
+
             notificationCenter.instance
-                .monitorOperation<ValidationOperationProgress>(databaseName, result.OperationId, (progress) =>
+                .monitorOperation<ValidationOperationProgress>(databaseName, operationId, (progress) =>
                     setMonitorOperationProgress((prev) => ({
                         ...prev,
                         [collectionName]: { ...progress, isLoading: true, isCompleted: false, isErrored: false },
@@ -120,21 +140,24 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
             return [];
         }
 
-        return Promise.all(
-            asyncGetOperationIds.result.map(async (result) =>
-                databasesService.killOperation(databaseName, result.OperationId)
-            )
+        const settledResults = asyncGetOperationIds.result;
+
+        return Promise.allSettled(
+            settledResults
+                .filter((r) => r.status === "fulfilled")
+                .map((fulfilledResult) =>
+                    databasesService.killOperation(databaseName, fulfilledResult.value.OperationId)
+                )
         );
     });
+
     const { control, handleSubmit } = form;
 
     const formValues = useWatch({
         control,
     });
 
-    const isValidating = useMemo(() => {
-        return validators.some((validator) => monitorOperationProgress[validator.Name]?.isLoading);
-    }, [monitorOperationProgress, validators]);
+    const isValidating = validators.some((validator) => monitorOperationProgress[validator.Name]?.isLoading);
 
     const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || isValidating;
 
@@ -303,7 +326,7 @@ function useValidationInvalidDocumentsColumns(availableWidth: number): { columns
         ];
 
         return cols;
-    }, []);
+    }, [getSize]);
 
     return { columns };
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -33,6 +33,7 @@ import { documentSchemaUtils } from "components/pages/database/settings/document
 import { CellWithCopyWrapper } from "components/common/virtualTable/cells/CellWithCopy";
 import CellDocumentValue from "components/common/virtualTable/cells/CellDocumentValue";
 import Code from "components/common/Code";
+import { virtualTableConstants } from "components/common/virtualTable/utils/virtualTableConstants";
 
 interface ValidationSchemaViewSheetPanelProps {
     validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[];
@@ -295,7 +296,14 @@ const ValidatedDocumentsTable = ({ width, loading, result }: ValidatedDocumentsT
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
     });
-    return <VirtualTable className="panel-bg-1" isLoading={loading} table={table} heightInPx={400} />;
+    return (
+        <VirtualTable
+            className="panel-bg-1"
+            isLoading={loading}
+            table={table}
+            heightInPx={virtualTableUtils.getHeightInPx(data.length, virtualTableConstants.defaultTableHeightInPx)}
+        />
+    );
 };
 
 function useValidationInvalidDocumentsColumns(availableWidth: number): { columns: ColumnDef<TableProps>[] } {
@@ -305,8 +313,8 @@ function useValidationInvalidDocumentsColumns(availableWidth: number): { columns
         [bodyWidth]
     );
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const columns: ColumnDef<TableProps>[] = useMemo(() => {
-        const cols: ColumnDef<TableProps>[] = [
+    const columns: ColumnDef<TableProps>[] = useMemo(
+        () => [
             {
                 header: "@id",
                 accessorKey: "documentId",
@@ -321,10 +329,9 @@ function useValidationInvalidDocumentsColumns(availableWidth: number): { columns
                 cell: CellWithCopyWrapper,
                 size: getSize(75),
             },
-        ];
-
-        return cols;
-    }, [getSize]);
+        ],
+        [getSize]
+    );
 
     return { columns };
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/store/documentSchemaSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/store/documentSchemaSlice.ts
@@ -81,6 +81,9 @@ export const documentSchemaSlice = createSlice({
                 state.selectedCollectionNames.push(name);
             }
         },
+        selectedCollectionNamesCleared: (state) => {
+            state.selectedCollectionNames = [];
+        },
         selectedValidatorsDeleted: (state) => {
             validatorsAdapter.removeMany(state.validators, state.selectedCollectionNames);
             state.selectedCollectionNames = [];
@@ -102,9 +105,7 @@ export const documentSchemaSlice = createSlice({
     extraReducers: () => {},
 });
 
-export const documentSchemaActions = {
-    ...documentSchemaSlice.actions,
-};
+export const documentSchemaActions = documentSchemaSlice.actions;
 
 export const documentSchemaSliceInternal = {
     validatorsSelectors,

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -76,6 +76,7 @@ import getDocumentWithMetadataCommand = require("commands/database/documents/get
 import getDocumentsByIDPrefixCommand = require("commands/database/documents/getDocumentsByIDPrefixCommand");
 import getSchemaValidationCommand from "commands/database/settings/getSchemaValidationCommand";
 import saveSchemaValidationCommand from "commands/database/settings/saveSchemaValidationCommand";
+import validateSchemaCommand from "commands/database/settings/validateSchemaCommand";
 
 export default class DatabasesService {
     async setLockMode(databaseNames: string[], newLockMode: DatabaseLockMode) {
@@ -364,5 +365,9 @@ export default class DatabasesService {
 
     async saveSchemaValidation(...args: ConstructorParameters<typeof saveSchemaValidationCommand>) {
         return new saveSchemaValidationCommand(...args).execute();
+    }
+
+    async validateSchema(...args: ConstructorParameters<typeof validateSchemaCommand>) {
+        return new validateSchemaCommand(...args).execute();
     }
 }

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -298,6 +298,7 @@ class indexDefinition {
 
     toDto(): Raven.Client.Documents.Indexes.IndexDefinition {
         return {
+            SchemaDefinitions: null,
             Name: this.name(),
             Maps: this.maps().map(m => m.map()),
             Reduce: this.reduce(),
@@ -404,6 +405,7 @@ class indexDefinition {
     
     static createDefaultIndexDefinition(indexingDatabaseSettings?: indexingDatabaseSettingsTypes.IndexingDatabaseSettingsType): indexDefinition {
         return new indexDefinition({
+            SchemaDefinitions: null,
             Fields: {},
             Maps: [""],
             Name: "",

--- a/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
@@ -201,6 +201,7 @@ export class IndexesStubs {
                         AdditionalSources: {},
                         AdditionalAssemblies: [],
                         CompoundFields: [],
+                        SchemaDefinitions: null,
                     },
                     Collection: "Products",
                     SurpassingIndex: "",

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/validateSchemaDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/validateSchemaDetails.ts
@@ -1,0 +1,147 @@
+import app = require("durandal/app");
+
+import operation = require("common/notifications/models/operation");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import abstractOperationDetails = require("viewmodels/common/notificationCenter/detailViewer/operations/abstractOperationDetails");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import generalUtils = require("common/generalUtils");
+
+type gridItem = {
+    Id: string;
+    Message: string;
+};
+
+class validateSchemaDetails extends abstractOperationDetails {
+    view = require("views/common/notificationCenter/detailViewer/operations/validateSchemaDetails.html");
+
+    progress: KnockoutObservable<ValidateSchemaResult>;
+
+    private gridController = ko.observable<virtualGridController<gridItem>>();
+    private columnPreview = new columnPreviewPlugin<gridItem>();
+    private allErrors = ko.observableArray<gridItem>([]);
+
+    private gridInitialized = false;
+
+    constructor(op: operation, notificationCenter: notificationCenter) {
+        super(op, notificationCenter);
+        this.initObservables();
+    }
+
+    static supportsDetailsFor(notification: abstractNotification) {
+        return notification instanceof operation && notification.taskType() === "ValidateSchema";
+    }
+
+    static showDetailsFor(op: operation, center: notificationCenter) {
+        return app.showBootstrapDialog(new validateSchemaDetails(op, center));
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+
+        const initialResult = this.progress();
+        if (initialResult) {
+            this.updateErrors(initialResult);
+            this.ensureGridInitialized();
+        }
+
+        this.progress.subscribe((result) => {
+            if (result) {
+                this.updateErrors(result);
+                this.ensureGridInitialized();
+                this.refreshGrid();
+            }
+        });
+    }
+
+    protected initObservables() {
+        super.initObservables();
+
+        this.progress = ko.pureComputed(() => {
+            const progressResults = this.op.status() === "Completed" ? this.op.result() : this.op.progress();
+
+            if (this.op.status() === "Completed") {
+                this.allErrors(
+                    Object.entries((this.op.result() as ValidateSchemaResult).Errors ?? {}).map(
+                        ([key, value]): gridItem => ({
+                            Id: key,
+                            Message: value,
+                        })
+                    )
+                );
+            }
+
+            return progressResults as ValidateSchemaResult;
+        });
+    }
+
+    private ensureGridInitialized() {
+        if (!this.gridInitialized) {
+            this.initGrid();
+        }
+    }
+
+    private refreshGrid() {
+        const grid = this.gridController();
+        if (grid) {
+            grid.reset(true);
+        }
+    }
+
+    private updateErrors(result: ValidateSchemaResult) {
+        this.allErrors(
+            Object.entries(result.Errors ?? {}).map(([key, value]): gridItem => ({
+                Id: key,
+                Message: value,
+            }))
+        );
+    }
+
+    private initGrid() {
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init(
+            () => this.fetcher(),
+            () => {
+                return [
+                    new textColumn<gridItem>(grid, (x) => x.Id, "Document ID", "30%", {
+                        sortable: "string",
+                    }),
+                    new textColumn<gridItem>(grid, (x) => x.Message, "Error", "70%", {
+                        sortable: "string",
+                    }),
+                ];
+            }
+        );
+
+        this.columnPreview.install(
+            ".validateSchemaDetails",
+            ".js-validate-schema-tooltip",
+            (
+                details: gridItem,
+                column: textColumn<gridItem>,
+                e: JQuery.TriggeredEvent,
+                onValue: (context: any, valueToCopy?: string) => void
+            ) => {
+                const value = column.getCellValue(details);
+                if (value) {
+                    onValue(generalUtils.escapeHtml(value));
+                }
+            }
+        );
+
+        this.gridInitialized = true;
+    }
+
+    private fetcher(): JQueryPromise<pagedResult<gridItem>> {
+        return $.Deferred<pagedResult<gridItem>>().resolve({
+            items: this.allErrors(),
+            totalResultCount: this.allErrors().length,
+        });
+    }
+}
+
+export = validateSchemaDetails;

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -289,7 +289,7 @@ class shell extends viewModelBase {
         this.helpAndResourcesWidgetView = ko.pureComputed(() => ({ component: HelpAndResourcesWidget.HelpAndResourcesWidget }));
 
         this.isHelpAndResourcesWidgetVisible = ko.pureComputed(() => {
-            const routesToHide: string[] = ["databases/ai/agents/edit", "databases/ai/agents/chat"];
+            const routesToHide: string[] = ["databases/ai/agents/edit", "databases/ai/agents/chat", "databases/settings/documentSchema", "databases/settings/documentSchema/playground"];
             const route = genUtils.getSingleRoute(router.activeInstruction()?.config?.route);
 
             return !routesToHide.includes(route);

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1120,3 +1120,23 @@ interface AiModelsRequestDto {
 interface GetAiAgentResultDto {
     AiAgents: Raven.Client.Documents.Operations.AI.Agents.AiAgentConfiguration[];
 }
+
+interface ValidateSchemaRequestDto {
+    SchemaDefinition: string;
+    Collection: string;
+    MaxErrorMessages?: number;
+    MaxDocumentsToValidate?: number;
+    StartEtag?: string;
+}
+
+interface ValidateSchemaResponseDto {
+    OperationId: number;
+    OperationNodeTag: string;
+}
+
+interface ValidateSchemaResult {
+    ErrorCount: number;
+    Errors: Record<string, string>
+    LastEtag: number;
+    ValidatedCount: number;
+}

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/validateSchemaDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/validateSchemaDetails.html
@@ -1,0 +1,57 @@
+<div class="modal-dialog modal-lg validateSchemaDetails" role="document" id="validateSchemaModal">
+    <div class="modal-content" tabindex="-1">
+        <div class="modal-header">
+            <div class="flex-horizontal">
+                <div class="flex-grow">
+                    <h3 class="modal-title" id="myModalLabel" data-bind="text: op.title, attr:{ class: 'modal-title ' + op.headerClass() }"></h3>
+                </div>
+                <div class="flex-grow text-right margin-right margin-right-sm">
+                    <span class="text-muted">Time elapsed:</span> <span data-bind="text: op.duration"></span>
+                </div>
+                <div>
+                    <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                        <i class="icon-cancel"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="notification-time" data-bind="text: op.displayDate().format('LLL')"></div>
+        </div>
+        <div class="modal-body">
+            <p data-bind="html: op.message"></p>
+            <div class="modal-details" data-bind="with: progress">
+                <div class="details-item">
+                    <div class="row">
+                        <div class="col-sm-6 text-right">Scanned documents:</div>
+                        <div class="col-sm-6 details-value" data-bind="text: ValidatedCount.toLocaleString()"></div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6 text-right">Errors count:</div>
+                        <div class="col-sm-6 details-value" data-bind="text: ErrorCount.toLocaleString()"></div>
+                    </div>
+                </div>
+            </div>
+            <div data-bind="if: operationFailed">
+                <h3 class="text-danger text-center">Operation failed!</h3>
+                <pre class="margin-top error-messages">
+                    <code data-bind="foreach: errorMessages"><span data-bind="text: $data"></span></code>
+                </pre>
+            </div>
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController, emptyTemplate: 'empty-validate-schema-template'"></virtual-grid>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: $root.footerPartialView">
+        </div>
+    </div>
+</div>
+
+<div class="tooltip json-preview js-validate-schema-tooltip" style="opacity: 0">
+</div>
+
+<script type="text/html" id="empty-validate-schema-template">
+    No errors were found.
+    <br/>
+    Your data matches the provided schema.
+    <br/>
+    If you expected errors, please re-run validation with a different schema or dataset.
+</script>

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -492,20 +492,15 @@ namespace Sparrow.Json
             if (field == null)
                 return null;
 
-            return GetLazyString(field, longLived: false);
+            return GetLazyString(field, field, longLived: false);
         }
 
         private LazyStringValue GetLazyString(StringSegment field, bool longLived)
         {
-            return GetLazyString(field.AsSpan(), field, longLived);
-        }
-
-        public LazyStringValue GetLazyString(ReadOnlySpan<char> value, bool longLived)
-        {
-            return GetLazyString(value, StringSegment.Empty, longLived);
+            return GetLazyString(field.AsSpan(), field.Value, longLived);
         }
         
-        public unsafe LazyStringValue GetLazyString(ReadOnlySpan<char> value, StringSegment strValue, bool longLived)
+        public unsafe LazyStringValue GetLazyString(ReadOnlySpan<char> value, string strValue, bool longLived)
         {
             var state = new JsonParserState();
             var maxByteCount = Encodings.Utf8.GetMaxByteCount(value.Length);
@@ -521,7 +516,7 @@ namespace Sparrow.Json
             state.FindEscapedPositionsAndEscapeControls(address, ref actualSize, escapePositionsSize);
 
             state.WriteEscapePositionsTo(address + actualSize);
-            LazyStringValue result = longLived == false ? AllocateStringValue(strValue.Value, address, actualSize) : new LazyStringValue(strValue.Value, address, actualSize, this);
+            LazyStringValue result = longLived == false ? AllocateStringValue(strValue, address, actualSize) : new LazyStringValue(strValue, address, actualSize, this);
             result.AllocatedMemoryData = memory;
 
             if (state.EscapePositions.Count > 0)

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -495,33 +495,40 @@ namespace Sparrow.Json
             return GetLazyString(field, longLived: false);
         }
 
-        private unsafe LazyStringValue GetLazyString(StringSegment field, bool longLived)
+        private LazyStringValue GetLazyString(StringSegment field, bool longLived)
+        {
+            return GetLazyString(field.AsSpan(), field, longLived);
+        }
+
+        public LazyStringValue GetLazyString(ReadOnlySpan<char> value, bool longLived)
+        {
+            return GetLazyString(value, StringSegment.Empty, longLived);
+        }
+        
+        public unsafe LazyStringValue GetLazyString(ReadOnlySpan<char> value, StringSegment strValue, bool longLived)
         {
             var state = new JsonParserState();
-            var maxByteCount = Encodings.Utf8.GetMaxByteCount(field.Length);
+            var maxByteCount = Encodings.Utf8.GetMaxByteCount(value.Length);
 
-            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(field, out _);
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(value, out _);
 
             int memorySize = maxByteCount + escapePositionsSize;
             var memory = longLived ? GetLongLivedMemory(memorySize) : GetMemory(memorySize);
 
-            fixed (char* pField = field.Buffer)
+            var address = memory.Address;
+            var actualSize = Encodings.Utf8.GetBytes(value, new Span<byte>(address, memory.SizeInBytes));
+
+            state.FindEscapedPositionsAndEscapeControls(address, ref actualSize, escapePositionsSize);
+
+            state.WriteEscapePositionsTo(address + actualSize);
+            LazyStringValue result = longLived == false ? AllocateStringValue(strValue.Value, address, actualSize) : new LazyStringValue(strValue.Value, address, actualSize, this);
+            result.AllocatedMemoryData = memory;
+
+            if (state.EscapePositions.Count > 0)
             {
-                var address = memory.Address;
-                var actualSize = Encodings.Utf8.GetBytes(pField + field.Offset, field.Length, address, memory.SizeInBytes);
-
-                state.FindEscapedPositionsAndEscapeControls(address, ref actualSize, escapePositionsSize);
-
-                state.WriteEscapePositionsTo(address + actualSize);
-                LazyStringValue result = longLived == false ? AllocateStringValue(field.Value, address, actualSize) : new LazyStringValue(field.Value, address, actualSize, this);
-                result.AllocatedMemoryData = memory;
-
-                if (state.EscapePositions.Count > 0)
-                {
-                    result.EscapePositions = state.EscapePositions.ToArray();
-                }
-                return result;
+                result.EscapePositions = state.EscapePositions.ToArray();
             }
+            return result;
         }
 
         public unsafe LazyStringValue GetLazyString(Span<byte> span, bool longLived)

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -492,7 +492,7 @@ namespace Sparrow.Json
             if (field == null)
                 return null;
 
-            return GetLazyString(field, field, longLived: false);
+            return GetLazyString(field.AsSpan(), field, longLived: false);
         }
 
         private LazyStringValue GetLazyString(StringSegment field, bool longLived)

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -77,7 +77,7 @@ namespace FastTests.Client
                 "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand",
                 "GetCollectionRevisionsStatisticsCommand", "AddGenAiCommand","UpdateGenAiCommand", "AddEmbeddingsGenerationCommand",
                 "AddOrUpdateAiAgentOperationCommand","DeleteAiAgentOperationCommand","RunConversationOperationCommand","GetAiAgentOperationCommand",
-                "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand", "ValidateSchemaCommand"
+                "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand", "StartSchemaValidationCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -77,7 +77,7 @@ namespace FastTests.Client
                 "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand",
                 "GetCollectionRevisionsStatisticsCommand", "AddGenAiCommand","UpdateGenAiCommand", "AddEmbeddingsGenerationCommand",
                 "AddOrUpdateAiAgentOperationCommand","DeleteAiAgentOperationCommand","RunConversationOperationCommand","GetAiAgentOperationCommand",
-                "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand", "ValidateSchemaValidationCommand"
+                "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand", "ValidateSchemaCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -77,7 +77,7 @@ namespace FastTests.Client
                 "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand",
                 "GetCollectionRevisionsStatisticsCommand", "AddGenAiCommand","UpdateGenAiCommand", "AddEmbeddingsGenerationCommand",
                 "AddOrUpdateAiAgentOperationCommand","DeleteAiAgentOperationCommand","RunConversationOperationCommand","GetAiAgentOperationCommand",
-                "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand"
+                "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand", "ValidateSchemaValidationCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Issues/RavenDB-6250.cs
+++ b/test/FastTests/Issues/RavenDB-6250.cs
@@ -46,7 +46,8 @@ namespace FastTests.Issues
                 OperationType.EnforceRevisionConfiguration,
                 OperationType.DumpRawIndexData,
                 OperationType.Resharding,
-                OperationType.AdoptOrphanedRevisions
+                OperationType.AdoptOrphanedRevisions,
+                OperationType.ValidateSchema
             };
 
             var operationWithoutDetails = new HashSet<OperationType>

--- a/test/FastTests/SchemaValidation/SchemaValidationTestsBase.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationTestsBase.cs
@@ -59,7 +59,7 @@ public static class SchemaValidationTestsHelper
                 return true;
             }
 
-            errors = new string(errorBuilder.GetErrors());
+            errors = new string(errorBuilder.ToString());
             return false;
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-17597.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17597.cs
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
                 Configuration = conf,
                 CompoundFields = new List<string[]> { new[] { "Name", "Age" } },
                 ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior.ExcludeArchived,
-                SchemaValidation = "{'properties':{'Name':{'type':'string'}}}"
+                SchemaDefinitions = new IndexSchemaDefinitions{{"Users", "{ 'type': 'object', 'properties': { 'Name': { 'type': 'string' } } }"}}
             };
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB-17597.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17597.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Indexes)]
         public void CopyToIndexDefinitionWorksProperly()
         {
-            IndexDefinition a = GetNonDefaultIndexDefinition();
+            var a = GetNonDefaultIndexDefinition();
 
 
             var defaultIndexDefinition = new IndexDefinition();
@@ -80,14 +80,16 @@ namespace SlowTests.Issues
                 PatternReferencesCollectionName = "abcdef",
                 DeploymentMode = IndexDeploymentMode.Rolling,
                 AdditionalSources = new Dictionary<string, string>() { { "a", "A" }, { "b", "B" } },
-                AdditionalAssemblies = new HashSet<AdditionalAssembly>(){
+                AdditionalAssemblies = new HashSet<AdditionalAssembly>()
+                {
                     asm1,
                     asm2,
                 },
                 Maps = new HashSet<string>() { "m1", "m2" },
                 Fields = new Dictionary<string, IndexFieldOptions>()
                 {
-                    {"x", new IndexFieldOptions()
+                    {
+                        "x", new IndexFieldOptions()
                         {
                             Analyzer = "x1",
                             Spatial = new SpatialOptions()
@@ -101,7 +103,8 @@ namespace SlowTests.Issues
                             TermVector = FieldTermVector.WithPositions
                         }
                     },
-                    {"y", new IndexFieldOptions()
+                    {
+                        "y", new IndexFieldOptions()
                         {
                             Analyzer = "y1",
                             Spatial = new SpatialOptions()
@@ -117,8 +120,9 @@ namespace SlowTests.Issues
                     }
                 },
                 Configuration = conf,
-                CompoundFields = new List<string[]> {new []{"Name","Age"}},
-                ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior.ExcludeArchived
+                CompoundFields = new List<string[]> { new[] { "Name", "Age" } },
+                ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior.ExcludeArchived,
+                SchemaValidation = "{'properties':{'Name':{'type':'string'}}}"
             };
         }
 

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -690,7 +690,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
                 { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
-        var e = await Assert.ThrowsAnyAsync<Exception>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
         Assert.Contains("Define a schema validation on metadata is not allowed.", e.Message);
     }
     
@@ -711,7 +711,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
                 { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
-        var e = await Assert.ThrowsAnyAsync<Exception>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
         Assert.Contains("The value of 'properties' must be an object, but received 'ShouldBeObject' of type 'string'. Schema path '#/properties'.", e.Message);
     }
     

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -653,7 +653,49 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
     }
     
     [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenRevertRevisionToInvalidData_ShouldNotThrow()
+    public async Task SchemaValidation_WhenDefineSchemaOnMetadata_ShouldReject()
+    {
+        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { [Constants.Documents.Metadata.Key] = new DynamicJsonValue { [SVC.Const] = "123" } } };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore();
+
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+        Assert.Contains("Define a schema validation on metadata is not allowed.", e.Message);
+    }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenDefineInvalidSchema_ShouldReject()
+    {
+        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = "ShouldBeObject" };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore();
+
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+        Assert.Contains("The value of 'properties' must be an object, but received 'ShouldBeObject' of type 'string'. Schema path '#/properties'.", e.Message);
+    }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenRevertRevisionAndSchemaIsEnabled_ShouldThrowWhen()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
 
@@ -694,18 +736,37 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             var changeVector = revisions[1].GetString(Constants.Documents.Metadata.ChangeVector);
             
             var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Operations.SendAsync(new RevertRevisionsByIdOperation(id, changeVector)));
-            Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
+            Assert.Contains("System.InvalidOperationException: Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
+            
+            configuration.Disabled = true;
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            await store.Operations.SendAsync(new RevertRevisionsByIdOperation(id, changeVector));
         }
     }
-    
+
     [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenDefineSchemaOnMetadata_ShouldReject()
+    public async Task SchemaValidation_WhenRevertRevisionByTimeSchemaIsEnabled_ShouldThrow()
     {
-        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { [Constants.Documents.Metadata.Key] = new DynamicJsonValue { [SVC.Const] = "123" } } };
+        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 3 } } };
 
         using var context = JsonOperationContext.ShortTermSingleUse();
         using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
         using var store = GetDocumentStore();
+
+        await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore);
+        
+        DateTime revisionTime;
+        
+        const string withInvalidRevisions = "withInvalidRevisions";
+        const string withOnlyValidRevisions = "withOnlyValidRevisions";
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "1234" }, withInvalidRevisions);
+            await session.StoreAsync(new TestObj { Prop = "123" }, withOnlyValidRevisions);
+            await session.SaveChangesAsync();
+            revisionTime = DateTime.UtcNow;
+        }
 
         var configuration = new SchemaValidationConfiguration
         {
@@ -715,29 +776,28 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
                 { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
-        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
-        Assert.Contains("Define a schema validation on metadata is not allowed.", e.Message);
-    }
-    
-    [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenDefineInvalidSchema_ShouldReject()
-    {
-        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = "ShouldBeObject" };
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
 
-        using var context = JsonOperationContext.ShortTermSingleUse();
-        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
-        using var store = GetDocumentStore();
-
-        var configuration = new SchemaValidationConfiguration
+        await Task.Delay(TimeSpan.FromSeconds(10));
+        using (var session = store.OpenAsyncSession())
         {
-            Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
-            {
-                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
-            }
-        };
-        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
-        Assert.Contains("The value of 'properties' must be an object, but received 'ShouldBeObject' of type 'string'. Schema path '#/properties'.", e.Message);
+            await session.StoreAsync(new TestObj { Prop = "12" }, withInvalidRevisions);
+            await session.StoreAsync(new TestObj { Prop = "12" }, withOnlyValidRevisions);
+            await session.SaveChangesAsync();
+        }
+
+        var e = await Assert.ThrowsAnyAsync<RavenException>(async () =>
+        {
+            var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(revisionTime, 1));
+            await operation.WaitForCompletionAsync<RevertResult>(TimeSpan.FromSeconds(5));
+        });
+        Assert.Contains("System.InvalidOperationException: Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
+        
+        configuration.Disabled = true;
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+        
+        var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(revisionTime, 1));
+        await operation.WaitForCompletionAsync<RevertResult>(TimeSpan.FromSeconds(5));
     }
     
     private static void AssertError(string expected, string actual)

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -673,6 +673,48 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         }
     }
     
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenDefineSchemaOnMetadata_ShouldReject()
+    {
+        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { [Constants.Documents.Metadata.Key] = new DynamicJsonValue { [SVC.Const] = "123" } } };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore();
+
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        var e = await Assert.ThrowsAnyAsync<Exception>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+        Assert.Contains("Define a schema validation on metadata is not allowed.", e.Message);
+    }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenDefineInvalidSchema_ShouldReject()
+    {
+        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = "ShouldBeObject" };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore();
+
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        var e = await Assert.ThrowsAnyAsync<Exception>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+        Assert.Contains("The value of 'properties' must be an object, but received 'ShouldBeObject' of type 'string'. Schema path '#/properties'.", e.Message);
+    }
+    
     private static void AssertError(string expected, string actual)
     {
         if(actual.Contains(expected) == false)

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -177,6 +177,32 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
         }
     }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenDefineOnEmptyCollection_ShouldValidateAndFailInNeeded()
+    {
+        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore();
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { Constants.Documents.Collections.EmptyCollection, new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new { Prop = "1234" });
+            var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await session.SaveChangesAsync());
+            Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
+        }
+    }
 
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenSingleDocumentPatch_ShouldValidateAndFailInNeeded()
@@ -392,7 +418,6 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         };
         await source.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
 
-        //TODO To change to shard as well
         var backupPath = NewDataPath();
         await Backup.CreateAndRunBackupAsync(source, RavenDatabaseMode.Single, backupPath);
 

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -158,7 +158,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
     }
 
     [RavenFact(RavenTestCategory.Indexes)]
-    public async Task ValidateSchemaOperation_WhenSettingEtagOnSharded_ShouldStartFromTheEtag()
+    public async Task ValidateSchemaOperation_WhenSettingEtagOnSharded_ShouldFail()
     {
         const int maxLength = 10;
         

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -43,12 +43,12 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             await session.SaveChangesAsync();
         }
         
-        var operation = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        var operation = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs"
         }));
-        var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        var result = await operation.WaitForCompletionAsync<ValidateSchemaResult>(TimeSpan.FromMinutes(1));
         Assert.Equal(1, result.ErrorCount);
         Assert.Equal(2, result.ValidatedCount);
         Assert.Equal(1, result.Errors.Count);
@@ -83,7 +83,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             }
         }
         
-        var operation = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        var operation = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
@@ -91,7 +91,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             
         }));
         
-        var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        var result = await operation.WaitForCompletionAsync<ValidateSchemaResult>(TimeSpan.FromMinutes(1));
         Assert.Equal(errorDocumentCount, result.ErrorCount);
         Assert.Equal(errorDocumentCount, result.ValidatedCount);
 
@@ -133,26 +133,26 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             await session.StoreAsync(new TestObj { Prop = "0123456789ab"}, id2);
         }
 
-        var operation1 = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        var operation1 = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
             MaxDocumentsToValidate = 1
         }));
 
-        var result1 = await operation1.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        var result1 = await operation1.WaitForCompletionAsync<ValidateSchemaResult>(TimeSpan.FromMinutes(1));
         Assert.Equal(id1, result1.Errors.First().Key);
         Assert.StartsWith("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", result1.Errors.First().Value);
 
-        var operation2 = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        var operation2 = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
-            Etag = result1.LastEtag + 1
+            StartEtag = result1.LastEtag + 1
 
         }));
 
-        var result2 = await operation2.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        var result2 = await operation2.WaitForCompletionAsync<ValidateSchemaResult>(TimeSpan.FromMinutes(1));
         Assert.Equal(id2, result2.Errors.First().Key);
         Assert.StartsWith("The length of the value '0123456789ab' at 'Prop' should not exceed 10, but its actual length is 12.", result2.Errors.First().Value);
     }
@@ -175,11 +175,11 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         
         var e = await Assert.ThrowsAnyAsync<BadRequestException>(async () =>
         {
-            await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+            await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
             {
                 SchemaDefinition = schemaDefinition,
                 Collection = "TestObjs",
-                Etag = 1
+                StartEtag = 1
             }));
         });
         Assert.Contains("Parameter 'Etag' is not supported for schema validation on a sharded database.", e.Message);

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -43,7 +43,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         
         var operation = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
         {
-            Schema = schemaDefinition,
+            SchemaDefinition = schemaDefinition,
             Collection = "TestObjs"
         }));
         var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
@@ -82,7 +82,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         
         var operation = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
         {
-            Schema = schemaDefinition,
+            SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
             MaxErrorMessages = maxErrorsMsg,
             

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -182,7 +182,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
                 StartEtag = 1
             }));
         });
-        Assert.Contains("Parameter 'Etag' is not supported for schema validation on a sharded database.", e.Message);
+        Assert.Contains("Parameter 'StartEtag' is not supported for schema validation on a sharded database", e.Message);
     }
     
     private class TestObj

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -87,7 +87,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
-            MaxErrorMessages = maxErrorsMsg,
+            MaxErrorMessages = maxErrorsMsg
             
         }));
         

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -43,7 +43,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             await session.SaveChangesAsync();
         }
         
-        var operation = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
+        var operation = await store.Maintenance.SendAsync(new StartSchemaValidationOperation(new StartSchemaValidationOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs"
@@ -83,7 +83,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             }
         }
         
-        var operation = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
+        var operation = await store.Maintenance.SendAsync(new StartSchemaValidationOperation(new StartSchemaValidationOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
@@ -133,7 +133,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
             await session.StoreAsync(new TestObj { Prop = "0123456789ab"}, id2);
         }
 
-        var operation1 = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
+        var operation1 = await store.Maintenance.SendAsync(new StartSchemaValidationOperation(new StartSchemaValidationOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
@@ -144,7 +144,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         Assert.Equal(id1, result1.Errors.First().Key);
         Assert.StartsWith("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", result1.Errors.First().Value);
 
-        var operation2 = await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
+        var operation2 = await store.Maintenance.SendAsync(new StartSchemaValidationOperation(new StartSchemaValidationOperation.Parameters
         {
             SchemaDefinition = schemaDefinition,
             Collection = "TestObjs",
@@ -175,7 +175,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         
         var e = await Assert.ThrowsAnyAsync<BadRequestException>(async () =>
         {
-            await store.Maintenance.SendAsync(new ValidateSchemaOperation(new ValidateSchemaOperation.Parameters
+            await store.Maintenance.SendAsync(new StartSchemaValidationOperation(new StartSchemaValidationOperation.Parameters
             {
                 SchemaDefinition = schemaDefinition,
                 Collection = "TestObjs",

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -84,7 +84,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         {
             Schema = schemaDefinition,
             Collection = "TestObjs",
-            MaxErrorsMsg = maxErrorsMsg,
+            MaxErrorMessages = maxErrorsMsg,
             
         }));
         

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.SchemaValidation;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using SVC = Raven.Server.Documents.SchemaValidation.SchemaValidatorConstants;
+
+namespace SlowTests.SchemaValidation;
+
+public class SchemaValidationOperationTests : ReplicationTestBase
+{
+    public SchemaValidationOperationTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ValidateSchema_WhenDone_ShouldAbleToFetchResult(Options options)
+    {
+        const string invalidDocId = "invalidDocId";
+        const string validDocId = "validDocId";
+        
+        using var store = GetDocumentStore(options);
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" }, invalidDocId);
+            await session.StoreAsync(new TestObj { Prop = "01" }, validDocId);
+            await session.SaveChangesAsync();
+        }
+        
+        var operation = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        {
+            Schema = schemaDefinition,
+            Collection = "TestObjs"
+        }));
+        var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        Assert.Equal(1, result.ErrorCount);
+        Assert.Equal(2, result.ScannedCount);
+        Assert.Equal(1, result.Errors.Count);
+        Assert.True(result.Errors.TryGetValue("invalidDocId", out var error));
+        Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", error);
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ValidateSchema_WhenLimitErrors_ShouldGetOnlyTheRequiredLimit(Options options)
+    {
+        const int errorDocumentCount = 10000;
+        const int maxErrorsMsg = 10;
+        
+        using var store = GetDocumentStore(options);
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = maxErrorsMsg } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        await using (var session = store.BulkInsert())
+        {
+            for (var i = 0; i < errorDocumentCount; i++)
+            {
+                await session.StoreAsync(new TestObj { Prop = "0123456789a" });
+            }
+        }
+        
+        var operation = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        {
+            Schema = schemaDefinition,
+            Collection = "TestObjs",
+            MaxErrorsMsg = maxErrorsMsg,
+            
+        }));
+        
+        var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        Assert.Equal(errorDocumentCount, result.ErrorCount);
+        Assert.Equal(errorDocumentCount, result.ScannedCount);
+
+        var expectedErrors = maxErrorsMsg;
+        if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+        {
+            var configuration = await Sharding.GetShardingConfigurationAsync(store);
+            var shardsCount = configuration.Shards.Count;
+            expectedErrors = maxErrorsMsg / shardsCount * shardsCount; //If the requested doesn't divide equally between the shards we will get fewer errors
+        }
+        Assert.Equal(expectedErrors, result.Errors.Count);
+        foreach (var keyValue in result.Errors)
+        {
+            Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", keyValue.Value);
+        }
+    }
+    
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+        public object Inner { get; set; }
+    }
+}

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Client.Exceptions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
@@ -48,7 +50,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         }));
         var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
         Assert.Equal(1, result.ErrorCount);
-        Assert.Equal(2, result.ScannedCount);
+        Assert.Equal(2, result.ValidatedCount);
         Assert.Equal(1, result.Errors.Count);
         Assert.True(result.Errors.TryGetValue("invalidDocId", out var error));
         Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", error);
@@ -60,6 +62,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
     {
         const int errorDocumentCount = 10000;
         const int maxErrorsMsg = 10;
+        const int maxLength = 10;
         
         using var store = GetDocumentStore(options);
 
@@ -68,7 +71,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         {
             schemaDefinition =
                 context.ReadObject(
-                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = maxErrorsMsg } } },
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = maxLength } } },
                     "schema-validation-configuration").ToString();
         }
 
@@ -90,7 +93,7 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         
         var result = await operation.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
         Assert.Equal(errorDocumentCount, result.ErrorCount);
-        Assert.Equal(errorDocumentCount, result.ScannedCount);
+        Assert.Equal(errorDocumentCount, result.ValidatedCount);
 
         var expectedErrors = maxErrorsMsg;
         if (options.DatabaseMode == RavenDatabaseMode.Sharded)
@@ -104,6 +107,82 @@ public class SchemaValidationOperationTests : ReplicationTestBase
         {
             Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", keyValue.Value);
         }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task ValidateSchemaOperation_WhenSettingEtagOnNonSharded_ShouldStartFromTheEtag()
+    {
+        const string id1 = "user/1";
+        const string id2 = "user/2";
+        const int maxLength = 10;
+        
+        using var store = GetDocumentStore();
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = maxLength } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        await using (var session = store.BulkInsert())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" }, id1);
+            await session.StoreAsync(new TestObj { Prop = "0123456789ab"}, id2);
+        }
+
+        var operation1 = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        {
+            SchemaDefinition = schemaDefinition,
+            Collection = "TestObjs",
+            MaxDocumentsToValidate = 1
+        }));
+
+        var result1 = await operation1.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        Assert.Equal(id1, result1.Errors.First().Key);
+        Assert.StartsWith("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", result1.Errors.First().Value);
+
+        var operation2 = await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+        {
+            SchemaDefinition = schemaDefinition,
+            Collection = "TestObjs",
+            Etag = result1.LastEtag + 1
+
+        }));
+
+        var result2 = await operation2.WaitForCompletionAsync<ValidateSchemaValidationResult>(TimeSpan.FromMinutes(1));
+        Assert.Equal(id2, result2.Errors.First().Key);
+        Assert.StartsWith("The length of the value '0123456789ab' at 'Prop' should not exceed 10, but its actual length is 12.", result2.Errors.First().Value);
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task ValidateSchemaOperation_WhenSettingEtagOnSharded_ShouldStartFromTheEtag()
+    {
+        const int maxLength = 10;
+        
+        using var store = GetDocumentStore(Options.ForMode(RavenDatabaseMode.Sharded));
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = maxLength } } },
+                    "schema-validation-configuration").ToString();
+        }
+        
+        var e = await Assert.ThrowsAnyAsync<BadRequestException>(async () =>
+        {
+            await store.Maintenance.SendAsync(new ValidateSchemaValidationOperation(new ValidateSchemaValidationOperation.Parameters
+            {
+                SchemaDefinition = schemaDefinition,
+                Collection = "TestObjs",
+                Etag = 1
+            }));
+        });
+        Assert.Contains("Parameter 'Etag' is not supported for schema validation on a sharded database.", e.Message);
     }
     
     private class TestObj

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -55,7 +56,7 @@ public class SchemaValidationIndexingTests : RavenTestBase
             Maps = { map },
             SchemaValidationConfiguration = new SchemaValidationConfiguration
             {
-                ValidatorsPerCollection = new Dictionary<string, SchemaValidator> { { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition } } }
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition> { { "TestObjs", new SchemaDefinition { Schema = schemaDefinition } } }
             }
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
@@ -108,7 +109,7 @@ public class SchemaValidationIndexingTests : RavenTestBase
             Maps = { map },
             SchemaValidationConfiguration = new SchemaValidationConfiguration
             {
-                ValidatorsPerCollection = new Dictionary<string, SchemaValidator> { { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition } } }
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition> { { "TestObjs", new SchemaDefinition { Schema = schemaDefinition } } }
             }
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
@@ -159,7 +160,7 @@ public class SchemaValidationIndexingTests : RavenTestBase
             Maps = { map },
             SchemaValidationConfiguration = new SchemaValidationConfiguration
             {
-                ValidatorsPerCollection = new Dictionary<string, SchemaValidator> { { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition } } }
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition> { { "TestObjs", new SchemaDefinition { Schema = schemaDefinition } } }
             },
             Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}}
         };
@@ -182,7 +183,7 @@ public class SchemaValidationIndexingTests : RavenTestBase
             Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", dicResults[invalidDocId].Error);
         }
     }
-
+    
     private class TestObj
     {
         public string Id { get; set; }

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
-using Raven.Client.Documents.Operations.SchemaValidation;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
@@ -50,14 +48,11 @@ public class SchemaValidationIndexingTests : RavenTestBase
                     "schema-validation-configuration").ToString();
         }
 
-        var indexDefinition = new IndexDefinition()
+        var indexDefinition = new IndexDefinition
         {
             Name = "MyCounterIndex",
             Maps = { map },
-            SchemaValidationConfiguration = new SchemaValidationConfiguration
-            {
-                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition> { { "TestObjs", new SchemaDefinition { Schema = schemaDefinition } } }
-            }
+            SchemaValidation = schemaDefinition
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
 
@@ -103,14 +98,11 @@ public class SchemaValidationIndexingTests : RavenTestBase
                     "schema-validation-configuration").ToString();
         }
 
-        var indexDefinition = new IndexDefinition()
+        var indexDefinition = new IndexDefinition
         {
             Name = "MyCounterIndex",
             Maps = { map },
-            SchemaValidationConfiguration = new SchemaValidationConfiguration
-            {
-                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition> { { "TestObjs", new SchemaDefinition { Schema = schemaDefinition } } }
-            }
+            SchemaValidation = schemaDefinition
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
 
@@ -154,14 +146,11 @@ public class SchemaValidationIndexingTests : RavenTestBase
                     "schema-validation-configuration").ToString();
         }
 
-        var indexDefinition = new IndexDefinition()
+        var indexDefinition = new IndexDefinition
         {
             Name = "MyCounterIndex",
             Maps = { map },
-            SchemaValidationConfiguration = new SchemaValidationConfiguration
-            {
-                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition> { { "TestObjs", new SchemaDefinition { Schema = schemaDefinition } } }
-            },
+            SchemaValidation = schemaDefinition,
             Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}}
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
@@ -21,73 +24,37 @@ public class SchemaValidationIndexingTests : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
-    public async Task IndexingSchemaValidity_WhenFilteringByNotSchemaValid_ShouldContainsOnlyInvalidDocuments()
+    private const string ValidateNonDocumentDataForMapIndex =
+"""
+from doc in docs 
+select new 
+{
+    Id = doc.Id,
+    Error = SchemaValid(doc.Inner)
+}
+""";
+
+    private const string ValidateNonDocumentDataForJavascriptMapIndex =
+"""
+map("TestObjs", (doc) => { 
+    return {
+        Id: id(doc),
+        Error: schemaValidate(doc.Inner)
+    };
+})
+""";
+
+    public static readonly TheoryData<string, IndexType> ValidateNonDocumentData = new TheoryData<string, IndexType>()
     {
-        const string invalidDocId = "invalidDocId";
-        const string validDocId = "validDocId";
-        
-        using var store = GetDocumentStore();
+        { ValidateNonDocumentDataForMapIndex, IndexType.Map },
+        { ValidateNonDocumentDataForJavascriptMapIndex, IndexType.JavaScriptMap }
+    };
 
-        const string map =
-            """
-            from doc in docs 
-            where SchemaValid(doc) == false
-            select new 
-            {
-                Id = doc.Id
-            }
-            """;
-
-        string schemaDefinition;
-        using (var context = JsonOperationContext.ShortTermSingleUse())
-        {
-            schemaDefinition =
-                context.ReadObject(
-                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
-                    "schema-validation-configuration").ToString();
-        }
-
-        var indexDefinition = new IndexDefinition
-        {
-            Name = "MyCounterIndex",
-            Maps = { map },
-            SchemaValidation = schemaDefinition
-        };
-        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
-
-        using (var session = store.OpenAsyncSession())
-        {
-            await session.StoreAsync(new TestObj { Prop = "0123456789a" }, invalidDocId);
-            await session.StoreAsync(new TestObj { Prop = "01" }, validDocId);
-            await session.SaveChangesAsync();
-        }
-        
-        await Indexes.WaitForIndexingAsync(store);
-        
-        using (var session = store.OpenAsyncSession())
-        {
-            var results = await session.Query<TestObj>(indexDefinition.Name).ToArrayAsync();
-            var ids = results.Select(o => o.Id).ToArray();
-            Assert.Contains(invalidDocId, ids);
-            Assert.DoesNotContain(validDocId, ids);
-        }
-    }
-    
-    [RavenFact(RavenTestCategory.Indexes)]
-    public async Task IndexingSchemaValidity_WhenSchemaValidNonDocument_ShouldFailIndexing()
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateNonDocumentData))]
+    public async Task IndexingSchemaValidity_WhenSchemaValidateNonDocument_ShouldFailIndexing(string map, IndexType indexType)
     {
         using var store = GetDocumentStore();
-
-        const string map =
-            """
-            from doc in docs 
-            where SchemaValid(doc.Inner) == false
-            select new 
-            {
-                Id = doc.Id
-            }
-            """;
 
         string schemaDefinition;
         using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -100,9 +67,10 @@ public class SchemaValidationIndexingTests : RavenTestBase
 
         var indexDefinition = new IndexDefinition()
         {
-            Name = "MyCounterIndex",
+            Name = "IndexWithSchemaValidation",
             Maps = { map },
-            SchemaValidation = schemaDefinition
+            SchemaValidation = schemaDefinition,
+            Type = indexType
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
 
@@ -110,7 +78,7 @@ public class SchemaValidationIndexingTests : RavenTestBase
         {
             for (int i = 0; i < 1000; i++)
             {
-                await bull.StoreAsync(new TestObj { Prop = "0123456789a" });
+                await bull.StoreAsync(new TestObj { Prop = "0123456789a", Inner = new { Prop = "0123456789a" } });
             }
         }
         
@@ -118,24 +86,42 @@ public class SchemaValidationIndexingTests : RavenTestBase
         
         Assert.NotEmpty(errors);
     }
+
+    private const string ValidateDocumentDataForMapIndex =
+        """
+        from doc in docs 
+        select new 
+        {
+            Id = doc.Id,
+            Error = SchemaValid(doc)
+        }
+        """;
+
+    private const string ValidateDocumentDataForJavascriptMapIndex =
+        """
+        map("TestObjs", (doc) => { 
+            return {
+                Id: id(doc),
+                Error: schemaValidate(doc)
+            };
+        })
+        """;
+
+    public static readonly TheoryData<string, IndexType> ValidateDocumentData = new TheoryData<string, IndexType>()
+    {
+        { ValidateDocumentDataForMapIndex, IndexType.Map },
+        { ValidateDocumentDataForJavascriptMapIndex, IndexType.JavaScriptMap }
+    };
     
-    [RavenFact(RavenTestCategory.Indexes)]
-    public async Task IndexingSchemaValidity_WhenIndexingSchemaError_ShouldGetSchemaValidationErrors()
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateDocumentData))]
+    public async Task IndexingSchemaValidity_WhenIndexingSchemaError_ShouldGetSchemaValidationErrors(string map, IndexType indexType)
     {
         const string invalidDocId = "invalidDocId";
         const string validDocId = "validDocId";
         
         using var store = GetDocumentStore();
-
-        const string map =
-            """
-            from doc in docs 
-            select new 
-            {
-                Id = doc.Id,
-                Error = SchemaError(doc)
-            }
-            """;
 
         string schemaDefinition;
         using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -148,10 +134,11 @@ public class SchemaValidationIndexingTests : RavenTestBase
 
         var indexDefinition = new IndexDefinition
         {
-            Name = "MyCounterIndex",
+            Name = "IndexWithSchemaValidation",
             Maps = { map },
             SchemaValidation = schemaDefinition,
-            Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}}
+            Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            Type = indexType
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
 
@@ -173,6 +160,38 @@ public class SchemaValidationIndexingTests : RavenTestBase
         }
     }
     
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateDocumentData))]
+    public async Task IndexingSchemaValidity_WhenDefineSchemaOnMetadata_ShouldReject(string map, IndexType indexType)
+    {
+        const string invalidDocId = "invalidDocId";
+        const string validDocId = "validDocId";
+        
+        using var store = GetDocumentStore();
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { [Constants.Documents.Metadata.Key] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var indexDefinition = new IndexDefinition
+        {
+            Name = "IndexWithSchemaValidation",
+            Maps = { map },
+            SchemaValidation = schemaDefinition,
+            Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            Type = indexType
+        };
+        
+        var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition)));
+        Assert.Contains("Define a schema validation on metadata is not allowed", e.Message);
+    }
+
     private class TestObj
     {
         public string Id { get; set; }

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -165,9 +165,6 @@ map("TestObjs", (doc) => {
     [MemberData(nameof(ValidateDocumentData))]
     public async Task IndexingSchemaValidity_WhenDefineSchemaOnMetadata_ShouldReject(string map, IndexType indexType)
     {
-        const string invalidDocId = "invalidDocId";
-        const string validDocId = "validDocId";
-        
         using var store = GetDocumentStore();
 
         string schemaDefinition;

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
@@ -39,7 +38,7 @@ select new
 map("TestObjs", (doc) => { 
     return {
         Id: id(doc),
-        Error: schemaValidate(doc.Inner)
+        Error: schema.validate(doc.Inner)
     };
 })
 """;
@@ -102,7 +101,7 @@ map("TestObjs", (doc) => {
         map("TestObjs", (doc) => { 
             return {
                 Id: id(doc),
-                Error: schemaValidate(doc)
+                Error: schema.validate(doc)
             };
         })
         """;
@@ -155,7 +154,7 @@ map("TestObjs", (doc) => {
         {
             var results = await session.Query<TestObj>(indexDefinition.Name).ProjectInto<IndexResult>().ToArrayAsync();
             var dicResults = results.ToDictionary(o => o.Id);
-            Assert.Equal(null, dicResults[validDocId].Error);
+            Assert.Null(dicResults[validDocId].Error);
             Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", dicResults[invalidDocId].Error);
         }
     }

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -6,6 +6,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Exceptions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -29,7 +30,7 @@ from doc in docs
 select new 
 {
     Id = doc.Id,
-    Error = SchemaValid(doc.Inner)
+    Errors = Schema.GetErrorsFor(doc.Inner)
 }
 """;
 
@@ -38,23 +39,25 @@ select new
 map("TestObjs", (doc) => { 
     return {
         Id: id(doc),
-        Error: schema.validate(doc.Inner)
+        Errors: schema.getErrorsFor(doc.Inner)
     };
 })
 """;
 
-    public static readonly TheoryData<string, IndexType> ValidateNonDocumentData = new TheoryData<string, IndexType>()
+    public static readonly TheoryData<string, IndexType, string> ValidateNonDocumentData = new TheoryData<string, IndexType, string>()
     {
-        { ValidateNonDocumentDataForMapIndex, IndexType.Map },
-        { ValidateNonDocumentDataForJavascriptMapIndex, IndexType.JavaScriptMap }
+        { ValidateNonDocumentDataForMapIndex, IndexType.Map, "Schema.GetErrorsFor may only be called with a document" },
+        { ValidateNonDocumentDataForJavascriptMapIndex, IndexType.JavaScriptMap, "'schema.GetErrorsFor' can only be performed on the source document." }
     };
 
     [RavenTheory(RavenTestCategory.Indexes)]
     [MemberData(nameof(ValidateNonDocumentData))]
-    public async Task IndexingSchemaValidity_WhenSchemaValidateNonDocument_ShouldFailIndexing(string map, IndexType indexType)
+    public async Task IndexingSchemaErrors_WhenSchemaValidateNonDocument_ShouldFailIndexing(string map, IndexType indexType, string errorMsg)
     {
         using var store = GetDocumentStore();
-
+        
+        var collection = store.Conventions.FindCollectionName(typeof(TestObj));
+        
         string schemaDefinition;
         using (var context = JsonOperationContext.ShortTermSingleUse())
         {
@@ -63,12 +66,12 @@ map("TestObjs", (doc) => {
                     new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
                     "schema-validation-configuration").ToString();
         }
-
+        var schemaDefinitions = new IndexSchemaDefinitions { { collection, schemaDefinition } };
         var indexDefinition = new IndexDefinition()
         {
             Name = "IndexWithSchemaValidation",
             Maps = { map },
-            SchemaValidation = schemaDefinition,
+            SchemaDefinitions = schemaDefinitions,
             Type = indexType
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
@@ -81,28 +84,34 @@ map("TestObjs", (doc) => {
             }
         }
         
-        var errors = Indexes.WaitForIndexingErrors(store);
+        var indexErrors = Indexes.WaitForIndexingErrors(store);
+        Assert.NotEmpty(indexErrors);
         
+        var errors = indexErrors.First().Errors;
         Assert.NotEmpty(errors);
+        Assert.Contains(errors, error => error.Error.Contains(errorMsg));
     }
 
     private const string ValidateDocumentDataForMapIndex =
         """
-        from doc in docs 
+        from doc in docs
+        where MetadataFor(doc)["@collection"] != "@hilo"
         select new 
         {
             Id = doc.Id,
-            Error = SchemaValid(doc)
+            Errors = Schema.GetErrorsFor(doc)
         }
         """;
 
     private const string ValidateDocumentDataForJavascriptMapIndex =
         """
-        map("TestObjs", (doc) => { 
-            return {
-                Id: id(doc),
-                Error: schema.validate(doc)
-            };
+        map("@all_docs", (doc) => { 
+            let metadata = doc["@metadata"];
+            if( metadata == null || metadata["@collection"] !== "@hilo")
+                return {
+                    Id: id(doc),
+                    Errors: schema.getErrorsFor(doc)
+                };
         })
         """;
 
@@ -115,13 +124,14 @@ map("TestObjs", (doc) => {
     
     [RavenTheory(RavenTestCategory.Indexes)]
     [MemberData(nameof(ValidateDocumentData))]
-    public async Task IndexingSchemaValidity_WhenIndexingSchemaError_ShouldGetSchemaValidationErrors(string map, IndexType indexType)
+    public async Task IndexingSchemaErrors_WhenFailsOneRule_ShouldGetTheError(string map, IndexType indexType)
     {
         const string invalidDocId = "invalidDocId";
         const string validDocId = "validDocId";
         
         using var store = GetDocumentStore();
-
+        var collection = store.Conventions.FindCollectionName(typeof(TestObj));
+        
         string schemaDefinition;
         using (var context = JsonOperationContext.ShortTermSingleUse())
         {
@@ -131,12 +141,13 @@ map("TestObjs", (doc) => {
                     "schema-validation-configuration").ToString();
         }
 
+        var schemaDefinitions = new IndexSchemaDefinitions { { collection, schemaDefinition } };
         var indexDefinition = new IndexDefinition
         {
             Name = "IndexWithSchemaValidation",
             Maps = { map },
-            SchemaValidation = schemaDefinition,
-            Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            SchemaDefinitions = schemaDefinitions,
+            Fields = new Dictionary<string, IndexFieldOptions>{{nameof(IndexResult.Errors), new IndexFieldOptions{Storage = FieldStorage.Yes}}},
             Type = indexType
         };
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
@@ -154,17 +165,81 @@ map("TestObjs", (doc) => {
         {
             var results = await session.Query<TestObj>(indexDefinition.Name).ProjectInto<IndexResult>().ToArrayAsync();
             var dicResults = results.ToDictionary(o => o.Id);
-            Assert.Null(dicResults[validDocId].Error);
-            Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", dicResults[invalidDocId].Error);
+            Assert.Null(dicResults[validDocId].Errors);
+
+            var errors = dicResults[invalidDocId].Errors;
+            Assert.NotNull(errors);
+            Assert.Single(errors);
+            Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", errors.First());
         }
     }
     
-
     [RavenTheory(RavenTestCategory.Indexes)]
     [MemberData(nameof(ValidateDocumentData))]
-    public async Task IndexingSchemaValidity_WhenDefineSchemaOnMetadata_ShouldReject(string map, IndexType indexType)
+    public async Task IndexingSchemaErrors_WhenFailsMultipleRules_ShouldGetTheErrors(string map, IndexType indexType)
+    {
+        var expectedErrors = new[]
+        {
+            "The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.",
+            "The pattern of the value '0123456789a' at 'Prop' does not match the required pattern '^something'.",
+            "The required property 'Prop1' is missing at ''."
+        };
+        
+        using var store = GetDocumentStore();
+        var collection = store.Conventions.FindCollectionName(typeof(TestObj));
+        
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { 
+                        [SVC.Properties] = new DynamicJsonValue
+                        {
+                            ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10, [SVC.Pattern] = "^something",   },
+                        },
+                        [SVC.Required] = new [] {"Prop1"}
+                    },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var schemaDefinitions = new IndexSchemaDefinitions { { collection, schemaDefinition } };
+        var indexDefinition = new IndexDefinition
+        {
+            Name = "IndexWithSchemaValidation",
+            Maps = { map },
+            SchemaDefinitions = schemaDefinitions,
+            Fields = new Dictionary<string, IndexFieldOptions>{{nameof(IndexResult.Errors), new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            Type = indexType
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" });
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" });
+            await session.SaveChangesAsync();
+        }
+        
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestObj>(indexDefinition.Name).ProjectInto<IndexResult>().ToArrayAsync();
+            Assert.All(results, result =>
+            {
+                Assert.NotNull(result.Errors);
+                Assert.Equivalent(expectedErrors, result.Errors);
+            });
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateDocumentData))]
+    public async Task IndexingSchemaErrors_WhenDefineSchemaOnMetadata_ShouldReject(string map, IndexType indexType)
     {
         using var store = GetDocumentStore();
+        var collection = store.Conventions.FindCollectionName(typeof(TestObj));
 
         string schemaDefinition;
         using (var context = JsonOperationContext.ShortTermSingleUse())
@@ -175,17 +250,164 @@ map("TestObjs", (doc) => {
                     "schema-validation-configuration").ToString();
         }
 
+        var schemaDefinitions = new IndexSchemaDefinitions { { collection, schemaDefinition } };
         var indexDefinition = new IndexDefinition
         {
             Name = "IndexWithSchemaValidation",
             Maps = { map },
-            SchemaValidation = schemaDefinition,
+            SchemaDefinitions = schemaDefinitions,
             Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}},
             Type = indexType
         };
         
         var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition)));
         Assert.Contains("Define a schema validation on metadata is not allowed", e.Message);
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateDocumentData))]
+    public async Task IndexingSchemaErrors_WhenSchemaDefinedInDatabase_ShouldIndexErrors(string map, IndexType indexType)
+    {
+        const string invalidDocId = "invalidDocId";
+        const string validDocId = "validDocId";
+        
+        using var store = GetDocumentStore();
+        var collection = store.Conventions.FindCollectionName(typeof(TestObj));
+        
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var indexDefinition = new IndexDefinition
+        {
+            Name = "IndexWithSchemaValidation",
+            Maps = { map },
+            Fields = new Dictionary<string, IndexFieldOptions>{{nameof(IndexResult.Errors), new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            Type = indexType
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" }, invalidDocId);
+            await session.StoreAsync(new TestObj { Prop = "01" }, validDocId);
+            await session.SaveChangesAsync();
+        }
+        
+        var configuration = new SchemaValidationConfiguration
+        {
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { collection, new SchemaDefinition { Schema = schemaDefinition } }
+            }
+        };
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+        
+        await store.Maintenance.SendAsync(new ResetIndexOperation(indexDefinition.Name));
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestObj>(indexDefinition.Name).ProjectInto<IndexResult>().ToArrayAsync();
+            var dicResults = results.ToDictionary(o => o.Id);
+            Assert.Null(dicResults[validDocId].Errors);
+
+            var errors = dicResults[invalidDocId].Errors;
+            Assert.NotNull(errors);
+            Assert.Single(errors);
+            Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", errors.First());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateDocumentData))]
+    public async Task IndexingSchemaErrors_WhenNoSchemaDefined_ShouldBeAlwaysValid(string map, IndexType indexType)
+    {
+        using var store = GetDocumentStore();
+        
+        var indexDefinition = new IndexDefinition
+        {
+            Name = "IndexWithSchemaValidation",
+            Maps = { map },
+            Fields = new Dictionary<string, IndexFieldOptions>{{nameof(IndexResult.Errors), new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            Type = indexType
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" });
+            await session.StoreAsync(new TestObj { Prop = "01" });
+            await session.SaveChangesAsync();
+        }
+        
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await (from x in session.Query<TestObj>(indexDefinition.Name).As<IndexResult>() 
+                let errors = x.Errors
+                select new
+                {
+                    Errors = errors,
+                }).ToArrayAsync();
+            
+            foreach (var r in results)
+            {
+                Assert.NotNull(r.Errors);
+                Assert.Empty(r.Errors);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [MemberData(nameof(ValidateDocumentData))]
+    public async Task IndexingSchemaErrors_WhenDefineOnEmptyCollection_ShouldGetTheError(string map, IndexType indexType)
+    {
+        using var store = GetDocumentStore();
+        
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var schemaDefinitions = new IndexSchemaDefinitions { { Constants.Documents.Collections.EmptyCollection, schemaDefinition } };
+        var indexDefinition = new IndexDefinition
+        {
+            Name = "IndexWithSchemaValidation",
+            Maps = { map },
+            SchemaDefinitions = schemaDefinitions,
+            Fields = new Dictionary<string, IndexFieldOptions>{{nameof(IndexResult.Errors), new IndexFieldOptions{Storage = FieldStorage.Yes}}},
+            Type = indexType
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new { Prop = "0123456789a" });
+            await session.SaveChangesAsync();
+        }
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<object>(indexDefinition.Name).ProjectInto<IndexResult>().ToArrayAsync();
+            Assert.Single(results);
+                
+            var errors = results.Single().Errors;
+            Assert.NotNull(errors);
+            Assert.Single(errors);
+            Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", errors.First());
+        }
     }
 
     private class TestObj
@@ -198,6 +420,6 @@ map("TestObjs", (doc) => {
     private class IndexResult
     {
         public string Id { get; set; }
-        public string Error { get; set; }
+        public string[] Errors { get; set; }
     }
 }

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -1,0 +1,198 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.SchemaValidation;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using SVC = Raven.Server.Documents.SchemaValidation.SchemaValidatorConstants;
+
+
+namespace SlowTests.Server.Documents.Indexing;
+
+public class SchemaValidationIndexingTests : RavenTestBase
+{
+    public SchemaValidationIndexingTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task IndexingSchemaValidity_WhenFilteringByNotSchemaValid_ShouldContainsOnlyInvalidDocuments()
+    {
+        const string invalidDocId = "invalidDocId";
+        const string validDocId = "validDocId";
+        
+        using var store = GetDocumentStore();
+
+        const string map =
+            """
+            from doc in docs 
+            where SchemaValid(doc) == false
+            select new 
+            {
+                Id = doc.Id
+            }
+            """;
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var indexDefinition = new IndexDefinition()
+        {
+            Name = "MyCounterIndex",
+            Maps = { map },
+            SchemaValidationConfiguration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaValidator> { { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition } } }
+            }
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" }, invalidDocId);
+            await session.StoreAsync(new TestObj { Prop = "01" }, validDocId);
+            await session.SaveChangesAsync();
+        }
+        
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestObj>(indexDefinition.Name).ToArrayAsync();
+            var ids = results.Select(o => o.Id).ToArray();
+            Assert.Contains(invalidDocId, ids);
+            Assert.DoesNotContain(validDocId, ids);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task IndexingSchemaValidity_WhenSchemaValidNonDocument_ShouldFailIndexing()
+    {
+        using var store = GetDocumentStore();
+
+        const string map =
+            """
+            from doc in docs 
+            where SchemaValid(doc.Inner) == false
+            select new 
+            {
+                Id = doc.Id
+            }
+            """;
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var indexDefinition = new IndexDefinition()
+        {
+            Name = "MyCounterIndex",
+            Maps = { map },
+            SchemaValidationConfiguration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaValidator> { { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition } } }
+            }
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        await using (var bull = store.BulkInsert())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                await bull.StoreAsync(new TestObj { Prop = "0123456789a" });
+            }
+        }
+        
+        var errors = Indexes.WaitForIndexingErrors(store);
+        
+        Assert.NotEmpty(errors);
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task IndexingSchemaValidity_WhenIndexingSchemaError_ShouldGetSchemaValidationErrors()
+    {
+        const string invalidDocId = "invalidDocId";
+        const string validDocId = "validDocId";
+        
+        using var store = GetDocumentStore();
+
+        const string map =
+            """
+            from doc in docs 
+            select new 
+            {
+                Id = doc.Id,
+                Error = SchemaError(doc)
+            }
+            """;
+
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 10 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        var indexDefinition = new IndexDefinition()
+        {
+            Name = "MyCounterIndex",
+            Maps = { map },
+            SchemaValidationConfiguration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaValidator> { { "TestObjs", new SchemaValidator { SchemaDefinition = schemaDefinition } } }
+            },
+            Fields = new Dictionary<string, IndexFieldOptions>{{"Error", new IndexFieldOptions{Storage = FieldStorage.Yes}}}
+        };
+        await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "0123456789a" }, invalidDocId);
+            await session.StoreAsync(new TestObj { Prop = "01" }, validDocId);
+            await session.SaveChangesAsync();
+        }
+        
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<TestObj>(indexDefinition.Name).ProjectInto<IndexResult>().ToArrayAsync();
+            var dicResults = results.ToDictionary(o => o.Id);
+            Assert.Equal(null, dicResults[validDocId].Error);
+            Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", dicResults[invalidDocId].Error);
+        }
+    }
+
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+        public object Inner { get; set; }
+    }
+    
+    private class IndexResult
+    {
+        public string Id { get; set; }
+        public string Error { get; set; }
+    }
+}

--- a/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/SchemaValidationIndexingTests.cs
@@ -98,7 +98,7 @@ public class SchemaValidationIndexingTests : RavenTestBase
                     "schema-validation-configuration").ToString();
         }
 
-        var indexDefinition = new IndexDefinition
+        var indexDefinition = new IndexDefinition()
         {
             Name = "MyCounterIndex",
             Maps = { map },


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24485

### Additional description
This change introduces two new capabilities:
1. Index schema validation inside indexes.  
2. A background operation to collect schema validation results.  

#### Index schema validation
Two functions were added: **SchemaValid** and **SchemaError**.  
- **SchemaValid** checks only whether a document is valid or not and returns immediately. It does not build an error message.  
- **SchemaError** performs full validation in order to collect all error messages.  

Validation is performed against a single defined schema.  
It applies only to database documents and will throw an error if used on arbitrary objects.  

#### Background operation to collect schema validation results
Schema validation results can be collected through a background operation.  
The operation takes as input both the collection to work on and the schema to validate against.  
The final result can be obtained by fetching the operation once it completes.  

The operation output includes:  
- The number of documents checked.  
- The number of errors found.  
- The collected error messages.  

The operation supports several limits:  
- A time limit for the overall operation.  
- A maximum duration for each read transaction.  
- A cap on the number of collected error messages.  

If the error message cap is reached, the operation continues to validate documents but stops collecting further messages.  
It only continues with counting the number of invalid documents.  

Note: if the operation is split into multiple read transactions, a document may, in principle, be counted more than once.


### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
