### PR TITLE
RavenDB-25107 UpdatePullReplicationAsSinkOperation fix

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -70,8 +70,16 @@ namespace Raven.Client.Documents.Operations.Replication
 #pragma warning disable CS0618 // Type or member is obsolete
             djv[nameof(HubDefinitionName)] = HubDefinitionName;
 #pragma warning restore CS0618 // Type or member is obsolete
-            djv[nameof(CertificateWithPrivateKey)] = CertificateWithPrivateKey;
-            djv[nameof(CertificatePassword)] = CertificatePassword;
+            if (CertificateWithPrivateKey != null)
+            {
+                djv[nameof(CertificateWithPrivateKey)] = CertificateWithPrivateKey;
+            }
+
+            if (CertificatePassword != null)
+            {
+                djv[nameof(CertificatePassword)] = CertificatePassword;
+            }
+
             djv[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             djv[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             djv[nameof(AccessName)] = AccessName;

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -70,16 +70,8 @@ namespace Raven.Client.Documents.Operations.Replication
 #pragma warning disable CS0618 // Type or member is obsolete
             djv[nameof(HubDefinitionName)] = HubDefinitionName;
 #pragma warning restore CS0618 // Type or member is obsolete
-            if (CertificateWithPrivateKey != null)
-            {
-                djv[nameof(CertificateWithPrivateKey)] = CertificateWithPrivateKey;
-            }
-
-            if (CertificatePassword != null)
-            {
-                djv[nameof(CertificatePassword)] = CertificatePassword;
-            }
-
+            djv[nameof(CertificateWithPrivateKey)] = CertificateWithPrivateKey;
+            djv[nameof(CertificatePassword)] = CertificatePassword;
             djv[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             djv[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             djv[nameof(AccessName)] = AccessName;
@@ -113,9 +105,6 @@ namespace Raven.Client.Documents.Operations.Replication
             return sb.ToString();
         }
 
-        public override string GetDefaultTaskName()
-        {
-            return ToString();
-        }
+        public override string GetDefaultTaskName() => ToString();
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -17,7 +17,7 @@ namespace Raven.Client.Documents.Operations.Replication
     public class UpdatePullReplicationAsSinkOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly PullReplicationAsSink _pullReplication;
-        private readonly bool _keepOriginalCertificateOnNull;
+        private readonly bool _useServerCertificate;
 
         // Kept for the binary compatibility purposes.
         public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication) : this(pullReplication, false)
@@ -28,15 +28,21 @@ namespace Raven.Client.Documents.Operations.Replication
         /// Initializes the update operation for the <see cref="PullReplicationAsSink"/>.
         /// </summary>
         /// <param name="pullReplication">The pull replication object.</param>
-        /// <param name="keepOriginalCertificateOnNull">If <see cref="PullReplicationAsSink.CertificateWithPrivateKey"/> is null, whether to keep the original or remove.</param>
+        /// <param name="useServerCertificate">Makes the replication use the server certificate. Requires <see cref="PullReplicationAsSink.CertificateWithPrivateKey"/> to be null.</param>
         /// <exception cref="AuthorizationException">If the <see cref="PullReplicationAsSink.CertificateWithPrivateKey"/> isn't null and cannot be parsed.</exception>
-        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool keepOriginalCertificateOnNull = false)
+        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool useServerCertificate = false)
         {
             _pullReplication = pullReplication;
-            _keepOriginalCertificateOnNull = keepOriginalCertificateOnNull;
+            _useServerCertificate = useServerCertificate;
 
             if (pullReplication.CertificateWithPrivateKey != null)
             {
+                if (useServerCertificate)
+                    throw new ArgumentException(
+                        $"When {nameof(useServerCertificate)} is set to true, " +
+                        $"{nameof(PullReplicationAsSink.CertificateWithPrivateKey)} should be null to use server certificate.");
+                
+                
                 var certBytes = Convert.FromBase64String(pullReplication.CertificateWithPrivateKey);
                 using (var certificate = CertificateLoaderUtil.CreateCertificate(certBytes,
                     pullReplication.CertificatePassword,
@@ -50,10 +56,10 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public RavenCommand<ModifyOngoingTaskResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdatePullEdgeReplication(_pullReplication, _keepOriginalCertificateOnNull);
+            return new UpdatePullEdgeReplication(_pullReplication, _useServerCertificate);
         }
 
-        private class UpdatePullEdgeReplication(PullReplicationAsSink pullReplication, bool keepOriginalCertificateOnNull) : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
+        private class UpdatePullEdgeReplication(PullReplicationAsSink pullReplication, bool useServerCertificate) : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
         {
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
@@ -61,7 +67,7 @@ namespace Raven.Client.Documents.Operations.Replication
                 DynamicJsonValue replication = pullReplication.ToJson();
                 
                 // Aligned with ServerStore.UpdatePullReplicationAsSink to not introduce breaking changes
-                if (pullReplication.CertificateWithPrivateKey == null && keepOriginalCertificateOnNull)
+                if (pullReplication.CertificateWithPrivateKey == null && useServerCertificate)
                 {
                     int removed = replication.Properties.RemoveAll(pair => pair.Name == nameof(PullReplicationAsSink.CertificateWithPrivateKey));
                     Debug.Assert(removed > 0);

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -16,10 +16,23 @@ namespace Raven.Client.Documents.Operations.Replication
     public class UpdatePullReplicationAsSinkOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly PullReplicationAsSink _pullReplication;
+        private readonly bool _keepOriginalCertificateOnNull;
 
-        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication)
+        // Kept for the binary compatibility purposes.
+        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication) : this(pullReplication, false)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes the update operation for the <see cref="PullReplicationAsSink"/>.
+        /// </summary>
+        /// <param name="pullReplication">The pull replication object.</param>
+        /// <param name="keepOriginalCertificateOnNull">If <see cref="PullReplicationAsSink.CertificateWithPrivateKey"/> is null, whether to keep the original or remove.</param>
+        /// <exception cref="AuthorizationException">If the <see cref="PullReplicationAsSink.CertificateWithPrivateKey"/> isn't null and cannot be parsed.</exception>
+        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool keepOriginalCertificateOnNull = false)
         {
             _pullReplication = pullReplication;
+            _keepOriginalCertificateOnNull = keepOriginalCertificateOnNull;
 
             if (pullReplication.CertificateWithPrivateKey != null)
             {
@@ -36,20 +49,22 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public RavenCommand<ModifyOngoingTaskResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdatePullEdgeReplication(_pullReplication);
+            return new UpdatePullEdgeReplication(_pullReplication, _keepOriginalCertificateOnNull);
         }
 
-        private class UpdatePullEdgeReplication : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
+        private class UpdatePullEdgeReplication(PullReplicationAsSink pullReplication, bool keepOriginalCertificateOnNull) : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
         {
-            private readonly PullReplicationAsSink _pullReplication;
-
-            public UpdatePullEdgeReplication(PullReplicationAsSink pullReplication)
-            {
-                _pullReplication = pullReplication ?? throw new ArgumentNullException(nameof(pullReplication));
-            }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
+                DynamicJsonValue replication = pullReplication.ToJson();
+                
+                // Aligned with ServerStore.UpdatePullReplicationAsSink to not introduce breaking changes
+                if (pullReplication.CertificateWithPrivateKey == null && keepOriginalCertificateOnNull)
+                {
+                    replication.Remove(nameof(PullReplicationAsSink.CertificateWithPrivateKey));
+                }
+                
                 url = $"{node.Url}/databases/{node.Database}/admin/tasks/sink-pull-replication";
 
                 var request = new HttpRequestMessage
@@ -59,7 +74,7 @@ namespace Raven.Client.Documents.Operations.Replication
                     {
                         var json = new DynamicJsonValue
                         {
-                            ["PullReplicationAsSink"] = _pullReplication.ToJson()
+                            ["PullReplicationAsSink"] = replication
                         };
 
                         await ctx.WriteAsync(stream, ctx.ReadObject(json, "update-pull-replication")).ConfigureAwait(false);

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using Raven.Client.Documents.Conventions;
@@ -62,7 +63,8 @@ namespace Raven.Client.Documents.Operations.Replication
                 // Aligned with ServerStore.UpdatePullReplicationAsSink to not introduce breaking changes
                 if (pullReplication.CertificateWithPrivateKey == null && keepOriginalCertificateOnNull)
                 {
-                    replication.Remove(nameof(PullReplicationAsSink.CertificateWithPrivateKey));
+                    int removed = replication.Properties.RemoveAll(pair => pair.Name == nameof(PullReplicationAsSink.CertificateWithPrivateKey));
+                    Debug.Assert(removed > 0);
                 }
                 
                 url = $"{node.Url}/databases/{node.Database}/admin/tasks/sink-pull-replication";

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -81,15 +81,18 @@ namespace StressTests.Server.Replication
                 var timeout = 5000;
                 Assert.True(WaitForDocument(sinkStore, "foo/bar", timeout), sinkStore.Identifier);
                 
-                // test if certificate is retained when we don't send one
-                // sending null as cert - but it should copy old one
+                // Test if certificate is retained when we don't send one and specify the flag to keep the old one.
                 await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
-                {
-                    TaskId = sinkTaskId,
-                    Name = pullReplicationName,
-                    HubName = pullReplicationName,
-                    ConnectionStringName = "ConnectionString-" + hubStore.Database
-                }));
+                    {
+                        TaskId = sinkTaskId,
+                        Name = pullReplicationName,
+                        HubName = pullReplicationName,
+                        ConnectionStringName = "ConnectionString-" + hubStore.Database,
+                        
+                        CertificateWithPrivateKey = null
+                    }, 
+                    keepOriginalCertificateOnNull: true
+                ));
                 
                 using (var hubSession = hubStore.OpenSession())
                 {

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -33,7 +33,7 @@ namespace StressTests.Server.Replication
             var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true, with2Eku: with2Eku);
             var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates);
 
-            var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: false, with2Eku: with2Eku);
+            var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true, with2Eku: with2Eku);
             var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates);
 
             var hubDB = GetDatabaseName();

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -30,11 +30,11 @@ namespace StressTests.Server.Replication
             var hubSettings = new ConcurrentDictionary<string, string>();
             var sinkSettings = new ConcurrentDictionary<string, string>();
 
-            var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true);
-            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates, with2Eku: with2Eku);
+            var hubCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true, with2Eku: with2Eku);
+            var hubCerts = Certificates.SetupServerAuthentication(hubSettings, certificates: hubCertificates);
 
-            var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: false);
-            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates, with2Eku: with2Eku);
+            var sinkCertificates = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: false, with2Eku: with2Eku);
+            var sinkCerts = Certificates.SetupServerAuthentication(sinkSettings, certificates: sinkCertificates);
 
             var hubDB = GetDatabaseName();
             var sinkDB = GetDatabaseName();
@@ -43,7 +43,7 @@ namespace StressTests.Server.Replication
             var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = hubSettings, RegisterForDisposal = true });
             var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = sinkSettings, RegisterForDisposal = true });
 
-            var dummy = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: false);
+            var dummy = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true);
             var pullReplicationCertificate = new X509Certificate2(dummy.ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
             Assert.True(pullReplicationCertificate.HasPrivateKey);
 

--- a/test/StressTests/Server/Replication/PullReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/PullReplicationStressTests.cs
@@ -91,7 +91,7 @@ namespace StressTests.Server.Replication
                         
                         CertificateWithPrivateKey = null
                     }, 
-                    keepOriginalCertificateOnNull: true
+                    useServerCertificate: true
                 ));
                 
                 using (var hubSession = hubStore.OpenSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25107/Pull-Replication-UpdatePullReplicationAsSinkOperation-doesnt-preserve-existing-certificate

### Additional description

This PR fixes the behavior of the `UpdatePullReplicationAsSinkOperation` by amending how it handles the null in the certificate property. The fix aligns it with the server handling so that the non-existence of such property and null mean the same on both server and the client side.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

`UpdatePullReplicationAsSinkOperation` operation properly handles updating non-certificate properties

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
