### PR TITLE
RavenDB-25095 Skip license check when feature is disabled

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -64,6 +64,9 @@ public sealed partial class ClusterStateMachine
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
     {
+        if (updateDatabaseCommand is UpdateDatabaseRecordFeaturesCommand { Disabled: true })
+            return;
+
         switch (type)
         {
             case nameof(AddDatabaseCommand):

--- a/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
@@ -11,7 +11,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.ETL
 {
-    public abstract class AddEtlCommand<T, TConnectionString> : UpdateDatabaseCommand where T : EtlConfiguration<TConnectionString> where TConnectionString : ConnectionString
+    public abstract class AddEtlCommand<T, TConnectionString> : UpdateDatabaseRecordFeaturesCommand where T : EtlConfiguration<TConnectionString> where TConnectionString : ConnectionString
     {
         public T Configuration { get; protected set; }
 
@@ -64,6 +64,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             Add(ref record.RavenEtls, record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class AddSqlEtlCommand : AddEtlCommand<SqlEtlConfiguration, SqlConnectionString>
@@ -82,6 +84,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             Add(ref record.SqlEtls, record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class AddElasticSearchEtlCommand : AddEtlCommand<ElasticSearchEtlConfiguration, ElasticSearchConnectionString>
@@ -100,6 +104,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             Add(ref record.ElasticSearchEtls, record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class AddOlapEtlCommand : AddEtlCommand<OlapEtlConfiguration, OlapConnectionString>
@@ -118,6 +124,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             Add(ref record.OlapEtls, record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class AddQueueEtlCommand : AddEtlCommand<QueueEtlConfiguration, QueueConnectionString>
@@ -136,5 +144,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             Add(ref record.QueueEtls, record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
@@ -11,7 +11,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.ETL
 {
-    public abstract class UpdateEtlCommand<T, TConnectionString> : UpdateDatabaseCommand where T : EtlConfiguration<TConnectionString> where TConnectionString : ConnectionString
+    public abstract class UpdateEtlCommand<T, TConnectionString> : UpdateDatabaseRecordFeaturesCommand where T : EtlConfiguration<TConnectionString> where TConnectionString : ConnectionString
     {
         public long TaskId { get; protected set; }
 
@@ -57,6 +57,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
             new AddRavenEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
 
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class UpdateSqlEtlCommand : UpdateEtlCommand<SqlEtlConfiguration, SqlConnectionString>
@@ -77,6 +79,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
             new AddSqlEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
 
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class UpdateOlapEtlCommand : UpdateEtlCommand<OlapEtlConfiguration, OlapConnectionString>
@@ -96,6 +100,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
             new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.OlapEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
             new AddOlapEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
     
     public sealed class UpdateElasticSearchEtlCommand : UpdateEtlCommand<ElasticSearchEtlConfiguration, ElasticSearchConnectionString>
@@ -115,6 +121,8 @@ namespace Raven.Server.ServerWide.Commands.ETL
             new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.ElasticSearchEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
             new AddElasticSearchEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 
     public sealed class UpdateQueueEtlCommand : UpdateEtlCommand<QueueEtlConfiguration, QueueConnectionString>
@@ -134,5 +142,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
             new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.QueueEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
             new AddQueueEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditDataArchivalCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditDataArchivalCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public class EditDataArchivalCommand : UpdateDatabaseCommand
+    public class EditDataArchivalCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public DataArchivalConfiguration Configuration;
         public void UpdateDatabaseRecord(DatabaseRecord databaseRecord)
@@ -32,5 +32,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditDatabaseClientConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditDatabaseClientConfigurationCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditDatabaseClientConfigurationCommand : UpdateDatabaseCommand
+    public sealed class EditDatabaseClientConfigurationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public ClientConfiguration Configuration { get; set; }
 
@@ -27,5 +27,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditDocumentsCompressionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditDocumentsCompressionCommand.cs
@@ -6,7 +6,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditDocumentsCompressionCommand : UpdateDatabaseCommand
+    public sealed class EditDocumentsCompressionCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public DocumentsCompressionConfiguration Configuration;
         
@@ -38,5 +38,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.CompressAllCollections == false && Configuration.CompressRevisions == false && Configuration.Collections?.Length == 0;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditExpirationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditExpirationCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditExpirationCommand : UpdateDatabaseCommand
+    public sealed class EditExpirationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public ExpirationConfiguration Configuration;
         public void UpdateDatabaseRecord(DatabaseRecord databaseRecord)
@@ -31,5 +31,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditRefreshCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditRefreshCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditRefreshCommand : UpdateDatabaseCommand
+    public sealed class EditRefreshCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public RefreshConfiguration Configuration;
         public void UpdateDatabaseRecord(DatabaseRecord databaseRecord)
@@ -31,5 +31,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditRevisionsConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditRevisionsConfigurationCommand.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide;
 using Raven.Server.Utils;
@@ -5,7 +6,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditRevisionsConfigurationCommand : UpdateDatabaseCommand
+    public sealed class EditRevisionsConfigurationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public RevisionsConfiguration Configuration { get; private set; }
 
@@ -26,6 +27,18 @@ namespace Raven.Server.ServerWide.Commands
         public override void FillJson(DynamicJsonValue json)
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
+        }
+
+        public override bool Disabled => isDisabled();
+
+        private bool isDisabled()
+        {
+            var disable = false;
+            if (Configuration.Default != null)
+                disable = Configuration.Default.Disabled;
+            if (Configuration.Collections != null && Configuration.Collections.Count > 0)
+                disable &= Configuration.Collections.All(x => x.Value.Disabled);
+            return disable;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditRevisionsForConflictsConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditRevisionsForConflictsConfigurationCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditRevisionsForConflictsConfigurationCommand : UpdateDatabaseCommand
+    public sealed class EditRevisionsForConflictsConfigurationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public RevisionsCollectionConfiguration Configuration { get; private set; }
 
@@ -27,5 +27,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/EditTimeSeriesConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditTimeSeriesConfigurationCommand.cs
@@ -1,10 +1,11 @@
-﻿using Raven.Client.Documents.Operations.TimeSeries;
+﻿using System.Linq;
+using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.ServerWide;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class EditTimeSeriesConfigurationCommand : UpdateDatabaseCommand
+    public sealed class EditTimeSeriesConfigurationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public TimeSeriesConfiguration Configuration { get; private set; }
 
@@ -28,5 +29,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Configuration)] = Configuration.ToJson();
         }
+
+        public override bool Disabled => Configuration.Collections != null && Configuration.Collections.All(collection => collection.Value.Disabled);
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutAutoIndexCommand.cs
@@ -14,7 +14,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.Indexes
 {
-    public sealed class PutAutoIndexCommand : UpdateDatabaseCommand
+    public sealed class PutAutoIndexCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public DateTime CreatedAt;
         public AutoIndexDefinition Definition;
@@ -114,5 +114,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
             return result;
         }
+
+        public override bool Disabled => Definition.State == IndexState.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -11,7 +11,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.Indexes
 {
-    public sealed class PutIndexCommand : UpdateDatabaseCommand
+    public sealed class PutIndexCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public IndexDefinition Definition;
 
@@ -114,5 +114,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
                 }
             }
         }
+
+        public override bool Disabled => Definition.State == IndexState.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
@@ -12,7 +12,7 @@ using Voron.Data.Tables;
 
 namespace Raven.Server.ServerWide.Commands.PeriodicBackup
 {
-    public sealed class UpdatePeriodicBackupCommand : UpdateDatabaseCommand
+    public sealed class UpdatePeriodicBackupCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public PeriodicBackupConfiguration Configuration;
         private bool _shouldRemoveBackupStatus;
@@ -83,5 +83,7 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/PutDatabaseClientConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutDatabaseClientConfigurationCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class PutDatabaseClientConfigurationCommand : UpdateDatabaseCommand
+    public sealed class PutDatabaseClientConfigurationCommand : UpdateDatabaseRecordFeaturesCommand
     {
 
         public ClientConfiguration Configuration;
@@ -30,5 +30,7 @@ namespace Raven.Server.ServerWide.Commands
             record.Client = Configuration;
             record.Client.Etag = etag;
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/PutDatabaseStudioConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutDatabaseStudioConfigurationCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class PutDatabaseStudioConfigurationCommand : UpdateDatabaseCommand
+    public sealed class PutDatabaseStudioConfigurationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public StudioConfiguration Configuration;
 
@@ -28,5 +28,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             record.Studio = Configuration;
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/QueueSink/AddQueueSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/QueueSink/AddQueueSinkCommand.cs
@@ -6,7 +6,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.QueueSink
 {
-    public class AddQueueSinkCommand: UpdateDatabaseCommand
+    public class AddQueueSinkCommand: UpdateDatabaseRecordFeaturesCommand
     {
         public QueueSinkConfiguration Configuration { get; protected set; }
         
@@ -47,5 +47,7 @@ namespace Raven.Server.ServerWide.Commands.QueueSink
         {
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/QueueSink/UpdateQueueSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/QueueSink/UpdateQueueSinkCommand.cs
@@ -6,7 +6,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.QueueSink
 {
-    public class UpdateQueueSinkCommand : UpdateDatabaseCommand
+    public class UpdateQueueSinkCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public long TaskId { get; protected set; }
 
@@ -36,5 +36,7 @@ namespace Raven.Server.ServerWide.Commands.QueueSink
             json[nameof(TaskId)] = TaskId;
             json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
         }
+
+        public override bool Disabled => Configuration.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
@@ -9,6 +9,9 @@ using Voron.Data.Tables;
 
 namespace Raven.Server.ServerWide.Commands
 {
+    // NOTE: For commands that represent license-limited features,
+    //       inherit from UpdateDatabaseRecordFeaturesCommand instead.
+
     public abstract class UpdateDatabaseCommand : CommandBase
     {
         public string DatabaseName;

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseRecordFeaturesCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseRecordFeaturesCommand.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    // Base for all UpdateDatabaseCommand types that represent features.
+    // Used to handle license-limited features and allow skipping license
+    // asserts when a feature is being disabled.
+    public abstract class UpdateDatabaseRecordFeaturesCommand : UpdateDatabaseCommand
+    {
+        protected UpdateDatabaseRecordFeaturesCommand() { }
+
+        protected UpdateDatabaseRecordFeaturesCommand(string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId) { }
+
+        public abstract bool Disabled { get; }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateExternalReplicationCommand.cs
@@ -6,7 +6,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class UpdateExternalReplicationCommand : UpdateDatabaseCommand
+    public sealed class UpdateExternalReplicationCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public ExternalReplication Watcher;
 
@@ -58,5 +58,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Watcher)] = Watcher.ToJson();
         }
+
+        public override bool Disabled => Watcher.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsHubCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsHubCommand.cs
@@ -4,7 +4,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class UpdatePullReplicationAsHubCommand : UpdateDatabaseCommand
+    public sealed class UpdatePullReplicationAsHubCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public PullReplicationDefinition Definition;
 
@@ -39,5 +39,7 @@ namespace Raven.Server.ServerWide.Commands
         {
             json[nameof(Definition)] = Definition.ToJson();
         }
+
+        public override bool Disabled => Definition.Disabled;
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsSinkCommand.cs
@@ -5,7 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands
 {
-    public sealed class UpdatePullReplicationAsSinkCommand : UpdateDatabaseCommand
+    public sealed class UpdatePullReplicationAsSinkCommand : UpdateDatabaseRecordFeaturesCommand
     {
         public PullReplicationAsSink PullReplicationAsSink;
         public bool? UseServerCertificate;
@@ -70,5 +70,7 @@ namespace Raven.Server.ServerWide.Commands
             json[nameof(PullReplicationAsSink)] = PullReplicationAsSink.ToJson();
             json[nameof(UseServerCertificate)] = UseServerCertificate;
         }
+
+        public override bool Disabled => PullReplicationAsSink.Disabled;
     }
 }

--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -13,10 +13,12 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Commercial;
+using Raven.Server.ServerWide.Commands;
 using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
@@ -57,7 +59,6 @@ namespace SlowTests.Issues
                     }));
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-
                 }
 
                 using (var store = GetDocumentStore())
@@ -84,27 +85,29 @@ namespace SlowTests.Issues
             var file = GetTempFileName();
             try
             {
+                PeriodicBackupConfiguration config;
                 using (var store = GetDocumentStore())
                 {
-                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
+                    await DisableRevisionCompression(Server, store.Database);
+                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
                     await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-
                 }
 
                 using (var store = GetDocumentStore())
                 {
                     await ChangeLicense(Server, RL_COMM, store);
 
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    config.Disabled = false;
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        await Backup.UpdateConfigAsync(Server, config, store);
                     });
                     Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
                 }
             }
             finally
@@ -123,29 +126,30 @@ namespace SlowTests.Issues
             var file = GetTempFileName();
             try
             {
+                PeriodicBackupConfiguration config;
                 using (var store = GetDocumentStore())
                 {
-                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
+                    await DisableRevisionCompression(Server, store.Database);
+                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
                     await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-
-
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-
                 }
 
                 using (var store = GetDocumentStore())
                 {
                     await ChangeLicense(Server, RL_PRO, store);
 
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    config.Disabled = false;
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        await Backup.UpdateConfigAsync(Server, config, store);
+
                     });
                     Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
                 }
             }
             finally
@@ -159,47 +163,55 @@ namespace SlowTests.Issues
         public async Task ExceptionWhenImportingExternalReplicationWithCommunityLicense()
         {
             DoNotReuseServer();
-
-            var file = GetTempFileName();
-            var dbName = $"db/{Guid.NewGuid()}";
-            var csName = $"cs/{Guid.NewGuid()}";
-            try
+            using (var server = GetNewServer())
+            using (var server2 = GetNewServer())
             {
-                using (var store = GetDocumentStore())
+                var file = GetTempFileName();
+                var dbName = $"db/{Guid.NewGuid()}";
+                var csName = $"cs/{Guid.NewGuid()}";
+                try
                 {
-                    var connectionString = new RavenConnectionString
+                    using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server }))
                     {
-                        Name = csName,
-                        Database = dbName,
-                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
-                    };
+                        var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store2.Database,
+                            RaftIdGenerator.NewId());
+                        await server.ServerStore.SendToLeaderAsync(command);
+                        command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store1.Database,
+                            RaftIdGenerator.NewId());
+                        await server2.ServerStore.SendToLeaderAsync(command);
 
-                    var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
-                    Assert.NotNull(result.RaftCommandIndex);
+                        var connectionString = new RavenConnectionString
+                        {
+                            Name = csName,
+                            Database = dbName,
+                            TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                        };
 
-                    var watcher = new ExternalReplication(dbName, csName);
-                    await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                        var result = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                        Assert.NotNull(result.RaftCommandIndex);
 
-                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
-                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-                }
+                        var watcher = new ExternalReplication(dbName, csName);
+                        await store1.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
 
-                using (var store = GetDocumentStore())
-                {
-                    await ChangeLicense(Server, RL_COMM, store);
+                        var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                        await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
-                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
-                    {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await ChangeLicense(server, RL_COMM, store2);
+                        var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-                    });
-                    Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
+                        var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                        {
+                            watcher.Disabled = false;
+                            await store2.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                        });
+                        Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
+                    }
                 }
-            }
-            finally
-            {
-                File.Delete(file);
+                finally
+                {
+                    File.Delete(file);
+                }
             }
         }
 
@@ -208,15 +220,23 @@ namespace SlowTests.Issues
         {
             DoNotReuseServer();
             using (var server = GetNewServer())
+            using (var server2 = GetNewServer())
             {
                 var file = GetTempFileName();
                 var dbName = $"cs/{Guid.NewGuid()}";
                 var csName = $"cs/{Guid.NewGuid()}";
                 try
                 {
-                    using (var store1 = GetDocumentStore())
-                    using (var store2 = GetDocumentStore(new Options(){Server = server}))
+                    using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server }))
                     {
+                        var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store2.Database,
+                            RaftIdGenerator.NewId());
+                        await server.ServerStore.SendToLeaderAsync(command);
+                        command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store1.Database,
+                            RaftIdGenerator.NewId());
+                        await server2.ServerStore.SendToLeaderAsync(command);
+
                         var connectionString = new RavenConnectionString { Name = csName, Database = dbName, TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" } };
 
                         var result = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
@@ -230,13 +250,15 @@ namespace SlowTests.Issues
 
                         await ChangeLicense(server, RL_COMM, store2);
 
+                        var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
                         var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                         {
-                            var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                            await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                            watcher.Disabled = false;
+                            await store2.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
                         });
                         Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
-                        Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
                     }
                 }
                 finally
@@ -375,9 +397,11 @@ namespace SlowTests.Issues
             var csName = $"cs/{Guid.NewGuid()}";
             try
             {
+                PullReplicationAsSink pullAsSink;
                 using (var store = GetDocumentStore())
                 {
-                    var pullAsSink = new PullReplicationAsSink(dbName, csName, "hub");
+                    await DisableRevisionCompression(Server, store.Database);
+                    pullAsSink = new PullReplicationAsSink(dbName, csName, "hub");
                     var result = await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(pullAsSink));
                     Assert.NotNull(result.RaftCommandIndex);
 
@@ -388,14 +412,15 @@ namespace SlowTests.Issues
                 using (var store = GetDocumentStore())
                 {
                     await ChangeLicense(Server, RL_COMM, store);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        pullAsSink.Disabled = false;
+                        await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(pullAsSink));
                     });
                     Assert.Equal(LimitType.PullReplicationAsSink, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding Sink Replication feature."));
                 }
             }
             finally
@@ -412,9 +437,12 @@ namespace SlowTests.Issues
             var file = GetTempFileName();
             try
             {
+                PullReplicationDefinition pull;
                 using (var store = GetDocumentStore())
                 {
-                    store.Maintenance.Send(new PutPullReplicationAsHubOperation("sink"));
+                    await DisableRevisionCompression(Server, store.Database);
+                    pull = new PullReplicationDefinition("pull");
+                    store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -424,13 +452,14 @@ namespace SlowTests.Issues
                 {
                     await ChangeLicense(Server, RL_COMM, store);
 
-                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    pull.Disabled = false;
+                    var exception = Assert.Throws<LicenseLimitException>(() =>
                     {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
                     });
                     Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
                 }
             }
             finally
@@ -447,9 +476,12 @@ namespace SlowTests.Issues
             var file = GetTempFileName();
             try
             {
+                PullReplicationDefinition pull;
                 using (var store = GetDocumentStore())
                 {
-                    store.Maintenance.Send(new PutPullReplicationAsHubOperation("sink"));
+                    await DisableRevisionCompression(Server, store.Database);
+                    pull = new PullReplicationDefinition("pull");
+                    store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -459,13 +491,14 @@ namespace SlowTests.Issues
                 {
                     await ChangeLicense(Server, RL_PRO, store);
 
-                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    pull.Disabled = false;
+                    var exception = Assert.Throws<LicenseLimitException>(() =>
                     {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
                     });
                     Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
                 }
             }
             finally
@@ -483,9 +516,12 @@ namespace SlowTests.Issues
             var file = GetTempFileName();
             try
             {
+                AddEtlOperationResult etl;
+                RavenEtlConfiguration etlConfiguration;
                 using (var store = GetDocumentStore())
                 {
-                    var etlConfiguration = new RavenEtlConfiguration
+                    await DisableRevisionCompression(Server, store.Database);
+                    etlConfiguration = new RavenEtlConfiguration
                     {
                         Name = csName,
                         ConnectionStringName = csName,
@@ -500,7 +536,7 @@ namespace SlowTests.Issues
                     };
 
                     Assert.NotNull(store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString)));
-                    store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
+                    etl = store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -510,13 +546,16 @@ namespace SlowTests.Issues
                 {
                     await ChangeLicense(Server, RL_COMM, store);
 
-                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    etlConfiguration.Disabled = false;
+                    var op = new UpdateEtlOperation<RavenConnectionString>(etl.TaskId, etlConfiguration);
+
+                    var exception = Assert.Throws<LicenseLimitException>( () =>
                     {
-                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                        store.Maintenance.Send(op);
                     });
                     Assert.Equal(LimitType.RavenEtl, exception.LimitType);
-                    Assert.True(exception.Message.Contains("Your license doesn't support adding Raven ETL feature."));
                 }
             }
             finally
@@ -532,6 +571,13 @@ namespace SlowTests.Issues
             LicenseHelper.TryDeserializeLicense(license, out License li);
             await RavenDB_21427.DisableRevisionCompression(server, store);
             await server.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+        }
+
+        internal static async Task DisableRevisionCompression(RavenServer leader, string name)
+        {
+            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, name,
+                RaftIdGenerator.NewId());
+            await leader.ServerStore.SendToLeaderAsync(command);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -42,6 +42,8 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Commands.ETL;
+using Raven.Server.ServerWide.Commands.QueueSink;
 using SlowTests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
@@ -443,6 +445,19 @@ namespace SlowTests.Issues
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task Put_Disabled_Revisions()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = true, MinimumRevisionsToKeep = 0 } };
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+            }
+        }
+
         // ----------------------------------------
         // Tests for Backup License Limits
         // ----------------------------------------
@@ -641,6 +656,20 @@ namespace SlowTests.Issues
                 await DisableRevisionCompression(Server, store);
                 await ChangeLicense(Server, RL_DEV);
                 await ChangeLicense(Server, RL_PRO);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task Put_Disabled_PeriodicBackup()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
             }
         }
 
@@ -916,6 +945,22 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Put_Disabled_ClientConfiguration()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var config = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50, Disabled = true };
+
+                var command = new PutDatabaseClientConfigurationCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
         // ----------------------------------------
         // Tests for Studio Configuration License Limits
         //  ----------------------------------------
@@ -961,6 +1006,22 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Put_Disabled_StudioConfiguration()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var command = new PutDatabaseStudioConfigurationCommand(
+                    new ServerWideStudioConfiguration { DisableAutoIndexCreation = true, Disabled = true },
+                    store.Database, RaftIdGenerator.NewId());
+
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
         // ----------------------------------------
         // Tests for Expiration License Limits
         //  ----------------------------------------
@@ -999,6 +1060,23 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Put_Disabled_ExpirationConfiguration()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = new ExpirationConfiguration { Disabled = true, DeleteFrequencyInSec = 60 };
+                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Refresh License Limits
+        //  ----------------------------------------
+
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ExpirationRefresh)]
         public async Task Prevent_License_Downgrade_Refresh_Configuration()
         {
@@ -1035,6 +1113,21 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ExpirationRefresh)]
+        public async Task Put_Disabled_Refresh_Configuration()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = true };
+                await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
+            }
+        }
+        
         // ----------------------------------------
         // Tests for Encryption License Limits
         //  ----------------------------------------
@@ -1204,6 +1297,45 @@ public class MyAnalyzer2 : Analyzer
                 await FailToChangeLicense(Server, RL_COMM, LimitType.DocumentsCompression);
                 await FailToChangeLicense(Server, RL_PRO, LimitType.DocumentsCompression);
                 await ChangeLicense(Server, RL_DEV);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Put_Disabled_Document_Compression()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var config = new DocumentsCompressionConfiguration
+                {
+                    CompressAllCollections = false,
+                    Collections = new string[] { }
+                };
+                await Server.ServerStore.SendToLeaderAsync(
+                    new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()));
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Revisions)]
+        public async Task Put_Disabled_Revision_Compression()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var config = new DocumentsCompressionConfiguration
+                {
+                    CompressRevisions = false,
+                    CompressAllCollections = false,
+                    Collections = new string[] { }
+                };
+                await Server.ServerStore.SendToLeaderAsync(
+                    new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()));
             }
         }
 
@@ -1735,6 +1867,237 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Put_Disabled_Raven_ETL()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+                var connectionString = new RavenConnectionString
+                {
+                    Name = "RavenConnStr",
+                    Database = store.Database,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                };
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                var config = new RavenEtlConfiguration
+                {
+                    Name = "RavenEtlTask",
+                    ConnectionStringName = "RavenConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = null
+                        }
+                    },
+                    Disabled = true
+                };
+                var command = new AddRavenEtlCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Put_Disabled_Sql_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new SqlConnectionString
+                {
+                    Name = "SqlConnStr",
+                    FactoryName = "System.Data.SqlClient",
+                    ConnectionString = "Server=localhost;Database=Test;User Id=sa;Password=123456;"
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(connectionString));
+
+                var config = new SqlEtlConfiguration
+                {
+                    Name = "SqlEtlTask",
+                    ConnectionStringName = "SqlConnStr",
+                    SqlTables = { new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false } },
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = "loadToUsers(this)"
+                        }
+                    },
+                    Disabled = true
+                };
+
+                var command = new AddSqlEtlCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Put_Disabled_Olap_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new OlapConnectionString
+                {
+                    Name = "OlapConnStr",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = NewDataPath(suffix: "OlapOutput")
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<OlapConnectionString>(connectionString));
+
+                var config = new OlapEtlConfiguration
+                {
+                    Name = "OlapEtlTask",
+                    ConnectionStringName = "OlapConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "OlapTransform",
+                            Collections = new List<string> { "Orders" },
+                            Script = "loadToUsers(this)"
+                        }
+                    },
+                    Disabled = true
+                };
+
+                var command = new AddOlapEtlCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Put_Disabled_Elasticsearch_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new ElasticSearchConnectionString
+                {
+                    Name = "ElasticConnStr",
+                    Nodes = new[] { "http://localhost:9200" }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<ElasticSearchConnectionString>(connectionString));
+
+                var config = new ElasticSearchEtlConfiguration
+                {
+                    Name = "ElasticEtlTask",
+                    ConnectionStringName = "ElasticConnStr",
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Products" },
+                            Script = "loadToUsers(this)"
+                        }
+                    },
+                    Disabled = true
+                };
+                var command = new AddElasticSearchEtlCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Put_Disabled_Queue_ETL()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var connectionString = new QueueConnectionString
+                {
+                    Name = "QueueConnStr",
+                    BrokerType = QueueBrokerType.Kafka,
+                    KafkaConnectionSettings = new KafkaConnectionSettings
+                    {
+                        BootstrapServers = "localhost:9092"
+                    }
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<QueueConnectionString>(connectionString));
+
+                var config = new QueueEtlConfiguration
+                {
+                    Name = "QueueEtlTask",
+                    ConnectionStringName = "QueueConnStr",
+                    BrokerType = QueueBrokerType.Kafka,
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "QueueScript",
+                            Collections = new List<string> { "Orders" },
+                            Script = "loadToUsers(this)"
+                        }
+                    },
+                    Disabled = true
+                };
+
+                var command = new AddQueueEtlCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task Put_Disabled_Downgrade_QueueSink()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(
+                    new PutConnectionStringOperation<QueueConnectionString>(
+                        new QueueConnectionString
+                        {
+                            Name = "KafkaConStr",
+                            BrokerType = QueueBrokerType.Kafka,
+                            KafkaConnectionSettings = new KafkaConnectionSettings() { BootstrapServers = "localhost:9092" }
+                        }));
+
+                QueueSinkScript queueSinkScript = new()
+                {
+                    Name = "orders",
+                    Queues = new List<string>() { "orders" },
+                    Script = @"this['@metadata']['@collection'] = 'Orders';
+               put(this.Id.toString(), this)"
+                };
+
+                var config = new QueueSinkConfiguration() { ConnectionStringName = "KafkaConStr", BrokerType = QueueBrokerType.Kafka, Scripts = { queueSinkScript }, Disabled = true };
+
+                store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
+
+                var command = new AddQueueSinkCommand(config, store.Database, RaftIdGenerator.NewId());
+                await Server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
         // ----------------------------------------
         // Tests for Replication License Limits
         //  ----------------------------------------
@@ -2091,6 +2454,39 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.TimeSeries)]
+        public async Task Put_Disabled_TimeSeries_Configuration()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                await DisableRevisionCompression(Server, store);
+                await PutLicense(Server, RL_COMM);
+
+                var timeSeriesConfig = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        {
+                            "Users", new TimeSeriesCollectionConfiguration
+                            {
+                                Policies = new List<TimeSeriesPolicy>
+                                {
+                                    new TimeSeriesPolicy("30Seconds", TimeValue.FromSeconds(30)),
+                                    new TimeSeriesPolicy("1Hour", TimeValue.FromHours(1))
+                                },
+                                RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromMinutes(1)),
+                                Disabled = true
+                            }
+                        }
+                    }
+
+                };
+
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
+            }
+        }
         private static async Task FailToChangeLicense(RavenServer leader, string licenseType, LimitType limitType)
         {
             var license = Environment.GetEnvironmentVariable(licenseType);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25095

### Additional description
This change allows RavenDB to skip license checks when a feature is disabled.

Behavior Change:
Some licensed features (e.g., backups, ETL, etc.) are imported in a disabled state.
Previously, importing a database that contained these disabled features would fail if the current license didn’t include them.
Now, the import will succeed, and those features will remain disabled. The license check will occur only when the user tries to enable the feature.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
