### PR TITLE
RavenDB-25102 Query parameters should only apear once

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentQueryToolItem.tsx
@@ -69,10 +69,11 @@ export default function EditAiAgentQueryToolItem({ index, remove, save, edit }: 
         let queryText = "";
 
         const regexToFind$: RegExp = /\$\w+/g;
-        const matches = queryItem.query.match(regexToFind$) || [];
+        const allMatches = queryItem.query.match(regexToFind$) || [];
+        const uniqueMatches = [...new Set(allMatches)];
 
-        if (matches.length > 0) {
-            queryText += matches.map((x) => `${x} = null`).join("\n");
+        if (uniqueMatches.length > 0) {
+            queryText += uniqueMatches.map((x) => `${x} = null`).join("\n");
             queryText += "\n\n";
         }
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentMessages.tsx
@@ -553,10 +553,11 @@ function ToolDetailsQuery({
 
     const getQueryWithParameters = (): string => {
         const regexToFind$: RegExp = /\$\w+/g;
-        const matches = queryText.match(regexToFind$)?.map((x) => x.replace("$", "")) || [];
+        const allMatches = queryText.match(regexToFind$)?.map((x) => x.replace("$", "")) || [];
+        const uniqueMatches = [...new Set(allMatches)];
 
-        const llmParametersForQuery = getLlmParametersForQuery(matches);
-        const agentParametersForQuery = getAgentParametersForQuery(matches);
+        const llmParametersForQuery = getLlmParametersForQuery(uniqueMatches);
+        const agentParametersForQuery = getAgentParametersForQuery(uniqueMatches);
 
         let resultQuery = "";
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25102/Query-parameters-should-only-apear-once

### Additional description

Fixed in edit AI Agent and Chat view

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
