### PR TITLE
RavenDB-21091 Handle VoronConcurrencyErrorException during `put` executed from a patch when using "/" at the end of ID and a document with same ID already exists

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -25,6 +25,7 @@ using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Patching;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Config;
+using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Queries;
@@ -1175,14 +1176,37 @@ namespace Raven.Server.Documents.Patch
                     }
                     reader = JsBlittableBridge.Translate(_jsonCtx, ScriptEngine, args[1].AsObject(), usageMode: BlittableJsonDocumentBuilder.UsageMode.ToDisk, removeSpecialMetadata: true);
 
-                    var putResult = _database.DocumentsStorage.Put(
-                        _docsCtx,
-                        id,
-                        _docsCtx.GetLazyString(changeVector),
-                        reader,
-                        //RavenDB-11391 Those flags were added to cause attachment/counter metadata table check & remove metadata properties if not necessary
-                        nonPersistentFlags: NonPersistentDocumentFlags.ResolveAttachmentsConflict | NonPersistentDocumentFlags.ResolveCountersConflict | NonPersistentDocumentFlags.ResolveTimeSeriesConflict
-                    );
+                    DocumentsStorage.PutOperationResults putResult;
+
+                    while (true)
+                    {
+                        try
+                        {
+                            putResult = _database.DocumentsStorage.Put(
+                                _docsCtx,
+                                id,
+                                _docsCtx.GetLazyString(changeVector),
+                                reader,
+                                //RavenDB-11391 Those flags were added to cause attachment/counter metadata table check & remove metadata properties if not necessary
+                                nonPersistentFlags: NonPersistentDocumentFlags.ResolveAttachmentsConflict | NonPersistentDocumentFlags.ResolveCountersConflict | NonPersistentDocumentFlags.ResolveTimeSeriesConflict
+                            );
+
+                            break;
+                        }
+                        catch (Voron.Exceptions.VoronConcurrencyErrorException)
+                        {
+                            // RavenDB-21091 / RavenDB-10581 - If we have a concurrency error on "doc-id/"
+                            // this means that we have existing values under the current etag
+                            // we'll generate a new (random) id for them.
+                            if (id?.EndsWith(_database.IdentityPartsSeparator) == true)
+                            {
+                                id = MergedPutCommand.GenerateNonConflictingId(_database, id);
+                                continue;
+                            }
+
+                            throw;
+                        }
+                    }
 
                     _database.HugeDocuments.AddIfDocIsHuge(putResult.Id, reader.Size);
 

--- a/test/SlowTests/Issues/RavenDB_21091.cs
+++ b/test/SlowTests/Issues/RavenDB_21091.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21091 : RavenTestBase
+{
+    public RavenDB_21091(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CanPutDocumentWithIdIdentityPartsSeparatorInPatch(bool useBatchPatch)
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order(), "orders/0000000000000000002-A");
+                await session.SaveChangesAsync();
+            }
+
+            if (useBatchPatch)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.Defer(new BatchPatchCommandData(new List<string>()
+                    {
+                        "orders/0000000000000000002-A"
+                    }, new PatchRequest
+                    {
+                        Script = "put('orders/', this);"
+                    }, null));
+                    
+                    await session.SaveChangesAsync();
+                }
+            }
+            else
+            {
+                var operation = await store.Operations.SendAsync(new PatchByQueryOperation(new IndexQuery { Query = "from Orders update { put('orders/', this); }" }));
+                await operation.WaitForCompletionAsync();
+            }
+            
+            using (var session = store.OpenAsyncSession())
+            {
+                var orders = await session.Query<Order>().ToListAsync();
+                
+                Assert.Equal(2, orders.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21091

### Additional description

In  https://github.com/ravendb/ravendb/pull/6189 we have handled the scenario of putting a document that has "/" at the end of ID and a document already exists.

In this PR we apply the same fix for patching.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
