### PR TITLE
RavenDB-21861 pull IO usage for threads runaway view

### DIFF
--- a/docs/readme.linux.txt
+++ b/docs/readme.linux.txt
@@ -21,8 +21,9 @@ Open bash terminal, and create file /etc/systemd/system/ravendb.service, using s
     LimitMEMLOCK=infinity
     TasksMax=infinity
     StartLimitBurst=0
+    AmbientCapabilities=CAP_NET_BIND_SERVICE  
     Restart=on-failure
-    Type=simple
+    Type=exec
     TimeoutStopSec=300
     User=<desired user>
     ExecStart=/path/to/RavenDB/run.sh

--- a/scripts/linux/install-daemon.sh
+++ b/scripts/linux/install-daemon.sh
@@ -138,6 +138,7 @@ LimitAS=infinity
 LimitMEMLOCK=infinity
 TasksMax=infinity
 StartLimitBurst=0
+AmbientCapabilities=CAP_NET_BIND_SERVICE  
 Restart=on-failure
 Type=exec
 TimeoutStopSec=300

--- a/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.postinst
+++ b/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.postinst
@@ -48,10 +48,6 @@ done
 
 chown root:ravendb /usr/lib/ravendb/server/{Raven.Server,rvn}
 
-if command -v setcap &> /dev/null; then
-    setcap CAP_NET_BIND_SERVICE=+eip /usr/lib/ravendb/server/Raven.Server
-fi
-
 CREATEDUMP_PATH="/usr/lib/ravendb/server/createdump"
 RAVEN_DEBUG_PATH="/usr/lib/ravendb/server/Raven.Debug"
 debugBinList=("$CREATEDUMP_PATH" "$RAVEN_DEBUG_PATH")

--- a/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.service
+++ b/scripts/linux/pkg/deb/assets/ravendb/debian/ravendb.service
@@ -11,6 +11,7 @@ LimitMEMLOCK=infinity
 TasksMax=infinity
 User=ravendb
 StartLimitBurst=0
+AmbientCapabilities=CAP_NET_BIND_SERVICE  
 Restart=on-failure
 Type=exec
 TimeoutStopSec=300

--- a/scripts/linux/ravendb.service
+++ b/scripts/linux/ravendb.service
@@ -10,6 +10,7 @@ LimitAS=infinity
 LimitMEMLOCK=infinity
 TasksMax=infinity
 StartLimitBurst=0
+AmbientCapabilities=CAP_NET_BIND_SERVICE  
 Restart=on-failure
 Type=exec
 TimeoutStopSec=300

--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -96,6 +96,26 @@ namespace Raven.Server.Dashboard
 
         public ThreadWaitReason? WaitReason { get; set; }
 
+        // Per-thread IO metrics (Linux only, populated when available)
+        // Last measured I/O operations per second (syscr + syscw delta / interval)
+        public double? IoOpsPerSecLast { get; set; }
+        // Last measured throughput in KB/s based on read_bytes+write_bytes delta
+        public double? ThroughputKbPerSecLast { get; set; }
+        // Total number of I/O operations since metering started
+        public long? IoOpsTotal { get; set; }
+        // Total data volume in KB since metering started
+        public double? ThroughputKbTotal { get; set; }
+
+        // Split read/write metrics
+        public double? ReadIoOpsPerSecLast { get; set; }
+        public double? WriteIoOpsPerSecLast { get; set; }
+        public double? ReadThroughputKbPerSecLast { get; set; }
+        public double? WriteThroughputKbPerSecLast { get; set; }
+        public long? ReadIoOpsTotal { get; set; }
+        public long? WriteIoOpsTotal { get; set; }
+        public double? ReadThroughputKbTotal { get; set; }
+        public double? WriteThroughputKbTotal { get; set; }
+
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
@@ -112,7 +132,19 @@ namespace Raven.Server.Dashboard
                 [nameof(UserProcessorTime)] = UserProcessorTime,
                 [nameof(State)] = State,
                 [nameof(Priority)] = Priority,
-                [nameof(WaitReason)] = WaitReason
+                [nameof(WaitReason)] = WaitReason,
+                [nameof(IoOpsPerSecLast)] = IoOpsPerSecLast,
+                [nameof(ThroughputKbPerSecLast)] = ThroughputKbPerSecLast,
+                [nameof(IoOpsTotal)] = IoOpsTotal,
+                [nameof(ThroughputKbTotal)] = ThroughputKbTotal,
+                [nameof(ReadIoOpsPerSecLast)] = ReadIoOpsPerSecLast,
+                [nameof(WriteIoOpsPerSecLast)] = WriteIoOpsPerSecLast,
+                [nameof(ReadThroughputKbPerSecLast)] = ReadThroughputKbPerSecLast,
+                [nameof(WriteThroughputKbPerSecLast)] = WriteThroughputKbPerSecLast,
+                [nameof(ReadIoOpsTotal)] = ReadIoOpsTotal,
+                [nameof(WriteIoOpsTotal)] = WriteIoOpsTotal,
+                [nameof(ReadThroughputKbTotal)] = ReadThroughputKbTotal,
+                [nameof(WriteThroughputKbTotal)] = WriteThroughputKbTotal
             };
         }
     }

--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -68,6 +68,48 @@ namespace Raven.Server.Dashboard
         }
     }
 
+    public sealed class IoStats : IDynamicJson
+    {
+        // Per-thread IO metrics (Linux only, populated when available)
+        // Last measured I/O operations per second (syscr + syscw delta / interval)
+        public double? IoOpsPerSecLast { get; set; }
+        // Last measured throughput in KB/s based on read_bytes+write_bytes delta
+        public double? ThroughputKbPerSecLast { get; set; }
+        // Total number of I/O operations since metering started
+        public long? IoOpsTotal { get; set; }
+        // Total data volume in KB since metering started
+        public double? ThroughputKbTotal { get; set; }
+
+        // Split read/write metrics
+        public double? ReadIoOpsPerSecLast { get; set; }
+        public double? WriteIoOpsPerSecLast { get; set; }
+        public double? ReadThroughputKbPerSecLast { get; set; }
+        public double? WriteThroughputKbPerSecLast { get; set; }
+        public long? ReadIoOpsTotal { get; set; }
+        public long? WriteIoOpsTotal { get; set; }
+        public double? ReadThroughputKbTotal { get; set; }
+        public double? WriteThroughputKbTotal { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(IoOpsPerSecLast)] = IoOpsPerSecLast,
+                [nameof(ThroughputKbPerSecLast)] = ThroughputKbPerSecLast,
+                [nameof(IoOpsTotal)] = IoOpsTotal,
+                [nameof(ThroughputKbTotal)] = ThroughputKbTotal,
+                [nameof(ReadIoOpsPerSecLast)] = ReadIoOpsPerSecLast,
+                [nameof(WriteIoOpsPerSecLast)] = WriteIoOpsPerSecLast,
+                [nameof(ReadThroughputKbPerSecLast)] = ReadThroughputKbPerSecLast,
+                [nameof(WriteThroughputKbPerSecLast)] = WriteThroughputKbPerSecLast,
+                [nameof(ReadIoOpsTotal)] = ReadIoOpsTotal,
+                [nameof(WriteIoOpsTotal)] = WriteIoOpsTotal,
+                [nameof(ReadThroughputKbTotal)] = ReadThroughputKbTotal,
+                [nameof(WriteThroughputKbTotal)] = WriteThroughputKbTotal
+            };
+        }
+    }
+
     public sealed class ThreadInfo : IDynamicJson
     {
         public int Id { get; set; }
@@ -96,25 +138,7 @@ namespace Raven.Server.Dashboard
 
         public ThreadWaitReason? WaitReason { get; set; }
 
-        // Per-thread IO metrics (Linux only, populated when available)
-        // Last measured I/O operations per second (syscr + syscw delta / interval)
-        public double? IoOpsPerSecLast { get; set; }
-        // Last measured throughput in KB/s based on read_bytes+write_bytes delta
-        public double? ThroughputKbPerSecLast { get; set; }
-        // Total number of I/O operations since metering started
-        public long? IoOpsTotal { get; set; }
-        // Total data volume in KB since metering started
-        public double? ThroughputKbTotal { get; set; }
-
-        // Split read/write metrics
-        public double? ReadIoOpsPerSecLast { get; set; }
-        public double? WriteIoOpsPerSecLast { get; set; }
-        public double? ReadThroughputKbPerSecLast { get; set; }
-        public double? WriteThroughputKbPerSecLast { get; set; }
-        public long? ReadIoOpsTotal { get; set; }
-        public long? WriteIoOpsTotal { get; set; }
-        public double? ReadThroughputKbTotal { get; set; }
-        public double? WriteThroughputKbTotal { get; set; }
+        public IoStats IoStats { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -133,18 +157,7 @@ namespace Raven.Server.Dashboard
                 [nameof(State)] = State,
                 [nameof(Priority)] = Priority,
                 [nameof(WaitReason)] = WaitReason,
-                [nameof(IoOpsPerSecLast)] = IoOpsPerSecLast,
-                [nameof(ThroughputKbPerSecLast)] = ThroughputKbPerSecLast,
-                [nameof(IoOpsTotal)] = IoOpsTotal,
-                [nameof(ThroughputKbTotal)] = ThroughputKbTotal,
-                [nameof(ReadIoOpsPerSecLast)] = ReadIoOpsPerSecLast,
-                [nameof(WriteIoOpsPerSecLast)] = WriteIoOpsPerSecLast,
-                [nameof(ReadThroughputKbPerSecLast)] = ReadThroughputKbPerSecLast,
-                [nameof(WriteThroughputKbPerSecLast)] = WriteThroughputKbPerSecLast,
-                [nameof(ReadIoOpsTotal)] = ReadIoOpsTotal,
-                [nameof(WriteIoOpsTotal)] = WriteIoOpsTotal,
-                [nameof(ReadThroughputKbTotal)] = ReadThroughputKbTotal,
-                [nameof(WriteThroughputKbTotal)] = WriteThroughputKbTotal
+                [nameof(IoStats)] = IoStats?.ToJson()
             };
         }
     }

--- a/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfoNotificationSender.cs
@@ -39,7 +39,10 @@ public sealed class ThreadsInfoNotificationSender : BackgroundWorkBase
                 return;
 
             if (_watchers.IsEmpty)
+            {
+                ThreadIoStatsReader.DisposeInstance();
                 return;
+            }
 
             var threadsInfo = _threadsUsage.Calculate();
             foreach (var watcher in _watchers)

--- a/src/Raven.Server/Utils/ThreadIoStatsReader.cs
+++ b/src/Raven.Server/Utils/ThreadIoStatsReader.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Utils
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ThreadIoStatsReader>(nameof(ThreadIoStatsReader));
         private readonly ConcurrentDictionary<int, Stats> _stats = new ConcurrentDictionary<int, Stats>();
         private readonly ConcurrentDictionary<int, PrevSample> _prevSamples = new ConcurrentDictionary<int, PrevSample>();
-        private readonly Timer _timer;
+        private Timer _timer;
         private int _collecting;
 
         public sealed class Stats
@@ -120,11 +120,15 @@ namespace Raven.Server.Utils
             try
             {
                 _timer?.Dispose();
+                _timer = null;
             }
             catch
             {
                 // ignore
             }
+            
+            _stats.Clear();
+            _prevSamples.Clear();
         }
 
         private void CollectOnce()

--- a/src/Raven.Server/Utils/ThreadIoStatsReader.cs
+++ b/src/Raven.Server/Utils/ThreadIoStatsReader.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Sparrow.Logging;
+using Sparrow.Platform;
+
+namespace Raven.Server.Utils
+{
+    internal sealed class ThreadIoStatsReader : IDisposable
+    {
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<ThreadIoStatsReader>(nameof(ThreadIoStatsReader));
+        private readonly ConcurrentDictionary<int, Stats> _stats = new ConcurrentDictionary<int, Stats>();
+        private readonly ConcurrentDictionary<int, PrevSample> _prevSamples = new ConcurrentDictionary<int, PrevSample>();
+        private readonly Timer _timer;
+        private int _collecting;
+
+        public sealed class Stats
+        {
+            public double OpsPerSecLast;
+            public double KbPerSecLast;
+            public long OpsTotal;
+            public double KbTotal;
+
+            // Split metrics when available
+            public double? ReadOpsPerSecLast;
+            public double? WriteOpsPerSecLast;
+            public double? ReadKbPerSecLast;
+            public double? WriteKbPerSecLast;
+            public long? ReadOpsTotal;
+            public long? WriteOpsTotal;
+            public double? ReadKbTotal;
+            public double? WriteKbTotal;
+        }
+
+        private ThreadIoStatsReader()
+        {
+            if (PlatformDetails.RunningOnLinux == false)
+                return;
+
+            try
+            {
+                _timer = new Timer(_ =>
+                {
+                    if (Interlocked.Exchange(ref _collecting, 1) != 0)
+                        return;
+                    try
+                    {
+                        CollectOnce();
+                    }
+                    catch (Exception e)
+                    {
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info("Error in thread IO stats collector.", e);
+                    }
+                    finally
+                    {
+                        Volatile.Write(ref _collecting, 0);
+                    }
+                }, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Failed to start timer for thread IO stats collector. Thread IO stats disabled.", e);
+            }
+        }
+
+        private sealed class PrevSample
+        {
+            public long Syscr;
+            public long Syscw;
+            public long ReadBytes;
+            public long WriteBytes;
+            public DateTime Last;
+        }
+
+
+        private static ThreadIoStatsReader _instance;
+        private static readonly object InstanceLock = new object();
+
+        public static ThreadIoStatsReader Instance
+        {
+            get
+            {
+                if (_instance != null)
+                    return _instance;
+                lock (InstanceLock)
+                {
+                    return _instance ??= new ThreadIoStatsReader();
+                }
+            }
+        }
+
+        public static void DisposeInstance()
+        {
+            lock (InstanceLock)
+            {
+                try
+                {
+                    _instance?.Dispose();
+                }
+                catch
+                {
+                    // ignore
+                }
+                finally
+                {
+                    _instance = null;
+                }
+            }
+        }
+
+        public bool TryGet(int tid, out Stats stats) => _stats.TryGetValue(tid, out stats);
+
+        public void Dispose()
+        {
+            try
+            {
+                _timer?.Dispose();
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        private void CollectOnce()
+        {
+            const double Kb = 1024.0;
+            var taskDir = "/proc/self/task";
+
+            try
+            {
+                var seen = new HashSet<int>();
+                string[] taskSubDirs = Array.Empty<string>();
+                try
+                {
+                    if (Directory.Exists(taskDir))
+                        taskSubDirs = Directory.GetDirectories(taskDir);
+                }
+                catch
+                {
+                    // ignore
+                }
+
+                foreach (var dir in taskSubDirs)
+                {
+                    int tid;
+                    try
+                    {
+                        var name = Path.GetFileName(dir);
+                        if (int.TryParse(name, out tid) == false)
+                            continue;
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    seen.Add(tid);
+
+                    var ioPath = Path.Combine(dir, "io");
+                    string[] lines;
+                    try
+                    {
+                        lines = File.ReadAllLines(ioPath);
+                    }
+                    catch
+                    {
+                        // thread might have exited
+                        continue;
+                    }
+
+                    long syscr = 0, syscw = 0, readBytes = 0, writeBytes = 0;
+                    foreach (var line in lines)
+                    {
+                        if (line.StartsWith("syscr:"))
+                            long.TryParse(line.AsSpan(6).Trim(), out syscr);
+                        else if (line.StartsWith("syscw:"))
+                            long.TryParse(line.AsSpan(6).Trim(), out syscw);
+                        else if (line.StartsWith("read_bytes:"))
+                            long.TryParse(line.AsSpan(11).Trim(), out readBytes);
+                        else if (line.StartsWith("write_bytes:"))
+                            long.TryParse(line.AsSpan(12).Trim(), out writeBytes);
+                    }
+
+                    var now = DateTime.UtcNow;
+                    _prevSamples.AddOrUpdate(tid, new PrevSample
+                    {
+                        Syscr = syscr,
+                        Syscw = syscw,
+                        ReadBytes = readBytes,
+                        WriteBytes = writeBytes,
+                        Last = now
+                    }, (k, prev) =>
+                    {
+                        var elapsed = (now - prev.Last).TotalSeconds;
+                        if (elapsed <= 0)
+                            elapsed = 1;
+
+                        var dReadOps = Math.Max(0, syscr - prev.Syscr);
+                        var dWriteOps = Math.Max(0, syscw - prev.Syscw);
+                        var dReadBytes = Math.Max(0L, readBytes - prev.ReadBytes);
+                        var dWriteBytes = Math.Max(0L, writeBytes - prev.WriteBytes);
+
+                        var readOpsPerSec = dReadOps / elapsed;
+                        var writeOpsPerSec = dWriteOps / elapsed;
+                        var readKbPerSec = dReadBytes / Kb / elapsed;
+                        var writeKbPerSec = dWriteBytes / Kb / elapsed;
+
+                        var opsTotal = syscr + syscw;
+                        var kbTotal = (readBytes + writeBytes) / Kb;
+
+                        _stats.AddOrUpdate(tid, new Stats
+                        {
+                            OpsPerSecLast = readOpsPerSec + writeOpsPerSec,
+                            KbPerSecLast = readKbPerSec + writeKbPerSec,
+                            OpsTotal = opsTotal,
+                            KbTotal = kbTotal,
+                            ReadOpsPerSecLast = readOpsPerSec,
+                            WriteOpsPerSecLast = writeOpsPerSec,
+                            ReadKbPerSecLast = readKbPerSec,
+                            WriteKbPerSecLast = writeKbPerSec,
+                            ReadOpsTotal = syscr,
+                            WriteOpsTotal = syscw,
+                            ReadKbTotal = readBytes / Kb,
+                            WriteKbTotal = writeBytes / Kb
+                        }, (kk, s) =>
+                        {
+                            s.OpsPerSecLast = readOpsPerSec + writeOpsPerSec;
+                            s.KbPerSecLast = readKbPerSec + writeKbPerSec;
+                            s.OpsTotal = opsTotal;
+                            s.KbTotal = kbTotal;
+                            s.ReadOpsPerSecLast = readOpsPerSec;
+                            s.WriteOpsPerSecLast = writeOpsPerSec;
+                            s.ReadKbPerSecLast = readKbPerSec;
+                            s.WriteKbPerSecLast = writeKbPerSec;
+                            s.ReadOpsTotal = syscr;
+                            s.WriteOpsTotal = syscw;
+                            s.ReadKbTotal = readBytes / Kb;
+                            s.WriteKbTotal = writeBytes / Kb;
+                            return s;
+                        });
+
+                        prev.Syscr = syscr;
+                        prev.Syscw = syscw;
+                        prev.ReadBytes = readBytes;
+                        prev.WriteBytes = writeBytes;
+                        prev.Last = now;
+                        return prev;
+                    });
+                }
+
+                // cleanup disappeared threads
+                try
+                {
+                    foreach (var key in _prevSamples.Keys)
+                    {
+                        if (seen.Contains(key) == false)
+                            _prevSamples.TryRemove(key, out _);
+                    }
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Error while collecting thread IO stats.", ex);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -120,7 +120,7 @@ namespace Raven.Server.Utils
                             threadName ??= ThreadHelper.GetThreadName(process.Id, thread.Id);
 
                             var threadState = GetThreadInfoOrDefault<ThreadState?>(() => thread.ThreadState);
-                            threadsInfo.List.Add(new ThreadInfo
+                            var ti = new ThreadInfo
                             {
                                 Id = thread.Id,
                                 CpuUsage = threadCpuUsage.Value,
@@ -139,7 +139,37 @@ namespace Raven.Server.Utils
                                 Priority = GetThreadInfoOrDefault<ThreadPriorityLevel?>(() => thread.PriorityLevel),
 #pragma warning restore CA1416 // Validate platform compatibility
                                 WaitReason = GetThreadInfoOrDefault(() => threadState == ThreadState.Wait ? thread.WaitReason : (ThreadWaitReason?)null)
-                            });
+                            };
+
+                            try
+                            {
+                                if (Sparrow.Platform.PlatformDetails.RunningOnLinux)
+                                {
+                                    var reader = ThreadIoStatsReader.Instance;
+                                    if (reader != null && reader.TryGet(thread.Id, out var io))
+                                    {
+                                        ti.IoOpsPerSecLast = io.OpsPerSecLast;
+                                        ti.ThroughputKbPerSecLast = io.KbPerSecLast;
+                                        ti.IoOpsTotal = io.OpsTotal;
+                                        ti.ThroughputKbTotal = io.KbTotal;
+
+                                        ti.ReadIoOpsPerSecLast = io.ReadOpsPerSecLast;
+                                        ti.WriteIoOpsPerSecLast = io.WriteOpsPerSecLast;
+                                        ti.ReadThroughputKbPerSecLast = io.ReadKbPerSecLast;
+                                        ti.WriteThroughputKbPerSecLast = io.WriteKbPerSecLast;
+                                        ti.ReadIoOpsTotal = io.ReadOpsTotal;
+                                        ti.WriteIoOpsTotal = io.WriteOpsTotal;
+                                        ti.ReadThroughputKbTotal = io.ReadKbTotal;
+                                        ti.WriteThroughputKbTotal = io.WriteKbTotal;
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                                // ignore IO stats errors
+                            }
+
+                            threadsInfo.List.Add(ti);
                         }
                         catch (InvalidOperationException)
                         {

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -148,19 +148,22 @@ namespace Raven.Server.Utils
                                     var reader = ThreadIoStatsReader.Instance;
                                     if (reader != null && reader.TryGet(thread.Id, out var io))
                                     {
-                                        ti.IoOpsPerSecLast = io.OpsPerSecLast;
-                                        ti.ThroughputKbPerSecLast = io.KbPerSecLast;
-                                        ti.IoOpsTotal = io.OpsTotal;
-                                        ti.ThroughputKbTotal = io.KbTotal;
+                                        ti.IoStats = new IoStats
+                                        {
+                                            IoOpsPerSecLast = io.OpsPerSecLast,
+                                            ThroughputKbPerSecLast = io.KbPerSecLast,
+                                            IoOpsTotal = io.OpsTotal,
+                                            ThroughputKbTotal = io.KbTotal,
 
-                                        ti.ReadIoOpsPerSecLast = io.ReadOpsPerSecLast;
-                                        ti.WriteIoOpsPerSecLast = io.WriteOpsPerSecLast;
-                                        ti.ReadThroughputKbPerSecLast = io.ReadKbPerSecLast;
-                                        ti.WriteThroughputKbPerSecLast = io.WriteKbPerSecLast;
-                                        ti.ReadIoOpsTotal = io.ReadOpsTotal;
-                                        ti.WriteIoOpsTotal = io.WriteOpsTotal;
-                                        ti.ReadThroughputKbTotal = io.ReadKbTotal;
-                                        ti.WriteThroughputKbTotal = io.WriteKbTotal;
+                                            ReadIoOpsPerSecLast = io.ReadOpsPerSecLast,
+                                            WriteIoOpsPerSecLast = io.WriteOpsPerSecLast,
+                                            ReadThroughputKbPerSecLast = io.ReadKbPerSecLast,
+                                            WriteThroughputKbPerSecLast = io.WriteKbPerSecLast,
+                                            ReadIoOpsTotal = io.ReadOpsTotal,
+                                            WriteIoOpsTotal = io.WriteOpsTotal,
+                                            ReadThroughputKbTotal = io.ReadKbTotal,
+                                            WriteThroughputKbTotal = io.WriteKbTotal
+                                        };
                                     }
                                 }
                             }

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -99,60 +99,60 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                     new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Name, "Name", "20%", {
                         sortable: "string"
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => `${(x.CpuUsage === 0 ? "0" : generalUtils.formatNumberToStringFixed(x.CpuUsage, 2))}%`, "Current CPU %", "10%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => `${(x.CpuUsage === 0 ? "0" : generalUtils.formatNumberToStringFixed(x.CpuUsage, 2))}%`, "CPU%", "3%", {
                         sortable: x => x.CpuUsage,
                         defaultSortOrder: "desc"
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.UnmanagedAllocationsInBytes ? generalUtils.formatBytesToSize(x.UnmanagedAllocationsInBytes, 2) : "N/A", "Unmanaged Allocations", "10%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.UnmanagedAllocationsInBytes ? generalUtils.formatBytesToSize(x.UnmanagedAllocationsInBytes, 2) : "N/A", "Unmanaged Alloc.", "8%", {
                         sortable: x => x.UnmanagedAllocationsInBytes ?? 0,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsPerSecLast, 0) : "N/A", "Read IOPS", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsPerSecLast, 0) : "N/A", "Read IOPS", "5%", {
                         sortable: x => x.ReadIoOpsPerSecLast ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsPerSecLast, 0) : "N/A", "Write IOPS", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsPerSecLast, 0) : "N/A", "Write IOPS", "5%", {
                         sortable: x => x.WriteIoOpsPerSecLast ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Read KB/s", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Read KB/s", "4%", {
                         sortable: x => x.ReadThroughputKbPerSecLast ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Write KB/s", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Write KB/s", "5%", {
                         sortable: x => x.WriteThroughputKbPerSecLast ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsTotal, 0) : "N/A", "Total Read IOPS", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsTotal, 0) : "N/A", "Read IOPS Total", "7%", {
                         sortable: x => x.ReadIoOpsTotal ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsTotal, 0) : "N/A", "Total Write IOPS", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsTotal, 0) : "N/A", "Write IOPS Total", "8%", {
                         sortable: x => x.WriteIoOpsTotal ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbTotal, 2) + " KB" : "N/A", "Total Read KB", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbTotal, 2) + " KB" : "N/A", "Read KB Total", "6%", {
                         sortable: x => x.ReadThroughputKbTotal ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbTotal, 2) + " KB" : "N/A", "Total Write KB", "8%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbTotal, 2) + " KB" : "N/A", "Write KB Total", "7%", {
                         sortable: x => x.WriteThroughputKbTotal ?? -1,
                         defaultSortOrder: "desc",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Overall CPU Time", "10%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Total CPU Time", "7%", {
                         sortable: x => x.Duration,
                         defaultSortOrder: "desc"
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Id + " (" + (x.ManagedThreadId || "n/a") + ")", "Thread Id", "10%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Id + " (" + (x.ManagedThreadId || "n/a") + ")", "TID", "3%", {
                         sortable: x => x.Id
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.StartingTime), "Start Time", "10%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.StartingTime), "Start Time", "5%", {
                         sortable: x => x.StartingTime
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.State, "State", "10%", {
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.State, "State", "2%", {
                         sortable: "string"
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WaitReason, "Wait reason", "10%")
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WaitReason, "Wait reason", "5%")
                 ];
             }
         );

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -1,6 +1,5 @@
 import viewModelBase = require("viewmodels/viewModelBase");
 import moment = require("moment");
-
 import app = require("durandal/app")
 import virtualGridController = require("widgets/virtualGrid/virtualGridController");
 import textColumn = require("widgets/virtualGrid/columns/textColumn");
@@ -11,17 +10,20 @@ import prismjs = require("prismjs");
 import threadStackTrace = require("viewmodels/manage/threadStackTrace");
 import threadsInfoWebSocketClient = require("common/threadsInfoWebSocketClient");
 import eventsCollector = require("common/eventsCollector");
+import awesomeMultiselect = require("common/awesomeMultiselect");
+
+type Unit = "" | "%" | "KB" | "KB/s";
+type ThreadInfo = Raven.Server.Dashboard.ThreadInfo;
 
 class debugAdvancedThreadsRuntime extends viewModelBase {
-
     view = require("views/manage/debugAdvancedThreadsRuntime.html");
 
-    allData = ko.observable<Raven.Server.Dashboard.ThreadInfo[]>();
-    filteredData = ko.observable<Raven.Server.Dashboard.ThreadInfo[]>();
+    allData = ko.observable<ThreadInfo[]>();
+    filteredData = ko.observable<ThreadInfo[]>();
 
     private liveClient = ko.observable<threadsInfoWebSocketClient>();
-    private gridController = ko.observable<virtualGridController<Raven.Server.Dashboard.ThreadInfo>>();
-    private columnPreview = new columnPreviewPlugin<Raven.Server.Dashboard.ThreadInfo>();
+    private gridController = ko.observable<virtualGridController<ThreadInfo>>();
+    private columnPreview = new columnPreviewPlugin<ThreadInfo>();
 
     isConnectedToWebSocket: KnockoutComputed<boolean>;
     
@@ -33,6 +35,46 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
     isPause = ko.observable<boolean>(false);
     
     filter = ko.observable<string>();
+
+    allColumnHeaders = [
+        "Stack",
+        "Name",
+        "CPU%",
+        "Unmanaged Alloc.",
+        "IOPS",
+        "IOPS Read",
+        "IOPS Write",
+        "IO Throughput",
+        "IO Throughput Read",
+        "IO Throughput Write",
+        "Total IOPS",
+        "Total IOPS Read",
+        "Total IOPS Write",
+        "Total IO Throughput",
+        "Total IO Throughput Read",
+        "Total IO Throughput Write",
+        "Total CPU Time",
+        "Thread ID",
+        "Start Time",
+        "State",
+        "Wait reason",
+    ] as const;
+
+    visibleColumnHeaders = ko.observableArray<(typeof this.allColumnHeaders)[number]>([
+        "Stack",
+        "Name",
+        "CPU%",
+        "Unmanaged Alloc.",
+        "IOPS",
+        "IO Throughput",
+        "Total IOPS",
+        "Total IO Throughput",
+        "Total CPU Time",
+        "Thread ID",
+        "Start Time",
+        "State",
+        "Wait reason",
+    ]);
     
     constructor() {
         super();
@@ -48,10 +90,21 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
             return 0;
         });
         
-        this.filter.throttle(500).subscribe(() => this.filterEntries());
+        this.filter.throttle(300).subscribe(() => this.filterEntries());
+        this.visibleColumnHeaders.subscribe(() => this.filterEntries(true));
     }
     
-     private filterEntries() {
+    attached() {
+        super.attached();
+        
+        awesomeMultiselect.build($("#visibleColumnsSelector"), opts => {
+            opts.includeSelectAllOption = true;
+            opts.nSelectedText = " columns selected";
+            opts.allSelectedText = "All columns selected";
+        });
+    }
+    
+     private filterEntries(hard: boolean = false) {
         if (this.gridController()) {
             const filter = this.filter();
             if (filter) {
@@ -60,13 +113,13 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                 this.filteredData(this.allData().slice());
             }
     
-            this.gridController().reset(true);
+            this.gridController().reset(hard);
         } else {
             this.filteredData(this.allData().slice());
         }
     }
     
-    private matchesFilter(item: Raven.Server.Dashboard.ThreadInfo): boolean {
+    private matchesFilter(item: ThreadInfo): boolean {
         const filter = this.filter();
         if (!filter) {
             return true;
@@ -76,7 +129,34 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         return item.Name.toLocaleLowerCase().includes(filterLowered) ||
                item.Id.toString().includes(filterLowered);
     }
+
+    private getUnitSeparator(unit: Unit): string {
+        if (unit === "KB" || unit === "KB/s") {
+            return " ";
+        }
+
+        return "";
+    }
     
+    private getStringValue(value: number, fractionDigits: number, unit: Unit = ""): string {
+        if (value == null) {
+            return "N/A";
+        }
+
+        const unitSeparator = this.getUnitSeparator(unit);
+        const fractionDigitsToUse = value === 0 ? 0 : fractionDigits;
+
+        return generalUtils.formatNumberToStringFixed(value, fractionDigitsToUse) + unitSeparator + unit;
+    }
+
+    private getSortableValue(value: number | string): number | string {
+        if (value == null) {
+            return -1;
+        }
+
+        return value;
+    }
+
     compositionComplete(): void {
         super.compositionComplete();
 
@@ -86,81 +166,92 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
             return $.when({
                 totalResultCount: data.length,
                 items: data
-            } as pagedResult<Raven.Server.Dashboard.ThreadInfo>);
+            } as pagedResult<ThreadInfo>);
         };
-
+        
         const grid = this.gridController();
         grid.headerVisible(true);
         grid.setDefaultSortBy(2, "desc");
         grid.init(fetcher, () => {
-                return [
-                    new actionColumn<Raven.Server.Dashboard.ThreadInfo>(grid, (x) => this.showStackTrace(x), "Stack",
-                                () => `<i title="Click to view Stack Trace" class="icon-thread-stack-trace"></i>`, "55px"),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Name, "Name", "20%", {
+                type ColumnHeader = (typeof this.allColumnHeaders)[number];
+
+                const columns = [
+                    new actionColumn<ThreadInfo>(grid, (x) => this.showStackTrace(x), "Stack" satisfies ColumnHeader, () => `<i title="Click to view Stack Trace" class="icon-thread-stack-trace"></i>`, "55px"),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => x.Name, "Name", "20%", {
                         sortable: "string"
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => `${(x.CpuUsage === 0 ? "0" : generalUtils.formatNumberToStringFixed(x.CpuUsage, 2))}%`, "CPU%", "3%", {
-                        sortable: x => x.CpuUsage,
-                        defaultSortOrder: "desc"
-                    }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.UnmanagedAllocationsInBytes ? generalUtils.formatBytesToSize(x.UnmanagedAllocationsInBytes, 2) : "N/A", "Unmanaged Alloc.", "8%", {
-                        sortable: x => x.UnmanagedAllocationsInBytes ?? 0,
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.CpuUsage, 2, "%"), "CPU%", "5%", {
+                        sortable: x => this.getSortableValue(x.CpuUsage),
                         defaultSortOrder: "desc",
+                        headerTitle: "Current CPU usage percentage",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsPerSecLast, 0) : "N/A", "Read IOPS", "5%", {
-                        sortable: x => x.ReadIoOpsPerSecLast ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.UnmanagedAllocationsInBytes, 2, "KB"), "Unmanaged Alloc.", "7%", {
+                        sortable: x => this.getSortableValue(x.UnmanagedAllocationsInBytes),
+                        headerTitle: "Unmanaged allocations in bytes",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsPerSecLast, 0) : "N/A", "Write IOPS", "5%", {
-                        sortable: x => x.WriteIoOpsPerSecLast ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoOpsPerSecLast, 0), "IOPS", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.IoOpsPerSecLast),
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Read KB/s", "4%", {
-                        sortable: x => x.ReadThroughputKbPerSecLast ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoOpsPerSecLast, 0), "IOPS Read", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ReadIoOpsPerSecLast),
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Write KB/s", "5%", {
-                        sortable: x => x.WriteThroughputKbPerSecLast ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoOpsPerSecLast, 0), "IOPS Write", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.WriteIoOpsPerSecLast),
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsTotal, 0) : "N/A", "Read IOPS Total", "7%", {
-                        sortable: x => x.ReadIoOpsTotal ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ThroughputKbPerSecLast, 2, "KB/s"), "IO Throughput", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ThroughputKbPerSecLast),
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsTotal, 0) : "N/A", "Write IOPS Total", "8%", {
-                        sortable: x => x.WriteIoOpsTotal ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadThroughputKbPerSecLast, 2, "KB/s"), "IO Throughput Read", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ReadThroughputKbPerSecLast),
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbTotal, 2) + " KB" : "N/A", "Read KB Total", "6%", {
-                        sortable: x => x.ReadThroughputKbTotal ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteThroughputKbPerSecLast, 2, "KB/s"), "IO Throughput Write", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.WriteThroughputKbPerSecLast),
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbTotal, 2) + " KB" : "N/A", "Write KB Total", "7%", {
-                        sortable: x => x.WriteThroughputKbTotal ?? -1,
-                        defaultSortOrder: "desc",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoOpsTotal, 0), "Total IOPS", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.IoOpsTotal),
+                        headerTitle: "Total IOPS aggregated since this view was open",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Total CPU Time", "7%", {
-                        sortable: x => x.Duration,
-                        defaultSortOrder: "desc"
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoOpsTotal, 0), "Total IOPS Read", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ReadIoOpsTotal),
+                        headerTitle: "Total IOPS Read aggregated since this view was open",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.Id + " (" + (x.ManagedThreadId || "n/a") + ")", "TID", "3%", {
-                        sortable: x => x.Id
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoOpsTotal, 0), "Total IOPS Write", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.WriteIoOpsTotal),
+                        headerTitle: "Total IOPS Write aggregated since this view was open",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.StartingTime), "Start Time", "5%", {
-                        sortable: x => x.StartingTime
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ThroughputKbTotal, 2, "KB"), "Total IO Throughput", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ThroughputKbTotal),
+                        headerTitle: "Total IO Throughput aggregated since this view was open",
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.State, "State", "2%", {
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadThroughputKbTotal, 2, "KB"), "Total IO Throughput Read", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ReadThroughputKbTotal),
+                        headerTitle: "Total IO Throughput Read aggregated since this view was open",
+                    }),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteThroughputKbTotal, 2, "KB"), "Total IO Throughput Write", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.WriteThroughputKbTotal),
+                        headerTitle: "Total IO Throughput Write aggregated since this view was open",
+                    }),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Total CPU Time", "7%", {
+                        sortable: x => this.getSortableValue(x.Duration),
+                    }),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => x.Id + " (" + (x.ManagedThreadId || "N/A") + ")", "Thread ID", "7%", {
+                        sortable: x => this.getSortableValue(x.Id)
+                    }),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => generalUtils.formatUtcDateAsLocal(x.StartingTime), "Start Time", "9%", {
+                        sortable: x => this.getSortableValue(x.StartingTime)
+                    }),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => x.State, "State", "5%", {
                         sortable: "string"
                     }),
-                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WaitReason, "Wait reason", "5%")
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => x.WaitReason, "Wait reason", "7%")
                 ];
+
+                return columns.filter(column => this.visibleColumnHeaders().includes(column.header as ColumnHeader));
             }
         );
 
         this.columnPreview.install("virtual-grid", ".js-threads-runtime-tooltip",
-            (entry: Raven.Server.Dashboard.ThreadInfo,
-                column: textColumn<Raven.Server.Dashboard.ThreadInfo>,
-             e: JQuery.TriggeredEvent, onValue: (context: any, valueToCopy?: string) => void) => {
+            (entry: ThreadInfo, column: textColumn<ThreadInfo>, _: JQuery.TriggeredEvent, onValue: (context: any, valueToCopy?: string) => void) => {
                 if (column.header === "Overall CPU Time") {
                     const timings = {
                         StartTime: entry.StartingTime,
@@ -196,8 +287,6 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         this.dedicatedThreadsCount(data.DedicatedThreadsCount);
 
         this.filterEntries();
-        
-        this.gridController().reset(false);
     }
 
     deactivate() {
@@ -208,7 +297,7 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
     }
     }
 
-    private showStackTrace(thread: Raven.Server.Dashboard.ThreadInfo) {
+    private showStackTrace(thread: ThreadInfo) {
         app.showBootstrapDialog(new threadStackTrace(thread.Id, thread.Name));
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -107,6 +107,38 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                         sortable: x => x.UnmanagedAllocationsInBytes ?? 0,
                         defaultSortOrder: "desc",
                     }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsPerSecLast, 0) : "N/A", "Read IOPS", "8%", {
+                        sortable: x => x.ReadIoOpsPerSecLast ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsPerSecLast, 0) : "N/A", "Write IOPS", "8%", {
+                        sortable: x => x.WriteIoOpsPerSecLast ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Read KB/s", "8%", {
+                        sortable: x => x.ReadThroughputKbPerSecLast ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbPerSecLast != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbPerSecLast, 2) + " KB/s" : "N/A", "Write KB/s", "8%", {
+                        sortable: x => x.WriteThroughputKbPerSecLast ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadIoOpsTotal, 0) : "N/A", "Total Read IOPS", "8%", {
+                        sortable: x => x.ReadIoOpsTotal ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteIoOpsTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteIoOpsTotal, 0) : "N/A", "Total Write IOPS", "8%", {
+                        sortable: x => x.WriteIoOpsTotal ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.ReadThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.ReadThroughputKbTotal, 2) + " KB" : "N/A", "Total Read KB", "8%", {
+                        sortable: x => x.ReadThroughputKbTotal ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
+                    new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => x.WriteThroughputKbTotal != null ? generalUtils.formatNumberToStringFixed(x.WriteThroughputKbTotal, 2) + " KB" : "N/A", "Total Write KB", "8%", {
+                        sortable: x => x.WriteThroughputKbTotal ?? -1,
+                        defaultSortOrder: "desc",
+                    }),
                     new textColumn<Raven.Server.Dashboard.ThreadInfo>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Overall CPU Time", "10%", {
                         sortable: x => x.Duration,
                         defaultSortOrder: "desc"

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/textColumn.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/textColumn.ts
@@ -10,12 +10,12 @@ type preparedValue = {
     typeCssClass: string;
 }
 
-class textColumn<T extends object> implements virtualColumn {
+class textColumn<T extends object, THeader extends string = string> implements virtualColumn {
     protected gridController: virtualGridController<T>;
 
     public valueAccessor: ((item: T) => any) | string;
 
-    public header: string;
+    public header: THeader;
 
     public width: string;
 
@@ -24,7 +24,7 @@ class textColumn<T extends object> implements virtualColumn {
     constructor(
         gridController: virtualGridController<T>,
         valueAccessor: ((item: T) => any) | string,
-        header: string, 
+        header: THeader, 
         width: string,
         opts: textColumnOpts<T> = {}) {
         this.opts = opts;

--- a/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedThreadsRuntime.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedThreadsRuntime.html
@@ -15,6 +15,14 @@
                 <div>
                     <input class="form-control" placeholder="Filter (Name, Thread Id)" data-bind="textInput: filter" />
                 </div>
+                <div class="btn-group">
+                    <select
+                        id="visibleColumnsSelector"
+                        size="5"
+                        multiple="multiple"
+                        data-bind="options: allColumnHeaders, selectedOptions: visibleColumnHeaders"
+                    ></select>
+                </div>
                 <div>
                     <div class="text-muted info-block">
                         <div class="text-center"><small>RavenDB CPU Usage:</small></div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21861

### Additional description

We gather detailed, per-thread I/O statistics (IOPS and throughput for both reads and writes) on Linux. We're reading from /proc/[pid]/task/[tid]/io in the main Raven.Server process.

The following 12 metrics have been added:

- IOPS - current IOPS
  - read
  - write  
  - sum of read and write
- IO Throughput - current IO throughput
  - read
  - write  
  - sum of read and write
- Total IOPS - IOPS aggregated over time, since opening the view
  - read
  - write  
  - sum of read and write
- Total IO Throughput - throughput aggregated over time, since opening the view
  - read
  - write  
  - sum of read and write

By default we display 4 new columns presenting *sum* of reads and writes together.

<img width="2261" height="1227" alt="image" src="https://github.com/user-attachments/assets/ac65e950-f5f5-4353-a4c9-ac96634d53fc" />

Default column set:

<img width="319" height="626" alt="image" src="https://github.com/user-attachments/assets/8d425158-469b-4bfd-b963-badc9831f9a6" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. This PR addresses Linux IO usage
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Threads runaway
- [ ] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed

* I force-added columns for new metrics  but we might want to refine it
