### PR TITLE
RavenDB-21091 Moving handing of VoronConcurrencyErrorException to DocumentPutAction.TryHandleVoronConcurrencyError()

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -19,6 +19,7 @@ using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
 using Raven.Client.Util;
+using Voron.Exceptions;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Documents;
 using Constants = Raven.Client.Constants;
@@ -772,6 +773,29 @@ namespace Raven.Server.Documents
             {
                 data.NoCache = originalNoCacheValue;
             }
+        }
+        
+        public static bool TryHandleVoronConcurrencyError(VoronConcurrencyErrorException e, DocumentDatabase database, string id, out string newId)
+        {
+            Debug.Assert(e != null, "It must be called only in handling of VoronConcurrencyErrorException");
+            
+            // RavenDB-10581 / RavenDB-21091 - If we have a concurrency error on "doc-id/"
+            // this means that we have existing values under the current etag
+            // we'll generate a new (random) id for them
+            
+            if (id?.EndsWith(database.IdentityPartsSeparator) == true)
+            {
+                newId = GenerateNonConflictingId(database, id);
+                return true;
+            }
+
+            newId = null;
+            return false;
+        }
+        
+        private static string GenerateNonConflictingId(DocumentDatabase database, string prefix)
+        {
+            return prefix + database.DocumentsStorage.GenerateNextEtag().ToString("D19") + "-" + Guid.NewGuid().ToBase64Unpadded();
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -103,20 +103,15 @@ public sealed class MergedBatchCommand : TransactionMergedCommand
                         putResult = Database.DocumentsStorage.Put(context, cmd.Id, cmd.ChangeVector, cmd.Document,
                             oldChangeVectorForClusterTransactionIndexCheck: cmd.OriginalChangeVector, flags: flags);
                     }
-                    catch (Voron.Exceptions.VoronConcurrencyErrorException)
+                    catch (Voron.Exceptions.VoronConcurrencyErrorException e)
                     {
-                        // RavenDB-10581 - If we have a concurrency error on "doc-id/"
-                        // this means that we have existing values under the current etag
-                        // we'll generate a new (random) id for them.
-
-                        // The TransactionMerger will re-run us when we ask it to as a
-                        // separate transaction
                         for (; i < ParsedCommands.Count; i++)
                         {
                             cmd = ParsedCommands.Array[ParsedCommands.Offset + i];
-                            if (cmd.Type == CommandType.PUT && cmd.Id?.EndsWith(Database.IdentityPartsSeparator) == true)
+                            if (cmd.Type == CommandType.PUT && DocumentPutAction.TryHandleVoronConcurrencyError(e, Database, cmd.Id, out var newId))
                             {
-                                cmd.Id = MergedPutCommand.GenerateNonConflictingId(Database, cmd.Id);
+                                cmd.Id = newId;
+                                // The TransactionMerger will re-run us when we ask it to as a separate transaction
                                 RetryOnError = true;
                             }
                         }

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -95,12 +95,7 @@ namespace Raven.Server.Documents.Handlers
         private readonly DocumentDatabase _database;
         private readonly bool _shouldValidateAttachments;
         public DocumentsStorage.PutOperationResults PutResult;
-
-        public static string GenerateNonConflictingId(DocumentDatabase database, string prefix)
-        {
-            return prefix + database.DocumentsStorage.GenerateNextEtag().ToString("D19") + "-" + Guid.NewGuid().ToBase64Unpadded();
-        }
-
+        
         public MergedPutCommand(BlittableJsonReaderObject doc, string id, LazyStringValue changeVector, DocumentDatabase database, bool shouldValidateAttachments = false)
         {
             _document = doc;
@@ -124,19 +119,15 @@ namespace Raven.Server.Documents.Handlers
             {
                 PutResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _document);
             }
-            catch (Voron.Exceptions.VoronConcurrencyErrorException)
+            catch (Voron.Exceptions.VoronConcurrencyErrorException e)
             {
-                // RavenDB-10581 - If we have a concurrency error on "doc-id/"
-                // this means that we have existing values under the current etag
-                // we'll generate a new (random) id for them.
-
-                // The TransactionMerger will re-run us when we ask it to as a
-                // separate transaction
-                if (_id?.EndsWith(_database.IdentityPartsSeparator) == true)
+                if (DocumentPutAction.TryHandleVoronConcurrencyError(e, _database, _id, out var newId))
                 {
-                    _id = GenerateNonConflictingId(_database, _id);
+                    _id = newId;
+                    // The TransactionMerger will re-run us when we ask it to as a separate transaction
                     RetryOnError = true;
                 }
+                
                 throw;
             }
             return 1;

--- a/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/MergedInsertBulkCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/MergedInsertBulkCommand.cs
@@ -58,24 +58,18 @@ public sealed class MergedInsertBulkCommand : DocumentMergedTransactionCommand
 
                         Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document);
                     }
-                    catch (VoronConcurrencyErrorException)
+                    catch (VoronConcurrencyErrorException e)
                     {
-                        // RavenDB-10581 - If we have a concurrency error on "doc-id/"
-                        // this means that we have existing values under the current etag
-                        // we'll generate a new (random) id for them.
-
-                        // The TransactionMerger will re-run us when we ask it to as a
-                        // separate transaction
-
                         for (; i < NumberOfCommands; i++)
                         {
                             cmd = Commands[i];
                             if (cmd.Type != CommandType.PUT)
                                 continue;
 
-                            if (cmd.Id?.EndsWith(Database.IdentityPartsSeparator) == true)
+                            if (DocumentPutAction.TryHandleVoronConcurrencyError(e, Database, cmd.Id, out var newId))
                             {
-                                cmd.Id = MergedPutCommand.GenerateNonConflictingId(Database, cmd.Id);
+                                cmd.Id = newId;
+                                // The TransactionMerger will re-run us when we ask it to as a separate transaction
                                 RetryOnError = true;
                             }
                         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -1193,14 +1193,11 @@ namespace Raven.Server.Documents.Patch
 
                             break;
                         }
-                        catch (Voron.Exceptions.VoronConcurrencyErrorException)
+                        catch (Voron.Exceptions.VoronConcurrencyErrorException e)
                         {
-                            // RavenDB-21091 / RavenDB-10581 - If we have a concurrency error on "doc-id/"
-                            // this means that we have existing values under the current etag
-                            // we'll generate a new (random) id for them.
-                            if (id?.EndsWith(_database.IdentityPartsSeparator) == true)
+                            if (DocumentPutAction.TryHandleVoronConcurrencyError(e, _database, id, out var newId))
                             {
-                                id = MergedPutCommand.GenerateNonConflictingId(_database, id);
+                                id = newId;
                                 continue;
                             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21091

### Additional description

It addresses the PR comment - https://github.com/ravendb/ravendb/pull/21524#discussion_r2404331577

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Refactoring

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
