### PR TITLE
RavenDB-25130 adjusted asserted test timings due to voron changes

### DIFF
--- a/src/Raven.Client/Util/CertificateLoaderUtil.cs
+++ b/src/Raven.Client/Util/CertificateLoaderUtil.cs
@@ -49,7 +49,9 @@ internal static class CertificateLoaderUtil
         {
             collection.Add(CertificateHelper.CreateCertificateFromPfx(rawData, password, f));
         }
+#pragma warning disable CS0168 // Variable is declared but never used
         catch (Exception e)
+#pragma warning restore CS0168 // Variable is declared but never used
         {
 #if NET9_0_OR_GREATER
             throw;
@@ -101,7 +103,9 @@ internal static class CertificateLoaderUtil
         {
             certificate = creator(f);
         }
+#pragma warning disable CS0168 // Variable is declared but never used
         catch (Exception e)
+#pragma warning restore CS0168 // Variable is declared but never used
         {
 #if NET9_0_OR_GREATER
             throw;

--- a/test/StressTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
+++ b/test/StressTests/Server/Documents/PeriodicBackup/MaxReadOpsPerSecOptionTests.cs
@@ -516,11 +516,11 @@ public class MaxReadOpsPerSecOptionTests : ClusterTestBase
                     return (DocumentsToCreate - MaxReadOpsPerSecToTest) / MaxReadOpsPerSecToTest;
 
                 case BackupType.Snapshot:
-                    // snapshot data requires 10 or 11 buffer iterations for a database with 5 docs, depending on the system environment's bitness (values obtained experimentally)
+                    // snapshot data requires 6 or 7 buffer iterations for a database with 5 docs, depending on the system environment's bitness (values obtained experimentally)
                     return RuntimeInformation.ProcessArchitecture switch
                     {
-                        Architecture.X86 or Architecture.Arm => 10,
-                        Architecture.X64 or Architecture.Arm64 => 11,
+                        Architecture.X86 or Architecture.Arm => 6,
+                        Architecture.X64 or Architecture.Arm64 => 7,
                         _ => throw new ArgumentOutOfRangeException(nameof(RuntimeInformation.ProcessArchitecture), "Unsupported architecture.")
                     };
 

--- a/test/Tryouts.Fast/Program.cs
+++ b/test/Tryouts.Fast/Program.cs
@@ -1,15 +1,13 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Tests.Infrastructure;
 using Raven.Server.Utils;
-using Xunit;
 using FastTests;
 using FastTests.Client;
-using Raven.Client.Documents.Operations.AI;
 
 namespace Tryouts.Fast;
 
@@ -29,7 +27,7 @@ public static class Program
         for (int i = 0; i < 1; i++)
         {
             Console.WriteLine($"Starting to run {i}");
-            
+
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using System;
 using System.Diagnostics;
 using System.IO;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25130

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
