### PR TITLE
RavenDB-25086 Allow to get tags with version only for docker images

### DIFF
--- a/docker/build-nanoserver.ps1
+++ b/docker/build-nanoserver.ps1
@@ -3,7 +3,8 @@ param(
     $ArtifactsDir = "..\artifacts",
     $RavenDockerSettingsPath = "..\src\Raven.Server\Properties\Settings\settings.docker.windows.json",
     $WinVer = "1809",
-    $DockerfileDir = "./ravendb-nanoserver")
+    $DockerfileDir = "./ravendb-nanoserver",
+    [switch]$UseVersionTagsOnly)
 
 $ErrorActionPreference = "Stop"
 
@@ -28,7 +29,7 @@ function BuildWindowsDockerImage ($version, $WinVer) {
 
 
     write-host "Build docker image: $version"
-    $tags = GetWindowsImageTags $repo $version $WinVer
+    [string[]]$tags = GetWindowsImageTags $repo $version $WinVer $UseVersionTagsOnly
     $fullNameTag = $tags[0]
     
     write-host "Tags: $tags"

--- a/docker/build-ubuntu.ps1
+++ b/docker/build-ubuntu.ps1
@@ -3,7 +3,8 @@ param(
     $ArtifactsDir = "..\artifacts",
     $RavenDockerSettingsPath = "..\src\Raven.Server\Properties\Settings\settings.docker.posix.json",
     $Arch = "x64",
-    $DockerfileDir = "./ravendb-ubuntu")
+    $DockerfileDir = "./ravendb-ubuntu",
+    [switch]$UseVersionTagsOnly)
 
 $ErrorActionPreference = "Stop"
 
@@ -43,7 +44,7 @@ function BuildUbuntuDockerImage ($version, $arch) {
     Copy-Item -Path $RavenDockerSettingsPath -Destination $(Join-Path -Path $DockerfileDir -ChildPath "settings.json") -Force
 
     write-host "Build docker image: $version"
-    $tags = GetUbuntuImageTags $repo $version $arch
+    [string[]]$tags = GetUbuntuImageTags $repo $version $arch $UseVersionTagsOnly
     write-host "Tags: $tags"
 
     $fullNameTag = $tags[0]

--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -31,48 +31,72 @@ CALLSTACK:$(Get-PSCallStack | Out-String)
     }
 }
 
-function GetUbuntuImageTags($repo, $version, $arch) {
+function GetUbuntuImageTags($repo, $version, $arch, [bool]$useVersionTagsOnly = $false) {
     switch ($arch) {
         "x64" { 
-            return @(
-                "$($repo):5.4-ubuntu-latest",
+            $versionTags = @(
                 "$($repo):$($version)-ubuntu.22.04-x64"
+            )
+            if ($useVersionTagsOnly) {
+                return $versionTags
+            }
+            return $versionTags + @(
+                "$($repo):5.4-ubuntu-latest"
             )
             break;
         }
         "arm32v7" {
-            return @(
-                "$($repo):5.4-ubuntu-arm32v7-latest",
+            $versionTags = @(
                 "$($repo):$($version)-ubuntu.22.04-arm32v7"
+            )
+            if ($useVersionTagsOnly) {
+                return $versionTags
+            }
+            return $versionTags + @(
+                "$($repo):5.4-ubuntu-arm32v7-latest"
             )
             break;
         }
         "arm64v8" {
-            return @(
-                "$($repo):5.4-ubuntu-arm64v8-latest",
+            $versionTags = @(
                 "$($repo):$($version)-ubuntu.22.04-arm64v8"
-                )
-                break;
+            )
+            if ($useVersionTagsOnly) {
+                return $versionTags
+            }
+            return $versionTags + @(
+                "$($repo):5.4-ubuntu-arm64v8-latest"
+            )
+            break;
         }
         Default {
             throw "Arch not supported."
         }
     }
-        
 }
 
-function GetWindowsImageTags($repo, $version, $WinVer) {
+function GetWindowsImageTags($repo, $version, $WinVer, [bool]$useVersionTagsOnly = $false) {
     switch ($winver) {
         "1809" {
-            return @(
-                "$($repo):$($version)-windows-1809",
+            $versionTags = @(
+                "$($repo):$($version)-windows-1809"
+            )
+            if ($useVersionTagsOnly) {
+                return $versionTags
+            }
+            return $versionTags + @(
                 "$($repo):5.4-windows-1809-latest"
             )
             break;
         }
         "ltsc2022" {
-             return @(
-                "$($repo):$($version)-windows-ltsc2022",
+            $versionTags = @(
+                "$($repo):$($version)-windows-ltsc2022"
+            )
+            if ($useVersionTagsOnly) {
+                return $versionTags
+            }
+            return $versionTags + @(
                 "$($repo):5.4-windows-ltsc2022-latest"
             )
             break;
@@ -81,7 +105,6 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
             throw "Windows Version not supported. There are 'ltsc2022' and '1809' avaliable."
         }        
     }
-
 }
 
 function GetManifestTags {

--- a/docker/publish-nanoserver.ps1
+++ b/docker/publish-nanoserver.ps1
@@ -1,19 +1,21 @@
 param(
-    $Repo = "ravendb/ravendb",
-    $ArtifactsDir = "..\artifacts",
-    $WinVer = "1809",
+    [string]$Repo = "ravendb/ravendb",
+    [string]$ArtifactsDir = "..\artifacts",
+    [string]$WinVer = "1809",
     [switch]$DryRun = $False,
-    [switch]$RemoveImages = $False)
+    [switch]$RemoveImages = $False,
+    [switch]$UseVersionTagsOnly
+)
 
 $ErrorActionPreference = "Stop"
 
 . ".\common.ps1"
 
 if ($env:DRY_RUN) {
-    $DryRun=$True
+    $DryRun = $True
 }
 
-function PushImagesToDockerHub($imageTags) {
+function PushImagesToDockerHub([string[]]$imageTags) {
     write-host "Pushing images to Docker Hub."
     foreach ($tag in $imageTags) {
         write-host "Push $tag"
@@ -31,14 +33,14 @@ function RemoveImages($imageTags) {
     }
 }
 
-function PushImagesDryRun($imageTags) {
+function PushImagesDryRun([string[]]$imageTags) {
     write-host "DRY RUN: Pushing images."
     foreach ($tag in $imageTags) {
         write-host "DRY RUN: docker push $tag"
     }
 }
 
-function PushImages($imageTags) {
+function PushImages([string[]]$imageTags) {
     if ($DryRun -eq $False) {
         PushImagesToDockerHub $imageTags
     } else {
@@ -47,7 +49,7 @@ function PushImages($imageTags) {
 }
 
 $version = GetVersionFromArtifactName
-$tags = GetWindowsImageTags $Repo $version $WinVer
+[string[]]$tags = GetWindowsImageTags $Repo $version $WinVer $UseVersionTagsOnly
 PushImages $tags
 
 if ($RemoveImages) {

--- a/docker/publish-ubuntu.ps1
+++ b/docker/publish-ubuntu.ps1
@@ -1,19 +1,21 @@
 param(
-    $Repo = "ravendb/ravendb", 
-    $ArtifactsDir = "..\artifacts",
-    $Arch = "x64",
+    [string]$Repo = "ravendb/ravendb",
+    [string]$ArtifactsDir = "..\artifacts",
+    [string]$Arch = "x64",
     [switch]$DryRun = $False,
-    [switch]$RemoveImages = $False)
+    [switch]$RemoveImages = $False,
+    [switch]$UseVersionTagsOnly
+)
 
 $ErrorActionPreference = "Stop"
 
 . ".\common.ps1"
 
 if ($env:DRY_RUN) {
-    $DryRun=$True
+    $DryRun = $True
 }
 
-function PushImagesToDockerHub($imageTags) {
+function PushImagesToDockerHub([string[]]$imageTags) {
     write-host "Pushing images to Docker Hub."
     foreach ($tag in $imageTags) {
         write-host "Push $tag"
@@ -22,14 +24,14 @@ function PushImagesToDockerHub($imageTags) {
     }
 }
 
-function PushImagesDryRun($imageTags) {
+function PushImagesDryRun([string[]]$imageTags) {
     write-host "DRY RUN: Pushing images."
     foreach ($tag in $imageTags) {
         write-host "DRY RUN: docker push $tag"
     }
 }
 
-function PushImages($imageTags) {
+function PushImages([string[]]$imageTags) {
     if ($DryRun -eq $False) {
         PushImagesToDockerHub $imageTags
     }
@@ -48,7 +50,7 @@ function RemoveImages($imageTags) {
 }
 
 $version = GetVersionFromArtifactName
-$tags = GetUbuntuImageTags $Repo $version $Arch
+[string[]]$tags = GetUbuntuImageTags $Repo $version $Arch $UseVersionTagsOnly
 PushImages $tags
 
 if ($RemoveImages) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25086 

### Additional description

Allow to get tags with version only for docker images. This is needed for automating custom builds for docker.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
