### PR TITLE
RavenDB-25105 always include latest log if the name is static

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -140,28 +140,33 @@ namespace Raven.Server.Documents.Handlers.Admin
                 throw new ArgumentException($"End Date '{endUtc:yyyy-MM-ddTHH:mm:ss.fffffff} UTC' must be greater than Start Date '{startUtc:yyyy-MM-ddTHH:mm:ss.fffffff} UTC'");
 
             await using (var stream = SafeFileStream.Create(adminLogsFilePath.FullPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, 4096,
-                       FileOptions.DeleteOnClose | FileOptions.SequentialScan))
+                             FileOptions.DeleteOnClose | FileOptions.SequentialScan))
             {
                 using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, true))
                 {
                     bool isEmptyArchive = true;
 
+                    var fileTargetFileName = RavenLogManager.Instance.FindDefaultFileTargetFileName();
+                    
                     foreach (var file in RavenLogManager.Instance.GetLogFiles(Server, startUtc, endUtc))
                     {
-                        // Skip this file if either the last write time or the creation time could not be determined
-                        if (RavenLogManager.Instance.TryGetLastWriteTimeUtc(file, out var logLastWriteTimeUtc) == false ||
-                            RavenLogManager.Instance.TryGetCreationTimeUtc(file, out var logCreationTimeUtc) == false)
-                            continue;
+                        if (file.Name != fileTargetFileName?.Name)
+                        {
+                            // Skip this file if either the last write time or the creation time could not be determined
+                            if (RavenLogManager.Instance.TryGetLastWriteTimeUtc(file, out var logLastWriteTimeUtc) == false ||
+                                RavenLogManager.Instance.TryGetCreationTimeUtc(file, out var logCreationTimeUtc) == false)
+                                continue;
 
-                        bool isWithinDateRange =
-                            // Check if the file was created before the end date.
-                            (endUtc.HasValue == false || logCreationTimeUtc < endUtc.Value) &&
-                            // Check if the file was last modified after the start date.
-                            (startUtc.HasValue == false || logLastWriteTimeUtc > startUtc.Value);
+                            bool isWithinDateRange =
+                                // Check if the file was created before the end date.
+                                (endUtc.HasValue == false || logCreationTimeUtc < endUtc.Value) &&
+                                // Check if the file was last modified after the start date.
+                                (startUtc.HasValue == false || logLastWriteTimeUtc > startUtc.Value);
 
-                        // Skip this file if it does not fall within the specified date range
-                        if (isWithinDateRange == false)
-                            continue;
+                            // Skip this file if it does not fall within the specified date range
+                            if (isWithinDateRange == false)
+                                continue;
+                        }
 
                         try
                         {

--- a/src/Raven.Server/Logging/RavenLogManagerServerExtensions.cs
+++ b/src/Raven.Server/Logging/RavenLogManagerServerExtensions.cs
@@ -667,10 +667,16 @@ internal static class RavenLogManagerServerExtensions
         if (Path.Exists(path) == false)
             yield break;
 
+        var fileTargetFileName = logManager.FindDefaultFileTargetFileName();
+
         foreach (var file in Directory.GetFiles(path, "*.log", SearchOption.TopDirectoryOnly))
         {
             var fileInfo = new FileInfo(file);
             var fileName = fileInfo.Name;
+            
+            if (fileTargetFileName?.Name == fileName)
+                yield return fileInfo;
+            
             var fileExtension = fileInfo.Extension;
             var fileNameWithoutExtension = fileName;
             if (string.IsNullOrEmpty(fileExtension) == false)
@@ -838,6 +844,39 @@ internal static class RavenLogManagerServerExtensions
 
         legacyArchiveAboveSize = default;
         return false;
+    }
+
+    public static FileInfo FindDefaultFileTargetFileName(this RavenLogManager logManager)
+    {
+        if (DefaultRule == null)
+            return null;
+
+        foreach (var target in DefaultRule.Targets)
+        {
+            if (target is FileTarget fileTarget1)
+                return GetFileNameSafely(fileTarget1);
+
+            if (target is AsyncTargetWrapper asyncTargetWrapper && asyncTargetWrapper.WrappedTarget is FileTarget fileTarget2)
+                return GetFileNameSafely(fileTarget2);
+        }
+
+        return null;
+
+        static FileInfo GetFileNameSafely(FileTarget fileTarget)
+        {
+            try
+            {
+                var fileName = fileTarget.FileName?.ToString();
+                if (fileName == null)
+                    return null;
+                
+                return new FileInfo(fileName);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 #endif
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25105

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
