### PR TITLE
RavenDB-25137 implemented StopServerAsync

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -7,9 +7,7 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 
 #if !NET462
-
 using System.Runtime.Loader;
-
 #endif
 
 using System.Text;
@@ -53,11 +51,11 @@ namespace Raven.Embedded
         {
             var existingServerTask = _serverTask;
             if (_serverOptions == null || existingServerTask == null || existingServerTask.IsValueCreated == false)
-                throw new InvalidOperationException("Cannot call RestartServer() before calling Start()");
+                throw new InvalidOperationException($"Cannot call {nameof(RestartServerAsync)}() before calling {nameof(StartServer)}()");
 
             try
             {
-                var (serverUrl, serverProcess) = await existingServerTask.Value.ConfigureAwait(false);
+                var (_, serverProcess) = await existingServerTask.Value.ConfigureAwait(false);
                 ShutdownServerProcess(serverProcess);
             }
             catch
@@ -66,7 +64,7 @@ namespace Raven.Embedded
             }
 
             if (Interlocked.CompareExchange(ref _serverTask, null, existingServerTask) != existingServerTask)
-                throw new InvalidOperationException("The server changed while restarting it. Are you calling RestartServer() concurrently?");
+                throw new InvalidOperationException($"The server changed while restarting it. Are you calling {nameof(RestartServerAsync)}() concurrently?");
 
             await StartServerInternalAsync().ConfigureAwait(false);
         }
@@ -102,6 +100,27 @@ namespace Raven.Embedded
 
             var task = StartServerInternalAsync();
             GC.KeepAlive(task); // make sure that we aren't allowing to elide the call
+        }
+
+        public async Task StopServerAsync(CancellationToken forceServerKillToken = default)
+        {
+            var existingServerTask = _serverTask;
+            if (_serverOptions == null || existingServerTask == null || existingServerTask.IsValueCreated == false)
+                throw new InvalidOperationException($"Cannot call {nameof(StopServerAsync)}() before calling {nameof(StartServer)}()");
+
+            var (_, serverProcess) = await existingServerTask.Value.ConfigureAwait(false);
+
+            if (forceServerKillToken.CanBeCanceled)
+                forceServerKillToken.Register(() => KillServerProcess(serverProcess));
+
+            try
+            {
+                ShutdownServerProcess(serverProcess);
+            }
+            catch
+            {
+                // we will ignore errors here, the process might already be dead, we failed to start, etc
+            }
         }
 
         private Task StartServerInternalAsync()
@@ -222,6 +241,20 @@ namespace Raven.Embedded
                         _logger.Warn($"Failed to shutdown server PID {process.Id} gracefully in {_serverOptions!.GracefulShutdownTimeout.ToString()}", e);
                     }
                 }
+
+                KillServerProcess(process);
+            }
+        }
+
+        private void KillServerProcess(Process process)
+        {
+            if (process == null || process.HasExited)
+                return;
+
+            lock (process)
+            {
+                if (process.HasExited)
+                    return;
 
                 try
                 {
@@ -407,6 +440,7 @@ namespace Raven.Embedded
                     item.Value.Value.Dispose();
                 }
             }
+
             _documentStores.Clear();
         }
     }

--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -262,6 +262,8 @@ namespace Raven.Embedded
                         _logger.Debug($"Killing global server PID {process.Id}.");
 
                     process.Kill();
+                    
+                    _forTestingPurposes?.OnProcessKilled?.Invoke(process);
                 }
                 catch (Exception e)
                 {
@@ -442,6 +444,21 @@ namespace Raven.Embedded
             }
 
             _documentStores.Clear();
+        }
+        
+        private TestingStuff? _forTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (_forTestingPurposes != null)
+                return _forTestingPurposes;
+
+            return _forTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            public Action<Process>? OnProcessKilled;
         }
     }
 }

--- a/test/EmbeddedTests/EmbeddedTestBase.cs
+++ b/test/EmbeddedTests/EmbeddedTestBase.cs
@@ -100,7 +100,7 @@ namespace EmbeddedTests
 
                 try
                 {
-                    Directory.Delete(path);
+                    IOExtensions.DeleteDirectory(path);
                 }
                 catch
                 {
@@ -114,14 +114,14 @@ namespace EmbeddedTests
             // Delete all files in the current directory
             foreach (var p in directoryInfo.GetFiles().Select(x => ToFullPath(x.FullName)))
             {
-                File.Delete(p);
+                IOExtensions.DeleteFile(p);
             }
 
             // Recursively delete all subdirectories
             foreach (var subdirectory in directoryInfo.GetDirectories())
             {
                 DeleteAllFilesAndSubfolders(subdirectory);
-                Directory.Delete(ToFullPath(subdirectory.FullName));
+                IOExtensions.DeleteDirectory(ToFullPath(subdirectory.FullName));
             }
         }
 

--- a/test/EmbeddedTests/Issues/RavenDB_25137.cs
+++ b/test/EmbeddedTests/Issues/RavenDB_25137.cs
@@ -1,0 +1,50 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Indexes;
+using Raven.Embedded;
+using Xunit;
+
+namespace EmbeddedTests.Issues
+{
+    public class RavenDB_25137 : EmbeddedTestBase
+    {
+        [Fact]
+        public async Task Can_Stop_Server_Gently()
+        {
+            var options = CopyServerAndCreateOptions();
+
+            using (var embedded = new EmbeddedServer())
+            {
+                embedded.StartServer(options);
+
+                await embedded.StopServerAsync(CancellationToken.None);
+            }
+        }
+
+        [Fact]
+        public async Task Can_Force_Stop_Server()
+        {
+            var options = CopyServerAndCreateOptions();
+
+            using (var embedded = new EmbeddedServer())
+            {
+                bool killed = false;
+                embedded.ForTestingPurposesOnly().OnProcessKilled = process => killed = true;
+
+                using (var cts = new CancellationTokenSource(0))
+                {
+                    embedded.StartServer(options);
+
+                    Assert.True(cts.IsCancellationRequested);
+                    Assert.True(cts.Token.IsCancellationRequested);
+                    
+                    await embedded.StopServerAsync(cts.Token);
+                    
+                    Assert.True(killed);
+                }
+            }
+        }
+    }
+}

--- a/test/EmbeddedTests/Utils/IOExtensions.cs
+++ b/test/EmbeddedTests/Utils/IOExtensions.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Raven.Client.Exceptions;
+
+namespace EmbeddedTests
+{
+    internal static class IOExtensions
+    {
+        private const int Retries = 50;
+
+        public static EventHandler<(string Path, TimeSpan Duration, int Attempt)> AfterGc;
+
+        public static void DeleteFile(string file)
+        {
+            try
+            {
+                File.Delete(file);
+            }
+            catch (IOException)
+            {
+
+            }
+            catch (UnauthorizedAccessException)
+            {
+
+            }
+        }
+
+        public static bool EnsureReadWritePermissionForDirectory(string directory)
+        {
+            string tmpFileName = null;
+            string testString = "I can write here!";
+            try
+            {
+                if (string.IsNullOrWhiteSpace(directory))
+                {
+                    return false;
+                }
+
+                if (Directory.Exists(directory) == false)
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                tmpFileName = Path.Combine(directory, Path.GetRandomFileName());
+                File.WriteAllText(tmpFileName, testString);
+                var read = File.ReadAllText(tmpFileName); //I can read too!
+                File.Delete(tmpFileName);
+                return read == testString;
+            }
+            catch
+            {
+                //We need to try and delete the file here too since we can't modify the return value from a finally block.                
+                try
+                {
+                    if (File.Exists(tmpFileName))
+                    {
+                        File.Delete(tmpFileName);
+                    }
+                }
+                catch
+                {
+                }
+                return false;
+            }
+        }
+
+        public static void MoveDirectory(string src, string dst)
+        {
+            for (var i = 0; i < Retries; i++)
+            {
+                try
+                {
+                    DeleteDirectory(dst);
+
+                    SetDirectoryAttributes(src, FileAttributes.Normal);
+                    SetDirectoryAttributes(dst, FileAttributes.Normal);
+
+                    Directory.Move(src, dst);
+                    return;
+                }
+                catch (Exception)
+                {
+                    if (i == Retries - 1)
+                        throw;
+
+                    RunGc(src, i);
+                }
+            }
+        }
+
+        public static void DeleteDirectory(string directory)
+        {
+            for (var i = 0; i < Retries; i++)
+            {
+                try
+                {
+                    if (Directory.Exists(directory) == false)
+                        return;
+
+                    SetDirectoryAttributes(directory, FileAttributes.Normal);
+
+                    Directory.Delete(directory, true);
+                    return;
+                }
+                catch (IOException e)
+                {
+                    try
+                    {
+                        foreach (var childDir in Directory.GetDirectories(directory, "*", SearchOption.AllDirectories))
+                        {
+                            SetDirectoryAttributes(childDir, FileAttributes.Normal);
+                        }
+                    }
+                    catch (IOException)
+                    {
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                    }
+
+                    TryHandlingError(directory, i, e);
+                }
+                catch (UnauthorizedAccessException e)
+                {
+                    TryHandlingError(directory, i, e);
+                }
+            }
+        }
+
+        public static void CreateDirectory(string directory)
+        {
+            for (var i = 0; i < Retries; i++)
+            {
+                try
+                {
+                    if (Directory.Exists(directory))
+                        return;
+
+                    Directory.CreateDirectory(directory);
+                    return;
+                }
+                catch (Exception)
+                {
+                    if (i == Retries - 1)
+                        throw;
+
+                    RunGc(directory, i);
+                }
+            }
+        }
+
+        private static void TryHandlingError(string directory, int i, Exception e)
+        {
+            if (i == Retries - 1) // last try also failed
+            {
+                foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
+                {
+                    var path = Path.GetFullPath(file);
+                    try
+                    {
+                        File.Delete(path);
+                    }
+                    catch (Exception ex)
+                    {
+                        var message = UnsuccessfulFileAccessException.GetMessage(path, FileAccess.Write, ex);
+                        throw new IOException(message, ex);
+                    }
+                }
+                throw new IOException("Could not delete " + Path.GetFullPath(directory), e);
+            }
+
+            RunGc(directory, i);
+        }
+
+        private static void SetDirectoryAttributes(string path, FileAttributes attributes)
+        {
+            if (Directory.Exists(path) == false)
+                return;
+
+            try
+            {
+                File.SetAttributes(path, attributes);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        private static void RunGc(string path, int attempt)
+        {
+            Stopwatch sw = null;
+
+            if (AfterGc != null)
+                sw = Stopwatch.StartNew();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            if (AfterGc != null)
+                AfterGc(null, (path, sw.Elapsed, attempt));
+
+            Thread.Sleep(100);
+        }
+    }
+}

--- a/test/Tryouts.Fast/Program.cs
+++ b/test/Tryouts.Fast/Program.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25137

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
