### PR TITLE
RavenDB-25125 Improved error handling logic within the PAL initialization

### DIFF
--- a/src/Sparrow.Server/Platform/Pal.cs
+++ b/src/Sparrow.Server/Platform/Pal.cs
@@ -14,43 +14,36 @@ namespace Sparrow.Server.Platform
 
         static Pal()
         {
-            PalFlags.FailCodes rc;
-            int errorCode;
-            PalDefinitions.SystemInformation sysInfo; 
+            PalFlags.FailCodes rcConfigure;
+            int errorCodeConfigure;
+
+            PalFlags.FailCodes rcGetSysInfo;
+            int errorCodeGetSysInfo;
+
+            PalDefinitions.SystemInformation sysInfo;
+
+            var cfg = new rvn_configuration
+            {
+                io_ring_queue_size = PalConfiguration.IoRingQueueSize,
+                low_priority_io = PalConfiguration.LowPriorityIo,
+                pal_version = -1, // loaded by the call
+                version = RvnConfigurationVersion.Current,
+                write_mode = PalConfiguration.WriteMode,
+                memoryLockCallback = &MemoryLockUsage.UpdateLockedMemory,
+                recoveryMemoryLockFailureCallback = &MemoryLockUsage.RecoverLockedMemoryFailure
+            };
+
             try
             {
-                var cfg = new rvn_configuration
-                {
-                    io_ring_queue_size = PalConfiguration.IoRingQueueSize,
-                    low_priority_io = PalConfiguration.LowPriorityIo,
-                    pal_version = -1, // loaded by the call
-                    version = RvnConfigurationVersion.Current,
-                    write_mode = PalConfiguration.WriteMode,
-                    memoryLockCallback = &MemoryLockUsage.UpdateLockedMemory,
-                    recoveryMemoryLockFailureCallback = &MemoryLockUsage.RecoverLockedMemoryFailure
-                };
-                rc = rvn_startup_configure(ref cfg, out errorCode);
-                if(rc != PalFlags.FailCodes.Success)
-                    PalHelper.ThrowLastError(rc, errorCode, "Failed to configure PAL library.");
-                
+                rcConfigure = rvn_startup_configure(ref cfg, out errorCodeConfigure);
+
                 if (cfg.pal_version != PAL_VER)
                 {
                     throw new IncorrectDllException(
                         $"{LIBRVNPAL} version '{cfg.pal_version}' mismatches this RavenDB instance version (set to '{PAL_VER}'). Did you forget to set new value in 'rvn_get_pal_ver()'");
                 }
 
-                if (PalConfiguration.WriteMode == RvnWriteMode.Auto)
-                {
-                    // set the actual write mode
-                    PalConfiguration.WriteMode = cfg.write_mode;
-                }
-
-                if (PalConfiguration.WriteMode != cfg.write_mode)
-                {
-                    throw new InvalidOperationException($"Requested write mode '{PalConfiguration.WriteMode}', actual write mode was set to '{cfg.write_mode}'");
-                }
-                
-                rc = rvn_get_system_information(out sysInfo, out errorCode);
+                rcGetSysInfo = rvn_get_system_information(out sysInfo, out errorCodeGetSysInfo);
             }
             catch (Exception ex)
             {
@@ -65,8 +58,25 @@ namespace Sparrow.Server.Platform
                 throw new IncorrectDllException(errString, ex);
             }
 
-            if (rc != PalFlags.FailCodes.Success)
-                PalHelper.ThrowLastError(rc, errorCode, "Cannot get system information");
+            if (rcConfigure != PalFlags.FailCodes.Success)
+            {
+                PalHelper.ThrowLastError(rcConfigure, errorCodeConfigure, $"Failed to configure PAL library with '{cfg.write_mode}' write mode. " +
+                                                                       $"Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}");
+            }
+
+            if (PalConfiguration.WriteMode == RvnWriteMode.Auto)
+            {
+                // set the actual write mode
+                PalConfiguration.WriteMode = cfg.write_mode;
+            }
+
+            if (PalConfiguration.WriteMode != cfg.write_mode)
+            {
+                throw new InvalidOperationException($"Requested write mode '{PalConfiguration.WriteMode}', actual write mode was set to '{cfg.write_mode}'");
+            }
+
+            if (rcGetSysInfo != PalFlags.FailCodes.Success)
+                PalHelper.ThrowLastError(rcGetSysInfo, errorCodeGetSysInfo, "Cannot get system information");
             
             PalVoronPageSize = sysInfo.VoronPageSize;
         }

--- a/src/Sparrow.Server/Platform/PalHelper.cs
+++ b/src/Sparrow.Server/Platform/PalHelper.cs
@@ -12,6 +12,8 @@ namespace Sparrow.Server.Platform
         public const string ErrorMediaIsWriteProtectedHintMessage =
             "This might indicate a hardware or OS issue. If you are running in the cloud, please consider contacting your provider since your volume's data might be inconsistent.";
 
+        private const int ERROR_NOT_SUPPORTED = 50;
+
         [DoesNotReturn]
         public static void ThrowLastError(PalFlags.FailCodes rc, int lastError, string msg)
         {
@@ -25,6 +27,9 @@ namespace Sparrow.Server.Platform
 
             if ((specialErrnoCodes & PalFlags.ErrnoSpecialCodes.NoSpc) != 0)
                 throw new DiskFullException(txt);
+
+            if (lastError is ERROR_NOT_SUPPORTED)
+                throw new NotSupportedException(txt);
 
             if (lastError is ERROR_WRITE_PROTECT)
                 txt += $"{Environment.NewLine}{ErrorMediaIsWriteProtectedHintMessage}";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25125

### Additional description

- We now only throw `IncorrectDllException` if a DLL loading occurs
- If the PAL configuration fails with a specific error code, that error is now propagated directly
- Error code `ERROR_NOT_SUPPORTED` (50) is now translated into a `NotSupportedException`

Error will be:

```
Unhandled exception. System.TypeInitializationException: The type initializer for 'Sparrow.Server.Platform.Pal' threw an exception.
 ---> System.NotSupportedException: Failed to configure PAL library with 'IoRing' write mode. Arch: X64, OSDesc: Microsoft Windows 10.0.20348. Errno: 50='The request is not supported.
' (rc=0). FailCode=FailCreateIoRing.
   at Sparrow.Server.Platform.PalHelper.ThrowLastError(FailCodes rc, Int32 lastError, String msg) in C:\Users\arek\Documents\ravendb-8.0\src\Sparrow.Server\Platform\PalHelper.cs:line 32
   at Sparrow.Server.Platform.Pal..cctor() in C:\Users\arek\Documents\ravendb-8.0\src\Sparrow.Server\Platform\Pal.cs:line 62
   --- End of inner exception stack trace ---
   at Sparrow.Server.Platform.Pal.rvn_get_pal_ver()
   at Sparrow.Server.Platform.Pal.rvn_get_pal_ver()
   at Raven.Server.Utils.Cli.RavenCli.GetInfoText() in C:\Users\arek\Documents\ravendb-8.0\src\Raven.Server\Utils\Cli\RavenCli.cs:line 590
   at Raven.Server.Program.Main(String[] args) in C:\Users\arek\Documents\ravendb-8.0\src\Raven.Server\Program.cs:line 192
   ```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
