### PR TITLE
RavenDB-25125 Detection of Posix's ENOTSUP error code and throwing NotSupportedException then (same as on Windows). Better exception messages for OS native errors.

### DIFF
--- a/src/Raven.Server/Utils/ExceptionHelper.cs
+++ b/src/Raven.Server/Utils/ExceptionHelper.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Utils
         [DoesNotReturn]
         public static void ThrowMediaIsWriteProtected(Exception inner)
         {
-            throw new IOException($"{inner.Message}. {Sparrow.Server.Platform.PalHelper.ErrorMediaIsWriteProtectedHintMessage}", inner);
+            throw new IOException($"{inner.Message}. {Sparrow.Server.Platform.PalHelper.ErrorCodes.Windows.ErrorMediaIsWriteProtectedHintMessage}", inner);
         }
 
         [DoesNotReturn]

--- a/src/Sparrow.Server/Platform/Pal.cs
+++ b/src/Sparrow.Server/Platform/Pal.cs
@@ -72,7 +72,8 @@ namespace Sparrow.Server.Platform
 
             if (PalConfiguration.WriteMode != cfg.write_mode)
             {
-                throw new InvalidOperationException($"Requested write mode '{PalConfiguration.WriteMode}', actual write mode was set to '{cfg.write_mode}'");
+                throw new InvalidOperationException($"Requested write mode '{PalConfiguration.WriteMode}', actual write mode was set to '{cfg.write_mode}'" +
+                                                    $"Arch: {RuntimeInformation.OSArchitecture}, OSDesc: {RuntimeInformation.OSDescription}");
             }
 
             if (rcGetSysInfo != PalFlags.FailCodes.Success)

--- a/src/Sparrow.Server/Platform/PalHelper.cs
+++ b/src/Sparrow.Server/Platform/PalHelper.cs
@@ -2,17 +2,29 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+using Sparrow.Platform;
 using Sparrow.Server.Exceptions;
 
 namespace Sparrow.Server.Platform
 {
     public static class PalHelper
     {
-        private const int ERROR_WRITE_PROTECT = 19; 
-        public const string ErrorMediaIsWriteProtectedHintMessage =
-            "This might indicate a hardware or OS issue. If you are running in the cloud, please consider contacting your provider since your volume's data might be inconsistent.";
+        public static class ErrorCodes
+        {
+            public static class Windows
+            {
+                public const int ERROR_WRITE_PROTECT = 19; 
+                public const string ErrorMediaIsWriteProtectedHintMessage =
+                    "This might indicate a hardware or OS issue. If you are running in the cloud, please consider contacting your provider since your volume's data might be inconsistent.";
 
-        private const int ERROR_NOT_SUPPORTED = 50;
+                public const int ERROR_NOT_SUPPORTED = 50;
+            }
+
+            public class Posix
+            {
+                public const int ENOTSUP = 95;
+            }
+        }
 
         [DoesNotReturn]
         public static void ThrowLastError(PalFlags.FailCodes rc, int lastError, string msg)
@@ -28,11 +40,20 @@ namespace Sparrow.Server.Platform
             if ((specialErrnoCodes & PalFlags.ErrnoSpecialCodes.NoSpc) != 0)
                 throw new DiskFullException(txt);
 
-            if (lastError is ERROR_NOT_SUPPORTED)
-                throw new NotSupportedException(txt);
+            if (PlatformDetails.RunningOnWindows)
+            {
+                if (lastError is ErrorCodes.Windows.ERROR_NOT_SUPPORTED)
+                    throw new NotSupportedException(txt);
 
-            if (lastError is ERROR_WRITE_PROTECT)
-                txt += $"{Environment.NewLine}{ErrorMediaIsWriteProtectedHintMessage}";
+                if (lastError is ErrorCodes.Windows.ERROR_WRITE_PROTECT)
+                    txt += $"{Environment.NewLine}{ErrorCodes.Windows.ErrorMediaIsWriteProtectedHintMessage}";
+            }
+
+            if (PlatformDetails.RunningOnPosix)
+            {
+                if (lastError is ErrorCodes.Posix.ENOTSUP)
+                    throw new NotSupportedException(txt);
+            }
 
             throw new InvalidOperationException(txt);
         }
@@ -62,7 +83,7 @@ namespace Sparrow.Server.Platform
             var nativeMsg = size >= 0 ? Encoding.UTF8.GetString(buf, size) : lastError.ToString();
 
             errnoSpecialCodes = (PalFlags.ErrnoSpecialCodes)specialErrnoCodes;
-            return $"Errno: {lastError}='{nativeMsg}' (rc={specialErrnoCodes}) - '{msg}'";
+            return $"{msg}. Errno: {lastError}='{nativeMsg}' (rc={specialErrnoCodes})";
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25125

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/21516

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
