### PR TITLE
RavenDB-23231 removing obsolete method

### DIFF
--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -76,9 +76,6 @@ namespace Sparrow.Server
             return new FrozenAwaiter(_tcs, this);
         }
 
-        [Obsolete("Do not use it! this is here only to handle tests that are void")]
-        internal bool Wait(TimeSpan timeout) => WaitAsync(timeout).GetAwaiter().GetResult();
-        
         public readonly struct FrozenAwaiter
         {
             private readonly TaskCompletionSource<bool> _tcs;

--- a/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
@@ -255,7 +255,7 @@ namespace SlowTests.Issues
                 ModifyDatabaseName = s => dbNameA
             });
             long[] ids = new long[3];
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
             for (int i = 0; i < 3; i++)
             {
@@ -364,7 +364,7 @@ namespace SlowTests.Issues
                 await s.LoadAsync<object>("users/ayende");
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
             await storeA.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
             {
@@ -514,7 +514,7 @@ namespace SlowTests.Issues
                 await s.LoadAsync<object>("users/ayende");
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await storeB.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -640,7 +640,7 @@ namespace SlowTests.Issues
                 await s.SaveChangesAsync();
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await storeA.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -738,7 +738,7 @@ namespace SlowTests.Issues
                 ClientCertificate = adminCert,
             });
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             var result = await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -822,7 +822,7 @@ namespace SlowTests.Issues
                 ClientCertificate = adminCert,
             });
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -965,7 +965,7 @@ namespace SlowTests.Issues
                 ClientCertificate = adminCert,
             });
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -1135,10 +1135,10 @@ namespace SlowTests.Issues
                 ClientCertificate = adminCert,
             });
 
-            var fooCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var fooCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
-            var barCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate3Path), (string)null,
+            var barCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate3Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -1386,7 +1386,7 @@ namespace SlowTests.Issues
                 await s.SaveChangesAsync();
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await storeA.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -1534,7 +1534,7 @@ namespace SlowTests.Issues
                 Assert.True(changeVector.Contains(sinkDatabaseId));
     }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(hubCertificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(hubCertificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hub.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -1660,7 +1660,7 @@ namespace SlowTests.Issues
                 Assert.True(changeVector.Contains(sinkClusterId));
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(hubCertificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(hubCertificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hub.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -1803,7 +1803,7 @@ namespace SlowTests.Issues
                 Assert.True(hubDatabaseIds.Any(id => changeVector.Contains(id)));
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(hubCertificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(hubCertificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hub.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -1929,7 +1929,7 @@ namespace SlowTests.Issues
                 Assert.True(changeVector.Contains(hubClusterId));
             }
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(hubCertificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(hubCertificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hub.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition

--- a/test/SlowTests.Issues/Issues/RDoc_662.cs
+++ b/test/SlowTests.Issues/Issues/RDoc_662.cs
@@ -47,11 +47,11 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation());
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
-                new Employees_Query().Execute(store);
+                await new Employees_Query().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RDoc_76.cs
+++ b/test/SlowTests.Issues/Issues/RDoc_76.cs
@@ -105,8 +105,8 @@ namespace SlowTests.Issues
 
                 using (var commands = store.Commands())
                 {
-                    Assert.Null(commands.Get("a/1"));
-                    Assert.NotNull(commands.Get("mb/1"));
+                    Assert.Null(await commands.GetAsync("a/1"));
+                    Assert.NotNull(await commands.GetAsync("mb/1"));
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-10157.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-10157.cs
@@ -28,8 +28,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore())
             {
-                new UserByName().Execute(store);
-                new UserByNameCount().Execute(store);
+                await new UserByName().ExecuteAsync(store);
+                await new UserByNameCount().ExecuteAsync(store);
                 var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), exportFile);
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
             }

--- a/test/SlowTests.Issues/Issues/RavenDB-10343.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-10343.cs
@@ -1318,7 +1318,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new LatestBuildsIndex().Execute(store);
+                await new LatestBuildsIndex().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -1372,7 +1372,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-10446.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-10446.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Issues
                 Color = Colors.Brown
             };
 
-            var subsId = store.Subscriptions.Create(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions<Shirt>
+            var subsId = await store.Subscriptions.CreateAsync(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions<Shirt>
             {
                 Filter = x => x.ShirtType == tunicaType.FullName && x.Color == shirtWithValue.Color && x.ManufactureDate >= shirtWithValue.ManufactureDate && x.Price > shirtWithValue.Price
             });

--- a/test/SlowTests.Issues/Issues/RavenDB-10538.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-10538.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 1; i <= 10; i++)
@@ -86,7 +86,7 @@ namespace SlowTests.Issues
                     }
                     await session.SaveChangesAsync();
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var query = session.Query<Doc, DocsIndex>()
                         .AggregateBy(builder => builder.ByRanges(

--- a/test/SlowTests.Issues/Issues/RavenDB-10590.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-10590.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 0; i < 10; i++)
@@ -31,7 +31,7 @@ namespace SlowTests.Issues
                     }
                     await session.SaveChangesAsync();
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var query = session.Query<Doc, DocsIndex>()
                         .Where(x => x.Id == "doc-1")

--- a/test/SlowTests.Issues/Issues/RavenDB-10666.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-10666.cs
@@ -102,7 +102,7 @@ namespace SlowTests.Issues
                     const string fileName = "001.txt";
                     using (var writer = new StreamWriter(File.Open(fileName, FileMode.Create)))
                     {
-                        writer.Write("1010011010");
+                        await writer.WriteAsync("1010011010");
                     }
 
                     using (var session = store.OpenAsyncSession(dbName))
@@ -120,7 +120,7 @@ namespace SlowTests.Issues
                         {
                             using (var reader = new StreamReader(file.Stream))
                             {
-                                var str = reader.ReadLine();
+                                var str = await reader.ReadLineAsync();
                                 Assert.Equal("1010011010", str);
                             }
 

--- a/test/SlowTests.Issues/Issues/RavenDB-11166.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-11166.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
                     });
                     session.SaveChanges();
                 }
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"from Dogs include Owner"
                 });
@@ -117,7 +117,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"from Dogs (Revisions = true) as d include d.Current.Owner, d.Previous.Owner",
                 });
@@ -187,7 +187,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"declare function f(d) { 
                                 include(d.Current.Owner);
@@ -247,7 +247,7 @@ namespace SlowTests.Issues
                     });
                     session.SaveChanges();
                 }
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"declare function f(d) { 
     include(d.Owner);
@@ -308,7 +308,7 @@ select f(dog)
                     });
                     session.SaveChanges();
                 }
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"from Dogs include Owner"
                 });

--- a/test/SlowTests.Issues/Issues/RavenDB-11196.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-11196.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations;
 using Raven.Tests.Core.Utils.Entities;
@@ -17,7 +18,7 @@ namespace SlowTests.Issues
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_be_James(Options options)
+        public async Task Should_be_James(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -47,7 +48,7 @@ loadToPeople(person);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(100));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(100));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-11385.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-11385.cs
@@ -22,10 +22,10 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     // RQL ordering works with "Id"
                     var rquery = session.Advanced.AsyncRawQuery<Doc>("from index DocsIndex order by Id");

--- a/test/SlowTests.Issues/Issues/RavenDB-11786.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-11786.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
 
                 }
-                var subsId = store.Subscriptions.Create<User>(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions<User>()
+                var subsId = await store.Subscriptions.CreateAsync<User>(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions<User>()
                 {
                     Projection = x => new
                     {
@@ -83,7 +83,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
 
                 }
-                var subsId = store.Subscriptions.Create<User>(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions<User>()
+                var subsId = await store.Subscriptions.CreateAsync<User>(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions<User>()
                 {
                     Projection = x => new
                     {

--- a/test/SlowTests.Issues/Issues/RavenDB-12292.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-12292.cs
@@ -52,14 +52,14 @@ namespace SlowTests.Issues
                         OperateOnTypes = DatabaseItemType.Documents
                     }, file);
 
-                    operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                    await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                     var fileInfo = new FileInfo(file);
                     Assert.True(fileInfo.Exists);
                     Assert.True(file.Length < 500);
 
                     operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                    operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                    await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                     using (var session = store2.OpenSession())
                     {
@@ -128,13 +128,13 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
                 var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
             }
             // all data import
             using (var store2 = GetDocumentStore())
             {
                 var operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 using (var session = store2.OpenAsyncSession())
                 {
@@ -157,7 +157,7 @@ namespace SlowTests.Issues
                 importOptions.OperateOnTypes -= DatabaseItemType.Attachments;
 
                 var operation = await store3.Smuggler.ImportAsync(importOptions, file);
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 using (var session = store3.OpenAsyncSession())
                 {
@@ -199,7 +199,7 @@ namespace SlowTests.Issues
                 importOptions.OperateOnTypes -= DatabaseItemType.Attachments;
 
                 var operation = await store4.Smuggler.ImportAsync(importOptions, file);
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
                 using (var session = store4.OpenAsyncSession())
                 {
                     var metadata = session.Advanced.GetMetadataFor(await session.LoadAsync<User>(id));

--- a/test/SlowTests.Issues/Issues/RavenDB-12598.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-12598.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Issues
 
                 WaitForChangesApiOnAllNodes(blockingCollections,1);
                 WaitForDocumentOnAllNodes(stores, docId);
-                using(stores[1].AggressivelyCache(db))
+                using(await stores[1].AggressivelyCacheAsync(db))
                 using (var session = stores[1].OpenSession())
                 {
                     var user = session.Load<User>(docId);

--- a/test/SlowTests.Issues/Issues/RavenDB-12785.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-12785.cs
@@ -33,7 +33,7 @@ if(collection == 'ShoppingCarts')
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-12902.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-12902.cs
@@ -24,8 +24,8 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new UsersByName());
-                Indexes.WaitForIndexing(store);
+                await store.ExecuteIndexAsync(new UsersByName());
+                await Indexes.WaitForIndexingAsync(store);
                 using (var session = store.OpenSession())
                 {
                     var counter = 0;
@@ -124,8 +124,8 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new UsersByName());
-                Indexes.WaitForIndexing(store);
+                await store.ExecuteIndexAsync(new UsersByName());
+                await Indexes.WaitForIndexingAsync(store);
                 using (var session = store.OpenSession())
                 {
                     var counter = 0;
@@ -309,7 +309,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new UsersByName());
+                await store.ExecuteIndexAsync(new UsersByName());
 
                 using (var session = store.OpenSession())
                 {
@@ -404,7 +404,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new UsersByName());
+                await store.ExecuteIndexAsync(new UsersByName());
 
                 using (var session = store.OpenSession())
                 {
@@ -501,7 +501,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new UsersByName());
+                await store.ExecuteIndexAsync(new UsersByName());
 
                 using (var session = store.OpenSession())
                 {
@@ -561,7 +561,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                store.ExecuteIndex(new UsersByName());
+                await store.ExecuteIndexAsync(new UsersByName());
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-12921.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-12921.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
 
                 using (var session = (DocumentSession)store.OpenSession())
                 {
-                    session.Store(new Order { Company = "Hibernating Rhinos" }, id);
+                    await session.StoreAsync(new Order { Company = "Hibernating Rhinos" }, id);
                     session.SaveChanges();
 
                     Assert.True(await WaitForDocumentInClusterAsync<Order>(
@@ -88,7 +88,7 @@ namespace SlowTests.Issues
 
                 using (var session = (DocumentSession)store.OpenSession())
                 {
-                    session.Store(new Order { Company = "Hibernating Rhinos" }, id);
+                    await session.StoreAsync(new Order { Company = "Hibernating Rhinos" }, id);
                     session.SaveChanges();
 
                     Assert.True(await WaitForDocumentInClusterAsync<Order>(

--- a/test/SlowTests.Issues/Issues/RavenDB-13269.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-13269.cs
@@ -99,7 +99,7 @@ namespace SlowTests.Issues
                     Name = "test4"
                 }}));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 var stats = Indexes.WaitForIndexingErrors(store, new[] { "test1", "test2", "test3", "test4" }, errorsShouldExists: false);
                 Assert.Null(stats);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-13341.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-13341.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                store.Maintenance.Send(new CreateSampleDataOperation());
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var documentsStorage = documentDatabase.DocumentsStorage;
@@ -107,7 +107,7 @@ namespace SlowTests.Issues
                 CreateDatabase = false
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation());
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
                 const int timeout = 60_000;
                 await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(databaseName));

--- a/test/SlowTests.Issues/Issues/RavenDB-13452.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-13452.cs
@@ -279,7 +279,7 @@ namespace SlowTests.Issues
                 }
                 using (var commands = store.Commands())
                 {
-                    var item = commands.Get("items/1").BlittableJson;
+                    var item = (await commands.GetAsync("items/1")).BlittableJson;
                     Assert.True(item.TryGet(nameof(Item.Values), out BlittableJsonReaderObject values));
                     Assert.Equal(3, values.Count);
 
@@ -318,7 +318,7 @@ namespace SlowTests.Issues
                 }
                 using (var commands = store.Commands())
                 {
-                    var item = commands.Get("items/1").BlittableJson;
+                    var item = (await commands.GetAsync("items/1")).BlittableJson;
                     Assert.True(item.TryGet(nameof(Item.Values), out BlittableJsonReaderObject values));
                     Assert.Equal(3, values.Count);
 
@@ -439,7 +439,7 @@ namespace SlowTests.Issues
                 }
                 using (var commands = store.Commands())
                 {
-                    var item = commands.Get("items/1").BlittableJson;
+                    var item = (await commands.GetAsync("items/1")).BlittableJson;
                     Assert.True(item.TryGet(nameof(Item.Values), out BlittableJsonReaderObject values));
                     Assert.Equal(2, values.Count);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-14058.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14058.cs
@@ -48,8 +48,8 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                new OrdersMapReduceIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new OrdersMapReduceIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -59,7 +59,7 @@ namespace SlowTests.Issues
                     Assert.Equal(2, list[0].Count);
                 }
 
-                store.Maintenance.Send(new StopIndexOperation(nameof(OrdersMapReduceIndex)));
+                await store.Maintenance.SendAsync(new StopIndexOperation(nameof(OrdersMapReduceIndex)));
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -70,8 +70,8 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(store.Database);
                 await database.TombstoneCleaner.ExecuteCleanup();
 
-                store.Maintenance.Send(new StartIndexOperation(nameof(OrdersMapReduceIndex)));
-                Indexes.WaitForIndexing(store);
+                await store.Maintenance.SendAsync(new StartIndexOperation(nameof(OrdersMapReduceIndex)));
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-14342.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14342.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
         
             using (var store = GetDocumentStore())
             {
-                store.Maintenance.Send(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.Indexes));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.Indexes));
             
                 using (var commands = store.Commands())
                 {
@@ -102,7 +102,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.Indexes | DatabaseItemType.RevisionDocuments | DatabaseItemType.Attachments));
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await store.Maintenance.SendAsync(new DisableIndexOperation("Orders/ByCompany"));
 
                 using (var session = store.OpenSession())
@@ -114,7 +114,7 @@ namespace SlowTests.Issues
                     Assert.True(query.Count > 0);
                 }
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 using (var commands = store.Commands())
                 {
@@ -170,7 +170,7 @@ namespace SlowTests.Issues
             {
                 await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.Indexes |
                                                                                 DatabaseItemType.RevisionDocuments | DatabaseItemType.Attachments));
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await store.Maintenance.SendAsync(new DisableIndexOperation("Orders/ByCompany"));
 
                 using (var session = store.OpenSession())
@@ -182,7 +182,7 @@ namespace SlowTests.Issues
                     Assert.True(query.Count > 0);
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var commands = store.Commands())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-14806.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14806.cs
@@ -59,7 +59,7 @@ public class RavenDB_14806 : RavenTestBase
         }
         var index = new DataIndex();
         await index.ExecuteAsync(store);
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         {
             using var session = store.OpenAsyncSession();

--- a/test/SlowTests.Issues/Issues/RavenDB-14880.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-14880.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
                 }
 
                 ExecuteQuery(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var re = store.GetRequestExecutor(store.Database);
                 var configurationChanges = new List<long>();
@@ -127,7 +127,7 @@ namespace SlowTests.Issues
 
                 // shouldn't trigger a topology update
                 ExecuteQuery(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(1, toplogyUpdatesCount);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-15497.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-15497.cs
@@ -42,7 +42,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.Maintenance
                     .ForTesting(() => new StopIndexOperation(index.IndexName))
@@ -124,9 +124,9 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store1);
-                Indexes.WaitForIndexing(store2);
-                Indexes.WaitForIndexing(store3);
+                await Indexes.WaitForIndexingAsync(store1);
+                await Indexes.WaitForIndexingAsync(store2);
+                await Indexes.WaitForIndexingAsync(store3);
 
                 await store1.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
                 await store2.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));

--- a/test/SlowTests.Issues/Issues/RavenDB-15739.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-15739.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-15754.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-15754.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, _employeesCount);
 
                 var batchCount = 0;
@@ -91,7 +91,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
                 await AssertCount(store, _companyName1, 0);
                 await AssertCount(store, _companyName2, _employeesCount);
                 Assert.True(await Task.WhenAny(tcs.Task, Task.Delay(10_000)) == tcs.Task);
@@ -139,7 +139,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, _employeesCount);
 
                 using (var session = store.OpenAsyncSession())
@@ -158,7 +158,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
                 await AssertCount(store, _companyName1, 0);
                 await AssertCount(store, _companyName2, _employeesCount);
 
@@ -210,7 +210,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, employeesCount, managerName: oldManagerName);
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
                 Assert.Equal(employeesCount, indexStats.MapAttempts);
@@ -225,7 +225,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(10));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(10));
                 await AssertCount(store, _companyName1, 0);
                 await AssertCount(store, _companyName2, employeesCount, managerName: newManagerName);
 
@@ -270,7 +270,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await new DocumentsIndex().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, _employeesCount);
 
                 var batchCount = 0;
@@ -300,7 +300,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
                 await AssertCount(store, _companyName1, _employeesCount);
                 await AssertCount(store, _companyName2, 0);
 
@@ -341,7 +341,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, _employeesCount);
 
                 var batchCount = 0;
@@ -361,7 +361,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
                 await AssertCount(store, _companyName1, 0);
                 Assert.True(await Task.WhenAny(tcs.Task, Task.Delay(10_000)) == tcs.Task);
 
@@ -402,7 +402,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCount(store, _companyName1, _employeesCount);
                 await AssertCount(store, _companyName2, 0);
@@ -467,7 +467,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsWithCompareExchangeIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -536,7 +536,7 @@ namespace SlowTests.Issues
                 var index = new TimeSeriesIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -600,7 +600,7 @@ namespace SlowTests.Issues
                 var index = new TimeSeriesWithCompareExchangeIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -669,7 +669,7 @@ namespace SlowTests.Issues
                 var index = new TimeSeriesMapReduceIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -733,7 +733,7 @@ namespace SlowTests.Issues
                 var index = new CountersIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -791,7 +791,7 @@ namespace SlowTests.Issues
                 var index = new CountersWithCompareExchangeIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -855,7 +855,7 @@ namespace SlowTests.Issues
                 var index = new MapReduceCountersIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
 
                 await AssertCompaniesCount(store, GetItemsCount, _employeesCount, 0);
 
@@ -925,7 +925,7 @@ namespace SlowTests.Issues
                 var index = new DocumentsIndex();
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, employeesCount);
 
                 var database = await GetDatabase(store.Database);
@@ -952,7 +952,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
 
                 await AssertCount(store, _companyName1, 0);
                 await AssertCount(store, _companyName2, employeesCount);

--- a/test/SlowTests.Issues/Issues/RavenDB-15890.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-15890.cs
@@ -38,9 +38,9 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                new FakeIndex().Execute(store);
+                await new FakeIndex().ExecuteAsync(store);
 
-                store.Maintenance.Send(new DisableIndexOperation("FakeIndex", false));
+                await store.Maintenance.SendAsync(new DisableIndexOperation("FakeIndex", false));
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var indexInstance = db.IndexStore.GetIndex("FakeIndex");
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
                 Assert.Equal(IndexState.Disabled, indexInstance.State);
                 Assert.Equal(IndexRunningStatus.Disabled, indexInstance.Status);
 
-                store.Maintenance.Send(new EnableIndexOperation("FakeIndex", false));
+                await store.Maintenance.SendAsync(new EnableIndexOperation("FakeIndex", false));
 
                 indexInstance = db.IndexStore.GetIndex("FakeIndex");
 

--- a/test/SlowTests.Issues/Issues/RavenDB-16498.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16498.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
             }
 
             await new User_Search().ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var s = store.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-16958.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16958.cs
@@ -82,7 +82,7 @@ namespace SlowTests.Issues
                         session.SaveChanges();
                     }
 
-                    var id = storeB.Subscriptions.Create<User>();
+                    var id = await storeB.Subscriptions.CreateAsync<User>();
                     await using (var subscription = storeB.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                     {
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
@@ -133,7 +133,7 @@ namespace SlowTests.Issues
                         session.SaveChanges();
                     }
 
-                    var id = storeB.Subscriptions.Create<User>();
+                    var id = await storeB.Subscriptions.CreateAsync<User>();
                     await using (var subscription = storeB.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                     {
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)

--- a/test/SlowTests.Issues/Issues/RavenDB-17061.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17061.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
                     userId = user.Id;
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 QueryStatistics stats;
 
@@ -113,7 +113,7 @@ namespace SlowTests.Issues
                     userId = user.Id;
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var isCorax = options.SearchEngineMode is RavenSearchEngineMode.Corax;
                 var idComparer = isCorax
@@ -217,7 +217,7 @@ namespace SlowTests.Issues
                     userId = user.Id;
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-17068.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17068.cs
@@ -55,7 +55,7 @@ public sealed class RavenDB_17068: RavenDB_17068_Base
             var index = new DummyIndex();
             
             await index.ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             Tuple<bool, DynamicJsonValue> alertRaised;
 
             do
@@ -91,7 +91,7 @@ public sealed class RavenDB_17068: RavenDB_17068_Base
             var index = new DummyIndex();
             
             await index.ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             Tuple<bool, DynamicJsonValue> alertRaised = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
             
             while (alertRaised.Item1)

--- a/test/SlowTests.Issues/Issues/RavenDB-17206.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17206.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Issues
 
             await session.SaveChangesAsync();
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             WaitForUserToContinueTheTest(store);
 
             const int i = 1000;

--- a/test/SlowTests.Issues/Issues/RavenDB-17303.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17303.cs
@@ -72,7 +72,7 @@ namespace SlowTests.Issues
                 int nullNameCount = 4;
                 using (var session = store.OpenAsyncSession())
                 {
-                    new GreatIndex().Execute(store);
+                    await new GreatIndex().ExecuteAsync(store);
                     var document1 = new TestDocument { Document = new TestDocument2() { Name = "EGOR" }, SomeRandomDate = new DateTime(2021, 6, 14) };
                     for (int i = 0; i < nullNameCount; i++)
                     {
@@ -91,7 +91,7 @@ namespace SlowTests.Issues
 
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 WaitForUserToContinueTheTest(store);
                 using (var s = store.OpenAsyncSession())

--- a/test/SlowTests.Issues/Issues/RavenDB-17566.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17566.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
                 await s.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var s = store.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-17597.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17597.cs
@@ -139,8 +139,8 @@ namespace SlowTests.Issues
                 // Wait for indexing in first node
 
                 var index = new Index_ItemsByNum();
-                index.Execute(store);
-                Indexes.WaitForIndexing(store);
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
                 WaitForUserToContinueTheTest(store);
 
                 var database = await GetDatabase(server, store.Database);
@@ -178,11 +178,11 @@ namespace SlowTests.Issues
 
                 // Wait for indexing in first node
 
-                new Index_ItemsByNum().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new Index_ItemsByNum().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
                 if (stopIndex)
                 {
-                    store.Maintenance.Send(new StopIndexOperation("Items/ByNum"));
+                    await store.Maintenance.SendAsync(new StopIndexOperation("Items/ByNum"));
                 }
 
 
@@ -190,7 +190,7 @@ namespace SlowTests.Issues
                 await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 {
                     await new Index_ItemsByNum2().ExecuteAsync(store);
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
                 });
                 var indexNames1 = store.Maintenance.Send(new GetIndexNamesOperation(0, 10));
                 Assert.NotNull(indexNames1);

--- a/test/SlowTests.Issues/Issues/RavenDB-17745.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17745.cs
@@ -170,7 +170,7 @@ namespace SlowTests.Issues
                 await Task.Delay(_delay);
                 bulk.Store(new User { Name = "Ido" }, "users/3");
                 await Task.Delay(_delay);
-                bulk.Dispose();
+                await bulk.DisposeAsync();
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-17807.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17807.cs
@@ -32,16 +32,16 @@ public class RavenDB_17807 : RavenTestBase
                 await commands.PutAsync("items/1", null, new { Name = "testname" },
                     new Dictionary<string, object> { { Constants.Documents.Metadata.Collection, "Items" } });
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 var ids = new[] { "testname12", "testname1", "testname" };
-                var operation = store.Operations.Send(
+                var operation = await store.Operations.SendAsync(
                     new PatchByQueryOperation(
                         new IndexQuery
                         {
                             Query = $"FROM INDEX 'MyIndex' where Name in ($p0) UPDATE {{ this.NewName = 'NewValue'; this.IsActive = false; }} ",
                             QueryParameters = new Parameters { { "p0", ids } }
                         }, new QueryOperationOptions { AllowStale = true }));
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 dynamic document = await commands.GetAsync("items/1");
                 Assert.Equal("NewValue", document.NewName.ToString());
@@ -64,14 +64,14 @@ public class RavenDB_17807 : RavenTestBase
                 await commands.PutAsync("items/1", null, new { Name = "testname" },
                     new Dictionary<string, object> { { Constants.Documents.Metadata.Collection, "Items" } });
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var ids = new[] { "testname12", "testname1", "testname" };
 
-                var operation = store.Operations.Send(new DeleteByQueryOperation(
+                var operation = await store.Operations.SendAsync(new DeleteByQueryOperation(
                     new IndexQuery() { Query = $"FROM INDEX 'MyIndex'  where Name in ($p0)", QueryParameters = new Parameters { { "p0", ids } } },
                     new QueryOperationOptions { AllowStale = true }));
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 var documents = await commands.GetAsync(0, 25);
                 Assert.Equal(0, documents.Count());
@@ -93,12 +93,12 @@ public class RavenDB_17807 : RavenTestBase
                 await commands.PutAsync("items/1", null, new { Name = "testname" },
                     new Dictionary<string, object> { { Constants.Documents.Metadata.Collection, "Items" } });
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var ids = new[] { "testname12", "testname1", "testname" };
 
 
-                var result = commands.Query(new IndexQuery()
+                var result = await commands.QueryAsync(new IndexQuery()
                 {
                     Query = $"FROM INDEX 'MyIndex'  where Name in ($p0)", QueryParameters = new Parameters { { "p0", ids } }
                 });

--- a/test/SlowTests.Issues/Issues/RavenDB-17937.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17937.cs
@@ -47,7 +47,7 @@ namespace SlowTests.Issues
                 await index1.ExecuteAsync(store);
                 await new Index2(indexName).ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store, allowErrors: true, timeout: TimeSpan.FromSeconds(5));
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true, timeout: TimeSpan.FromSeconds(5));
 
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 Assert.Equal(1, record.Indexes.Count);
@@ -73,7 +73,7 @@ namespace SlowTests.Issues
 
                 // replacing with another index with another index with an error
                 await new Index3(indexName).ExecuteAsync(store);
-                Indexes.WaitForIndexing(store, allowErrors: true, timeout: TimeSpan.FromSeconds(5));
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true, timeout: TimeSpan.FromSeconds(5));
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
@@ -82,7 +82,7 @@ namespace SlowTests.Issues
                 // an index with no errors will replace both the original and the replacement
                 var index4 = new Index4(indexName);
                 await new Index4(indexName).ExecuteAsync(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 index = database.IndexStore.GetIndex(indexName);
                 Assert.Contains("New_Count = 5", index.GetIndexDefinition().Maps.First());

--- a/test/SlowTests.Issues/Issues/RavenDB-18096.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-18096.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-18373.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-18373.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store, timeout: TimeSpan.FromSeconds(15));
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromSeconds(15));
 
             await store.Maintenance.SendAsync(new StopIndexingOperation());
 

--- a/test/SlowTests.Issues/Issues/RavenDB-18554.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-18554.cs
@@ -41,8 +41,8 @@ namespace SlowTests.Issues
                 }
                 
                 var index = new Categoroies_Details();
-                index.Execute(store);
-                Indexes.WaitForIndexing(store);
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 // Test
                 CompactSettings settings = new CompactSettings {DatabaseName = store.Database, Documents = true, Indexes = new[]{ index.IndexName } };
@@ -69,8 +69,8 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(store.Database);
                 database.ForTestingPurposesOnly().CompactionAfterDatabaseUnload = d;
 
-                var operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
-                operation.WaitForCompletion();
+                var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(settings));
+                await operation.WaitForCompletionAsync();
 
                 Assert.NotNull(exception);
                 Assert.True(exception is DatabaseDisabledException);
@@ -105,8 +105,8 @@ namespace SlowTests.Issues
                 }
 
                 var index = new Categoroies_Details();
-                index.Execute(store);
-                Indexes.WaitForIndexing(store);
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 // Test
                 CompactSettings settings = new CompactSettings { DatabaseName = store.Database, Documents = true, Indexes = new[] { index.IndexName } };
@@ -140,8 +140,8 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(responsibleNode, store.Database);
                 database.ForTestingPurposesOnly().CompactionAfterDatabaseUnload = d;
 
-                var operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(settings));
-                operation.WaitForCompletion();
+                var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(settings));
+                await operation.WaitForCompletionAsync();
 
                 // Check if failover succeeded
                 Assert.Null(exception);
@@ -170,8 +170,8 @@ namespace SlowTests.Issues
 
                 // Wait for indexing in first node
                 var index = new Categoroies_Details();
-                index.Execute(store);
-                Indexes.WaitForIndexing(store);
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 // Test
                 CompactSettings settings = new CompactSettings {DatabaseName = store.Database, Documents = true, Indexes = new[] { index.IndexName } };
@@ -238,7 +238,7 @@ namespace SlowTests.Issues
                 {
                     // wait for indexing to finish on the current node
                     var nodeTag = n.ServerStore.NodeTag;
-                    Indexes.WaitForIndexing(store,
+                    await Indexes.WaitForIndexingAsync(store,
                         databaseName: store.Database,
                         timeout: TimeSpan.FromMinutes(2),
                         nodeTag: nodeTag);

--- a/test/SlowTests.Issues/Issues/RavenDB-18657.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-18657.cs
@@ -68,7 +68,7 @@ namespace SlowTests.Issues
 
             var index = new Item_Content();
             await index.ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-19016.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19016.cs
@@ -116,7 +116,7 @@ public class RavenDB_19016 : RavenTestBase
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 var index = database.IndexStore.GetIndex(deployedIndex.IndexName);
@@ -143,7 +143,7 @@ public class RavenDB_19016 : RavenTestBase
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -265,7 +265,7 @@ public class RavenDB_19016 : RavenTestBase
                 await session.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-19466.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19466.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -15,7 +16,7 @@ public class RavenDB_19466 : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Etl)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-    public void CanModifyDocumentMetadataUsingEtlTransformScriptWithDeleteDocumentsBehaviorFunction(Options options)
+    public async Task CanModifyDocumentMetadataUsingEtlTransformScriptWithDeleteDocumentsBehaviorFunction(Options options)
     {
         using (var src = GetDocumentStore(options))
         using (var dest = GetDocumentStore())
@@ -35,7 +36,7 @@ public class RavenDB_19466 : RavenTestBase
 
                 session.SaveChanges();
             }
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
             using (var session = dest.OpenSession())
             {
@@ -51,7 +52,7 @@ public class RavenDB_19466 : RavenTestBase
             }
 
             etlDone = Etl.WaitForEtlToComplete(src);
-            etlDone.Wait(TimeSpan.FromMinutes(1));
+            await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
             
             using (var session = dest.OpenSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-19488.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19488.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
             }
             var index = new DataIndex();
             await index.ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             {
                 using var session = store.OpenAsyncSession();
 

--- a/test/SlowTests.Issues/Issues/RavenDB-19544.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19544.cs
@@ -34,7 +34,7 @@ public class RavenDB_19544 : RavenTestBase
                 await session.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             using (var session = store.OpenAsyncSession())
             {
                 var projection =
@@ -73,7 +73,7 @@ public class RavenDB_19544 : RavenTestBase
                 await session.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             using (var session = store.OpenAsyncSession())
             {
                 var projection =

--- a/test/SlowTests.Issues/Issues/RavenDB-19563.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19563.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 database.ForTestingPurposesOnly().AfterSnapshotOfDocuments = () =>
@@ -67,7 +67,7 @@ namespace SlowTests.Issues
                     DatabaseName = databaseName
                 }))
                 {
-                    Indexes.WaitForIndexing(store, databaseName);
+                    await Indexes.WaitForIndexingAsync(store, databaseName);
 
                     using (var session = store.OpenAsyncSession(databaseName))
                     {
@@ -101,7 +101,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 long cleanedTombstones = 0;
@@ -129,7 +129,7 @@ namespace SlowTests.Issues
                     DatabaseName = databaseName
                 }))
                 {
-                    Indexes.WaitForIndexing(store, databaseName);
+                    await Indexes.WaitForIndexingAsync(store, databaseName);
 
                     using (var session = store.OpenAsyncSession(databaseName))
                     {
@@ -166,7 +166,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 long cleanedTombstones = 0;
@@ -194,7 +194,7 @@ namespace SlowTests.Issues
                     DatabaseName = databaseName
                 }))
                 {
-                    Indexes.WaitForIndexing(store, databaseName);
+                    await Indexes.WaitForIndexingAsync(store, databaseName);
 
                     using (var session = store.OpenAsyncSession(databaseName))
                     {
@@ -231,7 +231,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 long cleanedTombstones = 0;
@@ -259,7 +259,7 @@ namespace SlowTests.Issues
                     DatabaseName = databaseName
                 }))
                 {
-                    Indexes.WaitForIndexing(store, databaseName);
+                    await Indexes.WaitForIndexingAsync(store, databaseName);
 
                     using (var session = store.OpenAsyncSession(databaseName))
                     {

--- a/test/SlowTests.Issues/Issues/RavenDB-19951.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-19951.cs
@@ -104,7 +104,7 @@ public class RavenDB_19951 : RavenTestBase
         TestCertificatesHolder certificates = WithStore(with2Eku, out DocumentStore store);
         
         string key = TwoFactorAuthentication.GenerateSecret();
-        store.Maintenance.Server.Send(
+        await store.Maintenance.Server.SendAsync(
             new PutClientCertificateOperation("test",
                 certificates.ClientCertificate1.Value,
                 new(),

--- a/test/SlowTests.Issues/Issues/RavenDB-20979.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-20979.cs
@@ -41,7 +41,7 @@ public class RavenDB_20979 : RavenTestBase
         {
             for (int i = 0; i < 1024*5; ++i)
             {
-                bulkInsert.Store(new Query.Order() {Employee = i.ToString()});
+                await bulkInsert.StoreAsync(new Query.Order() {Employee = i.ToString()});
             }
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB-21427.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21427.cs
@@ -844,7 +844,7 @@ public class MyAnalyzer2 : Analyzer
             {
                 await DisableRevisionCompression(Server, store);
                 await PutLicense(Server, RL_COMM);
-                store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
+                await store.Maintenance.SendAsync(new PutAnalyzersOperation(new AnalyzerDefinition
                 {
                     Name = "MyAnalyzer2",
                     Code = GetAnalyzer("RavenDB_14939.MyAnalyzer.cs", "MyAnalyzer", "MyAnalyzer2")
@@ -859,7 +859,7 @@ public class MyAnalyzer2 : Analyzer
                 Assert.Equal(LimitType.CustomAnalyzers, exception.LimitType);
 
                 await PutLicense(Server, RL_PRO);
-                store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
+                await store.Maintenance.SendAsync(new PutAnalyzersOperation(new AnalyzerDefinition
                 {
                     Name = "MyAnalyzer",
                     Code = GetAnalyzer("RavenDB_14939.MyAnalyzer.cs", "MyAnalyzer", "MyAnalyzer")

--- a/test/SlowTests.Issues/Issues/RavenDB-21574.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21574.cs
@@ -90,7 +90,7 @@ public class RavenDB_21574 : RavenTestBase
     {
         var index = new T();
         await IndexCreation.CreateIndexesAsync(new List<AbstractIndexCreationTask> { index }, store);
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         var indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
         var indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
@@ -101,7 +101,7 @@ public class RavenDB_21574 : RavenTestBase
         index.SearchEngineType = SearchEngineType.Lucene;
 
         await IndexCreation.CreateIndexesAsync(new List<AbstractIndexCreationTask> { index }, store);
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
         indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
@@ -110,8 +110,8 @@ public class RavenDB_21574 : RavenTestBase
         Assert.Equal(SearchEngineType.Lucene, indexStats.SearchEngineType);
 
         index.SearchEngineType = SearchEngineType.Corax;
-        index.Execute(store);
-        Indexes.WaitForIndexing(store);
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
         indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
@@ -120,8 +120,8 @@ public class RavenDB_21574 : RavenTestBase
         Assert.Equal(SearchEngineType.Corax, indexStats.SearchEngineType);
 
         index.SearchEngineType = SearchEngineType.Lucene;
-        store.ExecuteIndex(index);
-        Indexes.WaitForIndexing(store);
+        await store.ExecuteIndexAsync(index);
+        await Indexes.WaitForIndexingAsync(store);
 
         indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
         indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
@@ -132,7 +132,7 @@ public class RavenDB_21574 : RavenTestBase
         index = new T();
         indexDefinition = index.CreateIndexDefinition();
         await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
         indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));

--- a/test/SlowTests.Issues/Issues/RavenDB-21679.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21679.cs
@@ -117,7 +117,7 @@ namespace SlowTests.Issues
                 var backupConfiguration = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(backupConfiguration));
 
-                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                await store.Maintenance.SendAsync(new PutClientConfigurationOperation(new ClientConfiguration
                 {
                     ReadBalanceBehavior = ReadBalanceBehavior.None, LoadBalanceBehavior = LoadBalanceBehavior.None, LoadBalancerContextSeed = 0, Disabled = false
                 }));

--- a/test/SlowTests.Issues/Issues/RavenDB-21960.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21960.cs
@@ -38,7 +38,7 @@ public class RavenDB_21960 : RavenTestBase
                 var otherIndex = new OtherDummyIndex();
                 await otherIndex.ExecuteAsync(store);
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var commands = store.Commands())
                 {
@@ -118,7 +118,7 @@ public class RavenDB_21960 : RavenTestBase
                 var otherIndex = new OtherDummyIndex();
                 await otherIndex.ExecuteAsync(store);
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var commands = store.Commands())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-22040.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22040.cs
@@ -39,7 +39,7 @@ public class RavenDB_22040 : ReplicationTestBase
             await session.StoreAsync(order1);
             await session.SaveChangesAsync();
             await new Index().ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
         }
 
         t1.Mend();
@@ -54,7 +54,7 @@ public class RavenDB_22040 : ReplicationTestBase
         {
             await session.StoreAsync(order2);
             await session.SaveChangesAsync();
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             session.Delete(order2.Id);
             await session.SaveChangesAsync();
@@ -67,8 +67,8 @@ public class RavenDB_22040 : ReplicationTestBase
         t2.Mend();
 
         await WaitForDocumentInClusterAsync<Employee>(cluster.Nodes, database, markerDocument.Id, null, defaultTimeout);
-        Indexes.WaitForIndexing(store, database, timeout: defaultTimeout, nodeTag: "A");
-        Indexes.WaitForIndexing(store, database, timeout: defaultTimeout, nodeTag: "B");
+        await Indexes.WaitForIndexingAsync(store, database, timeout: defaultTimeout, nodeTag: "A");
+        await Indexes.WaitForIndexingAsync(store, database, timeout: defaultTimeout, nodeTag: "B");
     }
 
     private class Index : AbstractIndexCreationTask<Order>

--- a/test/SlowTests.Issues/Issues/RavenDB-22178.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22178.cs
@@ -33,7 +33,7 @@ public class RavenDB_22178 : RavenTestBase
             await secondIndex.ExecuteAsync(store);
             await thirdIndex.ExecuteAsync(store);
             
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             
             var database = await GetDatabase(store.Database);
 
@@ -66,7 +66,7 @@ public class RavenDB_22178 : RavenTestBase
             await secondIndex.ExecuteAsync(store);
             await thirdIndex.ExecuteAsync(store);
             
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             
             var database = await GetDatabase(store.Database);
 
@@ -100,7 +100,7 @@ public class RavenDB_22178 : RavenTestBase
             await secondIndex.ExecuteAsync(store);
             await thirdIndex.ExecuteAsync(store);
             
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             
             var database = await GetDatabase(store.Database);
 
@@ -135,7 +135,7 @@ public class RavenDB_22178 : RavenTestBase
             await secondIndex.ExecuteAsync(store);
             await thirdIndex.ExecuteAsync(store);
             
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             
             var database = await GetDatabase(store.Database);
 
@@ -171,7 +171,7 @@ public class RavenDB_22178 : RavenTestBase
             await secondFailingIndex.ExecuteAsync(store);
             await workingIndex.ExecuteAsync(store);
             
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             
             var database = await GetDatabase(store.Database);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-22426.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22426.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Microsoft.Data.SqlClient;
 using Raven.Client.Documents;
@@ -29,7 +30,7 @@ public class RavenDB_22426 : SqlAwareTestBase
     }
 
     [RavenFact(RavenTestCategory.Etl, Requires = RavenServiceRequirement.MsSql)]
-    public void TestOldFactoryName()
+    public async Task TestOldFactoryName()
     {
         using (var store = GetDocumentStore())
         {
@@ -50,7 +51,7 @@ public class RavenDB_22426 : SqlAwareTestBase
                 
                 SetupSqlEtl(store, connectionString, EtlScript);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 Assert.Equal(1, GetDtosCount(connectionString));
             }

--- a/test/SlowTests.Issues/Issues/RavenDB-23100.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23100.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var indexInstance = database.IndexStore.GetIndex(index.IndexName);
@@ -72,7 +72,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -89,7 +89,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -147,7 +147,7 @@ namespace SlowTests.Issues
                         await session.SaveChangesAsync();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var session = store.OpenAsyncSession())
                     {
@@ -170,7 +170,7 @@ namespace SlowTests.Issues
                         // deleting the documents won't change the internal references tree like in new indexes
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -189,7 +189,7 @@ namespace SlowTests.Issues
                         // when we update the references, this will clean the leftovers
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -248,7 +248,7 @@ namespace SlowTests.Issues
                         await session.SaveChangesAsync();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var session = store.OpenAsyncSession())
                     {
@@ -267,7 +267,7 @@ namespace SlowTests.Issues
                         // deleting the documents won't change the internal references tree like in new indexes
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -286,7 +286,7 @@ namespace SlowTests.Issues
                         // when we update the references, this will clean the leftovers
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -324,7 +324,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var indexInstance = database.IndexStore.GetIndex(index.IndexName);
@@ -344,7 +344,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -361,7 +361,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -419,7 +419,7 @@ namespace SlowTests.Issues
                         await session.SaveChangesAsync();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var session = store.OpenAsyncSession())
                     {
@@ -442,7 +442,7 @@ namespace SlowTests.Issues
                         // deleting the documents won't change the internal references tree like in new indexes
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -461,7 +461,7 @@ namespace SlowTests.Issues
                         // when we update the references, this will clean the leftovers
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -519,7 +519,7 @@ namespace SlowTests.Issues
                         await session.SaveChangesAsync();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var session = store.OpenAsyncSession())
                     {
@@ -536,7 +536,7 @@ namespace SlowTests.Issues
                         // deleting the documents won't change the internal references tree like in new indexes
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -555,7 +555,7 @@ namespace SlowTests.Issues
                         // when we update the references, this will clean the leftovers
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenReadTransaction())
@@ -593,7 +593,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var indexInstance = database.IndexStore.GetIndex(index.IndexName);
@@ -613,7 +613,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -630,7 +630,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -668,7 +668,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var indexInstance = database.IndexStore.GetIndex(index.IndexName);
@@ -693,7 +693,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -715,7 +715,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())

--- a/test/SlowTests.Issues/Issues/RavenDB-23720.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23720.cs
@@ -51,7 +51,7 @@ public class RavenDB_23720 : EmbeddingsGenerationTestBase
                 
                 store.Maintenance.Send(putIndexOp);
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var textFieldName = staticDefinition.Fields.Single(x => x.Value.Vector.SourceEmbeddingType == VectorEmbeddingType.Text).Key;
                 var floatFieldName = staticDefinition.Fields.Single(x => x.Value.Vector.SourceEmbeddingType == VectorEmbeddingType.Single).Key;

--- a/test/SlowTests.Issues/Issues/RavenDB-23720.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23720.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Operations.Indexes;
@@ -17,7 +18,7 @@ public class RavenDB_23720 : EmbeddingsGenerationTestBase
     }
 
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
-    public void AutoIndexWithVectorSearchShouldBeConvertibleToStatic()
+    public async Task AutoIndexWithVectorSearchShouldBeConvertibleToStatic()
     {
         using (var store = GetDocumentStore())
         {
@@ -29,8 +30,8 @@ public class RavenDB_23720 : EmbeddingsGenerationTestBase
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
 
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 

--- a/test/SlowTests.Issues/Issues/RavenDB-23909.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23909.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
@@ -15,7 +16,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
 {
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void Auto(Options options)
+    public async Task Auto(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -29,8 +30,8 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.Store(new Dto() { Name = "fruit" });
                 session.SaveChanges();
                 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 
@@ -49,7 +50,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
     
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void AlreadyQuantizedVectorShouldThrow(Options options)
+    public async Task AlreadyQuantizedVectorShouldThrow(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -63,8 +64,8 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.Store(new Dto() { Name = "fruit" });
                 session.SaveChanges();
                 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 
@@ -96,7 +97,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void Static(Options options)
+    public async Task Static(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -110,8 +111,8 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.Store(new Dto() { Name = "fruit" });
                 session.SaveChanges();
                 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
 
@@ -133,7 +134,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void StaticJs(Options options)
+    public async Task StaticJs(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -147,8 +148,8 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.Store(new Dto() { Name = "fruit" });
                 session.SaveChanges();
 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-23909.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23909.cs
@@ -86,7 +86,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                     // Expected exception
                 }
                 
-                Indexes.WaitForIndexing(store, allowErrors: true);
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true);
                 var indexErrors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: true);
                 
                 Assert.Single(indexErrors);
@@ -117,8 +117,8 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Assert.True(indexingWorkerRegistered);
 
                 var index = new DummyIndex();
-                index.Execute(store);
-                Indexes.WaitForIndexing(store);
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 var result = session.Query<DummyIndex.IndexEntry, DummyIndex>()
                     .VectorSearch(x =>
@@ -154,8 +154,8 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Assert.True(indexingWorkerRegistered);
 
                 var index = new DummyJsIndex();
-                index.Execute(store);
-                Indexes.WaitForIndexing(store);
+                await index.ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 var result = session.Query<DummyJsIndex.IndexEntry, DummyJsIndex>()
                     .VectorSearch(x =>

--- a/test/SlowTests.Issues/Issues/RavenDB-23960.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23960.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents.Operations.OngoingTasks;
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -9,12 +10,12 @@ public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestB
 {
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void DisabledTaskDoesntImpactCreationOfOtherTasks(Options options)
+    public async Task DisabledTaskDoesntImpactCreationOfOtherTasks(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
             var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "Task1");
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -24,7 +25,7 @@ public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestB
             store.Maintenance.Send(new ToggleOngoingTaskStateOperation(taskInfo.TaskId, OngoingTaskType.EmbeddingsGeneration, true));
                 
             var (configuration2, _) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "Task2");
-            (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration2);
+            (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration2);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             

--- a/test/SlowTests.Issues/Issues/RavenDB-23962.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23962.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Server.Documents;
@@ -14,7 +15,7 @@ namespace SlowTests.Issues;
 public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Indexes)]
-    public void ReferencedCollectionsShouldWorkWithStalenessHandling()
+    public async Task ReferencedCollectionsShouldWorkWithStalenessHandling()
     {
         const string collectionName = "Dtos";
         var referencedCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collectionName);
@@ -29,8 +30,8 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
 
@@ -123,7 +124,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
     }
 
     [RavenFact(RavenTestCategory.Indexes)]
-    public void TombstonesAreProcessed()
+    public async Task TombstonesAreProcessed()
     {
         const string collectionName = "Dtos";
         var referencedCollection = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(collectionName);
@@ -139,8 +140,8 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
             
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 
@@ -175,7 +176,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
     }
 
     [RavenFact(RavenTestCategory.Indexes)]
-    public void DeletesAreHandled()
+    public async Task DeletesAreHandled()
     {
         using (var store = GetDocumentStore())
         {
@@ -189,8 +190,8 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
             
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
                 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 

--- a/test/SlowTests.Issues/Issues/RavenDB-23962.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23962.cs
@@ -59,7 +59,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 
                 var stopIndexOp = new StopIndexOperation(stats.IndexName);
                 
-                store.Maintenance.Send(stopIndexOp);
+                await store.Maintenance.SendAsync(stopIndexOp);
                 
                 dto.Name = "strawberry";
                 session.SaveChanges();
@@ -95,9 +95,9 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 }, true);
 
                 var startIndexOp = new StartIndexOperation(stats.IndexName);
-                store.Maintenance.Send(startIndexOp);
+                await store.Maintenance.SendAsync(startIndexOp);
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 result = session.Query<Dto>()
                     .Statistics(out stats)
@@ -165,7 +165,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.Delete(embeddingDocId);
                 session.SaveChanges();
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 tombstones = index.GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType.Documents);
 
@@ -207,7 +207,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 
                 var stopIndexOp = new StopIndexOperation(stats.IndexName);
                 
-                store.Maintenance.Send(stopIndexOp);
+                await store.Maintenance.SendAsync(stopIndexOp);
                 
                 var embeddingDocId = EmbeddingsHelper.GetEmbeddingDocumentId(dto.Id);
                 
@@ -226,9 +226,9 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still some tombstone references to process from collection '@embeddings/Dtos'")));
                 
                 var startIndexOp = new StartIndexOperation(stats.IndexName);
-                store.Maintenance.Send(startIndexOp);
+                await store.Maintenance.SendAsync(startIndexOp);
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 result = session.Query<Dto>()
                     .Customize(c => c.WaitForNonStaleResults())

--- a/test/SlowTests.Issues/Issues/RavenDB-24816.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24816.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.ETL.Providers.AI;
@@ -80,7 +81,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void OverlapTokensSettingInScriptShouldWork()
+    public async Task OverlapTokensSettingInScriptShouldWork()
     {
         const string plainTextToChunk =
             "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -110,8 +111,8 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ChunkedName: text.splitParagraphs(this.Name, 10, 5) });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -120,7 +121,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void OverlapTokensSettingViaPathShouldWork()
+    public async Task OverlapTokensSettingViaPathShouldWork()
     {
         const string plainTextToChunk =
             "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -158,8 +159,8 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
                     }}
                 ]);
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -202,7 +203,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void UnsupportedChunkingSettingsInScriptThrowRelevantException()
+    public async Task UnsupportedChunkingSettingsInScriptThrowRelevantException()
     {
         const string plainTextToChunk =
             "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -222,7 +223,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
             var (configuration, _) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ChunkedName: text.splitLines(this.Name, 10, 5) });");
 
-            aiTaskDone.Wait(TimeSpan.FromSeconds(5));
+            await aiTaskDone.WaitAsync(TimeSpan.FromSeconds(5));
 
             var transformationError = Etl.TryGetTransformationErrorAsync(store.Database, configuration).GetAwaiter().GetResult();
 
@@ -231,7 +232,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void OverlapTokensShouldBeBackwardCompatible()
+    public async Task OverlapTokensShouldBeBackwardCompatible()
     {
         const string plainTextToChunk =
             "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -258,8 +259,8 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ChunkedName: text.splitParagraphs(this.Name, 10) });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             

--- a/test/SlowTests.Issues/Issues/RavenDB-3179.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-3179.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new AdviceSearch().Execute(store);
+                await new AdviceSearch().ExecuteAsync(store);
                 using (var session = store.OpenSession())
                 {
                     SetupFacets(session);
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-3758.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-3758.cs
@@ -105,7 +105,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                new Orders_All().Execute(store);
+                await new Orders_All().ExecuteAsync(store);
                 using (var session = store.OpenSession())
                 {
                     session.Store(new Order { Currency = Currency.EUR, Product = "Milk", Total = 1000, Quantity = 1 });
@@ -119,11 +119,11 @@ namespace SlowTests.Issues
                     });
                     session.SaveChanges();
                 }
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(1, store.Maintenance.Send(new GetStatisticsOperation()).CountOfIndexes);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 await new Orders_All_Changed().ExecuteAsync(store);
                 await new Orders_All_Changed2().ExecuteAsync(store);

--- a/test/SlowTests.Issues/Issues/RavenDB-3987.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-3987.cs
@@ -108,15 +108,15 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                new Person_ByName().Execute(store);
-                new Person_ByAge().Execute(store);
+                await new Person_ByName().ExecuteAsync(store);
+                await new Person_ByAge().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var operation1 = await store.Operations.SendAsync(new DeleteByQueryOperation<Person>("Person/ByName", x => x.Name == "Bob"));
                 await operation1.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var operation2 = await store.Operations.SendAsync(new DeleteByQueryOperation<Person, Person_ByAge>(x => x.Age < 35));
                 await operation2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));

--- a/test/SlowTests.Issues/Issues/RavenDB-4011.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-4011.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Issues
                     store.Maintenance.Send(new PutIndexesOperation(new[] { indexDefinition }));
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-4041.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-4041.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -68,7 +68,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -136,7 +136,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(options))
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -144,7 +144,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -210,7 +210,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -218,7 +218,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -277,7 +277,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -285,7 +285,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -353,7 +353,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
                 var id = new string('a', 130);
 
                 using (var session = store.OpenSession())
@@ -362,7 +362,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var commands = store.Commands())
                 {
@@ -468,7 +468,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -476,7 +476,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -544,7 +544,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Customers_ByName();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -552,7 +552,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var commands = store.Commands())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB-4085.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-4085.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Issues
                     {
                         for (var i = 0; i < 1000; i++)
                         {
-                            commands.Put("users/" + (i + 1), null, new { Name = "test #" + i }, new Dictionary<string, object>
+                            await commands.PutAsync("users/" + (i + 1), null, new { Name = "test #" + i }, new Dictionary<string, object>
                             {
                                 { Constants.Documents.Metadata.Collection, "Users" }
                             });

--- a/test/SlowTests.Issues/Issues/RavenDB-4997.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-4997.cs
@@ -127,7 +127,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var conflicts = storeA.Commands().GetConflictsFor("users/1");
+                var conflicts = await storeA.Commands().GetConflictsForAsync("users/1");
                 Assert.Equal(0, conflicts.Length);
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-6259.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-6259.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
             using (var master = GetDocumentStore(options))
             using (var slave = GetDocumentStore(options))
             {
-                slave.ExecuteIndex(new PersonAndAddressIndex());
+                await slave.ExecuteIndexAsync(new PersonAndAddressIndex());
                 var res = await SetupReplicationAsync(master, slave);
 
                 using (var session = master.OpenAsyncSession())

--- a/test/SlowTests.Issues/Issues/RavenDB-8763.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-8763.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
                         Amount = 3
                     });
                     await session.SaveChangesAsync();
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
                     var query = session.Query<ReduceMe>(index.IndexName);
                     await using (var stream = await session.Advanced.StreamAsync(query))
                     {

--- a/test/SlowTests.Issues/Issues/RavenDB-9055.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-9055.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
 
                 var mre = new ManualResetEventSlim();
                 string changeVector;
-                using (documentStore.AggressivelyCache())
+                using (await documentStore.AggressivelyCacheAsync())
                 using (var session = documentStore.OpenSession())
                 {
                     var forAllDocuments = documentStore.Changes().ForAllDocuments();
@@ -51,7 +51,7 @@ namespace SlowTests.Issues
                 string updateChangeVector = null;
                 for (int i = 0; i < 15; i++)
                 {
-                    using (documentStore.AggressivelyCache())
+                    using (await documentStore.AggressivelyCacheAsync())
                     using (var session = documentStore.OpenSession())
                     {
                         var user = session.Load<User>("users/1");

--- a/test/SlowTests.Issues/Issues/RavenDB-9120.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-9120.cs
@@ -88,11 +88,11 @@ namespace SlowTests.Issues
                 await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
                 var backupDirectory = Directory.GetDirectories(backupPath).First(); // get the temp folder created for backups
 
-                store.Maintenance.Server.Send(new RestoreBackupOperation(new RestoreBackupConfiguration()
+                await (await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(new RestoreBackupConfiguration()
                 {
                     BackupLocation = backupDirectory,
                     DatabaseName = restoredDbMane
-                })).WaitForCompletion(TimeSpan.FromSeconds(30));
+                }))).WaitForCompletionAsync(TimeSpan.FromSeconds(30));
             }
 
             using (var store2 = GetDocumentStore(new Options()

--- a/test/SlowTests.Issues/Issues/RavenDB14709.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB14709.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
         {
             using var store = GetDocumentStore(options);
 
-            store.Subscriptions.Create(options: new SubscriptionCreationOptions
+            await store.Subscriptions.CreateAsync(options: new SubscriptionCreationOptions
             {
                 Name = "Subs1",
                 Query = "from Users as u where u.'@metadata'.'r' == 1"

--- a/test/SlowTests.Issues/Issues/RavenDB937.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB937.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new Users_ByActive().Execute(store);
+                await new Users_ByActive().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -51,7 +51,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -75,7 +75,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new Users_ByActive().Execute(store);
+                await new Users_ByActive().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -86,7 +86,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -127,7 +127,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -152,7 +152,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new Users_ByActive().Execute(store);
+                await new Users_ByActive().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -163,7 +163,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     await using var enumerator = await session.Advanced

--- a/test/SlowTests.Issues/Issues/RavenDB_10420.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_10420.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Issues
             {
                 await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_10504.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_10504.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocumentIndex().Execute(store);
+                await new DocumentIndex().ExecuteAsync(store);
 
                 var doc = new Document
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_10600.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_10600.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Issues
             {
                 await store.Maintenance.SendAsync(new CreateSampleDataOperation(Raven.Client.Documents.Smuggler.DatabaseItemType.Documents | DatabaseItemType.Attachments | Raven.Client.Documents.Smuggler.DatabaseItemType.Indexes));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 initialStats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
 

--- a/test/SlowTests.Issues/Issues/RavenDB_10637.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_10637.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Issues
                     await session.StoreAsync(new Doc());
                     await session.SaveChangesAsync();
                 }
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_10640.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_10640.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     QueryStatistics stats;

--- a/test/SlowTests.Issues/Issues/RavenDB_11097.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_11097.cs
@@ -1290,7 +1290,7 @@ public class RavenDB_11097 : RavenTestBase
                     };
 
                     var cmd = new PutTestIndexCommand(payload, isSharded: true, shardNumber: shardNumber);
-                    commands.Execute(cmd);
+                    await commands.ExecuteAsync(cmd);
                     var res = cmd.Result as BlittableJsonReaderObject;
                     
                     Assert.NotNull(res);
@@ -1353,7 +1353,7 @@ public class RavenDB_11097 : RavenTestBase
                     };
 
                     var cmd = new PutTestIndexCommand(payload, isSharded: true, shardNumber: nextShard);
-                    commands.Execute(cmd);
+                    await commands.ExecuteAsync(cmd);
                     var res = cmd.Result as BlittableJsonReaderObject;
                     
                     Assert.NotNull(res);

--- a/test/SlowTests.Issues/Issues/RavenDB_11171.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_11171.cs
@@ -97,7 +97,7 @@ namespace SlowTests.Issues
 
                         using (var sr = new StreamReader(attachment.Stream))
                         {
-                            var value = sr.ReadToEnd();
+                            var value = await sr.ReadToEndAsync();
                             Assert.Equal("123", value);
                         }
                     }
@@ -125,7 +125,7 @@ namespace SlowTests.Issues
 
                         using (var sr = new StreamReader(attachment.Stream))
                         {
-                            var value = sr.ReadToEnd();
+                            var value = await sr.ReadToEndAsync();
                             Assert.Equal("123", value);
                         }
                     }

--- a/test/SlowTests.Issues/Issues/RavenDB_11575.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_11575.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 RavenTestHelper.AssertNoIndexErrors(store);
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests.Issues/Issues/RavenDB_12127.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12127.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"from Dogs"
                 });
@@ -90,7 +90,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"from Dogs include Owner"
                 });

--- a/test/SlowTests.Issues/Issues/RavenDB_12257.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12257.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>
                 {
                     Includes = builder => builder
                         .IncludeDocuments(x => x.Category)
@@ -127,7 +127,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Order>
+                var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Order>
                 {
                     Includes = builder => builder
                         .IncludeDocuments(x => x.Lines.Select(y => y.Product))

--- a/test/SlowTests.Issues/Issues/RavenDB_12269.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12269.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
                     Name = "Users_ByName"
                 }));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var db = await GetDatabase(store.Database);
 
@@ -69,7 +69,7 @@ namespace SlowTests.Issues
 
                 db.IndexStore.StartIndexing();
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 // let's try to force calling storageEnvironment.Cleanup() inside ExecuteIndexing method
                 replacementIndex.LowMemory(LowMemorySeverity.ExtremelyLow);
@@ -81,7 +81,7 @@ namespace SlowTests.Issues
 
                     await session.SaveChangesAsync();
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     // this will ensure that index isn't in error state
                     try

--- a/test/SlowTests.Issues/Issues/RavenDB_12366.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12366.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new Doc { Id = "doc-1", StrVal = "abc" });
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
                     await session.StoreAsync(new Doc { Id = "doc-3", StrVal = "bcd" });
                     await session.SaveChangesAsync();
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var results = await session.Advanced.AsyncDocumentQuery<Doc, DocsIndex>()
                         .IncludeExplanations(out Explanations explanations)

--- a/test/SlowTests.Issues/Issues/RavenDB_12403.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12403.cs
@@ -199,13 +199,13 @@ namespace SlowTests.Issues
                     $"{store.Urls[0]}/databases/{store.Database}/streams/queries?query=from index \'Users/CoolCount\' select __all_stored_fields&format=csv");
                 TextReader tr = new StreamReader(stream);
                 var csv = new CsvReader(tr, CultureInfo.InvariantCulture);
-                csv.Read();
+                await csv.ReadAsync();
                 csv.TryGetField(0, out string value);
                 Assert.Equal("@id", value);
                 csv.TryGetField(1, out value);
                 Assert.Equal("CoolCount", value);
                 var k = 0;
-                while (csv.Read())
+                while (await csv.ReadAsync())
                 {
                     csv.TryGetField(0, out value);
                     Assert.Equal($"user/{k}", value);

--- a/test/SlowTests.Issues/Issues/RavenDB_12646.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12646.cs
@@ -28,9 +28,9 @@ namespace SlowTests.Issues
                 ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.MaxNumberOfResults)] = "1"
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation());
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_12816.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12816.cs
@@ -229,7 +229,7 @@ namespace SlowTests.Issues
                     }
 
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var facets = new List<Facet>
                     {
@@ -271,7 +271,7 @@ namespace SlowTests.Issues
                         new FacetSetup { Id = "facets/CameraFacets", Facets = facets, RangeFacets = rangeFacets },
                         null);
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var session = store.OpenAsyncSession())
                     {
@@ -396,7 +396,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new CameraCost();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var commands = store.Commands())
                 {
@@ -433,7 +433,7 @@ namespace SlowTests.Issues
                         }
                     };
 
-                    commands.Put(
+                    await commands.PutAsync(
                         "facets/CameraFacets",
                         null,
                         new FacetSetup { Id = "facets/CameraFacets", Facets = facets, RangeFacets = rangeFacets },

--- a/test/SlowTests.Issues/Issues/RavenDB_12859.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12859.cs
@@ -706,9 +706,9 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new Companies_ByName_Reduce().Execute(store);
-                new Companies_ByName_Counters().Execute(store);
-                new Companies_ByName_TimeSeries().Execute(store);
+                await new Companies_ByName_Reduce().ExecuteAsync(store);
+                await new Companies_ByName_Counters().ExecuteAsync(store);
+                await new Companies_ByName_TimeSeries().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_12867.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12867.cs
@@ -59,8 +59,8 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(options))
             {
-                store.Subscriptions.Create<User>(x => x.Name == "Marcin");
-                store.Subscriptions.Create<User>();
+                await store.Subscriptions.CreateAsync<User>(x => x.Name == "Marcin");
+                await store.Subscriptions.CreateAsync<User>();
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
                 
@@ -89,7 +89,7 @@ namespace SlowTests.Issues
                     })
                     {
                         restoredStore.Initialize();
-                        var subscriptions = restoredStore.Subscriptions.GetSubscriptions(0, 10);
+                        var subscriptions = await restoredStore.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                         Assert.Equal(2, subscriptions.Count);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_13293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13293.cs
@@ -165,8 +165,8 @@ namespace SlowTests.Issues
                     };
 
                     dbs.Add(name);
-                    var restoreBackupTask = store.Maintenance.Server.Send(new RestoreBackupOperation(restoreConfig, myBackup.NodeTag));
-                    restoreBackupTask.WaitForCompletion(TimeSpan.FromSeconds(30));
+                    var restoreBackupTask = await store.Maintenance.Server.SendAsync(new RestoreBackupOperation(restoreConfig, myBackup.NodeTag));
+                    await restoreBackupTask.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
                 }
                 var dbNames = await store.Maintenance.Server.SendAsync(new GetDatabaseNamesOperation(0, int.MaxValue));
                 Assert.Equal(clusterSize + 1, dbNames.Length);

--- a/test/SlowTests.Issues/Issues/RavenDB_13363.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13363.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_13457.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13457.cs
@@ -101,7 +101,7 @@ namespace SlowTests.Issues
 
 
                 // now, we modify the values and make sure that we received them
-                store.Maintenance.Server.Send(new PutServerWideClientConfigurationOperation(new ClientConfiguration
+                await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(new ClientConfiguration
                 {
                     MaxNumberOfRequestsPerSession = 10, ReadBalanceBehavior = Raven.Client.Http.ReadBalanceBehavior.None
                 }));
@@ -146,7 +146,7 @@ namespace SlowTests.Issues
 
                 // now we want to disable the client configuration and use the "default" ones
 
-                store.Maintenance.Server.Send(new PutServerWideClientConfigurationOperation(new ClientConfiguration
+                await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(new ClientConfiguration
                 {
                     MaxNumberOfRequestsPerSession = 10, ReadBalanceBehavior = Raven.Client.Http.ReadBalanceBehavior.None, Disabled = true
                 }));

--- a/test/SlowTests.Issues/Issues/RavenDB_13478.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13478.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>
                 {
                     Includes = builder => builder
                         .IncludeCounter("Likes")
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
 
                 await AssertSubscription(store, name, 0);
 
-                name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>
                 {
                     Includes = builder => builder
                         .IncludeAllCounters()
@@ -51,7 +51,7 @@ namespace SlowTests.Issues
 
                 await AssertSubscription(store, name, 0);
 
-                name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>
                 {
                     Includes = builder => builder
                         .IncludeCounter("Likes")
@@ -59,7 +59,7 @@ namespace SlowTests.Issues
 
                 await AssertSubscription(store, name, 1);
 
-                name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>());
+                name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>());
 
                 await AssertSubscription(store, name, 2);
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_13490.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13490.cs
@@ -56,7 +56,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                new MapReduce_WithOutput().Execute(store);
+                await new MapReduce_WithOutput().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -68,7 +68,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 string artificialDocumentId = null;
 
@@ -157,7 +157,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                new MapReduce_WithOutput().Execute(store);
+                await new MapReduce_WithOutput().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -169,7 +169,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 string artificialDocumentId = null;
 

--- a/test/SlowTests.Issues/Issues/RavenDB_13644.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13644.cs
@@ -1179,9 +1179,9 @@ namespace SlowTests.Issues
             {
                 var index = new TimeSeries_Index_With_CompareExchange();
                 var indexName = index.IndexName;
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
 
@@ -1286,7 +1286,7 @@ namespace SlowTests.Issues
                 
                 store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_13709.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13709.cs
@@ -34,13 +34,13 @@ namespace SlowTests.Issues
                     include Company").ToListAsync();
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
-                    operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                    await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                     var fileInfo = new FileInfo(file);
                     Assert.True(fileInfo.Exists);
 
                     operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                    operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                    await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_13759.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13759.cs
@@ -31,14 +31,14 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(new Options { Path = path }))
             {
                 var index = new Orders_ByOrderBy();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
 
                 Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion, indexInstance1.Definition.Version);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var indexTimeFields = indexInstance1._indexStorage.ReadIndexTimeFields();
                 Assert.Empty(indexTimeFields);
@@ -51,7 +51,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 indexTimeFields = indexInstance1._indexStorage.ReadIndexTimeFields();
                 Assert.Equal(1, indexTimeFields.Count);
@@ -65,7 +65,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 indexTimeFields = indexInstance1._indexStorage.ReadIndexTimeFields();
                 Assert.Equal(2, indexTimeFields.Count);
@@ -101,7 +101,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false, Path = databasePath }))
             {
                 databaseName = store.Database;
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -110,7 +110,7 @@ namespace SlowTests.Issues
                         .ToList();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 indexStoragePath1 = database.IndexStore.GetIndex(index.IndexName)._environment.Options.BasePath.FullPath;
@@ -137,7 +137,7 @@ namespace SlowTests.Issues
             {
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
                 var indexInstance2 = database.IndexStore.GetIndex("Auto/Orders/ByOrderedAt");
@@ -160,8 +160,8 @@ namespace SlowTests.Issues
                 Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.BaseVersion, indexInstance1.Definition.Version);
                 Assert.Equal(IndexDefinitionBaseServerSide.IndexVersion.BaseVersion, indexInstance2.Definition.Version);
 
-                store.Maintenance.Send(new ResetIndexOperation(index.IndexName));
-                store.Maintenance.Send(new ResetIndexOperation("Auto/Orders/ByOrderedAt"));
+                await store.Maintenance.SendAsync(new ResetIndexOperation(index.IndexName));
+                await store.Maintenance.SendAsync(new ResetIndexOperation("Auto/Orders/ByOrderedAt"));
 
                 indexInstance1 = database.IndexStore.GetIndex(index.IndexName);
                 indexInstance2 = database.IndexStore.GetIndex("Auto/Orders/ByOrderedAt");

--- a/test/SlowTests.Issues/Issues/RavenDB_13866.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13866.cs
@@ -22,7 +22,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                store.ExecuteIndex(new TestIndex());
+                await store.ExecuteIndexAsync(new TestIndex());
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_13868.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13868.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var subsId = store.Subscriptions.Create(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions()
+                var subsId = await store.Subscriptions.CreateAsync(new Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions()
                 {
                     Query = @"from orders as o where o.Employee=='zzz'"
                 });

--- a/test/SlowTests.Issues/Issues/RavenDB_13972.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13972.cs
@@ -252,7 +252,7 @@ namespace SlowTests.Issues
 
             await new Users_ByName().ExecuteAsync(store);
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB_14235.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14235.cs
@@ -151,7 +151,7 @@ namespace SlowTests.Issues
                 str += new string(Enumerable.Repeat(abc, partialSize).Select(s => s[random.Next(s.Length)]).ToArray());
 
                 using var store = GetDocumentStore();
-                store.Commands().Put(str, null, new { WeirdName = str }, new Dictionary<string, object>
+                await store.Commands().PutAsync(str, null, new { WeirdName = str }, new Dictionary<string, object>
                 {
                     { "@collection", str }
                 });

--- a/test/SlowTests.Issues/Issues/RavenDB_14619.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14619.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocsIndex().Execute(store);
+                await new DocsIndex().ExecuteAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new Doc { Id = "doc-1", StrVal = "test", StrValSecondary = "test", Type = "1", NumVal = 1 });
@@ -31,7 +31,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_14641.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14641.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Issues
         private async Task IndexStartupBehaviorTestInternal(DocumentStore store)
         {
             var index = new Companies_ByName();
-            index.Execute(store);
+            await index.ExecuteAsync(store);
 
             string autoIndexName = null;
 
@@ -58,7 +58,7 @@ namespace SlowTests.Issues
                 autoIndexName = stats.IndexName;
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             var database = await Databases.GetDocumentDatabaseInstanceFor(store);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_14687.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14687.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Issues
                    }))
             {
                 var index = new MyJSIndex(maxStepsForScript: null);
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
 
@@ -43,9 +43,9 @@ namespace SlowTests.Issues
 
                 const int maxStepsForScript = 1000;
                 index = new MyJSIndex(maxStepsForScript);
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var indexInstance2 = (MapIndex)database.IndexStore.GetIndex(index.IndexName);
                 var compiled2 = (JavaScriptIndex)indexInstance2._compiled;
@@ -62,7 +62,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_14826.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14826.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Employees_HeartBeat();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 RavenTestHelper.AssertNoIndexErrors(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(index.IndexName));
@@ -59,7 +59,7 @@ namespace SlowTests.Issues
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), store.Smuggler.ForDatabase(databaseName));
                     await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-                    Indexes.WaitForIndexing(store, databaseName);
+                    await Indexes.WaitForIndexingAsync(store, databaseName);
                     RavenTestHelper.AssertNoIndexErrors(store, databaseName);
 
                     staleness = store.Maintenance.ForDatabase(databaseName).Send(new GetIndexStalenessOperation(index.IndexName));

--- a/test/SlowTests.Issues/Issues/RavenDB_14881.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14881.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Issues
                 {
                     for (var i = 0; i < 20; i++)
                     {
-                        bulk.Store(new Company
+                        await bulk.StoreAsync(new Company
                         {
                             Id = "company/" + i,
                             Name = Convert.ToBase64String(Sodium.GenerateRandomBuffer(128 * 8))

--- a/test/SlowTests.Issues/Issues/RavenDB_14932.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14932.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Issues
                 await TimeSeries.VerifyPolicyExecutionAsync(store, config.Collections["Users"], 2, policies: new List<TimeSeriesPolicy> { p3 });
                 await TimeSeries.VerifyPolicyExecutionAsync(store, config.Collections["Users"], 3, policies: new List<TimeSeriesPolicy> { p4 });
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 RavenTestHelper.AssertNoIndexErrors(store);
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests.Issues/Issues/RavenDB_15240.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15240.cs
@@ -23,8 +23,8 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new MyTsIndex().Execute(store);
-                new MyCounterIndex().Execute(store);
+                await new MyTsIndex().ExecuteAsync(store);
+                await new MyCounterIndex().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
 
@@ -56,7 +56,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 state = tombstoneCleaner.GetState().Tombstones;
 
@@ -72,7 +72,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 WaitForValue(() =>
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_15460.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15460.cs
@@ -148,7 +148,7 @@ namespace SlowTests.Issues
             Assert.Equal(IndexPriority.Low, indexStats.Priority);
 
             index.Priority = IndexPriority.High;
-            index.Execute(store);
+            await index.ExecuteAsync(store);
 
             indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
             indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));
@@ -157,7 +157,7 @@ namespace SlowTests.Issues
             Assert.Equal(IndexPriority.High, indexStats.Priority);
 
             index.Priority = IndexPriority.Low;
-            store.ExecuteIndex(index);
+            await store.ExecuteIndexAsync(index);
 
             indexDefinition = await store.Maintenance.SendAsync(new GetIndexOperation(index.IndexName));
             indexStats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.IndexName));

--- a/test/SlowTests.Issues/Issues/RavenDB_15700.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15700.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Issues
             {
                 SetupData(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var searchedVakanzId = "Vakanz/89d3d971-a227-430e-97ba-613799253a37";
 

--- a/test/SlowTests.Issues/Issues/RavenDB_15746.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15746.cs
@@ -71,7 +71,7 @@ namespace SlowTests.Issues
                 await index.ExecuteAsync(store);
 
                 // should index all documents regardless throttling set to 1 hour
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromSeconds(30));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromSeconds(30));
             }
         }
 
@@ -104,7 +104,7 @@ namespace SlowTests.Issues
 
                 var indexingDuration = Stopwatch.StartNew();
                 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 indexingDuration.Stop();
 
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
 
                 indexingDuration.Restart();
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 indexingDuration.Stop();
 

--- a/test/SlowTests.Issues/Issues/RavenDB_15825.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15825.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_15944.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15944.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession(databaseName))
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_15988.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15988.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 RavenTestHelper.AssertNoIndexErrors(store);
 
                 var terms = await store.Maintenance.SendAsync(new GetTermsOperation(new TestIndex().IndexName, "IndexFirst", null));

--- a/test/SlowTests.Issues/Issues/RavenDB_16147.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16147.cs
@@ -27,10 +27,10 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(store.Database);
 
                 var index1 = new Index_Without_Overriden_Analyzers();
-                index1.Execute(store);
+                await index1.ExecuteAsync(store);
 
                 var index2 = new Index_With_Overriden_Analyzers();
-                index2.Execute(store);
+                await index2.ExecuteAsync(store);
 
                 var index1Instance = database.IndexStore.GetIndex(index1.IndexName);
                 Assert.Equal(database.Configuration.Indexing.DefaultAnalyzer, index1Instance.Configuration.DefaultAnalyzer);
@@ -97,10 +97,10 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(store.Database);
 
                 var index1 = new Index_Without_Overriden_Analyzers();
-                index1.Execute(store);
+                await index1.ExecuteAsync(store);
 
                 var index2 = new Index_With_Overriden_Analyzers();
-                index2.Execute(store);
+                await index2.ExecuteAsync(store);
 
                 var index1Instance = database.IndexStore.GetIndex(index1.IndexName);
                 Assert.Equal(database.Configuration.Indexing.DefaultAnalyzer, index1Instance.Configuration.DefaultAnalyzer);
@@ -170,10 +170,10 @@ namespace SlowTests.Issues
                 var database = await GetDatabase(store.Database);
 
                 var index1 = new Index_Without_Overriden_Analyzers();
-                index1.Execute(store);
+                await index1.ExecuteAsync(store);
 
                 var index2 = new Index_With_Overriden_Analyzers();
-                index2.Execute(store);
+                await index2.ExecuteAsync(store);
 
                 var index1Instance = database.IndexStore.GetIndex(index1.IndexName);
                 Assert.Equal(database.Configuration.Indexing.DefaultAnalyzer, index1Instance.Configuration.DefaultAnalyzer);

--- a/test/SlowTests.Issues/Issues/RavenDB_16262.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16262.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>
                 {
                     Includes = builder => builder
                         .IncludeCounter("Likes")

--- a/test/SlowTests.Issues/Issues/RavenDB_16336.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16336.cs
@@ -84,7 +84,7 @@ namespace SlowTests.Issues
                     stats = aggregator.ToBatchPerformanceStats();
                     amre.Set();
                 };
-                var name = store.Subscriptions.Create(new SubscriptionCreationOptions<Product>
+                var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Product>
                 {
                     Includes = builder => builder
                         .IncludeCounter(counter1)

--- a/test/SlowTests.Issues/Issues/RavenDB_16353.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16353.cs
@@ -67,7 +67,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplierNoTracking.IndexName, "Name", fromValue: null));
                 Assert.Equal(1, terms.Length);
@@ -85,7 +85,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 terms = await store.Maintenance.SendAsync(new GetTermsOperation(productsBySupplierNoTracking.IndexName, "Name", fromValue: null));
                 Assert.Equal(1, terms.Length);

--- a/test/SlowTests.Issues/Issues/RavenDB_16378.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16378.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                new Users_ByName_Count().Execute(store);
+                await new Users_ByName_Count().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
 
                 using (var session = store.OpenSession())
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var backupPath = NewDataPath(suffix: "BackupFolder");
                 var config = Backup.CreateBackupConfiguration(backupPath);
@@ -74,7 +74,7 @@ namespace SlowTests.Issues
                 };
 
                 RestoreBackupOperation restoreOperation = new RestoreBackupOperation(config2);
-                await store.Maintenance.Server.Send(restoreOperation)
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
                     .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var storeOfRestoredDb = GetDocumentStore(new Options() { CreateDatabase = false, ModifyDatabaseName = s => databaseName }))
@@ -157,7 +157,7 @@ namespace SlowTests.Issues
                 };
 
                 RestoreBackupOperation restoreOperation = new RestoreBackupOperation(config2);
-                await store.Maintenance.Server.Send(restoreOperation)
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
                     .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var storeOfRestoredDb = GetDocumentStore(new Options() { CreateDatabase = false, ModifyDatabaseName = s => databaseName }))

--- a/test/SlowTests.Issues/Issues/RavenDB_16378_Replication_NRE.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16378_Replication_NRE.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Issues
 
                 using (var stream = typeof(RavenDB_16378).Assembly.GetManifestResourceStream("SlowTests.Data.RavenDB_16378.RavenDB-16401-NRE.ravendb-snapshot"))
                 {
-                    stream.CopyTo(file);
+                    await stream.CopyToAsync(file);
                 }
             }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_16726.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16726.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
 
                 await index.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var notificationsQueue = new AsyncQueue<DynamicJsonValue>();
 
@@ -62,7 +62,7 @@ namespace SlowTests.Issues
                         session.SaveChanges();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     Tuple<bool, DynamicJsonValue> performanceHint;
 
@@ -107,7 +107,7 @@ namespace SlowTests.Issues
                         session.SaveChanges();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     db.NotificationCenter.Indexing.UpdateIndexing(null);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_16808.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16808.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Issues
 
             using (IAsyncDocumentSession session = store.OpenAsyncSession())
             {
-                using (store.AggressivelyCacheFor(TimeSpan.MaxValue, AggressiveCacheMode.DoNotTrackChanges))
+                using (await store.AggressivelyCacheForAsync(TimeSpan.MaxValue, AggressiveCacheMode.DoNotTrackChanges))
                 {
                     long reBefore = requestExecutor.NumberOfServerRequests;
                     int sessionBefore = session.Advanced.NumberOfRequests;

--- a/test/SlowTests.Issues/Issues/RavenDB_17237.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_17237.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Issues
 
                 await indexDef.ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
 
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(TimeSpan.FromSeconds(1), index._mre.ThrottlingInterval);
                 Assert.NotNull(index._mre._timerTask);
@@ -57,7 +57,7 @@ namespace SlowTests.Issues
 
                 // update index def
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var updatedIndexDef = new Orders_ByOrderedAtAndShippedAt(storeFields: true)
                 {
@@ -76,8 +76,8 @@ namespace SlowTests.Issues
                     mre.WaitOne(TimeSpan.FromMinutes(1));
                 }))
                 {
-                    store.Maintenance.Send(new StartIndexingOperation());
-                    Indexes.WaitForIndexing(store);
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
+                    await Indexes.WaitForIndexingAsync(store);
                 }
 
                 try
@@ -97,7 +97,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
             }
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_17260.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_17260.cs
@@ -30,14 +30,14 @@ public class RavenDB_17260 : RavenTestBase
             var indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Foo");
             await indexToCreate.ExecuteAsync(store);
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Bar");
             await indexToCreate.ExecuteAsync(store);
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
-            store.Maintenance.Send(new StopIndexingOperation());
+            await store.Maintenance.SendAsync(new StopIndexingOperation());
 
             indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "Baz");
             await indexToCreate.ExecuteAsync(store);

--- a/test/SlowTests.Issues/Issues/RavenDB_17423.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_17423.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Issues
                 await session.StoreAsync(new Location { Id = $"locations/{i}" });
                 identifiers.Add( $"locations/{i}");
                 await session.SaveChangesAsync();
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
     
                 var ravenQueryable = session
                     .Query<SearchIndex.Entry, SearchIndex>()

--- a/test/SlowTests.Issues/Issues/RavenDB_18938.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_18938.cs
@@ -36,7 +36,7 @@ public class RavenDB_18938 : RavenTestBase
 
         var index = new TIndex();
         await index.ExecuteAsync(store);
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         Tuple<bool, DynamicJsonValue> performanceHint;
 

--- a/test/SlowTests.Issues/Issues/RavenDB_19525.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_19525.cs
@@ -35,7 +35,7 @@ public class RavenDB_19525 : RavenTestBase
             session.SaveChanges();
         }
 
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
         var indexes = await store.Maintenance.SendAsync(new GetIndexErrorsOperation());
         Assert.DoesNotContain(indexes, idx => idx.Errors.Any());
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_19557.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_19557.cs
@@ -61,7 +61,7 @@ public class RavenDB_19557 : RavenTestBase
             await session.SaveChangesAsync();
         }
 
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
         using (var session = store.OpenAsyncSession())
         {
             var query = from r in session.Query<Index.Result, Index>()

--- a/test/SlowTests.Issues/Issues/RavenDB_1962.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_1962.cs
@@ -75,7 +75,7 @@ namespace SlowTests.Issues
                     await StoreDataAsync(store, session);
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_20059.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_20059.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Issues
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void CanModifyGlobalObjectUsingEtlTransformScriptWithDeleteDocumentsBehaviorFunction(Options options)
+        public async Task CanModifyGlobalObjectUsingEtlTransformScriptWithDeleteDocumentsBehaviorFunction(Options options)
         {
             using (var srcStore = GetDocumentStore(options))
             using (var destStore = GetDocumentStore())
@@ -37,7 +37,7 @@ function deleteDocumentsOfContractsBehavior(docId) {
 
                     session.SaveChanges();
                 }
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = destStore.OpenSession())
                 {
@@ -53,7 +53,7 @@ function deleteDocumentsOfContractsBehavior(docId) {
                 }
 
                 etlDone = Etl.WaitForEtlToComplete(srcStore);
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = destStore.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_20987.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_20987.cs
@@ -251,7 +251,7 @@ namespace SlowTests.Issues
                 }
                 finally
                 {
-                    cts.Cancel();
+                    await cts.CancelAsync();
                 }
 
                 await Task.WhenAll(t1, t2, t3);

--- a/test/SlowTests.Issues/Issues/RavenDB_21233.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21233.cs
@@ -102,13 +102,13 @@ select new
                  */
 
                 await store.Maintenance.SendAsync(new PutIndexesOperation(_indexDefinition));
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 options.IgnoreMaxStepsForScript = true;
                 operation = await store.Operations.SendAsync(new PatchByQueryOperation(q2, options));
                 await operation.WaitForCompletionAsync();
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 /*
                  * Execute the script q2 (static index query) with a greater number of steps than the default configuration

--- a/test/SlowTests.Issues/Issues/RavenDB_21525.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21525.cs
@@ -26,7 +26,7 @@ public class RavenDB_21525 : RavenTestBase
             {
                 for (int i = 0; i < size; ++i)
                 {
-                    bulkInsert.Store(new Person() { Name = $"ItemNo{i}", Age = i % 100, Height = i % 200 });
+                    await bulkInsert.StoreAsync(new Person() { Name = $"ItemNo{i}", Age = i % 100, Height = i % 200 });
                 }
             }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_21683.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21683.cs
@@ -33,7 +33,7 @@ public class RavenDB_21683 : RavenTestBase
             var indexDefinition = index.CreateIndexDefinition();
 
             await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             await WaitForIndexCountAsync(store, 1);
 
             using (var session = store.OpenAsyncSession())
@@ -47,7 +47,7 @@ public class RavenDB_21683 : RavenTestBase
                 indexDefinition.Configuration[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeForDocumentTransactionToRemainOpen)] = "10";
 
                 await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await WaitForIndexCountAsync(store, 1);
 
                 await session
@@ -61,7 +61,7 @@ public class RavenDB_21683 : RavenTestBase
                 indexDefinition.Configuration[RavenConfiguration.GetKey(x => x.Indexing.IndexEmptyEntries)] = "true";
 
                 await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await WaitForIndexCountAsync(store, 1);
 
                 await session

--- a/test/SlowTests.Issues/Issues/RavenDB_2209.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_2209.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                using (store.AggressivelyCache())
+                using (await store.AggressivelyCacheAsync())
                 {
                     // make sure that object is cached
                     using (var session = store.OpenSession())

--- a/test/SlowTests.Issues/Issues/RavenDB_22128.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22128.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Documents;
@@ -20,7 +21,7 @@ namespace SlowTests.Issues
         private const string TsName = "HeartRate";
 
         [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Etl)]
-        public void TimeSeriesEtlShouldSkipIncrementalTsBasingOnUpperCasedIncPrefix()
+        public async Task TimeSeriesEtlShouldSkipIncrementalTsBasingOnUpperCasedIncPrefix()
         {
             var collections = new List<string> { "Users" };
 
@@ -50,7 +51,7 @@ namespace SlowTests.Issues
                 session.SaveChanges();
             }
 
-            Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
             using (var session = dest.OpenSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB_22253.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22253.cs
@@ -22,7 +22,7 @@ public class RavenDB_22253 : RavenTestBase
     {
         using var store = GetDocumentStore();
 
-        store.ExecuteIndex(new PupilsIndex());
+        await store.ExecuteIndexAsync(new PupilsIndex());
 
         var tasks = new List<Task>();
         var failures = new ConcurrentSet<string>();

--- a/test/SlowTests.Issues/Issues/RavenDB_22750.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22750.cs
@@ -23,7 +23,7 @@ public class RavenDB_22750 : RavenTestBase
         {
             await new Companies_ByEmployeeLastName().ExecuteAsync(store);
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB_23132.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_23132.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
                 await store.Maintenance.SendAsync(new PutIndexesOperation(index));
 
                 
-                Indexes.WaitForIndexing(store, allowErrors: true);
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true);
 
                 var collectionStats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
                
@@ -73,7 +73,7 @@ namespace SlowTests.Issues
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store, allowErrors: true);
+                await Indexes.WaitForIndexingAsync(store, allowErrors: true);
 
                 collectionStats = await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation());
 

--- a/test/SlowTests.Issues/Issues/RavenDB_24613.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_24613.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Server.Documents.ETL.Providers.AI;
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.ETL.Providers.AI;
 using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
 using Tests.Infrastructure;
 using Xunit;
@@ -9,7 +10,7 @@ namespace SlowTests.Issues;
 public class RavenDB_24613_MultipleEmbeddingsGenerateCalls(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Ai)]
-    public void MultipleEmbeddingsGenerateCallsShouldCreateAllEmbeddings()
+    public async Task MultipleEmbeddingsGenerateCallsShouldCreateAllEmbeddings()
     {
         using var store = GetDocumentStore();
 
@@ -49,7 +50,7 @@ public class RavenDB_24613_MultipleEmbeddingsGenerateCalls(ITestOutputHelper out
 
         var (config, connection) = AddEmbeddingsGenerationTask(store, script: script, collectionName: "TestDocuments");
 
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
         var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
         var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connection.Identifier);

--- a/test/SlowTests.Issues/Issues/RavenDB_2877.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_2877.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new PersonsIndex().Execute(store);
+                await new PersonsIndex().ExecuteAsync(store);
 
                 //store.Conventions.MaxLengthOfQueryUsingGetUrl = 32;
                 var offices = Enumerable.Range(1, 20).Select(x => new Office { FacilityName = "Main Offices", OfficeNumber = x });

--- a/test/SlowTests.Issues/Issues/RavenDB_2955.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_2955.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(1, autoIndexes.Count);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_3232.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_3232.cs
@@ -156,7 +156,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.Maintenance.SendAsync(new StopIndexingOperation());
 
@@ -186,7 +186,7 @@ namespace SlowTests.Issues
 
                 await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.True(await amre.WaitAsync(TimeSpan.FromSeconds(15)));
 

--- a/test/SlowTests.Issues/Issues/RavenDB_4110.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_4110.cs
@@ -67,11 +67,11 @@ namespace SlowTests.Issues
                 var index = new People_ByName();
                 await index.ExecuteAsync(store);
 
-                store.Maintenance.Send(new SetIndexesLockOperation(index.IndexName, IndexLockMode.LockedError));
+                await store.Maintenance.SendAsync(new SetIndexesLockOperation(index.IndexName, IndexLockMode.LockedError));
 
                 await index.ExecuteAsync(store);
 
-                store.Maintenance.Send(new SetIndexesLockOperation(index.IndexName, IndexLockMode.Unlock));
+                await store.Maintenance.SendAsync(new SetIndexesLockOperation(index.IndexName, IndexLockMode.Unlock));
 
                 var definition = index.CreateIndexDefinition();
                 definition.LockMode = IndexLockMode.LockedError;
@@ -81,7 +81,7 @@ namespace SlowTests.Issues
                 };
                 store.Maintenance.Send(new PutIndexesOperation(definition));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var c = await Assert.ThrowsAsync<IndexCreationException>(() => index.ExecuteAsync(store));
                 Assert.Contains("IndexAlreadyExistException", c.Message);

--- a/test/SlowTests.Issues/Issues/RavenDB_5435.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_5435.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
                 Path = path
             }))
             {
-                new Users_ByName().Execute(store);
+                await new Users_ByName().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -54,9 +54,9 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                var operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings
+                var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(new CompactSettings
                 {
                     DatabaseName = store.Database,
                     Documents = true,

--- a/test/SlowTests.Issues/Issues/RavenDB_5489.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_5489.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore())
             {
-                new Users_ByName().Execute(store);
+                await new Users_ByName().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(IndexState.Normal, store.Maintenance.Send(new GetStatisticsOperation()).Indexes[0].State);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_5919.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_5919.cs
@@ -115,18 +115,18 @@ namespace SlowTests.Issues
         {
             using (var documentStore = GetDocumentStore())
             {
-                new Entity_ById_V1().Execute(documentStore);
+                await new Entity_ById_V1().ExecuteAsync(documentStore);
 
-                documentStore.Maintenance.Send(new StopIndexingOperation());
+                await documentStore.Maintenance.SendAsync(new StopIndexingOperation());
 
-                new Entity_ById_V2().Execute(documentStore);
+                await new Entity_ById_V2().ExecuteAsync(documentStore);
 
                 var index = $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}Entity/ById";
                 var index1 = documentStore.Maintenance.Send(new GetIndexOperation(index));
 
                 var indexInstance1 = (await Databases.GetDocumentDatabaseInstanceFor(documentStore)).IndexStore.GetIndex(index);
 
-                new Entity_ById_V2().Execute(documentStore);
+                await new Entity_ById_V2().ExecuteAsync(documentStore);
 
                 var indexInstance2 = (await Databases.GetDocumentDatabaseInstanceFor(documentStore)).IndexStore.GetIndex(index);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_6131.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_6131.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Issues
             }))
             {
                 var index = new SimpleIndex();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                 Assert.Equal(path1, database.Configuration.Core.DataDirectory.FullPath);
@@ -85,7 +85,7 @@ namespace SlowTests.Issues
                 }))
                 {
                     var index = new SimpleIndex();
-                    index.Execute(store);
+                    await index.ExecuteAsync(store);
 
                     var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                     Assert.Equal(path1, database.Configuration.Core.DataDirectory.FullPath);

--- a/test/SlowTests.Issues/Issues/RavenDB_6199.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_6199.cs
@@ -97,7 +97,7 @@ namespace SlowTests.Issues
                     definition.Name = index.IndexName;
                     store.Maintenance.Send(new PutIndexesOperation(new[] { definition }));
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     // we might have other notifications like StatsChanged
                     Assert.True(WaitForValue(() => notificationsQueue.Count > 0, true, interval: 100));

--- a/test/SlowTests.Issues/Issues/RavenDB_6292.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_6292.cs
@@ -68,7 +68,7 @@ namespace SlowTests.Issues
 
                     using (var commands = store2.Commands())
                     {
-                        var qr = commands.Query(iq);
+                        var qr = await commands.QueryAsync(iq);
 
                         var address = (BlittableJsonReaderObject)qr.Includes["addresses/1"];
                         var metadata = address.GetMetadata();
@@ -92,7 +92,7 @@ namespace SlowTests.Issues
                     {
                         var command = new GetDocumentsCommand(commands.RequestExecutor.Conventions, "users/1$addresses/1", includes: new[] { "AddressId" }, metadataOnly: false);
 
-                        commands.RequestExecutor.Execute(command, commands.Context);
+                        await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
 
                         var address = (BlittableJsonReaderObject)command.Result.Includes["addresses/1"];
                         var metadata = address.GetMetadata();

--- a/test/SlowTests.Issues/Issues/RavenDB_6967.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_6967.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
                 store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition { Name = "Index2", Maps = { "from doc in docs let x = 0 select new { Total = 4/x };" } } }));
                 store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition { Name = "Index3", Maps = { "from doc in docs let x = 0 select new { Total = 5/x };" } } }));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
 

--- a/test/SlowTests.Issues/Issues/RavenDB_7498.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_7498.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Issues
                 {
                     using (var session = store.OpenSession())
                     {
-                        using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+                        using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
                         {
                             session.Load<User>("users/not-there");
 
@@ -82,7 +82,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(oldNumOfRequests + 1, requestExecutor.NumberOfServerRequests);
 
-                backgroundUpdatesCts.Cancel();
+                await backgroundUpdatesCts.CancelAsync();
 
                 await backgroundUpdatesTask.WaitAsync(TimeSpan.FromMinutes(1));
             }
@@ -120,7 +120,7 @@ namespace SlowTests.Issues
                 {
                     using (var session = store.OpenSession())
                     {
-                        using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+                        using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
                         {
                             session.Load<User>("users/1-A");
 
@@ -133,7 +133,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(oldNumOfRequests + 1, requestExecutor.NumberOfServerRequests);
 
-                backgroundUpdatesCts.Cancel();
+                await backgroundUpdatesCts.CancelAsync();
 
                 await backgroundUpdatesTask.WaitAsync(TimeSpan.FromMinutes(1));
             }
@@ -171,7 +171,7 @@ namespace SlowTests.Issues
                 {
                     using (var session = store.OpenAsyncSession())
                     {
-                        using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+                        using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
                         {
                             await session.LoadAsync<User>("users/1");
 
@@ -183,7 +183,7 @@ namespace SlowTests.Issues
                 }
                 Assert.Equal(oldNumOfRequests + 1, requestExecutor.NumberOfServerRequests);
 
-                backgroundUpdatesCts.Cancel();
+                await backgroundUpdatesCts.CancelAsync();
 
                 await backgroundUpdatesTask;
             }
@@ -222,7 +222,7 @@ namespace SlowTests.Issues
                 {
                     using (var session = store.OpenSession())
                     {
-                        using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+                        using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
                         {
                             session.Query<User>().ToList();
                         }
@@ -230,7 +230,7 @@ namespace SlowTests.Issues
                 }
                 Assert.Equal(oldNumOfRequests + 1, requestExecutor.NumberOfServerRequests);
 
-                backgroundUpdatesCts.Cancel();
+                await backgroundUpdatesCts.CancelAsync();
 
                 await backgroundUpdatesTask.WaitAsync(TimeSpan.FromMinutes(1));
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_7940.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_7940.cs
@@ -53,7 +53,7 @@ namespace SlowTests.Issues
             }))
             {
                 var index = new Person_ByName_1();
-                store.ExecuteIndex(index);
+                await store.ExecuteIndexAsync(index);
 
                 var indexes = await store.Maintenance.SendAsync(new GetIndexesOperation(0, 128));
                 Assert.True(indexes.Length > 0);

--- a/test/SlowTests.Issues/Issues/RavenDB_9096.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_9096.cs
@@ -55,14 +55,14 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(options))
             {
-                new DocIndex().Execute(store);
+                await new DocIndex().ExecuteAsync(store);
 
                 if (await ShouldInitData(store))
                 {
                     await InitializeData(store);
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_9481.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_9481.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
                 {
                     await InitializeData(store);
                 }
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDB_9553.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_9553.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                new Users_ByName().Execute(store);
+                await new Users_ByName().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -52,9 +52,9 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                var operation = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings
+                var operation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(new CompactSettings
                 {
                     DatabaseName = store.Database,
                     Documents = true,

--- a/test/SlowTests.Issues/Issues/RavenDB_9680.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_9680.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await (await GetDatabase(store.Database)).TombstoneCleaner.ExecuteCleanup(); // will delete users/1 tombstone
 
@@ -65,11 +65,11 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 
                 using (var commands = store.Commands())
                 {
-                    var result = commands.Query(new IndexQuery { Query = $"from index '{indexName}'" }, indexEntriesOnly: true);
+                    var result = await commands.QueryAsync(new IndexQuery { Query = $"from index '{indexName}'" }, indexEntriesOnly: true);
 
                     Assert.Equal(0, result.Results.Length);
                 }

--- a/test/SlowTests.Issues/Issues/RavenDB_9895.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_9895.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
                 {
                     await InitializeData(store);
                 }
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {                    
 

--- a/test/SlowTests.Issues/Issues/RavenDb1962.cs
+++ b/test/SlowTests.Issues/Issues/RavenDb1962.cs
@@ -75,7 +75,7 @@ namespace SlowTests.Issues
                     await StoreDataAsync(store, session);
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RavenDb4583.cs
+++ b/test/SlowTests.Issues/Issues/RavenDb4583.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Issues
 
             using (var store = GetDocumentStore(options))
             {
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationEncryptionTests.cs
@@ -46,9 +46,9 @@ namespace SlowTests.Authentication
                 Path = NewDataPath()
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation(Raven.Client.Documents.Smuggler.DatabaseItemType.Documents | Raven.Client.Documents.Smuggler.DatabaseItemType.Indexes));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(Raven.Client.Documents.Smuggler.DatabaseItemType.Documents | Raven.Client.Documents.Smuggler.DatabaseItemType.Indexes));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var file = GetTempFileName();
                 var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
@@ -56,24 +56,24 @@ namespace SlowTests.Authentication
 
                 using (var commands = store.Commands())
                 {
-                    var result = commands.Query(new IndexQuery
+                    var result = await commands.QueryAsync(new IndexQuery
                     {
                         Query = "FROM @all_docs",
                         WaitForNonStaleResults = true
                     });
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     Assert.True(result.Results.Length > 1000);
 
-                    QueryResult queryResult = store.Commands().Query(new IndexQuery
+                    QueryResult queryResult = await store.Commands().QueryAsync(new IndexQuery
                     {
                         Query = "FROM INDEX 'Orders/ByCompany'"
                     });
-                    QueryResult queryResult2 = store.Commands().Query(new IndexQuery
+                    QueryResult queryResult2 = await store.Commands().QueryAsync(new IndexQuery
                     {
                         Query = "FROM INDEX 'Orders/Totals'"
                     });
-                    QueryResult queryResult3 = store.Commands().Query(new IndexQuery
+                    QueryResult queryResult3 = await store.Commands().QueryAsync(new IndexQuery
                     {
                         Query = "FROM INDEX 'Product/Search'"
                     });
@@ -128,7 +128,7 @@ namespace SlowTests.Authentication
                 Path = NewDataPath()
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation(operateOnTypes: DatabaseSmugglerOptions.DefaultOperateOnTypes));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: DatabaseSmugglerOptions.DefaultOperateOnTypes));
 
                 using (var commands = store.Commands())
                 {
@@ -139,7 +139,7 @@ namespace SlowTests.Authentication
                         WaitForNonStaleResults = true
                     });
 
-                    commands.RequestExecutor.Execute(command, commands.Context);
+                    await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
 
                     // create auto map reduce index
                     command = new QueryCommand(commands.Session, new IndexQuery
@@ -148,18 +148,18 @@ namespace SlowTests.Authentication
                         WaitForNonStaleResults = true
                     });
 
-                    commands.RequestExecutor.Execute(command, commands.Context);
+                    await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
 
                     var indexDefinitions = store.Maintenance.Send(new GetIndexesOperation(0, 10));
 
                     Assert.Equal(9, indexDefinitions.Length); // 6 sample data indexes + 2 new dynamic indexes
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     // perform a query per index
                     foreach (var indexDef in indexDefinitions)
                     {
-                        QueryResult queryResult = store.Commands().Query(new IndexQuery
+                        QueryResult queryResult = await store.Commands().QueryAsync(new IndexQuery
                         {
                             Query = $"FROM INDEX '{indexDef.Name}'"
                         });
@@ -174,7 +174,7 @@ namespace SlowTests.Authentication
                     // perform a query per index
                     foreach (var indexDef in indexDefinitions)
                     {
-                        QueryResult queryResult = store.Commands().Query(new IndexQuery
+                        QueryResult queryResult = await store.Commands().QueryAsync(new IndexQuery
                         {
                             Query = $"FROM INDEX '{indexDef.Name}'"
                         });
@@ -244,14 +244,14 @@ namespace SlowTests.Authentication
                     }
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var deleteOperation = await store.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery() { Query = "FROM orders" }));
                 await deleteOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
                 var oldSize = StorageCompactionTestsSlow.GetDirSize(new DirectoryInfo(path));
 
-                var compactOperation = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings
+                var compactOperation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(new CompactSettings
                 {
                     DatabaseName = store.Database,
                     Documents = true,

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -274,7 +274,7 @@ namespace SlowTests.Authentication
                 settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.ExternalIp), out string externalIp);
 
                 var tempFileName = GetTempFileName();
-                File.WriteAllBytes(tempFileName, serverCertBytes);
+                await File.WriteAllBytesAsync(tempFileName, serverCertBytes);
 
                 IDictionary<string, string> customSettings = new ConcurrentDictionary<string, string>
                 {

--- a/test/SlowTests/Blittable/JsonSerializerTests.cs
+++ b/test/SlowTests/Blittable/JsonSerializerTests.cs
@@ -160,8 +160,8 @@ namespace SlowTests.Blittable
                     using (var builder =
                         new BlittableJsonDocumentBuilder(context, BlittableJsonDocumentBuilder.UsageMode.None, "some tag", parser, state))
                     {
-                        UnmanagedJsonParserHelper.Read(peepingTomStream, parser, state, buffer);
-                        UnmanagedJsonParserHelper.ReadObject(builder, peepingTomStream, parser, buffer);
+                        await UnmanagedJsonParserHelper.ReadAsync(peepingTomStream, parser, state, buffer);
+                        await UnmanagedJsonParserHelper.ReadObjectAsync(builder, peepingTomStream, parser, buffer);
 
                         fromStream = builder.CreateReader();
                     }

--- a/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
+++ b/test/SlowTests/Blittable/SerializeAndDeserializeMergedTransactionCommandTests.cs
@@ -183,8 +183,8 @@ namespace SlowTests.Blittable
                     new CustomComparer<AttachmentHandler.MergedPutAttachmentCommand, DocumentsOperationContext, DocumentsTransaction>(context, new[] { typeof(Stream) }));
 
                 stream.Seek(0, SeekOrigin.Begin);
-                var expectedStream = expected.Stream.ReadData();
-                var actualStream = actual.Stream.ReadData();
+                var expectedStream = await expected.Stream.ReadDataAsync();
+                var actualStream = await actual.Stream.ReadDataAsync();
                 Assert.Equal(expectedStream, actualStream);
             }
         }

--- a/test/SlowTests/Bugs/AccessingHostPropertyOnUri.cs
+++ b/test/SlowTests/Bugs/AccessingHostPropertyOnUri.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Bugs
         {
             using (var store = GetDocumentStore(options))
             {
-                new WebActivityIndex().Execute(store);
+                await new WebActivityIndex().ExecuteAsync(store);
 
                 var activities1 = new WebItems()
                 {
@@ -95,7 +95,7 @@ namespace SlowTests.Bugs
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());

--- a/test/SlowTests/Bugs/AggressiveCaching.cs
+++ b/test/SlowTests/Bugs/AggressiveCaching.cs
@@ -85,7 +85,7 @@ namespace SlowTests.Bugs
                 {
                     using (var session = store.OpenAsyncSession())
                     {
-                        using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+                        using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
                         {
                             await session.LoadAsync<User>("users/1");
                         }

--- a/test/SlowTests/Bugs/Andrew.cs
+++ b/test/SlowTests/Bugs/Andrew.cs
@@ -42,11 +42,11 @@ namespace SlowTests.Bugs
                     session.SaveChanges();
                 }
 
-                new MyIndex().Execute(store);
+                await new MyIndex().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                var firstQueryResult = store.Commands().Query(new IndexQuery { Query = "FROM INDEX 'MyIndex'" });
+                var firstQueryResult = await store.Commands().QueryAsync(new IndexQuery { Query = "FROM INDEX 'MyIndex'" });
 
                 Assert.Equal(1, firstQueryResult.TotalResults);
 
@@ -76,17 +76,17 @@ namespace SlowTests.Bugs
 
                 for (int i = 0; i < 100; i++)
                 {
-                    QueryResult queryResult = store.Commands().Query(new IndexQuery { Query = "FROM INDEX 'MyIndex'" });
+                    QueryResult queryResult = await store.Commands().QueryAsync(new IndexQuery { Query = "FROM INDEX 'MyIndex'" });
 
                     Assert.Equal(1, queryResult.TotalResults);
                 }
 
-                cts.Cancel();
+                await cts.CancelAsync();
 
                 await car1.WaitAsync(TimeSpan.FromMinutes(1));
                 await car2.WaitAsync(TimeSpan.FromMinutes(1));
 
-                QueryResult finalQueryResult = store.Commands().Query(new IndexQuery { Query = "FROM INDEX 'MyIndex'" });
+                QueryResult finalQueryResult = await store.Commands().QueryAsync(new IndexQuery { Query = "FROM INDEX 'MyIndex'" });
 
                 Assert.Equal(1, finalQueryResult.TotalResults);
             }

--- a/test/SlowTests/Bugs/ArrayOfMaybeNull.cs
+++ b/test/SlowTests/Bugs/ArrayOfMaybeNull.cs
@@ -72,7 +72,7 @@ namespace SlowTests.Bugs
                     session.SaveChanges();
                 }
 
-                new Orders_Search().Execute(store);
+                await new Orders_Search().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Caching/UseCachingInLazyTests.cs
+++ b/test/SlowTests/Bugs/Caching/UseCachingInLazyTests.cs
@@ -101,7 +101,7 @@ namespace SlowTests.Bugs.Caching
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), AggressiveCacheMode.TrackChanges))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5), AggressiveCacheMode.TrackChanges))
             {
                 await loadFuncAsync(session, docId);
             }
@@ -119,7 +119,7 @@ namespace SlowTests.Bugs.Caching
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), aggressiveCacheMode))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5), aggressiveCacheMode))
             {
                 var loadAsync = session.Advanced.Lazily.LoadAsync<Doc>(docId);
                 _ = await loadAsync.Value;
@@ -201,7 +201,7 @@ namespace SlowTests.Bugs.Caching
             }
 
             using (var session = store.OpenSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), AggressiveCacheMode.TrackChanges))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5), AggressiveCacheMode.TrackChanges))
             {
                 loadFunc(session, docId);
             }
@@ -219,7 +219,7 @@ namespace SlowTests.Bugs.Caching
             }
 
             using (var session = store.OpenSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), aggressiveCacheMode))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5), aggressiveCacheMode))
             {
                 _ = session.Advanced.Lazily.Load<Doc>(docId).Value;
                 return session.Advanced.NumberOfRequests;
@@ -238,7 +238,7 @@ namespace SlowTests.Bugs.Caching
             const string notCachedId = "TestObjs/notCached";
 
             using var store = GetDocumentStore();
-            store.AggressivelyCacheFor(TimeSpan.FromMinutes(5));
+            await store.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5));
             using (var session = store.OpenAsyncSession())
             {
                 await session.StoreAsync(new TestObj(), cachedId);
@@ -339,7 +339,7 @@ namespace SlowTests.Bugs.Caching
                     documentStore.Conventions.MaxHttpCacheSize = conventionsMaxHttpCacheSize;
                 }
             });
-            store.AggressivelyCache();
+            await store.AggressivelyCacheAsync();
 
             async Task<int> GetSingleDocSize()
             {
@@ -423,7 +423,7 @@ namespace SlowTests.Bugs.Caching
 
             using (var store = GetDocumentStore())
             {
-                store.AggressivelyCache();
+                await store.AggressivelyCacheAsync();
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -502,7 +502,7 @@ namespace SlowTests.Bugs.Caching
 
             var requestExecutor = store.GetRequestExecutor();
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5), AggressiveCacheMode.DoNotTrackChanges))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5), AggressiveCacheMode.DoNotTrackChanges))
             using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
             {
                 var result = new List<Lazy<Task<BlittableJsonReaderObject>>>();

--- a/test/SlowTests/Bugs/CustomEntityName.cs
+++ b/test/SlowTests/Bugs/CustomEntityName.cs
@@ -150,7 +150,7 @@ namespace SlowTests.Bugs
 
             var index = new T();
             await index.ExecuteAsync(store);
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests/Bugs/Errors/CanIndexOnNull.cs
+++ b/test/SlowTests/Bugs/Errors/CanIndexOnNull.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Bugs.Errors
                 {
                     for (var i = 0; i < 50; i++)
                     {
-                        commands.Put("item/" + i, null, new { Type = "Car" }, null);
+                        await commands.PutAsync("item/" + i, null, new { Type = "Car" }, null);
                     }
                 }
 

--- a/test/SlowTests/Bugs/Indexing/CanMultiMapIndexNullableValueTypes.cs
+++ b/test/SlowTests/Bugs/Indexing/CanMultiMapIndexNullableValueTypes.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Bugs.Indexing
             using (var store = GetDocumentStore(options))
             {
                 var indexCreationTask = new Companies_ByTurnover();
-                indexCreationTask.Execute(store);
+                await indexCreationTask.ExecuteAsync(store);
 
                 using (var s = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/Indexing/SetIndexPriority.cs
+++ b/test/SlowTests/Bugs/Indexing/SetIndexPriority.cs
@@ -34,11 +34,11 @@ namespace SlowTests.Bugs.Indexing
         {
             using (var store = GetDocumentStore(options))
             {
-                new FakeIndex().Execute(store);
+                await new FakeIndex().ExecuteAsync(store);
 
                 foreach (var expected in new[] { IndexPriority.Normal, IndexPriority.High, IndexPriority.Low })
                 {
-                    store.Maintenance.Send(new SetIndexesPriorityOperation("FakeIndex", expected));
+                    await store.Maintenance.SendAsync(new SetIndexesPriorityOperation("FakeIndex", expected));
 
                     var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                     var indexInstance = db.IndexStore.GetIndex("FakeIndex");

--- a/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
+++ b/test/SlowTests/Bugs/Indexing/ThrowingAnalyzer.cs
@@ -104,7 +104,7 @@ namespace SlowTests.Bugs.Indexing
 
                     try
                     {
-                        Indexes.WaitForIndexing(store);
+                        await Indexes.WaitForIndexingAsync(store);
                     }
                     catch
                     {

--- a/test/SlowTests/Bugs/MapRedue/LargeKeysInVoron.cs
+++ b/test/SlowTests/Bugs/MapRedue/LargeKeysInVoron.cs
@@ -95,9 +95,9 @@ namespace SlowTests.Bugs.MapRedue
                     session.SaveChanges();
                 }
 
-                new LargeKeysInVoronFunction().Execute(store);
+                await new LargeKeysInVoronFunction().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/MapRedue/LetInReduceFunction.cs
+++ b/test/SlowTests/Bugs/MapRedue/LetInReduceFunction.cs
@@ -62,9 +62,9 @@ namespace SlowTests.Bugs.MapRedue
                     session.SaveChanges();
                 }
 
-                new IndexWithLetInReduceFunction().Execute(store);
+                await new IndexWithLetInReduceFunction().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());

--- a/test/SlowTests/Bugs/MapRedue/MinMax.cs
+++ b/test/SlowTests/Bugs/MapRedue/MinMax.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Bugs.MapRedue
                     session.SaveChanges();
                 }
 
-                new Users_LastLoggedInAt().Execute((IDocumentStore)store);
+                await new Users_LastLoggedInAt().ExecuteAsync((IDocumentStore)store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Bugs/MultiMap/MultiMapWithCustomProperties.cs
+++ b/test/SlowTests/Bugs/MultiMap/MultiMapWithCustomProperties.cs
@@ -28,9 +28,9 @@ namespace SlowTests.Bugs.MultiMap
                     session.SaveChanges();
                 }
 
-                new CatsAndDogs().Execute(store);
+                await new CatsAndDogs().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());

--- a/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnum.cs
+++ b/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnum.cs
@@ -29,9 +29,9 @@ namespace SlowTests.Bugs.MultiMap
                     session.SaveChanges();
                 }
 
-                new MySearchIndexTask().Execute(store);
+                await new MySearchIndexTask().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());

--- a/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnumAndCoalescingOperator.cs
+++ b/test/SlowTests/Bugs/MultiMap/MultiMapWithNullableEnumAndCoalescingOperator.cs
@@ -29,9 +29,9 @@ namespace SlowTests.Bugs.MultiMap
                     session.SaveChanges();
                 }
 
-                new MySearchIndexTask().Execute(store);
+                await new MySearchIndexTask().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var errorsCount = db.IndexStore.GetIndexes().Sum(index => index.GetErrorCount());

--- a/test/SlowTests/Client/Attachments/AttachmentFailover.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentFailover.cs
@@ -49,7 +49,7 @@ namespace SlowTests.Client.Attachments
             {
                 using (var session = (DocumentSession)store.OpenSession())
                 {
-                    session.Store(new User
+                    await session.StoreAsync(new User
                     {
                         Name = "Fitzchak"
                     }, "users/1");
@@ -75,7 +75,7 @@ namespace SlowTests.Client.Attachments
                         Assert.Equal(currentNode.ClusterTag, leader.ServerStore.NodeTag);
                         var currentServer = Servers.Single(x => x.ServerStore.NodeTag == currentNode.ClusterTag);
                         stream.Position++; // simulating that we already started to call this and we need to reset
-                        DisposeServerAndWaitForFinishOfDisposal(currentServer);
+                        await DisposeServerAndWaitForFinishOfDisposalAsync(currentServer);
                         var task = session.RequestExecutor.ExecuteAsync(currentNode, currentIndex, session.Context, command);
                         await task;
                         saveChangesOperation.SetResult(command.Result);
@@ -85,7 +85,7 @@ namespace SlowTests.Client.Attachments
                 using (var dummyStream = new BigDummyStream(size))
                 using (var attachment = session.Advanced.Attachments.Get("users/1", "File"))
                 {
-                    attachment.Stream.CopyTo(dummyStream);
+                    await attachment.Stream.CopyToAsync(dummyStream);
                     Assert.Equal("File", attachment.Details.Name);
                     Assert.Equal(size, dummyStream.Position);
                     Assert.Equal(size, attachment.Details.Size);
@@ -131,7 +131,7 @@ namespace SlowTests.Client.Attachments
             {
                 using (var session = (DocumentSession)store.OpenSession())
                 {
-                    session.Store(new User
+                    await session.StoreAsync(new User
                     {
                         Name = "Fitzchak"
                     }, "users/1");
@@ -157,7 +157,7 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal(currentNode.ClusterTag, leader.ServerStore.NodeTag);
 
                     stream.Position++; // simulating that we already started to call this and we need to reset
-                    DisposeServerAndWaitForFinishOfDisposal(currentServer);
+                    await DisposeServerAndWaitForFinishOfDisposalAsync(currentServer);
                     var task = requestExecutor.ExecuteAsync(currentNode, currentIndex, context, command);
 
                     await task;
@@ -173,7 +173,7 @@ namespace SlowTests.Client.Attachments
                 using (var dummyStream = new BigDummyStream(size))
                 using (var attachment = session.Advanced.Attachments.Get("users/1", "File"))
                 {
-                    attachment.Stream.CopyTo(dummyStream);
+                    await attachment.Stream.CopyToAsync(dummyStream);
                     Assert.Equal("File", attachment.Details.Name);
                     Assert.Equal(size, dummyStream.Position);
                     Assert.Equal(size, attachment.Details.Size);

--- a/test/SlowTests/Client/Attachments/AttachmentsCrud.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsCrud.cs
@@ -299,7 +299,7 @@ namespace SlowTests.Client.Attachments
                 }
                 AssertAttachmentCount(store, 3);
 
-                store.Operations.Send(new DeleteAttachmentOperation("users/1", "file2"));
+                await store.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "file2"));
                 AssertAttachmentCount(store, 2);
 
                 using (var session = store.OpenSession())
@@ -321,7 +321,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", "file1"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Contains("A:2", attachment.Details.ChangeVector);
                         Assert.Equal("file1", attachment.Details.Name);
                         Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
@@ -331,7 +331,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", "file3"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Contains("A:6", attachment.Details.ChangeVector);
                         Assert.Equal("file3", attachment.Details.Name);
                         Assert.Equal("NRQuixiqj+xvEokF6MdQq1u+uH1dk/gk2PLChJQ58Vo=", attachment.Details.Hash);
@@ -341,7 +341,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 // Delete document should delete all the attachments
-                store.Commands().Delete("users/1", null);
+                await store.Commands().DeleteAsync("users/1", null);
                 AssertAttachmentCount(store, 0, documentsCount: 0);
             }
         }

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -140,7 +140,7 @@ namespace SlowTests.Client.Attachments
                         using (var attachmentStream = new MemoryStream(readBuffer))
                         using (var attachment = session.Advanced.Attachments.Get("users/1", name))
                         {
-                            attachment.Stream.CopyTo(attachmentStream);
+                            await attachment.Stream.CopyToAsync(attachmentStream);
 
                             Assert.Equal(name, attachment.Details.Name);
                             Assert.Equal(i == 0 ? 3 : 5, attachmentStream.Position);
@@ -220,7 +220,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", name))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Equal(name, attachment.Details.Name);
                         Assert.Equal(new byte[] { 1, 2, 3 }, readBuffer.Take(3));
                         Assert.Equal(expectedContentType, attachment.Details.ContentType);
@@ -249,7 +249,7 @@ namespace SlowTests.Client.Attachments
                 }
                 await AssertAttachmentCount(store1, 3);
 
-                store1.Operations.Send(new DeleteAttachmentOperation("users/1", "file2"));
+                await store1.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "file2"));
 
                 await SetupAttachmentReplicationAsync(store1, store2);
                 await AssertAttachmentCount(store2, 2);
@@ -273,7 +273,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", "file1"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Contains("A:2", attachment.Details.ChangeVector);
                         Assert.Equal("file1", attachment.Details.Name);
                         Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
@@ -283,7 +283,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", "file3"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Contains("A:6", attachment.Details.ChangeVector);
                         Assert.Equal("file3", attachment.Details.Name);
                         Assert.Equal("NRQuixiqj+xvEokF6MdQq1u+uH1dk/gk2PLChJQ58Vo=", attachment.Details.Hash);
@@ -293,7 +293,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 // Delete document should delete all the attachments
-                store1.Commands().Delete("users/1", null);
+                await store1.Commands().DeleteAsync("users/1", null);
                 using (var session = store1.OpenSession())
                 {
                     session.Store(new User { Name = "Marker 2" }, "users/1$marker2");
@@ -347,7 +347,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/3", "file3"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Equal("file3", attachment.Details.Name);
                         Assert.Equal("uuBtr5rVX6NAXzdW2DhuG04MGGyUzFzpS7TelHw3fJQ=", attachment.Details.Hash);
                         Assert.Equal(128 * 1024, attachmentStream.Position);
@@ -358,7 +358,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", "big-file"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Equal("big-file", attachment.Details.Name);
                         Assert.Equal("zKHiLyLNRBZti9DYbzuqZ/EDWAFMgOXB+SwKvjPAINk=", attachment.Details.Hash);
                         Assert.Equal(999 * 1024, attachmentStream.Position);
@@ -366,16 +366,16 @@ namespace SlowTests.Client.Attachments
                     }
                 }
 
-                store1.Operations.Send(new DeleteAttachmentOperation("users/1", "file1"));
+                await store1.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "file1"));
                 await AssertDeleteAsync(store1, store2, "file1", 2, 3);
 
-                store1.Operations.Send(new DeleteAttachmentOperation("users/2", "file2"));
+                await store1.Operations.SendAsync(new DeleteAttachmentOperation("users/2", "file2"));
                 await AssertDeleteAsync(store1, store2, "file2", 2);
 
-                store1.Operations.Send(new DeleteAttachmentOperation("users/3", "file3"));
+                await store1.Operations.SendAsync(new DeleteAttachmentOperation("users/3", "file3"));
                 await AssertDeleteAsync(store1, store2, "file3", 1);
 
-                store1.Operations.Send(new DeleteAttachmentOperation("users/1", "big-file"));
+                await store1.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "big-file"));
                 await AssertDeleteAsync(store1, store2, "big-file", 0);
 
                 for (int i = 1; i <= 3; i++)
@@ -1055,7 +1055,7 @@ namespace SlowTests.Client.Attachments
                     {
                         store2.Operations.Send(new PutAttachmentOperation("users/1", "a2", a2, "a1/png"));
                     }
-                    store2.Operations.Send(new DeleteAttachmentOperation("users/1", "a2"));
+                    await store2.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "a2"));
 
                     await session.StoreAsync(new User { Name = "Marker 2" }, "marker 2");
                     await session.SaveChangesAsync();
@@ -1316,7 +1316,7 @@ namespace SlowTests.Client.Attachments
                     {
                         store2.Operations.Send(new PutAttachmentOperation("users/1", "a1", a2, "a1/png"));
                     }
-                    store2.Operations.Send(new DeleteAttachmentOperation("users/1", "a1"));
+                    await store2.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "a1"));
 
                     await session.StoreAsync(new User { Name = "Marker 2" }, "marker 2");
                     await session.SaveChangesAsync();
@@ -3448,7 +3448,7 @@ namespace SlowTests.Client.Attachments
 
                 await EnsureReplicatingAsync(source, destination);
 
-                conflicts = destination.Commands().GetConflictsFor("users/1");
+                conflicts = await destination.Commands().GetConflictsForAsync("users/1");
                 Assert.Equal(0, conflicts.Length);
 
                 using (var session = destination.OpenAsyncSession())

--- a/test/SlowTests/Client/Attachments/AttachmentsRevisions.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsRevisions.cs
@@ -315,7 +315,7 @@ namespace SlowTests.Client.Attachments
                 }, 9, shardNumber: shardNumber);
 
                 // Delete document should delete all the attachments
-                store.Commands().Delete("users/1", null);
+                await store.Commands().DeleteAsync("users/1", null);
                 AssertRevisions(store, names, (session, revisions) =>
                 {
                     AssertNoRevisionAttachment(revisions[0], session, true);

--- a/test/SlowTests/Client/Attachments/AttachmentsSession.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSession.cs
@@ -93,7 +93,7 @@ namespace SlowTests.Client.Attachments
                         using (var attachmentStream = new MemoryStream(readBuffer))
                         using (var attachment = session.Advanced.Attachments.Get(user, name))
                         {
-                            attachment.Stream.CopyTo(attachmentStream);
+                            await attachment.Stream.CopyToAsync(attachmentStream);
                             var expected = "A:" + (2 + i);
                             Assert.Equal(expected, attachment.Details.ChangeVector.Substring(0, expected.Length));
                             Assert.Equal(name, attachment.Details.Name);
@@ -308,7 +308,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get("users/1", "file1"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Equal("A:2", attachment.Details.ChangeVector.Substring(0, 3));
                         Assert.Equal("file1", attachment.Details.Name);
                         Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
@@ -322,7 +322,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = session.Advanced.Attachments.Get(user, "file3"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Equal("A:4", attachment.Details.ChangeVector.Substring(0, 3));
                         Assert.Equal("file3", attachment.Details.Name);
                         Assert.Equal("NRQuixiqj+xvEokF6MdQq1u+uH1dk/gk2PLChJQ58Vo=", attachment.Details.Hash);

--- a/test/SlowTests/Client/Attachments/AttachmentsSessionAsync.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSessionAsync.cs
@@ -90,7 +90,7 @@ namespace SlowTests.Client.Attachments
                         using (var attachmentStream = new MemoryStream(readBuffer))
                         using (var attachment = await session.Advanced.Attachments.GetAsync(user, name))
                         {
-                            attachment.Stream.CopyTo(attachmentStream);
+                            await attachment.Stream.CopyToAsync(attachmentStream);
                             Assert.Contains("A:" + (i + 2), attachment.Details.ChangeVector);
                             Assert.Equal(name, attachment.Details.Name);
                             Assert.Equal(i == 0 ? 3 : 5, attachmentStream.Position);
@@ -303,7 +303,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = await session.Advanced.Attachments.GetAsync("users/1", "file1"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Contains("A:2", attachment.Details.ChangeVector);
                         Assert.Equal("file1", attachment.Details.Name);
                         Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", attachment.Details.Hash);
@@ -317,7 +317,7 @@ namespace SlowTests.Client.Attachments
                     using (var attachmentStream = new MemoryStream(readBuffer))
                     using (var attachment = await session.Advanced.Attachments.GetAsync(user, "file3"))
                     {
-                        attachment.Stream.CopyTo(attachmentStream);
+                        await attachment.Stream.CopyToAsync(attachmentStream);
                         Assert.Contains("A:4", attachment.Details.ChangeVector);
                         Assert.Equal("file3", attachment.Details.Name);
                         Assert.Equal("NRQuixiqj+xvEokF6MdQq1u+uH1dk/gk2PLChJQ58Vo=", attachment.Details.Hash);
@@ -529,7 +529,7 @@ namespace SlowTests.Client.Attachments
             }
 
             foreach (var stream in streams)
-                stream.Dispose();
+                await stream.DisposeAsync();
         }
 
         [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Attachments)]

--- a/test/SlowTests/Client/Attachments/AttachmentsSmuggler.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSmuggler.cs
@@ -51,7 +51,7 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal(1, stats.CountOfAttachments);
                     Assert.Equal(1, stats.CountOfUniqueAttachments);
 
-                    store.Operations.Send(new DeleteAttachmentOperation("users/1", "file1"));
+                    await store.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "file1"));
 
                     stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
                     Assert.Equal(1, stats.CountOfDocuments);
@@ -131,7 +131,7 @@ namespace SlowTests.Client.Attachments
                 var getPeriodicBackupResult = store.Maintenance.Send(operation);
                 var etagForBackups = getPeriodicBackupResult.Status.LastEtag;
 
-                store.Operations.Send(new DeleteAttachmentOperation("users/1", "file1"));
+                await store.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "file1"));
                 using (var stream = new MemoryStream(new byte[] { 4, 5, 6 }))
                     store.Operations.Send(new PutAttachmentOperation("users/1", "file2", stream, "image/png"));
 
@@ -199,7 +199,7 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal(1, stats.CountOfAttachments);
                     Assert.Equal(1, stats.CountOfUniqueAttachments);
 
-                    store.Operations.Send(new DeleteAttachmentOperation("users/1", "file1"));
+                    await store.Operations.SendAsync(new DeleteAttachmentOperation("users/1", "file1"));
 
                     stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
                     Assert.Equal(1, stats.CountOfDocuments);
@@ -389,7 +389,7 @@ namespace SlowTests.Client.Attachments
                         using (var attachmentStream = new MemoryStream(readBuffer))
                         using (var attachment = session.Advanced.Attachments.Get(documentId, attachmentName))
                         {
-                            attachment.Stream.CopyTo(attachmentStream);
+                            await attachment.Stream.CopyToAsync(attachmentStream);
                             Assert.Equal(new byte[0], readBuffer.Take((int)attachmentStream.Position));
 
                             var attachmentCv = attachment.Details.ChangeVector;
@@ -496,7 +496,7 @@ namespace SlowTests.Client.Attachments
                             using (var attachmentStream = new MemoryStream(readBuffer))
                             using (var attachment = session.Advanced.Attachments.Get("users/1", "big-file"))
                             {
-                                attachment.Stream.CopyTo(attachmentStream);
+                                await attachment.Stream.CopyToAsync(attachmentStream);
                                 Assert.Equal("big-file", attachment.Details.Name);
                                 Assert.Equal("zKHiLyLNRBZti9DYbzuqZ/EDWAFMgOXB+SwKvjPAINk=", attachment.Details.Hash);
                                 Assert.Equal(999 * 1024, attachmentStream.Position);

--- a/test/SlowTests/Client/Attachments/AttachmentsStreamTests.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsStreamTests.cs
@@ -563,7 +563,7 @@ namespace SlowTests.Client.Attachments
             }
 
             foreach (var stream in attachmentDictionary.Values)
-                stream.Dispose();
+                await stream.DisposeAsync();
         }
 
         [RavenTheory(RavenTestCategory.Attachments)]

--- a/test/SlowTests/Client/ChangesApiFailover.cs
+++ b/test/SlowTests/Client/ChangesApiFailover.cs
@@ -365,7 +365,7 @@ update {{
                     await AssertWaitForTrueAsync(() => Task.FromResult(list.Count == 1));
                     
                     //make sure operation throws an error
-                    ctsToFail.Cancel();
+                    await ctsToFail.CancelAsync();
                     await waitForCompletionErrorTask;
 
                     using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_JavaScript.cs
+++ b/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_JavaScript.cs
@@ -438,27 +438,27 @@ return ({
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var timeSeriesIndex = new MyCounterIndex_Load();
                 var indexName = timeSeriesIndex.IndexName;
                 var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
 
-                timeSeriesIndex.Execute(store);
+                await timeSeriesIndex.ExecuteAsync(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.True(staleness.IsStale);
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var terms = store.Maintenance.Send(new GetTermsOperation(indexName, "Employee", null));
                 Assert.Equal(1, terms.Length);
@@ -477,14 +477,14 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "Employee", null));
                 Assert.Equal(1, terms.Length);
@@ -502,9 +502,9 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -514,7 +514,7 @@ return ({
 
                 // delete source document
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -528,9 +528,9 @@ return ({
                 Assert.Equal(2, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.All(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex(indexName);
@@ -551,7 +551,7 @@ return ({
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (index._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -746,22 +746,22 @@ return ({
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var timeSeriesIndex = new AverageHeartRate_WithLoad();
                 var indexName = timeSeriesIndex.IndexName;
                 var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
 
-                timeSeriesIndex.Execute(store);
+                await timeSeriesIndex.ExecuteAsync(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.True(staleness.IsStale);
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -778,7 +778,7 @@ return ({
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("ny", terms);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -796,9 +796,9 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -808,7 +808,7 @@ return ({
                 Assert.Contains("ny", terms);
                 Assert.Contains("la", terms);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -823,9 +823,9 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -835,7 +835,7 @@ return ({
                 Assert.Contains("la", terms);
                 Assert.Contains("NULL_VALUE", terms);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -850,9 +850,9 @@ return ({
                 Assert.Equal(2, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.All(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "City", null));
                 Assert.Equal(0, terms.Length);

--- a/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_StrongSyntax.cs
+++ b/test/SlowTests/Client/Indexing/Counters/BasicCountersIndexes_StrongSyntax.cs
@@ -475,28 +475,28 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var timeSeriesIndex = new MyCounterIndex_Load();
                 var indexName = timeSeriesIndex.IndexName;
                 var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
                 RavenTestHelper.AssertEqualRespectingNewLines("counters.Companies.HeartRate.Select(counter => new {\r\n    counter = counter,\r\n    company = this.LoadDocument(counter.DocumentId, \"Companies\")\r\n}).Select(this0 => new {\r\n    this0 = this0,\r\n    employee = this.LoadDocument(this0.company.Desc, \"Employees\")\r\n}).Select(this1 => new {\r\n    HeartBeat = this1.this0.counter.Value,\r\n    User = this1.this0.counter.DocumentId,\r\n    Employee = this1.employee.FirstName\r\n})", indexDefinition.Maps.First());
 
-                timeSeriesIndex.Execute(store);
+                await timeSeriesIndex.ExecuteAsync(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.True(staleness.IsStale);
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var terms = store.Maintenance.Send(new GetTermsOperation(indexName, "Employee", null));
                 Assert.Equal(1, terms.Length);
@@ -515,14 +515,14 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "Employee", null));
                 Assert.Equal(1, terms.Length);
@@ -540,9 +540,9 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -552,7 +552,7 @@ namespace SlowTests.Client.Indexing.Counters
 
                 // delete source document
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -566,9 +566,9 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(2, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.All(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex(indexName);
@@ -589,7 +589,7 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (index._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -786,7 +786,7 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var countersIndex = new AverageHeartRate_WithLoad();
                 var indexName = countersIndex.IndexName;
@@ -794,16 +794,16 @@ namespace SlowTests.Client.Indexing.Counters
                 RavenTestHelper.AssertEqualRespectingNewLines("counters.Users.HeartRate.Select(counter => new {\r\n    counter = counter,\r\n    user = this.LoadDocument(counter.DocumentId, \"Users\")\r\n}).Select(this0 => new {\r\n    this0 = this0,\r\n    address = this.LoadDocument(this0.user.AddressId, \"Addresses\")\r\n}).Select(this1 => new {\r\n    HeartBeat = ((double) this1.this0.counter.Value),\r\n    Count = 1,\r\n    City = this1.address.City\r\n})", indexDefinition.Maps.First());
                 RavenTestHelper.AssertEqualRespectingNewLines("results.GroupBy(r => r.City).Select(g => new {\r\n    g = g,\r\n    sumHeartBeat = Enumerable.Sum(g, x => ((double) x.HeartBeat))\r\n}).Select(this0 => new {\r\n    this0 = this0,\r\n    sumCount = Enumerable.Sum(this0.g, x0 => ((long) x0.Count))\r\n}).Select(this1 => new {\r\n    HeartBeat = this1.this0.sumHeartBeat / ((double) this1.sumCount),\r\n    City = this1.this0.g.Key,\r\n    Count = this1.sumCount\r\n})", indexDefinition.Reduce);
 
-                countersIndex.Execute(store);
+                await countersIndex.ExecuteAsync(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.True(staleness.IsStale);
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -820,7 +820,7 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(1, terms.Length);
                 Assert.Contains("ny", terms);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -838,9 +838,9 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -850,7 +850,7 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Contains("ny", terms);
                 Assert.Contains("la", terms);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -865,9 +865,9 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
@@ -877,7 +877,7 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Contains("la", terms);
                 Assert.Contains("NULL_VALUE", terms);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -892,9 +892,9 @@ namespace SlowTests.Client.Indexing.Counters
                 Assert.Equal(2, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.All(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "City", null));
                 Assert.Equal(0, terms.Length);
@@ -1205,7 +1205,7 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -1274,7 +1274,7 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var indexInstance = database.IndexStore.GetIndex(indexName);
@@ -1299,7 +1299,7 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -1321,7 +1321,7 @@ namespace SlowTests.Client.Indexing.Counters
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -1426,7 +1426,7 @@ namespace SlowTests.Client.Indexing.Counters
                 }
                 await session.SaveChangesAsync();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             await store.Maintenance.SendAsync(new StopIndexingOperation());
             using (var session = store.OpenAsyncSession())
@@ -1443,7 +1443,7 @@ namespace SlowTests.Client.Indexing.Counters
             }
 
             await store.Maintenance.SendAsync(new StartIndexingOperation());
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             await store.Maintenance.SendAsync(new StopIndexingOperation());
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_JavaScript.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_JavaScript.cs
@@ -394,27 +394,27 @@ return ({
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var timeSeriesIndex = new MyTsIndex_Load();
                 var indexName = timeSeriesIndex.IndexName;
                 var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
 
-                timeSeriesIndex.Execute(store);
+                await timeSeriesIndex.ExecuteAsync(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.True(staleness.IsStale);
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -435,14 +435,14 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -462,9 +462,9 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -473,7 +473,7 @@ return ({
 
                 // delete source document
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -487,9 +487,9 @@ return ({
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex(indexName);
@@ -510,7 +510,7 @@ return ({
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(0, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 0));
 
@@ -734,22 +734,22 @@ return ({
                         session.SaveChanges();
                     }
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     var timeSeriesIndex = new AverageHeartRateDaily_ByDateAndCity();
                     var indexName = timeSeriesIndex.IndexName;
                     var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
 
-                    timeSeriesIndex.Execute(store);
+                    await timeSeriesIndex.ExecuteAsync(store);
 
                     var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.True(staleness.IsStale);
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.False(staleness.IsStale);
@@ -770,7 +770,7 @@ return ({
                     Assert.Equal(1, terms.Length);
                     Assert.Equal("10", terms[0]);
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -785,9 +785,9 @@ return ({
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.False(staleness.IsStale);
@@ -796,7 +796,7 @@ return ({
                     Assert.Equal(1, terms.Length);
                     Assert.Contains("la", terms);
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -810,9 +810,9 @@ return ({
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     terms = store.Maintenance.Send(new GetTermsOperation(indexName, "City", null));
                     Assert.Equal(1, terms.Length);
@@ -820,7 +820,7 @@ return ({
 
                     // delete source document
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -834,9 +834,9 @@ return ({
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var database = await GetDatabase(store.Database);
                     var index = database.IndexStore.GetIndex(indexName);

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_MethodSyntax.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_MethodSyntax.cs
@@ -217,7 +217,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 string indexName = "MyTsIndex";
 
@@ -245,14 +245,14 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -273,14 +273,14 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -300,9 +300,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -311,7 +311,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
 
                 // delete source document
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -325,9 +325,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex(indexName);
@@ -348,7 +348,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(0, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 0));
 
@@ -601,7 +601,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                         session.SaveChanges();
                     }
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     string indexName = "AverageHeartRateDaily/ByDateAndCity";
 
@@ -644,9 +644,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.False(staleness.IsStale);
@@ -667,7 +667,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, terms.Length);
                     Assert.Equal("10", terms[0]);
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -682,9 +682,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.False(staleness.IsStale);
@@ -693,7 +693,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, terms.Length);
                     Assert.Contains("la", terms);
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -707,9 +707,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     terms = store.Maintenance.Send(new GetTermsOperation(indexName, "City", null));
                     Assert.Equal(1, terms.Length);
@@ -717,7 +717,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
 
                     // delete source document
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -731,9 +731,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var database = await GetDatabase(store.Database);
                     var index = database.IndexStore.GetIndex(indexName);

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
@@ -501,28 +501,28 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 var timeSeriesIndex = new MyTsIndex_Load();
                 var indexName = timeSeriesIndex.IndexName;
                 var indexDefinition = timeSeriesIndex.CreateIndexDefinition();
                 RavenTestHelper.AssertEqualRespectingNewLines("timeSeries.Companies.HeartRate.SelectMany(ts => ts.Entries, (ts, entry) => new {\r\n    ts = ts,\r\n    entry = entry\r\n}).Select(this0 => new {\r\n    this0 = this0,\r\n    employee = this.LoadDocument(this0.entry.Tag, \"Employees\")\r\n}).Select(this1 => new {\r\n    HeartBeat = this1.this0.entry.Value,\r\n    Date = this1.this0.entry.Timestamp.Date,\r\n    User = this1.this0.ts.DocumentId,\r\n    Employee = this1.employee.FirstName\r\n})", indexDefinition.Maps.First());
 
-                timeSeriesIndex.Execute(store);
+                await timeSeriesIndex.ExecuteAsync(store);
 
                 var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.True(staleness.IsStale);
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -543,14 +543,14 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                 Assert.False(staleness.IsStale);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -570,9 +570,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(2, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 2));
 
@@ -581,7 +581,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
 
                 // delete source document
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 using (var session = store.OpenSession())
                 {
@@ -595,9 +595,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 Assert.Equal(1, staleness.StalenessReasons.Count);
                 Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex(indexName);
@@ -618,7 +618,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.Equal(0, WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(indexName)).EntriesCount, 0));
 
@@ -844,7 +844,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                         session.SaveChanges();
                     }
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     var timeSeriesIndex = new AverageHeartRateDaily_ByDateAndCity();
                     var indexName = timeSeriesIndex.IndexName;
@@ -852,16 +852,16 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     RavenTestHelper.AssertEqualRespectingNewLines("timeSeries.Users.HeartRate.SelectMany(ts => ts.Entries, (ts, entry) => new {\r\n    ts = ts,\r\n    entry = entry\r\n}).Select(this0 => new {\r\n    this0 = this0,\r\n    address = this.LoadDocument(this0.entry.Tag, \"Addresses\")\r\n}).Select(this1 => new {\r\n    HeartBeat = this1.this0.entry.Value,\r\n    Date = new DateTime((int) this1.this0.entry.Timestamp.Date.Year, (int) this1.this0.entry.Timestamp.Date.Month, (int) this1.this0.entry.Timestamp.Date.Day),\r\n    City = this1.address.City,\r\n    Count = 1\r\n})", indexDefinition.Maps.First());
                     RavenTestHelper.AssertEqualRespectingNewLines("results.GroupBy(r => new {\r\n    Date = r.Date,\r\n    City = r.City\r\n}).Select(g => new {\r\n    g = g,\r\n    sumHeartBeat = Enumerable.Sum(g, x => ((double) x.HeartBeat))\r\n}).Select(this0 => new {\r\n    this0 = this0,\r\n    sumCount = Enumerable.Sum(this0.g, x0 => ((long) x0.Count))\r\n}).Select(this1 => new {\r\n    HeartBeat = this1.this0.sumHeartBeat / ((double) this1.sumCount),\r\n    Date = this1.this0.g.Key.Date,\r\n    City = this1.this0.g.Key.City,\r\n    Count = this1.sumCount\r\n})", indexDefinition.Reduce);
 
-                    timeSeriesIndex.Execute(store);
+                    await timeSeriesIndex.ExecuteAsync(store);
 
                     var staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.True(staleness.IsStale);
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.False(staleness.IsStale);
@@ -882,7 +882,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, terms.Length);
                     Assert.Equal("10", terms[0]);
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -897,9 +897,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     staleness = store.Maintenance.Send(new GetIndexStalenessOperation(indexName));
                     Assert.False(staleness.IsStale);
@@ -908,7 +908,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, terms.Length);
                     Assert.Contains("la", terms);
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -922,9 +922,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     terms = store.Maintenance.Send(new GetTermsOperation(indexName, "City", null));
                     Assert.Equal(1, terms.Length);
@@ -932,7 +932,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
 
                     // delete source document
 
-                    store.Maintenance.Send(new StopIndexingOperation());
+                    await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                     using (var session = store.OpenSession())
                     {
@@ -946,9 +946,9 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     Assert.Equal(1, staleness.StalenessReasons.Count);
                     Assert.True(staleness.StalenessReasons.Any(x => x.Contains("There are still")));
 
-                    store.Maintenance.Send(new StartIndexingOperation());
+                    await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var database = await GetDatabase(store.Database);
                     var index = database.IndexStore.GetIndex(indexName);
@@ -1330,7 +1330,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -1609,7 +1609,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var indexInstance = database.IndexStore.GetIndex(indexName);
@@ -1634,7 +1634,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -1656,7 +1656,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (indexInstance._contextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (var tx = context.OpenReadTransaction())
@@ -1779,7 +1779,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
                 session.TimeSeriesFor(user.Id, timeSeries).Append(time, 12);
                 await session.SaveChangesAsync();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             await store.Maintenance.SendAsync(new StopIndexingOperation());
             var baseTime = new DateTime(2020, 11, 9);
@@ -1798,7 +1798,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
             }
 
             await store.Maintenance.SendAsync(new StartIndexingOperation());
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             await store.Maintenance.SendAsync(new StopIndexingOperation());
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests/Client/Lazy/Async/lazyAsync.cs
+++ b/test/SlowTests/Client/Lazy/Async/lazyAsync.cs
@@ -172,7 +172,7 @@ namespace SlowTests.Client.Lazy.Async
                 session.Advanced.GetMetadataFor(contact)["Val"] = "hello";
                 session.SaveChanges();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             using (var session = store.OpenAsyncSession())
             {
                 var contactViewModel =

--- a/test/SlowTests/Client/MoreLikeThis/MoreLikeThisTests.cs
+++ b/test/SlowTests/Client/MoreLikeThis/MoreLikeThisTests.cs
@@ -204,14 +204,14 @@ namespace SlowTests.Client.MoreLikeThis
 
                 using (var session = store.OpenSession())
                 {
-                    new DataIndex(true, false).Execute(store);
+                    await new DataIndex(true, false).ExecuteAsync(store);
 
                     var list = GetDataList();
                     list.ForEach(session.Store);
                     session.SaveChanges();
 
                     id = session.Advanced.GetDocumentId(list.First());
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
                 }
 
                 await AssetMoreLikeThisHasMatchesForAsync<Data, DataIndex>(store, id);

--- a/test/SlowTests/Client/Operations/StudioOperationsTests.cs
+++ b/test/SlowTests/Client/Operations/StudioOperationsTests.cs
@@ -114,7 +114,7 @@ namespace SlowTests.Client.Operations
                 }
                 await store.ExecuteIndexAsync(new AllowedUsers());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var stats = store.Maintenance.Send(new GetStudioFooterStatisticsOperation());
 

--- a/test/SlowTests/Client/Queries/RavenDB-17041.cs
+++ b/test/SlowTests/Client/Queries/RavenDB-17041.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Client.Queries
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -95,7 +95,7 @@ namespace SlowTests.Client.Subscriptions
             var workersAmount = 10;
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
 
                 var workerToDocsAmount = new Dictionary<SubscriptionWorker<User>, ConcurrentSet<string>>();
 
@@ -140,7 +140,7 @@ namespace SlowTests.Client.Subscriptions
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -376,7 +376,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 await using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -468,7 +468,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 await using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -567,7 +567,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 await using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -666,7 +666,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 await using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -794,7 +794,7 @@ namespace SlowTests.Client.Subscriptions
             await WaitForDocumentInClusterAsync<User>(cluster.Nodes, database, "user/6", predicate: null, TimeSpan.FromSeconds(15));
             await WaitForDocumentInClusterAsync<User>(cluster.Nodes, database, "user/3", predicate: null, TimeSpan.FromSeconds(15));
 
-            var id = store.Subscriptions.Create<User>(options: new SubscriptionCreationOptions
+            var id = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions
             {
                 MentorNode = "A"
             });
@@ -878,7 +878,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using (var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -937,7 +937,7 @@ namespace SlowTests.Client.Subscriptions
                     await mre1.WaitAsync();
                     await mre2.WaitAsync();
 
-                    store.Subscriptions.DropSubscriptionWorker(worker2);
+                    await store.Subscriptions.DropSubscriptionWorkerAsync(worker2);
                     var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                     db.SubscriptionStorage.TryGetRunningSubscriptionConnectionsState(long.Parse(id), out var subscriptionConnectionsState);
                     Assert.Equal(1, subscriptionConnectionsState.GetConnections().Count);
@@ -954,7 +954,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using var subscription1 = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     Strategy = strategy1,
@@ -989,7 +989,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using var subscription1 = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     Strategy = strategy1,
@@ -1029,7 +1029,7 @@ namespace SlowTests.Client.Subscriptions
             {
                 Server.ServerStore.LicenseManager.LicenseStatus.Attributes[LicenseAttribute.ConcurrentSubscriptions] = false;
 
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     Strategy = SubscriptionOpeningStrategy.Concurrent,
@@ -1064,7 +1064,7 @@ namespace SlowTests.Client.Subscriptions
                 }
 
                 var amre = new AsyncManualResetEvent();
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = "from Users where Name != 'R'"
                 });
@@ -1113,7 +1113,7 @@ namespace SlowTests.Client.Subscriptions
                     var executor = store.GetRequestExecutor();
                     using var _ = executor.ContextPool.AllocateOperationContext(out var ctx);
                     var cmd = new GetSubscriptionResendListCommand(store.Database, id);
-                    executor.Execute(cmd, ctx);
+                    await executor.ExecuteAsync(cmd, ctx);
                     var res = cmd.Result;
 
                     // the last batch may still not be cleared

--- a/test/SlowTests/Client/Subscriptions/CriteriaScript.cs
+++ b/test/SlowTests/Client/Subscriptions/CriteriaScript.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Client.Subscriptions
                         Query = "from Things where Name = 'ThingNo3'",
                         ChangeVector = lastChangeVector
                     };
-                    var subsId = subscriptionManager.Create(subscriptionCreationParams);
+                    var subsId = await subscriptionManager.CreateAsync(subscriptionCreationParams);
                     using (var subscription = subscriptionManager.GetSubscriptionWorker<Thing>(new SubscriptionWorkerOptions(subsId)
                     {
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
@@ -140,7 +140,7 @@ select project(d)
                         ChangeVector = lastChangeVector
                     };
 
-                    var subsId = subscriptionManager.Create(subscriptionCreationParams);
+                    var subsId = await subscriptionManager.CreateAsync(subscriptionCreationParams);
                     using (var subscription = subscriptionManager.GetSubscriptionWorker<Thing>(new SubscriptionWorkerOptions(subsId)
                     {
                         TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)

--- a/test/SlowTests/Client/Subscriptions/LimitSubscriptionsConnectionsAmount.cs
+++ b/test/SlowTests/Client/Subscriptions/LimitSubscriptionsConnectionsAmount.cs
@@ -79,7 +79,7 @@ namespace SlowTests.Client.Subscriptions
                 await Assert.ThrowsAsync(typeof(SubscriptionClosedException), () => subscriptionTask);
 
 
-                subscriptionTasks[0].SubscriptionObject.Dispose();
+                await subscriptionTasks[0].SubscriptionObject.DisposeAsync();
 
                 using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())

--- a/test/SlowTests/Client/Subscriptions/RavenDB-8404.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-8404.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = @"From Users as u Where startsWith(u.Name,'Th')"
                 });
@@ -73,7 +73,7 @@ namespace SlowTests.Client.Subscriptions
         {            
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = @"From Users as u Where endsWith(u.Name,'nd')"
                 });
@@ -120,7 +120,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = @"From Users as u Where regex(u.Name,'^Th')"
                 });
@@ -171,7 +171,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = @"From Users as u Where exists(u.AddressId)"
                 });
@@ -214,7 +214,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = "From Users as u Where intersect(endsWith(u.Name,'nd'), startsWith(u.Name, 'Th'), regex(u.Name, 'fabulous'))"
                 });
@@ -257,7 +257,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = "From Users as u Where intersect(endsWith(u.Name,'nd'), startsWith(u.Name, 'Th'), regex(u.Name, '^(\\\\w+\\\\s+){4}\\\\w+$'))"
                 });
@@ -300,7 +300,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = "From Users as u Where startsWith(u.Name, 'my\\\\id')"
                 });
@@ -343,7 +343,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = @"
 

--- a/test/SlowTests/Client/Subscriptions/RavenDB-8464.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-8464.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var subsId = store.Subscriptions.Create<User>(x => true);
+                var subsId = await store.Subscriptions.CreateAsync<User>(x => true);
 
                 string cv;
                 
@@ -61,7 +61,7 @@ namespace SlowTests.Client.Subscriptions
 
                 using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out var context))
                 {
-                    store.GetRequestExecutor().Execute(new CreateSubscriptionCommand(store.Conventions, new SubscriptionCreationOptions()
+                    await store.GetRequestExecutor().ExecuteAsync(new CreateSubscriptionCommand(store.Conventions, new SubscriptionCreationOptions()
                     {
                         ChangeVector = "DoNotChange",
                         Name = subsId,

--- a/test/SlowTests/Client/Subscriptions/RavenDB-9068.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-9068.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Client.Subscriptions
                 var subscription = store.Subscriptions.GetSubscriptionWorker<User>(subscriptionId);
                 var cts = new CancellationTokenSource();
                 var subscriptionTask = subscription.Run(x => { }, cts.Token);
-                cts.Cancel();
+                await cts.CancelAsync();
 
                 var task = Assert.ThrowsAnyAsync<Exception>(() => subscriptionTask);
                 Assert.True(await task.WaitWithoutExceptionAsync(_reasonableWaitTime), "1. await task.WaitWithoutExceptionAsync(_reasonableWaitTime)");
@@ -44,7 +44,7 @@ namespace SlowTests.Client.Subscriptions
                 subscription = store.Subscriptions.GetSubscriptionWorker<User>(subscriptionId);
                 cts = new CancellationTokenSource();
                 subscriptionTask = subscription.Run(x => Task.CompletedTask, cts.Token);
-                cts.Cancel();
+                await cts.CancelAsync();
 
                 var task2 = Assert.ThrowsAnyAsync<Exception>(() => subscriptionTask);
                 Assert.True(await task2.WaitWithoutExceptionAsync(_reasonableWaitTime), "2. await task.WaitWithoutExceptionAsync(_reasonableWaitTime)");

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3082.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3082.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Client.Subscriptions
                     await session.SaveChangesAsync();
                 }
 
-                var id = store.Subscriptions.Create(
+                var id = await store.Subscriptions.CreateAsync(
                     new SubscriptionCreationOptions<PersonWithAddress>
                     {
                         Filter = p => p.Name == "James" && p.Address.ZipCode != 54321

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3484.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
@@ -69,7 +69,7 @@ namespace SlowTests.Client.Subscriptions
             {
                 Cluster.SuspendObserver(Server);
 
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
 
                 const int numberOfClients = 2;
 
@@ -185,7 +185,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
 
                 var userId = 0;
 
@@ -253,7 +253,7 @@ namespace SlowTests.Client.Subscriptions
 
                     Assert.True(await activeSubscriptionMre.WaitAsync(_reasonableWaitTime));
 
-                    activeSubscription.Dispose(); // disconnect the active client, the pending one should be notified the the subscription is free and retry to open it
+                    await activeSubscription.DisposeAsync(); // disconnect the active client, the pending one should be notified the the subscription is free and retry to open it
 
                     using (var s = store.OpenSession())
                     {
@@ -273,7 +273,7 @@ namespace SlowTests.Client.Subscriptions
                     
                     Assert.True(await pendingBatchAcknowledgedMre.WaitAsync(_reasonableWaitTime)); // let it acknowledge the processed batch before we open another subscription
 
-                    pendingSubscription.Dispose();
+                    await pendingSubscription.DisposeAsync();
                 }
             }
         }

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3917.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3917.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Client.Subscriptions
                 ModifyDatabaseName = x => x + "store2"
             }))
             {
-                var subscriptionId = store1.Subscriptions.Create<User>(new SubscriptionCreationOptions<User>()
+                var subscriptionId = await store1.Subscriptions.CreateAsync<User>(new SubscriptionCreationOptions<User>()
                 {
                     Name = "Foo"
                 });

--- a/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var subscriptionName = store.Subscriptions.Create<User>(options: new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions()
                 {
                     Name = "Subs1"
                 });
@@ -83,7 +83,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var subscriptionName = store.Subscriptions.Create<User>(options: new SubscriptionCreationOptions()
+                var subscriptionName = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions()
                 {
                     Name = "Subs1",
                     Query = "from Users as u select {Name:'David'}"

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
@@ -42,7 +42,7 @@ namespace SlowTests.Client.Subscriptions
                 firstItemchangeVector[0].Etag += 10;
                 string cvBigger = firstItemchangeVector.SerializeVector();
 
-                var sn = store.Subscriptions.Create<User>();
+                var sn = await store.Subscriptions.CreateAsync<User>();
                 var worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(sn)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(100)

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9294.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9294.cs
@@ -31,7 +31,7 @@ namespace SlowTests.Client.Subscriptions
                     await session.SaveChangesAsync();
                 }
 
-                var sn = store.Subscriptions.Create<User>();
+                var sn = await store.Subscriptions.CreateAsync<User>();
                 var worker = store.Subscriptions.GetSubscriptionWorker<User>(sn);
 
                 var firstBatchHappened = new AsyncManualResetEvent();
@@ -44,7 +44,7 @@ namespace SlowTests.Client.Subscriptions
 
                 _ = worker.Run(x => { });
                 Assert.True(await firstBatchHappened.WaitAsync(_reasonableWaitTime));
-                worker.Dispose();
+                await worker.DisposeAsync();
                 worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(sn)
                 {
                     Strategy = SubscriptionOpeningStrategy.WaitForFree,

--- a/test/SlowTests/Client/Subscriptions/Subscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/Subscriptions.cs
@@ -221,7 +221,7 @@ namespace SlowTests.Client.Subscriptions
 
                         Assert.True(await ackSentAmre.WaitAsync(TimeSpan.FromSeconds(50)));
 
-                        acceptedSubscription.Dispose();
+                        await acceptedSubscription.DisposeAsync();
 
                         await CreateDocuments(store, 5);
 

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -92,7 +92,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var sub = store.Subscriptions.Create(new SubscriptionCreationOptions<User>
+                var sub = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>
                 {
                     Filter = user => user.Count > 0
                 });
@@ -147,11 +147,11 @@ namespace SlowTests.Client.Subscriptions
                     await session.SaveChangesAsync();
                 }
 
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>() { Name = "sub1" });
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>() { Name = "sub2" });
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>() { Name = "sub1" });
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>() { Name = "sub2" });
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
-                var subscriptionStataList = store.Subscriptions.GetSubscriptions(0, 10);
+                var subscriptionStataList = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                 Assert.Equal(3, subscriptionStataList.Count);
 
@@ -166,7 +166,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     using (var store2 = GetDocumentStore(new Options { ModifyDatabaseName = s => databaseName, CreateDatabase = false }))
                     {
-                        subscriptionStataList = store2.Subscriptions.GetSubscriptions(0, 10, databaseName);
+                        subscriptionStataList = await store2.Subscriptions.GetSubscriptionsAsync(0, 10, databaseName);
 
                         Assert.Equal(3, subscriptionStataList.Count);
                         Assert.True(subscriptionStataList.Any(x => x.SubscriptionName.Equals("sub1")));
@@ -206,11 +206,11 @@ namespace SlowTests.Client.Subscriptions
                     ModifyDatabaseName = s => $"{s}_2"
                 }))
                 {
-                    store1.Subscriptions.Create(new SubscriptionCreationOptions<User>() { Name = "sub1" });
-                    store1.Subscriptions.Create(new SubscriptionCreationOptions<User>() { Name = "sub2" });
-                    store1.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                    await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>() { Name = "sub1" });
+                    await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>() { Name = "sub2" });
+                    await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
-                    var subscriptionStataList = store1.Subscriptions.GetSubscriptions(0, 10);
+                    var subscriptionStataList = await store1.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                     Assert.Equal(3, subscriptionStataList.Count);
 
@@ -220,7 +220,7 @@ namespace SlowTests.Client.Subscriptions
                     operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
-                    subscriptionStataList = store2.Subscriptions.GetSubscriptions(0, 10, store2.Database);
+                    subscriptionStataList = await store2.Subscriptions.GetSubscriptionsAsync(0, 10, store2.Database);
 
                     Assert.Equal(3, subscriptionStataList.Count);
                     Assert.True(subscriptionStataList.Any(x => x.SubscriptionName.Equals("sub1")));
@@ -328,7 +328,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var subscriptionId = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                var subscriptionId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionId)
                 {
                     MaxDocsPerBatch = 1,
@@ -483,7 +483,7 @@ namespace SlowTests.Client.Subscriptions
             using (var store = GetDocumentStore())
             {
                 var count = 10;
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -576,7 +576,7 @@ namespace SlowTests.Client.Subscriptions
             using (var store = GetDocumentStore())
             {
                 var count = 10;
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -622,7 +622,7 @@ namespace SlowTests.Client.Subscriptions
 
                 const string newQuery = "from Users where Age > 18";
 
-                store.Subscriptions.Update(new SubscriptionUpdateOptions
+                await store.Subscriptions.UpdateAsync(new SubscriptionUpdateOptions
                 {
                     Name = state.SubscriptionName,
                     Query = newQuery,
@@ -674,7 +674,7 @@ namespace SlowTests.Client.Subscriptions
             using (var store = GetDocumentStore())
             {
                 var count = 10;
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -714,7 +714,7 @@ namespace SlowTests.Client.Subscriptions
 
                 const string newQuery = "from Users where Age > 18";
 
-                store.Subscriptions.Update(new SubscriptionUpdateOptions
+                await store.Subscriptions.UpdateAsync(new SubscriptionUpdateOptions
                 {
                     Name = state.SubscriptionName,
                     Query = newQuery,
@@ -804,7 +804,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore())
             {
-                var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions() { Query = @"from Dogs" });
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions() { Query = @"from Dogs" });
 
                 using (var commands = store.Commands())
                 {
@@ -1146,7 +1146,7 @@ namespace SlowTests.Client.Subscriptions
                 }
             }))
             {
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions<Company>());
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Company>());
                 var workerOptions = new SubscriptionWorkerOptions(id) { IgnoreSubscriberErrors = true, Strategy = SubscriptionOpeningStrategy.TakeOver };
                 var worker = store.Subscriptions.GetSubscriptionWorker<Company>(workerOptions, store.Database);
 
@@ -1169,7 +1169,7 @@ namespace SlowTests.Client.Subscriptions
             var maxErroneousPeriod = TimeSpan.FromSeconds(1);
             using (var store = GetDocumentStore())
             {
-                var id1 = store.Subscriptions.Create(new SubscriptionCreationOptions<Company>());
+                var id1 = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<Company>());
                 var workerOptions1 = new SubscriptionWorkerOptions(id1) { Strategy = SubscriptionOpeningStrategy.WaitForFree, MaxErroneousPeriod = maxErroneousPeriod };
 
                 var worker1Ack = new AsyncManualResetEvent();

--- a/test/SlowTests/Client/Subscriptions/TestSubscriptionOnDisabledDatabase.cs
+++ b/test/SlowTests/Client/Subscriptions/TestSubscriptionOnDisabledDatabase.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Client.Subscriptions
         {
             using (var store = GetDocumentStore(options))
             {
-                store.Subscriptions.Create<User>(options: new SubscriptionCreationOptions()
+                await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions()
                 {
                     Name = "Subs1"
                 });

--- a/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert/BulkInsert.cs
@@ -1271,7 +1271,7 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
                         // insert Time Series
                         using (var timeSeriesBulkInsert = bulkInsert.TimeSeriesFor(bulk.Key, "HeartRate"))
                         {
-                            timeSeriesBulkInsert.Append(baseline.AddMinutes(1), 59d, "watches/fitBit");
+                            await timeSeriesBulkInsert.AppendAsync(baseline.AddMinutes(1), 59d, "watches/fitBit");
                         }
                     }
                 }

--- a/test/SlowTests/Client/TimeSeries/BulkInsert/TypedBulkInsert.cs
+++ b/test/SlowTests/Client/TimeSeries/BulkInsert/TypedBulkInsert.cs
@@ -937,7 +937,7 @@ namespace SlowTests.Client.TimeSeries.BulkInsert
                         // insert Time Series
                         using (var timeSeriesBulkInsert = bulkInsert.TimeSeriesFor<HeartRateMeasure>(bulk.Key, "HeartRate"))
                         {
-                            timeSeriesBulkInsert.Append(baseline.AddMinutes(1), new HeartRateMeasure { HeartRate = 59 }, "watches/fitBit");
+                            await timeSeriesBulkInsert.AppendAsync(baseline.AddMinutes(1), new HeartRateMeasure { HeartRate = 59 }, "watches/fitBit");
                         }
                     }
                 }

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_15343.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_15343.cs
@@ -55,7 +55,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                     await SetupReplicationAsync(master, slave);
                     replication.ReplicateOnce("users/karmel");
 
-                    Indexes.WaitForIndexing(slave);
+                    await Indexes.WaitForIndexingAsync(slave);
                     RavenTestHelper.AssertNoIndexErrors(slave);
                 }
             }
@@ -104,7 +104,7 @@ namespace SlowTests.Client.TimeSeries.Issues
                     replication.ReplicateOnce("users/karmel");
 
                     await new TimeSeriesIndex().ExecuteAsync(slave);
-                    Indexes.WaitForIndexing(slave);
+                    await Indexes.WaitForIndexingAsync(slave);
                     RavenTestHelper.AssertNoIndexErrors(slave);
                 }
             }

--- a/test/SlowTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Policies/TimeSeriesConfigurationTests.cs
@@ -1235,7 +1235,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                 var now = DateTime.UtcNow;
                 var baseline = now.AddHours(-2);
 
-                store.Maintenance.Send(new StartTransactionsRecordingOperation(recordFilePath));
+                await store.Maintenance.SendAsync(new StartTransactionsRecordingOperation(recordFilePath));
 
                 using (var session = store.OpenSession())
                 {
@@ -1255,7 +1255,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                 await database.TimeSeriesPolicyRunner.RunRollups();
                 await database.TimeSeriesPolicyRunner.DoRetention();
 
-                store.Maintenance.Send(new StopTransactionsRecordingOperation());
+                await store.Maintenance.SendAsync(new StopTransactionsRecordingOperation());
 
 
                 using (var session = store.OpenSession())
@@ -1274,7 +1274,7 @@ namespace SlowTests.Client.TimeSeries.Policies
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
 
                 var command = new GetNextOperationIdCommand();
-                store.Commands().Execute(command);
+                await store.Commands().ExecuteAsync(command);
                 store.Maintenance.Send(new ReplayTransactionsRecordingOperation(replayStream, command.Result));
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Cluster/ClusterIndexNotificationsTest.cs
+++ b/test/SlowTests/Cluster/ClusterIndexNotificationsTest.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Cluster
                         await session.SaveChangesAsync(cts.Token);
                     }
 
-                    cts.Cancel();
+                    await cts.CancelAsync();
 
                     try
                     {

--- a/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
+++ b/test/SlowTests/Cluster/ClusterModesForRequestExecutorTest.cs
@@ -367,7 +367,7 @@ namespace SlowTests.Cluster
                         await Task.Delay(100);
                     } while (requestExecutor.TopologyNodes == null);
 
-                    DisposeServerAndWaitForFinishOfDisposal(leader);
+                    await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
 
                     var failedRequests = new HashSet<(string, Exception)>();
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1828,7 +1828,7 @@ namespace SlowTests.Cluster
                 await session.StoreAsync(new TestObj(), id1);
                 await session.SaveChangesAsync();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using var mre = new ManualResetEvent(false);
             try
@@ -1894,7 +1894,7 @@ select incl(c)"
                 session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id1, "some-value");
                 await session.SaveChangesAsync();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using var mre = new ManualResetEvent(false);
             try
@@ -2026,7 +2026,7 @@ select incl(c)"
                 await session.StoreAsync(new TestObj());
                 await session.SaveChangesAsync();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {

--- a/test/SlowTests/Cluster/NodeRedistribution.cs
+++ b/test/SlowTests/Cluster/NodeRedistribution.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Cluster
                 Urls = new[] { cluster.Leader.WebUrl }
             }.Initialize())
             {
-                store.Maintenance.Server.Send(new SetDatabaseDynamicDistributionOperation(store.Database, true));
+                await store.Maintenance.Server.SendAsync(new SetDatabaseDynamicDistributionOperation(store.Database, true));
                 await DisposeAndRemoveServer(res.Servers.First());
                 var wait = (moveToRehabGraceTime + replicaTimeout)* 10 * 1000;
                 if (Debugger.IsAttached)

--- a/test/SlowTests/Cluster/ParallelClusterTransactionsTests.cs
+++ b/test/SlowTests/Cluster/ParallelClusterTransactionsTests.cs
@@ -164,7 +164,7 @@ namespace SlowTests.Cluster
 
                 }
 
-                cts.Cancel();
+                await cts.CancelAsync();
                 await checkingTask;
                 await destablizeTask;
 

--- a/test/SlowTests/Corax/IndexBackwardCompatibilityAndPersistence.cs
+++ b/test/SlowTests/Corax/IndexBackwardCompatibilityAndPersistence.cs
@@ -74,14 +74,14 @@ namespace SlowTests.Corax
             using (var store = GetDocumentStore(new Options {Server = server, RunInMemory = false, Path = _databasePath}))
             {
                 _databaseName = store.Database;
-                _index.Execute(store);
+                await _index.ExecuteAsync(store);
                 using (var session = store.OpenSession())
                 {
                     var orders = session.Query<Order>()
                         .Where(x => x.OrderedAt == DateTime.Now).ToList();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 WaitForUserToContinueTheTest(store);
 
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
@@ -99,7 +99,7 @@ namespace SlowTests.Corax
             using (var store = GetDocumentStore(new Options {Server = server, RunInMemory = false, Path = _databasePath, ModifyDatabaseName = _ => _databaseName}))
             {
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var indexInstance1 = database.IndexStore.GetIndex(_index.IndexName);
                 var indexInstance2 = database.IndexStore.GetIndex("Auto/Orders/ByOrderedAt");

--- a/test/SlowTests/Corax/RavenDB_18864.cs
+++ b/test/SlowTests/Corax/RavenDB_18864.cs
@@ -34,7 +34,7 @@ public class RavenDB_18864 : RavenTestBase
             await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
         }
         
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
 
 
         {

--- a/test/SlowTests/Core/Commands/Documents.cs
+++ b/test/SlowTests/Core/Commands/Documents.cs
@@ -163,17 +163,17 @@ namespace SlowTests.Core.Commands
                         {Constants.Documents.Metadata.Collection, "Items"}
                     });
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
-                    var operation = store.Operations.Send(new PatchByQueryOperation(new IndexQuery { Query = "FROM INDEX 'MyIndex' UPDATE { this.NewName = 'NewValue'; } " }));
-                    operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                    var operation = await store.Operations.SendAsync(new PatchByQueryOperation(new IndexQuery { Query = "FROM INDEX 'MyIndex' UPDATE { this.NewName = 'NewValue'; } " }));
+                    await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                     dynamic document = await commands.GetAsync("items/1");
                     Assert.Equal("NewValue", document.NewName.ToString());
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
-                    operation = store.Operations.Send(new DeleteByQueryOperation(new IndexQuery() { Query = $"FROM INDEX 'MyIndex'" }));
-                    operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                    operation = await store.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery() { Query = $"FROM INDEX 'MyIndex'" }));
+                    await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                     var documents = await commands.GetAsync(0, 25);
                     Assert.Equal(0, documents.Count());

--- a/test/SlowTests/Core/Commands/Indexes.cs
+++ b/test/SlowTests/Core/Commands/Indexes.cs
@@ -195,8 +195,8 @@ namespace SlowTests.Core.Commands
             var index2 = new Posts_ByTitleAndContent();
             using (var store = GetDocumentStore(options))
             {
-                index1.Execute(store);
-                index2.Execute(store);
+                await index1.ExecuteAsync(store);
+                await index2.ExecuteAsync(store);
 
                 var indexes = await store.Maintenance.SendAsync(new GetIndexNamesOperation(0, 10));
                 Assert.Equal(2, indexes.Length);
@@ -212,7 +212,7 @@ namespace SlowTests.Core.Commands
             var index = new Users_ByName();
             using (var store = GetDocumentStore(options))
             {
-                index.Execute(store);
+                await index.ExecuteAsync(store);
                 using (var session = store.OpenSession())
                 {
                     for (var i = 0; i < 20; i++)
@@ -223,7 +223,7 @@ namespace SlowTests.Core.Commands
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
                 Assert.Equal(0, stats.StaleIndexes.Length);

--- a/test/SlowTests/Core/Indexing/BloomFilters.cs
+++ b/test/SlowTests/Core/Indexing/BloomFilters.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Core.Indexing
                 }
 
                 await new Index().ExecuteAsync(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -74,7 +74,7 @@ namespace SlowTests.Core.Indexing
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var context = new TransactionOperationContext(index._environment, 1024, 1024, 32 * 1024, SharedMultipleUseFlag.None))
                 {
@@ -96,7 +96,7 @@ namespace SlowTests.Core.Indexing
             using (var store = GetDocumentStore())
             {
                 await new Index().ExecuteAsync(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -108,7 +108,7 @@ namespace SlowTests.Core.Indexing
                 }
 
                 await new Index().ExecuteAsync(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -125,7 +125,7 @@ namespace SlowTests.Core.Indexing
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Core/Indexing/ReferencedDocuments.cs
+++ b/test/SlowTests/Core/Indexing/ReferencedDocuments.cs
@@ -532,11 +532,11 @@ namespace SlowTests.Core.Indexing
                     await session.StoreAsync(company);
                     await session.SaveChangesAsync();
 
-                    index.Execute(store);
-                    Indexes.WaitForIndexing(store);
+                    await index.ExecuteAsync(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     //Index disable
-                    store.Maintenance.Send(new DisableIndexOperation(index.IndexName));
+                    await store.Maintenance.SendAsync(new DisableIndexOperation(index.IndexName));
 
                     foreach (var employee in employees)
                     {
@@ -546,10 +546,10 @@ namespace SlowTests.Core.Indexing
                     await session.SaveChangesAsync();
 
                     //Index enable
-                    store.Maintenance.Send(new EnableIndexOperation(index.IndexName));
+                    await store.Maintenance.SendAsync(new EnableIndexOperation(index.IndexName));
                     
                     //Assert
-                    Indexes.WaitForIndexing(store, timeout: TimeSpan.FromSeconds(10));
+                    await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -602,11 +602,11 @@ namespace SlowTests.Core.Indexing
                     await session.StoreAsync(firstCompany);
                     await session.SaveChangesAsync();
                     
-                    index.Execute(store);
-                    Indexes.WaitForIndexing(store);
+                    await index.ExecuteAsync(store);
+                    await Indexes.WaitForIndexingAsync(store);
                     
                     //Index disable
-                    store.Maintenance.Send(new DisableIndexOperation(index.IndexName));
+                    await store.Maintenance.SendAsync(new DisableIndexOperation(index.IndexName));
                     foreach (var (_, employee) in list)
                     {
                         await session.StoreAsync(employee);
@@ -622,8 +622,8 @@ namespace SlowTests.Core.Indexing
                     await session.SaveChangesAsync();
 
                     //Index enable
-                    store.Maintenance.Send(new EnableIndexOperation(index.IndexName));
-                    Indexes.WaitForIndexing(store);
+                    await store.Maintenance.SendAsync(new EnableIndexOperation(index.IndexName));
+                    await Indexes.WaitForIndexingAsync(store);
 
                     //Assert
                     var queryResult = await session

--- a/test/SlowTests/Core/Session/Advanced.cs
+++ b/test/SlowTests/Core/Session/Advanced.cs
@@ -551,7 +551,7 @@ namespace SlowTests.Core.Session
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
                 }
 
-                using (store.AggressivelyCacheFor(TimeSpan.FromHours(1)))
+                using (await store.AggressivelyCacheForAsync(TimeSpan.FromHours(1)))
                 using (var changes = await store.Changes().EnsureConnectedNow())
                 {
                     var amre = new AsyncManualResetEvent();

--- a/test/SlowTests/Core/Session/Keys.cs
+++ b/test/SlowTests/Core/Session/Keys.cs
@@ -68,10 +68,10 @@ namespace SlowTests.Core.Session
                     Assert.Equal("def/Bob", user.Id);
                 }
 
-                Assert.Equal("def/", store.Conventions.GenerateDocumentId(store.Database, new User()));
+                Assert.Equal("def/", await store.Conventions.GenerateDocumentIdAsync(store.Database, new User()));
                 Assert.Equal("def/", await store.Conventions.GenerateDocumentIdAsync(store.Database, new User()));
 
-                Assert.Equal("addresses/1-A", store.Conventions.GenerateDocumentId(store.Database, new Address()));
+                Assert.Equal("addresses/1-A", await store.Conventions.GenerateDocumentIdAsync(store.Database, new Address()));
                 Assert.Equal("companies/1-A", await store.Conventions.GenerateDocumentIdAsync(store.Database, new Company()));
             }
         }

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -49,7 +49,7 @@ namespace SlowTests.ExtensionPoints
                 customSettings[RavenConfiguration.GetKey(x => x.Storage.OnDirectoryInitializeExecArguments)] = $"{scriptFile} {outputFile}";
 
                 script = "#!/bin/bash\r\necho \"$2 $3 $4 $5 $6\" >> $1";
-                File.WriteAllText(scriptFile, script);
+                await File.WriteAllTextAsync(scriptFile, script);
                 Process.Start("chmod", $"700 {scriptFile}");
             }
             else
@@ -61,7 +61,7 @@ namespace SlowTests.ExtensionPoints
 param([string]$userArg ,[string]$type, [string]$name, [string]$dataPath, [string]$tempPath, [string]$journalPath)
 Add-Content $userArg ""$type $name $dataPath $tempPath $journalPath\r\n""
 exit 0";
-                File.WriteAllText(scriptFile, script);
+                await File.WriteAllTextAsync(scriptFile, script);
             }
 
             UseNewLocalServer(customSettings: customSettings);
@@ -71,12 +71,12 @@ exit 0";
             {
                 using (var store = GetDocumentStore())
                 {
-                    store.Maintenance.Send(new CreateSampleDataOperation(DatabaseItemType.Indexes));
+                    await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Indexes));
 
                     // the database loads after all indexes are loaded
                     var documentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
-                    var lines = File.ReadAllLines(outputFile);
+                    var lines = await File.ReadAllLinesAsync(outputFile);
                     Assert.Equal(10, lines.Length);
                     Assert.True(lines[0].Contains($"{DirectoryExecUtils.EnvironmentType.System} {SystemDbName} {options.BasePath} {options.TempPath} {options.JournalPath}"));
                     Assert.True(lines[1].Contains($"{DirectoryExecUtils.EnvironmentType.Database} {store.Database} {options.BasePath} {options.TempPath} {options.JournalPath}"));
@@ -117,7 +117,7 @@ exit 0";
                 customSettings[RavenConfiguration.GetKey(x => x.Storage.OnDirectoryInitializeExecArguments)] = $"{scriptFile} {outputFile}";
 
                 script = "#!/bin/bash\r\necho \"$2 $3 $4 $5 $6\" >> $1";
-                File.WriteAllText(scriptFile, script);
+                await File.WriteAllTextAsync(scriptFile, script);
                 Process.Start("chmod", $"700 {scriptFile}");
             }
             else
@@ -129,7 +129,7 @@ exit 0";
 param([string]$userArg ,[string]$type, [string]$name, [string]$dataPath, [string]$tempPath, [string]$journalPath)
 Add-Content $userArg ""$type $name $dataPath $tempPath $journalPath\r\n""
 exit 0";
-                File.WriteAllText(scriptFile, script);
+                await File.WriteAllTextAsync(scriptFile, script);
             }
 
             UseNewLocalServer(customSettings: customSettings, runInMemory: false);
@@ -140,12 +140,12 @@ exit 0";
                 Path = basePath
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation(DatabaseItemType.Indexes));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Indexes));
 
                 // The database loads after all indexes are loaded
                 var documentDatabase = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
-                var lines = File.ReadAllLines(outputFile);
+                var lines = await File.ReadAllLinesAsync(outputFile);
                 Assert.Equal(10, lines.Length);
 
                 var systemEnvOptions = Server.ServerStore._env.Options;
@@ -268,7 +268,7 @@ exit 129";
             {
                 cryptoRandom.GetBytes(buffer);
             }
-            File.WriteAllBytes(keyPath, buffer);
+            await File.WriteAllBytesAsync(keyPath, buffer);
             var certificates = Certificates.GenerateAndSaveSelfSignedCertificate();
             if (PlatformDetails.RunningOnPosix)
             {
@@ -283,7 +283,7 @@ exit 129";
                 customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = "https://" + Environment.MachineName + ":0";
 
                 script = "#!/bin/bash\ncat \"$1\"";
-                File.WriteAllText(scriptPath, script);
+                await File.WriteAllTextAsync(scriptPath, script);
                 Process.Start("chmod", $"700 {scriptPath}");
             }
             else
@@ -310,7 +310,7 @@ catch {
     exit 1
 }
 exit 0";
-                File.WriteAllText(scriptPath, script);
+                await File.WriteAllTextAsync(scriptPath, script);
             }
 
             UseNewLocalServer(customSettings: customSettings, runInMemory: false);

--- a/test/SlowTests/MailingList/AggresiveCacheWithLazy.cs
+++ b/test/SlowTests/MailingList/AggresiveCacheWithLazy.cs
@@ -22,14 +22,14 @@ namespace SlowTests.MailingList
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var docLazy = session.Advanced.Lazily.LoadAsync<Doc>("doc-1");
                 var doc = await docLazy.Value;
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var requests = session.Advanced.NumberOfRequests;
 
@@ -53,7 +53,7 @@ namespace SlowTests.MailingList
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var docLazy = session.Advanced.Lazily.LoadAsync<Doc>("doc-1");
                 session.Advanced.Lazily.LoadAsync<Doc>("doc-2"); // not used
@@ -61,7 +61,7 @@ namespace SlowTests.MailingList
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var requests = session.Advanced.NumberOfRequests;
 
@@ -87,7 +87,7 @@ namespace SlowTests.MailingList
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var docLazy = session.Advanced.Lazily.LoadAsync<Doc>(loadedDocId);
                 _ = await docLazy.Value;
@@ -95,7 +95,7 @@ namespace SlowTests.MailingList
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var docLazy = session.Advanced.Lazily.LoadAsync<Doc>(loadedDocId);
                 _ = await docLazy.Value;
@@ -103,7 +103,7 @@ namespace SlowTests.MailingList
             }
 
             using (var session = store.OpenAsyncSession())
-            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromMinutes(5)))
+            using (await session.Advanced.DocumentStore.AggressivelyCacheForAsync(TimeSpan.FromMinutes(5)))
             {
                 var cachedDocLazy = session.Advanced.Lazily.LoadAsync<Doc>(loadedDocId);
                 session.Advanced.Lazily.LoadAsync<Doc>(unloadedDocId); // not used

--- a/test/SlowTests/MailingList/Andrej.cs
+++ b/test/SlowTests/MailingList/Andrej.cs
@@ -29,7 +29,7 @@ namespace SlowTests.MailingList
                     await session.StoreAsync(new Doc { Id = "doc-3", StrVal = "doc1" });
                     await session.SaveChangesAsync();
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     var query = session.Query<Doc, DocsIndex>()
                         .Search(x => x.StrVal, "doc*", boost: 2); // when boost is removed, works ok

--- a/test/SlowTests/MailingList/AsyncSpatial.cs
+++ b/test/SlowTests/MailingList/AsyncSpatial.cs
@@ -22,7 +22,7 @@ namespace SlowTests.MailingList
         {
             using (var db = GetDocumentStore(options))
             {
-                new Promos_Index().Execute(db);
+                await new Promos_Index().ExecuteAsync(db);
 
                 using (IAsyncDocumentSession session = db.OpenAsyncSession())
                 {
@@ -42,7 +42,7 @@ namespace SlowTests.MailingList
                         Coordinate = new Coordinate { latitude = 12.233, longitude = -73.995 }
                     });
                     await session.SaveChangesAsync();
-                    Indexes.WaitForIndexing(db);
+                    await Indexes.WaitForIndexingAsync(db);
 
                     var result = await session.Query<Promo, Promos_Index>()
                         .Spatial("Coordinates", x => x.WithinRadius(3.0, 41.145556, -73.995))

--- a/test/SlowTests/MailingList/IndexTest.cs
+++ b/test/SlowTests/MailingList/IndexTest.cs
@@ -64,7 +64,7 @@ namespace SlowTests.MailingList
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 Assert.True(index.IndexPersistence.HasWriter);
 
                 index.IndexPersistence.Clean(IndexCleanup.All);
@@ -87,7 +87,7 @@ namespace SlowTests.MailingList
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 Assert.True(index.IndexPersistence.HasWriter);
 
                 using (var session = store.OpenSession())
@@ -116,7 +116,7 @@ namespace SlowTests.MailingList
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 Assert.True(SpinWait.SpinUntil(() => index.IndexPersistence.HasWriter == false, TimeSpan.FromSeconds(15)));
 
                 using (var session = store.OpenSession())

--- a/test/SlowTests/MailingList/SuggestAsync.cs
+++ b/test/SlowTests/MailingList/SuggestAsync.cs
@@ -41,7 +41,7 @@ namespace SlowTests.MailingList
         {
             using (var store = GetDocumentStore(options))
             {
-                new People_ByName().Execute(store);
+                await new People_ByName().ExecuteAsync(store);
                 using (IAsyncDocumentSession session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new Person { Name = "Jack", Age = 20 });

--- a/test/SlowTests/MailingList/TestRavenIncludes.cs
+++ b/test/SlowTests/MailingList/TestRavenIncludes.cs
@@ -22,7 +22,7 @@ namespace SlowTests.MailingList
         {
             using (var store = GetDocumentStore(options))
             {
-                new SampleData_Index().Execute(store);
+                await new SampleData_Index().ExecuteAsync(store);
 
                 const string name = "John Doe";
                 using (var session = store.OpenSession())

--- a/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
+++ b/test/SlowTests/Rolling/RollingIndexesClusterTests.cs
@@ -125,7 +125,7 @@ namespace SlowTests.Rolling
                     {
                         try
                         {
-                            cts.Cancel();
+                            await cts.CancelAsync();
                             await t;
                         }
                         catch
@@ -200,7 +200,7 @@ namespace SlowTests.Rolling
                     {
                         try
                         {
-                            cts.Cancel();
+                            await cts.CancelAsync();
                             await t;
                         }
                         catch
@@ -306,7 +306,7 @@ namespace SlowTests.Rolling
                     {
                         try
                         {
-                            cts.Cancel();
+                            await cts.CancelAsync();
                             await t;
                         }
                         catch
@@ -383,7 +383,7 @@ namespace SlowTests.Rolling
                 }
                 finally
                 {
-                    source.Cancel();
+                    await source.CancelAsync();
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Ai)]
-    public void CanSingleDocumentHaveTwoEmbeddings()
+    public async Task CanSingleDocumentHaveTwoEmbeddings()
     {
         using var store = GetDocumentStore();
         string id;
@@ -46,8 +46,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             new EmbeddingPathConfiguration() { Path = "SubDto.Name", ChunkingOptions = DefaultChunkingOptions }
         ]);
         
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         
@@ -68,7 +68,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             session.SaveChanges();
         }
 
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
         AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["Updated"], id);
         AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Names", ["Name2", "Name4"], id);
@@ -78,7 +78,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void DocumentsWithSingleValue()
+    public async Task DocumentsWithSingleValue()
     {
         using (var store = GetDocumentStore())
         {
@@ -91,8 +91,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -101,7 +101,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void DocumentsWithListOfValues()
+    public async Task DocumentsWithListOfValues()
     {
         using (var store = GetDocumentStore())
         {
@@ -115,8 +115,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }]);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -125,7 +125,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void DocumentsWithNestedPropertyPath()
+    public async Task DocumentsWithNestedPropertyPath()
     {
         using (var store = GetDocumentStore())
         {
@@ -141,8 +141,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "SubDto.Name" , ChunkingOptions = DefaultChunkingOptions }]);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -151,7 +151,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void DocumentsWithNestedArrayPropertyPath()
+    public async Task DocumentsWithNestedArrayPropertyPath()
     {
         using (var store = GetDocumentStore())
         {
@@ -167,8 +167,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "SubDtos.Name" , ChunkingOptions = DefaultChunkingOptions}]);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -177,7 +177,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void EmbeddingsMustBeGeneratedOnlyOnceInDifferentBatches()
+    public async Task EmbeddingsMustBeGeneratedOnlyOnceInDifferentBatches()
     {
         using (var store = GetDocumentStore())
         {
@@ -196,8 +196,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var embeddingDocName = EmbeddingsHelper.GetEmbeddingCacheDocumentId(aiConnectionStringIdentifier, EmbeddingsHelper.CalculateInputValueHash("Name1"), VectorEmbeddingType.Single);
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -217,7 +217,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 session.Store(dto2);
                 session.SaveChanges();
             }
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
             using (var session = store.OpenSession())
             {
@@ -231,7 +231,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void UpdateOfDocumentsWithSingleValue()
+    public async Task UpdateOfDocumentsWithSingleValue()
     {
         using (var store = GetDocumentStore())
         {
@@ -245,8 +245,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -263,14 +263,14 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 session.SaveChanges();
                 dto = loadDoc;
             }
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
             AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["updated"], dto.Id);
         }
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void HandlingOfNonStringValues()
+    public async Task HandlingOfNonStringValues()
     {
         using (var store = GetDocumentStore())
         {
@@ -284,8 +284,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Age", ChunkingOptions = DefaultChunkingOptions }]);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -294,7 +294,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void FieldsToIncludeMustBeRespected()
+    public async Task FieldsToIncludeMustBeRespected()
     {
         using (var store = GetDocumentStore())
         {
@@ -308,8 +308,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (config, connectionString) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -456,7 +456,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void HandlingOfDocumentDeletions()
+    public async Task HandlingOfDocumentDeletions()
     {
         var dto1 = new Dto { Name = "Name1" };
         var dto2 = new Dto { Name = "Name2" };
@@ -471,8 +471,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
 
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);
                 var (configuration, _) = AddEmbeddingsGenerationTask(store);
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 
@@ -481,7 +481,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
                 session.Delete(dto1);
                 session.SaveChanges();
                 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
             }
 
             var documentEmbeddingsId1 = EmbeddingsHelper.GetEmbeddingDocumentId(dto1.Id);
@@ -499,7 +499,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void WillSetExpirationOnCacheDocuments()
+    public async Task WillSetExpirationOnCacheDocuments()
     {
         var dto = new Dto { Name = "Name1" };
 
@@ -513,8 +513,8 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
             
             var aiTaskDone = Etl.WaitForEtlToComplete(store);
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -601,7 +601,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void SimpleJsTransformation()
+    public async Task SimpleJsTransformation()
     {
         const string aiIntegrationName = "local-Onnx-AI";
         var dto = new Dto { Name = "Name1" };
@@ -623,8 +623,8 @@ embeddings.generate(
     Bar: 'ConstValue'
 });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -635,7 +635,7 @@ embeddings.generate(
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void NestedJsTransformation()
+    public async Task NestedJsTransformation()
     {
         const string aiIntegrationName = "local-Onnx-AI";
         var dto = new Dto { Name = "<h1>Name1</a1>" };
@@ -656,8 +656,8 @@ embeddings.generate(
     Foo: [html.strip(this.Name, 15), 'hello'], 
 });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -667,7 +667,7 @@ embeddings.generate(
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void HashingOfTextShouldBeCaseInsensitiveAndTrimWhitespaces()
+    public async Task HashingOfTextShouldBeCaseInsensitiveAndTrimWhitespaces()
     {
         var dto = new Dto() { Name = "\n UPPERCASEVALUE\n\r " };
         
@@ -683,8 +683,8 @@ embeddings.generate(
 
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store);
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -695,7 +695,7 @@ embeddings.generate(
     private record Test(string Id, DateTime? Expires);
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void TextChunkingInScript()
+    public async Task TextChunkingInScript()
     {
         const string plainTextToChunk =
             "text to chunk text to chunk text to chunk text to chunk text to chunk text to chunk text to chunk text to chunk text to chunk text to chunk";
@@ -716,8 +716,8 @@ embeddings.generate(
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ChunkedName: text.splitLines(this.Name, 5) });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
 
@@ -748,7 +748,7 @@ embeddings.generate(
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void MarkdownChunkingInScript()
+    public async Task MarkdownChunkingInScript()
     {
         const string markdownTextToChunk =
             @"# Sample Markdown
@@ -794,8 +794,8 @@ Console.WriteLine(""Hello, World!"");";
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ChunkedName: markdown.splitLines(this.Name, 20) });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
@@ -803,7 +803,7 @@ Console.WriteLine(""Hello, World!"");";
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void CanUseHtmlChunkingInScript()
+    public async Task CanUseHtmlChunkingInScript()
     {
         const string htmlTextToChunk =
             @"<html>
@@ -842,8 +842,8 @@ Console.WriteLine(""Hello, World!"");";
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ChunkedName: html.strip(this.Name, 5) });");
             
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ChunkedName", expectedChunks, dto.Id);
@@ -851,7 +851,7 @@ Console.WriteLine(""Hello, World!"");";
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void CanUseHtmlChunkingInPaths()
+    public async Task CanUseHtmlChunkingInPaths()
     {
         const string htmlTextToChunk =
             @"<html>
@@ -896,8 +896,8 @@ Console.WriteLine(""Hello, World!"");";
                 }}
             });
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", expectedChunks, dto.Id);
@@ -905,7 +905,7 @@ Console.WriteLine(""Hello, World!"");";
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void TransformationWithArrayFieldOutput()
+    public async Task TransformationWithArrayFieldOutput()
     {
         var dto = new Dto { Name = "CoolName" };
 
@@ -922,8 +922,8 @@ Console.WriteLine(""Hello, World!"");";
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 script: "embeddings.generate({ ArrayField: [this.Name, 'ConstValue'] });");
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "ArrayField", ["CoolName", "ConstValue"], dto.Id);
@@ -931,7 +931,7 @@ Console.WriteLine(""Hello, World!"");";
     }
 
     [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Vector | RavenTestCategory.Etl)]
-    public void QuantizationOfEmbeddingsInTwoTasks()
+    public async Task QuantizationOfEmbeddingsInTwoTasks()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         string id;
@@ -946,8 +946,8 @@ Console.WriteLine(""Hello, World!"");";
         var aiTaskDone = Etl.WaitForEtlToComplete(store);
         var (configuration1, connectionString1) = AddEmbeddingsGenerationTask(store,
             embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], targetQuantization: VectorEmbeddingType.Int8);
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration1);
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration1);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configuration1, connectionString1, "Name", ["CoolName"], id, VectorEmbeddingType.Int8);
@@ -955,8 +955,8 @@ Console.WriteLine(""Hello, World!"");";
         aiTaskDone.Reset();
         var (configuration2, connectionString2) = AddEmbeddingsGenerationTask(store, embeddingsGenerationTaskName: "secondtask",
             embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }], targetQuantization: VectorEmbeddingType.Single);
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration2);
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration2);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configuration1, connectionString1, "Name", ["CoolName"], id, VectorEmbeddingType.Int8);
@@ -964,7 +964,7 @@ Console.WriteLine(""Hello, World!"");";
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void QuantizationOfEmbeddingsInTask()
+    public async Task QuantizationOfEmbeddingsInTask()
     {
         var dto = new Dto { Name = "CoolName" };
         var targetQuantization = VectorEmbeddingType.Binary;
@@ -981,8 +981,8 @@ Console.WriteLine(""Hello, World!"");";
                 var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                     embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], targetQuantization: targetQuantization);
 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 var connectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
@@ -1014,7 +1014,7 @@ Console.WriteLine(""Hello, World!"");";
     [InlineData(VectorEmbeddingType.Int8)]
     [InlineData(VectorEmbeddingType.Binary)]
     [InlineData(VectorEmbeddingType.Single)]
-    public void ChunkingInEmbeddingsGenerationTaskConfiguration(VectorEmbeddingType quantization)
+    public async Task ChunkingInEmbeddingsGenerationTaskConfiguration(VectorEmbeddingType quantization)
     {
         var subDto = new SubDto() { Name = "pretty long text that will generate multiple chunks" };
         var dto = new Dto { Name = "different text that won't be chunked because of the configuration", SubDto = subDto};
@@ -1043,8 +1043,8 @@ Console.WriteLine(""Hello, World!"");";
                     targetQuantization: quantization,
                     embeddingsPaths: [nameConfig, subdtoNameConfig]);
                 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 AssertEmbeddingsForPath(store, configuration, connectionString, nameConfig.Path, Raven.Server.Documents.AI.TextChunker.Chunk(dto.Name, nameConfig.ChunkingOptions).ToArray(), dto.Id, quantization);
@@ -1109,7 +1109,7 @@ Console.WriteLine(""Hello, World!"");";
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void CollisionOfTwoEmbeddingsInSingleTask()
+    public async Task CollisionOfTwoEmbeddingsInSingleTask()
     {
         using var store = GetDocumentStore();
         string id;
@@ -1128,8 +1128,8 @@ Console.WriteLine(""Hello, World!"");";
             new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions },
         ]);
         
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connection, "Name", ["Name1"], id);
@@ -1141,13 +1141,13 @@ Console.WriteLine(""Hello, World!"");";
             session.Load<Dto>(id).Name = "Updated";
             session.SaveChanges();
         }        
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
         AssertEmbeddingsForPath(store, config, connection, "Name", ["Updated"], id);
         AssertEmbeddingsForPath(store, config, connection, "Names", ["Name1"], id);
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void CollisionOfTwoEmbeddingsInTwoTasks()
+    public async Task CollisionOfTwoEmbeddingsInTwoTasks()
     {
         using var store = GetDocumentStore();
         string id;
@@ -1170,11 +1170,11 @@ Console.WriteLine(""Hello, World!"");";
             new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions },
         ]);
         
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
-        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config2);
+        (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config2);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         
@@ -1188,14 +1188,14 @@ Console.WriteLine(""Hello, World!"");";
             session.SaveChanges();
         }        
 
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
         AssertEmbeddingsForPath(store, config, connection, "Name", ["Updated"], id);
         AssertEmbeddingsForPath(store, config2, connection2, "Names", ["Name1"], id);
     }
     
     [RavenFact(RavenTestCategory.Ai)]
-    public void CanUseProjectedFieldNameForQuery()
+    public async Task CanUseProjectedFieldNameForQuery()
     {
         const string plainTextToChunk = "some text that should produce a single chunk";
         string[] expectedChunks = ["some text that should produce a single chunk"];
@@ -1214,8 +1214,8 @@ Console.WriteLine(""Hello, World!"");";
                 var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                     script: "embeddings.generate({ ChunkedName: text.split(this.Name, 2048) });");
 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(configuration.Identifier),

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
-    public void CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int8()
+    public async Task CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int8()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         string id;
@@ -37,8 +38,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
             nameConfig
         }, targetQuantization: VectorEmbeddingType.Int8);
         
-        etl.Wait(DefaultEtlTimeout);
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        await etl.WaitAsync(DefaultEtlTimeout);
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Int8);
@@ -65,7 +66,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     }
     
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
-    public void CanPerformQuantizationInIndexFromEtl()
+    public async Task CanPerformQuantizationInIndexFromEtl()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         var id = "dtos/1";
@@ -80,8 +81,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         {
             new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 }}
         }, targetQuantization: VectorEmbeddingType.Single);
-        Assert.True(etl.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        Assert.True(await etl.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         
@@ -108,7 +109,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     }
     
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
-    public void CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int1()
+    public async Task CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int1()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         var id = "dtos/1";
@@ -120,8 +121,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
 
         var etl = Etl.WaitForEtlToComplete(store);
         var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Binary);
-        Assert.True(etl.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        Assert.True(await etl.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
 
@@ -148,7 +149,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
     }
     
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
-    public void QuantizedValuesInCacheAreSeparated()
+    public async Task QuantizedValuesInCacheAreSeparated()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         string id = "Dtos/1";
@@ -160,16 +161,16 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
 
         var etl = Etl.WaitForEtlToComplete(store);
         var (configurationSingle, connectionStringSingle) = AddEmbeddingsGenerationTask(embeddingsGenerationTaskName: "secondEtl", store: store, targetQuantization: VectorEmbeddingType.Single);
-        Assert.True(etl.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configurationSingle);
+        Assert.True(await etl.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configurationSingle);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configurationSingle, connectionStringSingle, "Name", ["car"], id, VectorEmbeddingType.Single);
         etl.Reset();
         
         var (configurationInt8, connectionStringInt8) = AddEmbeddingsGenerationTask(store, targetQuantization: VectorEmbeddingType.Int8);
-        Assert.True(etl.Wait(DefaultEtlTimeout));
-        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configurationInt8);
+        Assert.True(await etl.WaitAsync(DefaultEtlTimeout));
+        (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configurationInt8);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, configurationInt8, connectionStringInt8, "Name", ["car"], id, VectorEmbeddingType.Int8);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
@@ -45,8 +45,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Int8);
         
         
-        new Index().Execute(store);
-        Indexes.WaitForIndexing(store);
+        await new Index().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -88,8 +88,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id);
         
-        new QuantizationInIndex().Execute(store);
-        Indexes.WaitForIndexing(store);
+        await new QuantizationInIndex().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -128,8 +128,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
 
         AssertEmbeddingsForPath(store, configuration, connectionString, "Name", ["car"], id, VectorEmbeddingType.Binary);
 
-        new Index().Execute(store);
-        Indexes.WaitForIndexing(store);
+        await new Index().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -177,8 +177,8 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
 
         
         
-        new Index().Execute(store);
-        Indexes.WaitForIndexing(store);
+        await new Index().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
@@ -13,18 +13,19 @@ using Sparrow.Threading;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using System.Threading.Tasks;
 
 namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanIndexSingleVectorGeneratedByEtl() => CanIndexSingleVectorGeneratedByEtlBase<IndexByName>();
+    public async Task CanIndexSingleVectorGeneratedByEtl() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByName>();
 
     [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanIndexSingleVectorGeneratedByEtlJs() => CanIndexSingleVectorGeneratedByEtlBase<IndexByNameJs>();
+    public async Task CanIndexSingleVectorGeneratedByEtlJs() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByNameJs>();
 
-    private void CanIndexSingleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    private async Task CanIndexSingleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
     {
         using var store = GetDocumentStore();
 
@@ -53,8 +54,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         store.Maintenance.Send(new StopIndexOperation(index.IndexName));
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store);
-        Assert.True(etlStatus.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Joe"], id);
@@ -87,7 +88,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
             session.SaveChanges();
         }
 
-        Assert.True(etlStatus.Wait(DefaultEtlTimeout));
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
         Indexes.WaitForIndexing(store);
         using (var session = store.OpenSession())
         {
@@ -106,12 +107,12 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
     }
 
     [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanIndexMultipleVectorGeneratedByEtl() => CanIndexMultipleVectorGeneratedByEtlBase<IndexByNames>();
+    public async Task CanIndexMultipleVectorGeneratedByEtl() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNames>();
 
     [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanIndexMultipleVectorGeneratedByEtlJs() => CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesJs>();
+    public async Task CanIndexMultipleVectorGeneratedByEtlJs() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesJs>();
 
-    private void CanIndexMultipleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    private async Task CanIndexMultipleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
     {
         using var store = GetDocumentStore();
 
@@ -137,8 +138,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         store.Maintenance.Send(new StopIndexOperation(index.IndexName));
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }]);
-        Assert.True(etlStatus.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         store.Maintenance.Send(new StartIndexOperation(index.IndexName));
@@ -169,7 +170,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
             session.SaveChanges();
         }
 
-        Assert.True(etlStatus.Wait(DefaultEtlTimeout));
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
         Indexes.WaitForIndexing(store);
         using (var session = store.OpenSession())
         {
@@ -189,12 +190,12 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
 
 
     [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanIndexVectorFromTwoDifferentEtl() => CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFields>();
+    public async Task CanIndexVectorFromTwoDifferentEtl() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFields>();
 
     [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanIndexVectorFromTwoDifferentEtlJs() => CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsJs>();
+    public async Task CanIndexVectorFromTwoDifferentEtlJs() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsJs>();
 
-    private void CanIndexVectorFromTwoDifferentEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    private async Task CanIndexVectorFromTwoDifferentEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
     {
         const string embeddingEtlName = "V1";
         const string embeddingEtlName2 = "V2";
@@ -227,8 +228,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName);
         
-        Assert.True(etlStatus.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["Joe"], id);
@@ -254,8 +255,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
 
         etlStatus.Reset();
         var (config2, connectionString2) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName2);
-        Assert.True(etlStatus.Wait(DefaultEtlTimeout));
-        (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config2);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config2);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         Indexes.WaitForIndexing(store);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
@@ -39,8 +39,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         }
 
         var index = new TIndex();
-        index.Execute(store);
-        Indexes.WaitForIndexing(store);
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -51,7 +51,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
             Assert.Contains("Couldn't find Embeddings Generation task with 'localaitask' identifier", ex.Message);
         }
 
-        store.Maintenance.Send(new StopIndexOperation(index.IndexName));
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store);
         Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
@@ -60,8 +60,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Joe"], id);
 
-        store.Maintenance.Send(new StartIndexOperation(index.IndexName));
-        Indexes.WaitForIndexing(store);
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
         using (var session = store.OpenSession())
         {
             var nullElements = session.Query<Dto, TIndex>().Count(x => x.Vector == null);
@@ -89,7 +89,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         }
 
         Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
         using (var session = store.OpenSession())
         {
             var nullElements = session.Query<Dto, TIndex>().Count(x => x.Vector == null);
@@ -126,8 +126,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         }
 
         var index = new TIndex();
-        index.Execute(store);
-        Indexes.WaitForIndexing(store);
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -135,15 +135,15 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
             Assert.Equal(1, nullElements);
         }
 
-        store.Maintenance.Send(new StopIndexOperation(index.IndexName));
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }]);
         Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
         var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
-        store.Maintenance.Send(new StartIndexOperation(index.IndexName));
-        Indexes.WaitForIndexing(store);
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -171,7 +171,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         }
 
         Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
         using (var session = store.OpenSession())
         {
             var nullElements = session.Query<Dto, TIndex>().Count(x => x.Vector == null);
@@ -212,8 +212,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         }
 
         var index = new TIndex();
-        index.Execute(store);
-        Indexes.WaitForIndexing(store);
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -224,7 +224,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
             Assert.Equal(1, nullElements);
         }
 
-        store.Maintenance.Send(new StopIndexOperation(index.IndexName));
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
         var etlStatus = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName);
         
@@ -234,8 +234,8 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["Joe"], id);
         
-        store.Maintenance.Send(new StartIndexOperation(index.IndexName));
-        Indexes.WaitForIndexing(store);
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {
@@ -259,7 +259,7 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config2);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
         using (var session = store.OpenSession())
         {
             var nullElements = session.Query<Dto, TIndex>().Count(x => x.Vector2 == null);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -39,7 +39,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void CanGenerateEmbeddingsForQuerying(Options options)
+    public async Task CanGenerateEmbeddingsForQuerying(Options options)
     {
         const string queriedText = "fruit";
 
@@ -60,8 +60,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", ["apple"], dto1.Id);
@@ -92,7 +92,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void CanFetchEmbeddingFromCache(Options options)
+    public async Task CanFetchEmbeddingFromCache(Options options)
     {
         const string queriedText = "fruit";
 
@@ -114,8 +114,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store,
                 embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
@@ -135,7 +135,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void DoesIncorrectTaskNameInQueryThrow(Options options)
+    public async Task DoesIncorrectTaskNameInQueryThrow(Options options)
     {
         const string queriedText = "fruit";
 
@@ -164,8 +164,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                     }
                 });
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [queriedText], dto1.Id);
@@ -186,7 +186,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void CanGenerateEmbeddingsWhenQueryingStaticIndex(Options options)
+    public async Task CanGenerateEmbeddingsWhenQueryingStaticIndex(Options options)
     {
         const string queriedText = "fruit";
 
@@ -207,8 +207,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
             var (configuration, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
@@ -237,7 +237,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void CanChunkValueInQuery(Options options)
+    public async Task CanChunkValueInQuery(Options options)
     {
         const string queriedText = "computer machine technology tech";
 
@@ -263,8 +263,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 }
             ], chunkingOptionsForQuerying: new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 5 });
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
@@ -284,7 +284,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void CanSearchByMultipleVectorsByTexts(Options options)
+    public async Task CanSearchByMultipleVectorsByTexts(Options options)
     {
         using var store = GetDocumentStore(options);
 
@@ -304,8 +304,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.Store(dto3);
             session.SaveChanges();
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             
@@ -399,7 +399,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void WillFindUpdatedEmbeddingValues(Options options)
+    public async Task WillFindUpdatedEmbeddingValues(Options options)
     {
         using var store = GetDocumentStore(options);
 
@@ -411,8 +411,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.Store(new Dto() { TextualValue = "asdsdfsdf" }, "dto/1");
             session.SaveChanges();
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-            var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
             AssertEmbeddingsForPath(store, config, connection, "TextualValue", ["asdsdfsdf"], "dto/1");
@@ -429,7 +429,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             session.Store(new Dto() { TextualValue = "pizza" }, "dto/1");
             session.SaveChanges();
 
-            Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+            Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
             AssertEmbeddingsForPath(store, config, connection, "TextualValue", ["pizza"], "dto/1");
 
             var multiVectorTextualQuery = session.Query<Dto>().Customize(p => p.WaitForNonStaleResults())
@@ -441,7 +441,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void MultiVectorSearchSumsDuplicates(Options options)
+    public async Task MultiVectorSearchSumsDuplicates(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -457,8 +457,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 session.Store(dto2);
                 session.SaveChanges();
 
-                Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
-                var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
                 Assert.True(queriesWorkerRegistered);
                 Assert.True(indexingWorkerRegistered);
                 AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -217,8 +217,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             
             var connectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
             var index = new SomeIndex();
-            index.Execute(store);
-            Indexes.WaitForIndexing(store);
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenSession())
             {
@@ -270,8 +270,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             AssertEmbeddingsForPath(store, configuration, connectionString, "TextualValue", [dto1.TextualValue], dto1.Id);
             
             var index = new SomeIndex();
-            index.Execute(store);
-            Indexes.WaitForIndexing(store);
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenSession())
             {
@@ -327,8 +327,8 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
             Assert.Equal(0, multiVectorTextualQuery.Count);
         }
 
-        new VectorStaticIndex().Execute(store);
-        Indexes.WaitForIndexing(store);
+        await new VectorStaticIndex().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
@@ -34,8 +34,8 @@ public class RavenDB_24620(ITestOutputHelper output) : EmbeddingsGenerationTestB
         Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
         var index = new VectorIndex(source, destination);
-        index.Execute(store);
-        Indexes.WaitForIndexing(store);
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
 
         using (var session = store.OpenSession())
         {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
@@ -24,13 +25,13 @@ public class RavenDB_24620(ITestOutputHelper output) : EmbeddingsGenerationTestB
     [InlineData(VectorEmbeddingType.Single, VectorEmbeddingType.Binary)]
     [InlineData(VectorEmbeddingType.Int8, VectorEmbeddingType.Int8)]
     [InlineData(VectorEmbeddingType.Binary, VectorEmbeddingType.Binary)]
-    public void CanUseTaskToQueryPregeneratedEmbedding(VectorEmbeddingType? source, VectorEmbeddingType? destination)
+    public async Task CanUseTaskToQueryPregeneratedEmbedding(VectorEmbeddingType? source, VectorEmbeddingType? destination)
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         PrepareDocumentsWithAttachments(store, source);
         var aiTaskDone = Etl.WaitForEtlToComplete(store);
         var (aiIntegrationConfiguration, aiConnectionString) = AddEmbeddingsGenerationTask(store, targetQuantization: source ?? VectorEmbeddingType.Single);
-        Assert.True(aiTaskDone.Wait(DefaultEtlTimeout));
+        Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
 
         var index = new VectorIndex(source, destination);
         index.Execute(store);

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
@@ -49,8 +49,8 @@ public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestB
         var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [cityConfig, countryConfig], collectionName: "Orders");
         await etl.WaitAsync(DefaultEtlTimeout);
         var index = new Index();
-        index.Execute(store);
-        Indexes.WaitForIndexing(store);
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
         var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
@@ -62,7 +62,7 @@ public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Query = $@"from index '{index.IndexName}' where vector.search(VectorCity, ""uk"", 0.82, 20)"
             });
 
-            commands.RequestExecutor.Execute(command, commands.Context);
+            await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
 
             var results = new DynamicArray(command.Result.Results);
             Assert.Equal(1, results.Count());
@@ -75,7 +75,7 @@ public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestB
                 Query = $@"from index '{index.IndexName}' where vector.search(VectorCity, ""uk"", 0.82, 20)"
             }, indexEntriesOnly: true);
 
-            commands.RequestExecutor.Execute(command, commands.Context);
+            await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
 
             var results = new DynamicArray(command.Result.Results);
             Assert.Equal(1, results.Count());

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
@@ -1,13 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Net.Http;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Orders;
-using Raven.Client;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Queries;
 using Raven.Server.Documents.Indexes.Static;
@@ -20,7 +16,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void CanUseEmbeddingGenerationTaskInIndexEntriesQuery()
+    public async Task CanUseEmbeddingGenerationTaskInIndexEntriesQuery()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         var etl = Etl.WaitForEtlToComplete(store);
@@ -51,11 +47,11 @@ public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
 
         var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [cityConfig, countryConfig], collectionName: "Orders");
-        etl.Wait(DefaultEtlTimeout);
+        await etl.WaitAsync(DefaultEtlTimeout);
         var index = new Index();
         index.Execute(store);
         Indexes.WaitForIndexing(store);
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, configuration);
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
 

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
@@ -1,5 +1,5 @@
-﻿using Raven.Client.Documents.Operations.AI;
-using Raven.Server.Documents.AI;
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI.Embeddings;
 using Tests.Infrastructure;
 using Xunit;
@@ -10,7 +10,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 public class RemovalTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
     [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Etl)]
-    public void TaskRemoveEmbeddingsDocumentOfRemovedDocument()
+    public async Task TaskRemoveEmbeddingsDocumentOfRemovedDocument()
     {
         using var store = GetDocumentStore();
         string id0;
@@ -28,8 +28,8 @@ public class RemovalTests(ITestOutputHelper output) : EmbeddingsGenerationTestBa
         
         var etlWait = Etl.WaitForEtlToComplete(store);
         var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: "eg");
-        Assert.True(etlWait.Wait(DefaultEtlTimeout));
-        var (queriesWorkerRegistered, indexingWorkerRegistered) = WaitForEmbeddingsGenerationWorkerToRegister(store, config);
+        Assert.True(await etlWait.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
         Assert.True(queriesWorkerRegistered);
         Assert.True(indexingWorkerRegistered);
         AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Maciej"], id0);
@@ -42,7 +42,7 @@ public class RemovalTests(ITestOutputHelper output) : EmbeddingsGenerationTestBa
         }
         
         etlWait.Reset();
-        Assert.True(etlWait.Wait(DefaultEtlTimeout));
+        Assert.True(await etlWait.WaitAsync(DefaultEtlTimeout));
         using (var session = store.OpenSession())
         {
             var removedDocumentEmbeddings = EmbeddingsHelper.GetEmbeddingDocumentId(id0);

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -60,7 +60,7 @@ for(const comment of this.Comments)
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.Ollama, DatabaseMode = RavenDatabaseMode.Single)]
-    public void CanProcessDocuments(Options options, GenAiConfiguration config)
+    public async Task CanProcessDocuments(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -103,7 +103,7 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(etl.Wait(TimeSpan.FromSeconds(30)));
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(30)));
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/CompactDatabaseTest.cs
+++ b/test/SlowTests/Server/Documents/CompactDatabaseTest.cs
@@ -31,25 +31,25 @@ namespace SlowTests.Server.Documents
                 Path = path
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation(Raven.Client.Documents.Smuggler.DatabaseItemType.Documents | Raven.Client.Documents.Smuggler.DatabaseItemType.Indexes));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(Raven.Client.Documents.Smuggler.DatabaseItemType.Documents | Raven.Client.Documents.Smuggler.DatabaseItemType.Indexes));
 
                 for (int i = 0; i < 3; i++)
                 {
-                    await store.Operations.Send(new PatchByQueryOperation(new IndexQuery
+                    await (await store.Operations.SendAsync(new PatchByQueryOperation(new IndexQuery
                     {
                         Query = @"FROM Orders UPDATE { put(""orders/"", this); } "
-                    })).WaitForCompletionAsync(TimeSpan.FromSeconds(300));
+                    }))).WaitForCompletionAsync(TimeSpan.FromSeconds(300));
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                var deleteOperation = store.Operations.Send(new DeleteByQueryOperation(new IndexQuery() { Query = "FROM orders" }));
+                var deleteOperation = await store.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery() { Query = "FROM orders" }));
                 await deleteOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(60));
 
 
                 var oldSize = StorageCompactionTestsSlow.GetDirSize(new DirectoryInfo(path));
 
-                var compactOperation = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings
+                var compactOperation = await store.Maintenance.Server.SendAsync(new CompactDatabaseOperation(new CompactSettings
                 {
                     DatabaseName = store.Database,
                     Documents = true,

--- a/test/SlowTests/Server/Documents/Counters/CountersTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/Counters/CountersTombstoneCleaner.cs
@@ -70,7 +70,7 @@ namespace SlowTests.Server.Documents.Counters
 
                 await store.Maintenance.ForDatabase(storage.Name).SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await cleaner.ExecuteCleanup();
 
@@ -147,7 +147,7 @@ namespace SlowTests.Server.Documents.Counters
 
                 await store.Maintenance.ForDatabase(storage.Name).SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await cleaner.ExecuteCleanup();
 

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalPatchingTests.cs
@@ -286,7 +286,7 @@ public class DataArchivalPatchingTests : RavenTestBase
                     returnDebugInformation: false,
                     test: true);
 
-                commands.RequestExecutor.Execute(command, commands.Context);
+                await commands.RequestExecutor.ExecuteAsync(command, commands.Context);
                 var metadata = command.Result.ModifiedDocument[Constants.Documents.Metadata.Key] as BlittableJsonReaderObject;
                 Assert.False(metadata.TryGet(Constants.Documents.Metadata.Archived, out object _));
             }

--- a/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
@@ -32,7 +32,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void Simple_script(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task Simple_script(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -52,7 +52,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -71,7 +71,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -284,7 +284,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void No_script(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task No_script(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -303,7 +303,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -322,7 +322,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -335,7 +335,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Filtering_and_transformation_with_load_document(Options dstOptions)
+        public async Task Filtering_and_transformation_with_load_document(Options dstOptions)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore(dstOptions))
@@ -380,7 +380,7 @@ loadToUsers(
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -416,7 +416,7 @@ loadToUsers(
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -432,7 +432,7 @@ loadToUsers(
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Loading_to_different_collections(Options dstOptions)
+        public async Task Loading_to_different_collections(Options dstOptions)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore(dstOptions))
@@ -467,7 +467,7 @@ loadToAddresses(load(this.AddressId));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -509,7 +509,7 @@ loadToAddresses(load(this.AddressId));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -534,7 +534,7 @@ loadToAddresses(load(this.AddressId));
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void Loading_to_different_collections_using_this(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task Loading_to_different_collections_using_this(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -566,7 +566,7 @@ loadToAddresses(this.Address);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -601,7 +601,7 @@ loadToAddresses(this.Address);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -623,7 +623,7 @@ loadToAddresses(this.Address);
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void Loading_to_the_same_collection_by_js_object_should_preserve_collection_metadata(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task Loading_to_the_same_collection_by_js_object_should_preserve_collection_metadata(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -649,7 +649,7 @@ loadToUsers({Name: this.Name + ' ' + this.LastName });
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -798,7 +798,7 @@ loadToOrders(orderData);
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void Can_get_document_id(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task Can_get_document_id(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -817,7 +817,7 @@ loadToOrders(orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -899,7 +899,7 @@ loadToOrders(orderData);
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void Can_load_to_specific_collection_when_applying_to_all_docs(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task Can_load_to_specific_collection_when_applying_to_all_docs(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -921,7 +921,7 @@ loadToUsers(this);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/MultipleCollectionsRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/MultipleCollectionsRavenEtlTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -18,7 +19,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
         [InlineData(RavenDatabaseMode.Single, RavenDatabaseMode.Sharded)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Single)]
         [InlineData(RavenDatabaseMode.Sharded, RavenDatabaseMode.Sharded)]
-        public void Docs_from_two_collections_loaded_to_single_one(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
+        public async Task Docs_from_two_collections_loaded_to_single_one(RavenDatabaseMode srcDbMode, RavenDatabaseMode dstDbMode)
         {
             using (var src = GetDocumentStore(Options.ForMode(srcDbMode)))
             using (var dest = GetDocumentStore(Options.ForMode(dstDbMode)))
@@ -42,7 +43,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -76,7 +77,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -115,7 +116,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_10308.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_10308.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Extensions.Streams;
@@ -18,7 +19,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_load_all_attachments_when_no_script_is_defined(Options options)
+        public async Task Should_load_all_attachments_when_no_script_is_defined(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -39,7 +40,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -65,7 +66,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -83,7 +84,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_not_send_attachments_metadata_when_using_script(Options options)
+        public async Task Should_not_send_attachments_metadata_when_using_script(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -105,7 +106,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11157_Raven.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11157_Raven.cs
@@ -35,7 +35,7 @@ function loadCountersOfUsersBehavior(doc, counter)
         [RavenData("Users", null, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(null, null, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData("Users", BasicScript, DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_load_all_counters_when_no_script_is_defined_or_load_counter_behavior_sends_everyting_internal(Options options, string collection, string script)
+        public async Task Should_load_all_counters_when_no_script_is_defined_or_load_counter_behavior_sends_everyting_internal(Options options, string collection, string script)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -59,7 +59,7 @@ function loadCountersOfUsersBehavior(doc, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -83,7 +83,7 @@ function loadCountersOfUsersBehavior(doc, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -102,7 +102,7 @@ function loadCountersOfUsersBehavior(doc, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -119,7 +119,7 @@ function loadCountersOfUsersBehavior(doc, counter)
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_not_send_counters_metadata_when_using_script(Options options)
+        public async Task Should_not_send_counters_metadata_when_using_script(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -141,7 +141,7 @@ function loadCountersOfUsersBehavior(doc, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -159,7 +159,7 @@ function loadCountersOfUsersBehavior(doc, counter)
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_handle_counters(Options options)
+        public async Task Should_handle_counters(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -201,7 +201,7 @@ person.addCounter(loadCounter('down'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertCounters(dest, new[]
                 {
@@ -225,7 +225,7 @@ person.addCounter(loadCounter('down'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -255,7 +255,7 @@ person.addCounter(loadCounter('down'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -273,7 +273,7 @@ person.addCounter(loadCounter('down'));
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_use_get_counters(Options options)
+        public async Task Can_use_get_counters(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -309,7 +309,7 @@ for (var i = 0; i < counters.length; i++) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertCounters(dest, new[]
                 {
@@ -328,7 +328,7 @@ for (var i = 0; i < counters.length; i++) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_remove_counter_if_add_counter_gets_null_argument(Options options)
+        public async Task Should_remove_counter_if_add_counter_gets_null_argument(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -364,7 +364,7 @@ doc.addCounter(loadCounter('likes'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -389,7 +389,7 @@ doc.addCounter(loadCounter('likes'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -400,7 +400,7 @@ doc.addCounter(loadCounter('likes'));
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_use_has_counter(Options options)
+        public async Task Can_use_has_counter(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -438,7 +438,7 @@ if (hasCounter('down')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertCounters(dest, new[]
                 {
@@ -455,7 +455,7 @@ if (hasCounter('down')) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Must_not_send_counters_and_counter_tombstones_from_non_relevant_collections(Options options)
+        public async Task Must_not_send_counters_and_counter_tombstones_from_non_relevant_collections(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -484,7 +484,7 @@ if (hasCounter('down')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -509,7 +509,7 @@ if (hasCounter('down')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -521,7 +521,7 @@ if (hasCounter('down')) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_send_counter_even_if_doc_was_updater_later(Options options)
+        public async Task Should_send_counter_even_if_doc_was_updater_later(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -546,7 +546,7 @@ if (hasCounter('down')) {
 
                 Etl.AddEtl(src, dest, "Users", script: null);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -559,7 +559,7 @@ if (hasCounter('down')) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_send_updated_counter_values(Options options)
+        public async Task Should_send_updated_counter_values(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -577,7 +577,7 @@ if (hasCounter('down')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 etlDone.Reset();
 
@@ -590,7 +590,7 @@ if (hasCounter('down')) {
                         session.SaveChanges();
                     }
 
-                    etlDone.Wait(TimeSpan.FromMinutes(1));
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                     using (var session = dest.OpenSession())
                     {
@@ -604,7 +604,7 @@ if (hasCounter('down')) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
-        public void Should_skip_counter_if_has_lower_etag_than_document(Options options)
+        public async Task Should_skip_counter_if_has_lower_etag_than_document(Options options)
         {
             options.ModifyDatabaseRecord += x => 
                 x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxNumberOfExtractedDocuments)] = "2";
@@ -626,7 +626,7 @@ if (hasCounter('down')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 etlDone = Etl.WaitForEtlToComplete(src, numOfProcessesToWaitFor: 3);
 
@@ -665,7 +665,7 @@ if (hasCounter('down')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -739,7 +739,7 @@ if (hasCounter('down')) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_handle_counters_according_to_behavior_defined_in_script(Options options)
+        public async Task Should_handle_counters_according_to_behavior_defined_in_script(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -777,7 +777,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertCounters(dest, new[]
                 {
@@ -794,7 +794,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertCounters(dest, new[]
                 {
@@ -809,7 +809,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -828,7 +828,7 @@ function loadCountersOfUsersBehavior(docId, counter)
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_not_send_counters_if_load_counters_behavior_isnt_defined(Options options)
+        public async Task Should_not_send_counters_if_load_counters_behavior_isnt_defined(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -848,7 +848,7 @@ loadToUsers(this);");
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -866,7 +866,7 @@ loadToUsers(this);");
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -968,7 +968,7 @@ function loadCountersOfCustomersBehavior(docId, counter) // it's ok
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Load_counters_behavior_function_can_use_other_function_defined_in_script(Options options)
+        public async Task Load_counters_behavior_function_can_use_other_function_defined_in_script(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -996,7 +996,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1008,7 +1008,7 @@ function loadCountersOfUsersBehavior(docId, counter)
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_override_counter_value(Options options)
+        public async Task Should_override_counter_value(Options options)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -1026,7 +1026,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1049,7 +1049,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1060,7 +1060,7 @@ function loadCountersOfUsersBehavior(docId, counter)
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_define_multiple_load_counter_behavior_functions(Options options)
+        public async Task Can_define_multiple_load_counter_behavior_functions(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -1107,7 +1107,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -1125,7 +1125,7 @@ function loadCountersOfUsersBehavior(docId, counter)
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11379.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11379.cs
@@ -46,7 +46,7 @@ for (var i = 0; i < attachments.length; i++) {
 }
 ", false, "photo.png", "photo.png", DatabaseMode = RavenDatabaseMode.All)]
 
-        public void Should_remove_attachment(Options options, string script, bool applyToAllDocuments, string attachmentSourceName, string attachmentDestinationName)
+        public async Task Should_remove_attachment(Options options, string script, bool applyToAllDocuments, string attachmentSourceName, string attachmentDestinationName)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -67,7 +67,7 @@ for (var i = 0; i < attachments.length; i++) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -86,7 +86,7 @@ for (var i = 0; i < attachments.length; i++) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11515_Raven.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_11515_Raven.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_filter_out_deletions_of_documents(Options options)
+        public async Task Can_filter_out_deletions_of_documents(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -41,7 +42,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -56,7 +57,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -67,7 +68,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_define_multiple_delete_behavior_functions(Options options)
+        public async Task Can_define_multiple_delete_behavior_functions(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -102,7 +103,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -120,7 +121,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_14707.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_14707.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using Raven.Tests.Core.Utils.Entities;
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_delete_existing_document_when_filtered_by_script(Options options)
+        public async Task Should_delete_existing_document_when_filtered_by_script(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -34,7 +35,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -51,7 +52,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_3639.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_3639.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Docs_are_transformed_according_to_provided_collection_specific_scripts(Options options)
+        public async Task Docs_are_transformed_according_to_provided_collection_specific_scripts(Options options)
         {
             using (var master = GetDocumentStore(options))
             using (var slave = GetDocumentStore())
@@ -41,7 +42,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = slave.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_3760.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_3760.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_use_metadata_in_transform_script(Options options)
+        public async Task Can_use_metadata_in_transform_script(Options options)
         {
             using (var master = GetDocumentStore(options))
             using (var slave = GetDocumentStore())
@@ -39,7 +40,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = slave.OpenSession())
                 {
@@ -52,7 +53,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Null_returned_from_script_means_that_document_is_filtered_out(Options options)
+        public async Task Null_returned_from_script_means_that_document_is_filtered_out(Options options)
         {
             using (var master = GetDocumentStore(options))
             using (var slave = GetDocumentStore())
@@ -81,7 +82,7 @@ loadToUsers(this);");
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = slave.OpenSession())
                 {
@@ -104,7 +105,7 @@ loadToUsers(this);");
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Null_script_means_no_transformation_nor_filtering_within_specified_collection(Options options)
+        public async Task Null_script_means_no_transformation_nor_filtering_within_specified_collection(Options options)
         {
             using (var master = GetDocumentStore(options))
             using (var slave = GetDocumentStore())
@@ -128,7 +129,7 @@ loadToUsers(this);");
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = slave.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6711_RavenEtl.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6711_RavenEtl.cs
@@ -158,7 +158,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Script_defined_for_all_documents(Options options)
+        public async Task Script_defined_for_all_documents(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -192,7 +192,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 DatabaseStatistics stats;
                 using (var session = dest.OpenSession())
@@ -226,7 +226,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 stats = dest.Maintenance.Send(new GetStatisticsOperation());
                 Assert.Equal(3, stats.CountOfDocuments);
@@ -243,7 +243,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -258,7 +258,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Script_defined_for_all_documents_with_filtering_and_loads_to_the_same_collection_for_some_docs(Options options)
+        public async Task Script_defined_for_all_documents_with_filtering_and_loads_to_the_same_collection_for_some_docs(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -290,7 +290,7 @@ if (this['@metadata']['@collection'] != 'Orders')
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 DatabaseStatistics stats;
                 using (var session = dest.OpenSession())
@@ -318,7 +318,7 @@ if (this['@metadata']['@collection'] != 'Orders')
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 stats = dest.Maintenance.Send(new GetStatisticsOperation());
                 Assert.Equal(2, stats.CountOfDocuments);
@@ -335,7 +335,7 @@ if (this['@metadata']['@collection'] != 'Orders')
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_7064.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_7064.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using FastTests;
 using FastTests.Voron.Util;
 using Raven.Client;
@@ -19,7 +20,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Should_handle_attachments(Options options)
+        public async Task Should_handle_attachments(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -61,7 +62,7 @@ person.addAttachment('photo2.jpg-etl', loadAttachment('photo2.jpg'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertAttachments(dest, new[]
                 {
@@ -85,7 +86,7 @@ person.addAttachment('photo2.jpg-etl', loadAttachment('photo2.jpg'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -116,7 +117,7 @@ person.addAttachment('photo2.jpg-etl', loadAttachment('photo2.jpg'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -168,7 +169,7 @@ person.addAttachment('photo2.jpg-etl', loadAttachment('photo2.jpg'));
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_use_get_attachments(Options options)
+        public async Task Can_use_get_attachments(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -204,7 +205,7 @@ for (var i = 0; i < attachments.length; i++) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertAttachments(dest, new[]
                 {
@@ -223,7 +224,7 @@ for (var i = 0; i < attachments.length; i++) {
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_use_has_attachment(Options options)
+        public async Task Can_use_has_attachment(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -262,7 +263,7 @@ if (hasAttachment('photo2.jpg')) {
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 AssertAttachments(dest, new[]
                 {

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9403.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9403.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Identifier_of_loaded_doc_should_not_be_created_using_cluster_identities(Options options)
+        public async Task Identifier_of_loaded_doc_should_not_be_created_using_cluster_identities(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -34,7 +35,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11891.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11891.cs
@@ -5,6 +5,7 @@ using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using System.Threading.Tasks;
 
 namespace SlowTests.Server.Documents.ETL
 {
@@ -15,7 +16,7 @@ namespace SlowTests.Server.Documents.ETL
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void Should_filter_out_deletions_using_generic_delete_behavior()
+        public async Task Should_filter_out_deletions_using_generic_delete_behavior()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -51,7 +52,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -69,7 +70,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -85,7 +86,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -102,7 +103,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -117,7 +118,7 @@ namespace SlowTests.Server.Documents.ETL
         [RavenTheory(RavenTestCategory.Etl)]
         [InlineData(new string[0], true)]
         [InlineData(new[] { "Users", "Employees" }, false)]
-        public void Should_filter_out_deletions_using_generic_delete_behavior_function_and_marker_document(string[] collections, bool applyToAllDocuments)
+        public async Task Should_filter_out_deletions_using_generic_delete_behavior_function_and_marker_document(string[] collections, bool applyToAllDocuments)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -150,7 +151,7 @@ function deleteDocumentsBehavior(docId, collection) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -170,7 +171,7 @@ function deleteDocumentsBehavior(docId, collection) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -181,7 +182,7 @@ function deleteDocumentsBehavior(docId, collection) {
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void Should_filter_out_deletions_using_delete_behavior_function_and_marker_document()
+        public async Task Should_filter_out_deletions_using_delete_behavior_function_and_marker_document()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -215,7 +216,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -233,7 +234,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
                     session.SaveChanges();
                 }
 
-                Assert.False(etlDone.Wait(TimeSpan.FromSeconds(3)));
+                Assert.False(await etlDone.WaitAsync(TimeSpan.FromSeconds(3)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -272,7 +273,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
         return true;
     }
 ")]
-        public void Should_choose_more_specific_delete_behavior_function(string script)
+        public async Task Should_choose_more_specific_delete_behavior_function(string script)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -296,7 +297,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -314,7 +315,7 @@ function deleteDocumentsOfEmployeesBehavior(docId) {
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_11897.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_11897.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Tests.Core.Utils.Entities;
@@ -34,7 +35,7 @@ namespace SlowTests.Server.Documents.ETL
       return true;
     }
 ")]
-        public void Should_handle_as_empty_script_but_filter_out_deletions(string script)
+        public async Task Should_handle_as_empty_script_but_filter_out_deletions(string script)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -64,7 +65,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -81,7 +82,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -97,7 +98,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -112,7 +113,7 @@ namespace SlowTests.Server.Documents.ETL
                     session.SaveChanges();
                 }
 
-                Assert.False(etlDone.Wait(TimeSpan.FromSeconds(3)));
+                Assert.False(await etlDone.WaitAsync(TimeSpan.FromSeconds(3)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_13218.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_13218.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.Operations;
@@ -26,7 +27,7 @@ function loadCountersOfOrdersBehavior(doc, counter)
     return true;
 }
 ")]
-        public void MustNotIterateCountersTooFar(string collection, string script)
+        public async Task MustNotIterateCountersTooFar(string collection, string script)
         {
             using (var src = GetDocumentStore(new Options()
             {
@@ -65,7 +66,7 @@ function loadCountersOfOrdersBehavior(doc, counter)
 
                 var etlDone = Etl.WaitForEtlToComplete(src, (n, s) => s.LoadSuccesses >= numberOfDocs * 2);
 
-                etlDone.Wait(TimeSpan.FromSeconds(60));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(60));
 
                 var destStats = dest.Maintenance.Send(new GetStatisticsOperation());
 

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_13218.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_13218.cs
@@ -51,9 +51,9 @@ function loadCountersOfOrdersBehavior(doc, counter)
                     session.SaveChanges();
                 }
 
-                src.Operations.Send(new PatchByQueryOperation(@"from Orders update{
+                await (await src.Operations.SendAsync(new PatchByQueryOperation(@"from Orders update{
     incrementCounter(this, 'Foo', 1);
-}")).WaitForCompletion(TimeSpan.FromMinutes(5));
+}"))).WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
                 if (collection == null)
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_14848.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_14848.cs
@@ -112,7 +112,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 etlDone.Reset();
 
-                src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allDocs"));
+                await src.Maintenance.SendAsync(new ResetEtlOperation("myConfiguration", "allDocs"));
 
                 await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_14848.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_14848.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -63,7 +64,7 @@ namespace SlowTests.Server.Documents.ETL
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void ShouldResetEtl(Options options)
+        public async Task ShouldResetEtl(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -92,7 +93,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 var etlDone = Etl.WaitForEtlToComplete(src);
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 var configuration2 = new RavenEtlConfiguration()
                 {
@@ -113,7 +114,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allDocs"));
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_15637.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_15637.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -32,7 +33,7 @@ loadToUsers(this);
 function deleteDocumentsOfUsersBehavior(docId, deleted){
 return deleted;
 }")]
-        public void ShouldNotDeleteDestinationDocumentWhenFilteredOutOfLoad(string script)
+        public async Task ShouldNotDeleteDestinationDocumentWhenFilteredOutOfLoad(string script)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -51,7 +52,7 @@ return deleted;
 
                     Etl.AddEtl(src, dest, "Users", script);
                     var etlDone = Etl.WaitForEtlToComplete(src);
-                    etlDone.Wait(timeout:TimeSpan.FromSeconds(10));
+                    await etlDone.WaitAsync(timeout:TimeSpan.FromSeconds(10));
                 }
 
                 using (var session = dest.OpenSession())
@@ -80,7 +81,7 @@ loadToUsers(this);
 function deleteDocumentsOfUsersBehavior(docId, deleted) {
 return !deleted;
 }")]
-        public void ShouldDeleteDestinationDocumentWhenFilteredOutOfLoad(string script)
+        public async Task ShouldDeleteDestinationDocumentWhenFilteredOutOfLoad(string script)
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -101,7 +102,7 @@ return !deleted;
 
                 Etl.AddEtl(src, dest, "Users", script);
                 var etlDone = Etl.WaitForEtlToComplete(src);
-                etlDone.Wait(timeout:TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(timeout:TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_7284.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_7284.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
@@ -17,7 +18,7 @@ namespace SlowTests.Server.Documents.ETL
 
         [RavenTheory(RavenTestCategory.Etl)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void EtlTaskDeletionShouldDeleteItsState(Options options)
+        public async Task EtlTaskDeletionShouldDeleteItsState(Options options)
         {
             using (var src = GetDocumentStore(options))
             using (var dest = GetDocumentStore())
@@ -51,7 +52,7 @@ namespace SlowTests.Server.Documents.ETL
                     Database = dest.Database,
                 });
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 src.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.RavenEtl));
 
@@ -64,7 +65,7 @@ namespace SlowTests.Server.Documents.ETL
                     Database = dest.Database,
                 });
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
-                src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allUsers"));
+                await src.Maintenance.SendAsync(new ResetEtlOperation("myConfiguration", "allUsers"));
 
                 Assert.True(await resetDone.WaitAsync(TimeSpan.FromMinutes(1)));
             }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_8866.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.ETL
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void CanResetEtl()
+        public async Task CanResetEtl()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -59,16 +59,16 @@ namespace SlowTests.Server.Documents.ETL
                     Database = dest.Database,
                 });
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allUsers"));
 
-                Assert.True(resetDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await resetDone.WaitAsync(TimeSpan.FromMinutes(1)));
             }
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void CanResetEtl2()
+        public async Task CanResetEtl2()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -119,7 +119,7 @@ namespace SlowTests.Server.Documents.ETL
 
                 for (int i = 0; i < 10; i++)
                 {
-                    Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)), $"blah at {i}");
+                    Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)), $"blah at {i}");
 
                     mre.Set();
 

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -901,12 +901,12 @@ loadToOrders(orderData);
                         {
                             dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/1-A'";
 
-                            var sqlDataReader = dbCommand.ExecuteReader();
+                            var sqlDataReader = await dbCommand.ExecuteReaderAsync();
 
                             Assert.True(sqlDataReader.Read());
                             var stream = sqlDataReader.GetStream(0);
 
-                            var bytes = stream.ReadData();
+                            var bytes = await stream.ReadDataAsync();
 
                             Assert.Equal(attachmentBytes, bytes);
                         }
@@ -976,12 +976,12 @@ loadToOrders(orderData);
                         {
                             dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/2-A'";
 
-                            var sqlDataReader = dbCommand.ExecuteReader();
+                            var sqlDataReader = await dbCommand.ExecuteReaderAsync();
 
                             Assert.True(sqlDataReader.Read());
                             var stream = sqlDataReader.GetStream(0);
 
-                            var bytes = stream.ReadData();
+                            var bytes = await stream.ReadDataAsync();
 
                             Assert.Equal(attachmentBytes, bytes);
                         }
@@ -1116,7 +1116,7 @@ loadToOrders(orderData);
 
                             dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/1-A'";
 
-                            var sqlDataReader = dbCommand.ExecuteReader();
+                            var sqlDataReader = await dbCommand.ExecuteReaderAsync();
 
                             Assert.True(sqlDataReader.Read());
                             Assert.True(sqlDataReader.IsDBNull(0));

--- a/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
@@ -1137,7 +1137,7 @@ loadToOrders(orderData);
     }
     
     [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
-    public void Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
+    public async Task Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
     {
         using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxBatchSize)] = "5" }))
         {
@@ -1176,7 +1176,7 @@ var orderData = {
 loadToOrders(orderData);
 ");
     
-                etlDone.Wait(TimeSpan.FromMinutes(5));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(5));
 
                 var database = GetDatabase(store.Database).Result;
 
@@ -1188,7 +1188,7 @@ loadToOrders(orderData);
 
                 etlDone = Etl.WaitForEtlToComplete(store, (n, s) => s.LoadSuccesses >= 6);
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
@@ -421,9 +421,9 @@ loadToOrders(orderData);");
                     using (var dbCommand = con.CreateCommand())
                     {
                         dbCommand.CommandText = " SELECT COUNT(*) FROM Orders";
-                        Assert.Equal(1L, dbCommand.ExecuteScalar());
+                        Assert.Equal(1L, await dbCommand.ExecuteScalarAsync());
                         dbCommand.CommandText = " SELECT City FROM Orders";
-                        Assert.Equal(DBNull.Value, dbCommand.ExecuteScalar());
+                        Assert.Equal(DBNull.Value, await dbCommand.ExecuteScalarAsync());
                     }
                 }
             }
@@ -942,19 +942,19 @@ loadToOrders(orderData);
                     using (var dbCommand = con.CreateCommand())
                     {
                         dbCommand.CommandText = " SELECT COUNT(*) FROM Orders";
-                        Assert.Equal(3L, dbCommand.ExecuteScalar());
+                        Assert.Equal(3L, await dbCommand.ExecuteScalarAsync());
                     }
 
                     using (var dbCommand = con.CreateCommand())
                     {
                         dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/2-A'";
 
-                        var sqlDataReader = dbCommand.ExecuteReader();
+                        var sqlDataReader = await dbCommand.ExecuteReaderAsync();
 
-                        Assert.True(sqlDataReader.Read());
+                        Assert.True(await sqlDataReader.ReadAsync());
                         var stream = sqlDataReader.GetStream(0);
 
-                        var bytes = stream.ReadData();
+                        var bytes = await stream.ReadDataAsync();
 
                         Assert.Equal(attachmentBytes, bytes);
                     }
@@ -1026,7 +1026,7 @@ for (var i = 0; i < attachments.length; i++)
                     using (var dbCommand = con.CreateCommand())
                     {
                         dbCommand.CommandText = " SELECT COUNT(*) FROM Attachments";
-                        Assert.Equal(2L, dbCommand.ExecuteScalar());
+                        Assert.Equal(2L, await dbCommand.ExecuteScalarAsync());
                     }
                 }
             }
@@ -1073,13 +1073,13 @@ loadToOrders(orderData);
                     using (var dbCommand = con.CreateCommand())
                     {
                         dbCommand.CommandText = " SELECT COUNT(*) FROM Orders";
-                        Assert.Equal(1L, dbCommand.ExecuteScalar());
+                        Assert.Equal(1L, await dbCommand.ExecuteScalarAsync());
 
                         dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/1-A'";
 
-                        var sqlDataReader = dbCommand.ExecuteReader();
+                        var sqlDataReader = await dbCommand.ExecuteReaderAsync();
 
-                        Assert.True(sqlDataReader.Read());
+                        Assert.True(await sqlDataReader.ReadAsync());
                         Assert.True(sqlDataReader.IsDBNull(0));
                     }
                 }
@@ -1127,9 +1127,9 @@ loadToOrders(orderData);
                     using (var dbCommand = con.CreateCommand())
                     {
                         dbCommand.CommandText = " SELECT COUNT(*) FROM Orders";
-                        Assert.Equal(2L, dbCommand.ExecuteScalar());
+                        Assert.Equal(2L, await dbCommand.ExecuteScalarAsync());
                         dbCommand.CommandText = " SELECT COUNT(*) FROM OrderLines";
-                        Assert.Equal(3L, dbCommand.ExecuteScalar());
+                        Assert.Equal(3L, await dbCommand.ExecuteScalarAsync());
                     }
                 }
             }
@@ -1233,12 +1233,12 @@ loadToOrders(orderData);
                     {
                         dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/1-A'";
 
-                        var sqlDataReader = dbCommand.ExecuteReader();
+                        var sqlDataReader = await dbCommand.ExecuteReaderAsync();
 
-                        Assert.True(sqlDataReader.Read());
+                        Assert.True(await sqlDataReader.ReadAsync());
                         var stream = sqlDataReader.GetStream(0);
 
-                        var bytes = stream.ReadData();
+                        var bytes = await stream.ReadDataAsync();
 
                         Assert.Equal(attachmentBytes, bytes);
                     }

--- a/test/SlowTests/Server/Documents/Indexing/LiveIndexingPerformanceCollectorTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/LiveIndexingPerformanceCollectorTests.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Server.Documents.Indexing
             using (var store = GetDocumentStore())
             {
                 store.Initialize();
-                new UsersByName().Execute(store);
+                await new UsersByName().ExecuteAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.Indexing
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                 var index = database.IndexStore.GetIndex("Users/ByName");
@@ -88,7 +88,7 @@ namespace SlowTests.Server.Documents.Indexing
                 store.Initialize();
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
 
-                new UsersByName().Execute(store);
+                await new UsersByName().ExecuteAsync(store);
                 
                 var index = database.IndexStore.GetIndex("Users/ByName");
 
@@ -109,7 +109,7 @@ namespace SlowTests.Server.Documents.Indexing
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var dequeueCount = 0;
 

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -38,7 +38,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store1);
+                await Indexes.WaitForIndexingAsync(store1);
 
                 using (var session = store1.OpenAsyncSession())
                 {
@@ -69,7 +69,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.StoreAsync(new OutputReduceToCollectionTests.Marker { Name = "Marker 2" }, "marker2");
                     await session.SaveChangesAsync();
                 }
-                Indexes.WaitForIndexing(store1);
+                await Indexes.WaitForIndexingAsync(store1);
                 Assert.True(WaitForDocument(store2, "marker2"));
 
                 using (var context = DocumentsOperationContext.ShortTermSingleUse(database))

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
@@ -131,12 +131,12 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 await CreateDataAndIndexes(store);
 
                 await store.ExecuteIndexAsync(new Reset.DailyInvoicesIndex());
-                store.Operations.Send(new DeleteByQueryOperation(new IndexQuery {Query = "FROM DailyInvoices"})).WaitForCompletion(TimeSpan.FromSeconds(60));
+                await (await store.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery {Query = "FROM DailyInvoices"}))).WaitForCompletionAsync(TimeSpan.FromSeconds(60));
                 // We need to wait for the cluster to update the index before overwriting the index again
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.ExecuteIndexAsync(new Replacement_AverageFieldAdded.DailyInvoicesIndex());
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 RavenTestHelper.AssertNoIndexErrors(store);
 
@@ -161,7 +161,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 await store.Maintenance.SendAsync(new ResetIndexOperation(new MonthlyInvoicesIndex().IndexName));
                 await store.Maintenance.SendAsync(new ResetIndexOperation(new YearlyInvoicesIndex().IndexName));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -178,7 +178,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
         {
             using (var store = GetDocumentStore())
             {
-                store.ExecuteIndex(new DailyInvoicesIndex());
+                await store.ExecuteIndexAsync(new DailyInvoicesIndex());
 
                 var date = new DateTime(2017, 1, 1);
 
@@ -201,9 +201,9 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await store.ExecuteIndexAsync(new Replacement_AverageFieldAdded.DailyInvoicesIndex());
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -218,7 +218,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
             using (var store = GetDocumentStore())
             {
                 var index = new DailyInvoicesIndex();
-                store.ExecuteIndex(index);
+                await store.ExecuteIndexAsync(index);
 
                 var date = new DateTime(2017, 1, 1);
 
@@ -241,9 +241,9 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 await store.ExecuteIndexAsync(new Replacement_DifferentOutputReduceToCollection.DailyInvoicesIndex());
 
@@ -263,9 +263,9 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 Assert.StartsWith("DailyInvoices/", prefixesOfDocumentsToDelete[0].Key);
                 Assert.StartsWith("MyDailyInvoices/", prefixesOfDocumentsToDelete[1].Key);
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 WaitForUserToContinueTheTest(store);
 
@@ -306,7 +306,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.Maintenance.SendAsync(new StopIndexingOperation());
 
@@ -323,9 +323,9 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 // new replacement needs to delete docs created by original index
                 Assert.Equal(2, replacement.OutputReduceToCollection.GetPrefixesOfDocumentsToDelete().Count);
 
-                store.Maintenance.Send(new StartIndexingOperation());
+                await store.Maintenance.SendAsync(new StartIndexingOperation());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -341,7 +341,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
         {
             using (var store = GetDocumentStore())
             {
-                store.ExecuteIndex(new DailyInvoicesIndex());
+                await store.ExecuteIndexAsync(new DailyInvoicesIndex());
 
                 var date = new DateTime(2017, 1, 1);
 
@@ -364,11 +364,11 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.ExecuteIndexAsync(new Replacement_OutputReduceToCollection_Changed.DailyInvoicesIndex());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -411,7 +411,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -435,7 +435,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
         {
             using (var store = GetDocumentStore())
             {
-                store.ExecuteIndex(new DailyInvoicesIndex());
+                await store.ExecuteIndexAsync(new DailyInvoicesIndex());
 
                 var date = new DateTime(2017, 1, 1);
 
@@ -458,9 +458,9 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
                 await store.ExecuteIndexAsync(new Replacement_DifferentOutputReduceToCollection.DailyInvoicesIndex());
 
@@ -469,7 +469,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                 var replacementIndex = (MapReduceIndex)db.IndexStore.GetIndexes().Single(x => x.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix));
                 var replacementIndexReduceOutputIndex = replacementIndex.Definition.ReduceOutputIndex.Value;
 
-                store.Maintenance.Send(new DeleteIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}DailyInvoicesIndex"));
+                await store.Maintenance.SendAsync(new DeleteIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}DailyInvoicesIndex"));
 
                 var indexes = db.IndexStore.GetIndexes().ToList();
 
@@ -511,7 +511,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
 
                 await store.ExecuteIndexAsync(new DailyInvoicesIndex());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await AssertNumberOfResults();
                 string lastChangeVector;
 
@@ -534,7 +534,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     lastChangeVector = session.Advanced.GetChangeVectorFor(invoice);
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await AssertNumberOfResults();
 
                 var newChangeVector = store.Maintenance.Send(new GetStatisticsOperation()).DatabaseChangeVector;
@@ -626,7 +626,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
             await store.ExecuteIndexAsync(new MonthlyInvoicesIndex());
             await store.ExecuteIndexAsync(new YearlyInvoicesIndex());
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             WaitForValue(() =>
             {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests_Counters.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests_Counters.cs
@@ -151,7 +151,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
             await store.ExecuteIndexAsync(new MonthlyInvoicesIndex());
             await store.ExecuteIndexAsync(new YearlyInvoicesIndex());
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             Assert.True(WaitForValue(() =>
             {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests_TimeSeries.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests_TimeSeries.cs
@@ -151,7 +151,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
             await store.ExecuteIndexAsync(new MonthlyInvoicesIndex());
             await store.ExecuteIndexAsync(new YearlyInvoicesIndex());
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             Assert.True(WaitForValue(() =>
             {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_12932.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/RavenDB_12932.cs
@@ -249,15 +249,15 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     session.SaveChanges();
                 }
 
-                new Orders_ProfitByProductAndOrderedAt().Execute(store);
+                await new Orders_ProfitByProductAndOrderedAt().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.ExecuteIndexAsync(new Replacement.Orders_ProfitByProductAndOrderedAt());
 
                 WaitForUserToContinueTheTest(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -304,7 +304,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
             using (var store = GetDocumentStore())
             {
                 var indexToCreate = new Orders_ProfitByProductAndOrderedAt(referencesCollectionName: "CustomCollection");
-                indexToCreate.Execute(store);
+                await indexToCreate.ExecuteAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndexes().First();
@@ -369,13 +369,13 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     session.SaveChanges();
                 }
 
-                new Orders_ProfitByProductAndOrderedAt().Execute(store);
+                await new Orders_ProfitByProductAndOrderedAt().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.ExecuteIndexAsync(new Replacement_DifferentPattern.Orders_ProfitByProductAndOrderedAt());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -409,15 +409,15 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
                     session.SaveChanges();
                 }
 
-                new Orders_ProfitByProductAndOrderedAt().Execute(store);
+                await new Orders_ProfitByProductAndOrderedAt().ExecuteAsync(store);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 WaitForUserToContinueTheTest(store);
 
                 await store.ExecuteIndexAsync(new Replacement_PatternFieldUpdate.Orders_ProfitByProductAndOrderedAt());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 WaitForUserToContinueTheTest(store);
 

--- a/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
@@ -109,7 +109,7 @@ namespace SlowTests.Server.Documents.Notifications
 
                 using (var commands = store.Commands())
                 {
-                    commands.Delete("users/1", null);
+                    await commands.DeleteAsync("users/1", null);
                 }
 
                 DocumentChange documentChange;
@@ -188,12 +188,12 @@ namespace SlowTests.Server.Documents.Notifications
                 });
                 await observableWithTask.EnsureSubscribedNow();
 
-                new UsersIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new UsersIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
                 Assert.True(list.Count == 0);
 
-                new UsersIndexChanged().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new UsersIndexChanged().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 Assert.True(list.TryTake(out var indexChange, TimeSpan.FromSeconds(1)));
                 Assert.Equal("Users/All", indexChange.Name);

--- a/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/ReplicationOngoingTaskProgressTests.cs
@@ -198,7 +198,7 @@ namespace SlowTests.Server.Documents.OngoingTasks
                 CreateDatabase = true
             });
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hub.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition

--- a/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
+++ b/test/SlowTests/Server/Documents/Patching/AdvancedPatching.cs
@@ -1020,12 +1020,12 @@ this.Else = a;
                         Name = "TestIndex"
                     }}));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                var operation = store.Operations.Send(new PatchByQueryOperation(
+                var operation = await store.Operations.SendAsync(new PatchByQueryOperation(
                     $"FROM INDEX \'TestIndex\' WHERE Owner = \'Bob\' UPDATE {{ {SampleScript}}}"));
 
-                operation.WaitForCompletion(TimeSpan.FromSeconds(15));
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
 
                 using (var commands = store.Commands())
                 {

--- a/test/SlowTests/Server/Documents/Patching/PatchByIndexTests.cs
+++ b/test/SlowTests/Server/Documents/Patching/PatchByIndexTests.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Server.Documents.Patching
                     }
                     await session.SaveChangesAsync();
                 }
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var context = QueryOperationContext.ShortTermSingleUse(database))
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Azure.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Azure.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 holder.Client.DeleteBlobs(blobs);
 
-                var listBlobs = holder.Client.ListBlobs(prefix, null, listFolders: false);
+                var listBlobs = await holder.Client.ListBlobsAsync(prefix, null, listFolders: false);
                 var blobNames = listBlobs.List.Select(b => b.Name).ToList();
                 Assert.Equal(0, blobNames.Count);
             }
@@ -111,7 +111,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.True(blob.Size.GetValue(SizeUnit.Bytes) > 0);
 
                 using (var reader = new StreamReader(blob.Data))
-                    Assert.Equal("123", reader.ReadToEnd());
+                    Assert.Equal("123", await reader.ReadToEndAsync());
 
                 var property1 = blob.Metadata.Keys.Single(x => x.Contains("property1"));
                 var property2 = blob.Metadata.Keys.Single(x => x.Contains("property2"));
@@ -135,7 +135,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.NotNull(blob);
 
                 using (var reader = new StreamReader(blob.Data))
-                    Assert.Equal("123", reader.ReadToEnd());
+                    Assert.Equal("123", await reader.ReadToEndAsync());
 
                 var property1 = blob.Metadata.Keys.Single(x => x.Contains("property1"));
                 var property2 = blob.Metadata.Keys.Single(x => x.Contains("property2"));
@@ -174,7 +174,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(blob);
 
                     using (var reader = new StreamReader(blob.Data))
-                        Assert.Equal("123", reader.ReadToEnd());
+                        Assert.Equal("123", await reader.ReadToEndAsync());
 
                     var property1 = blob.Metadata.Keys.Single(x => x.Contains("property1"));
                     var property2 = blob.Metadata.Keys.Single(x => x.Contains("property2"));
@@ -183,7 +183,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal("value2", blob.Metadata[property2]);
                 }
 
-                var listBlobs = holder.Client.ListBlobs(prefix, null, listFolders: false);
+                var listBlobs = await holder.Client.ListBlobsAsync(prefix, null, listFolders: false);
                 Assert.Equal(blobsCount, listBlobs.List.Count());
             }
         }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
@@ -855,9 +855,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.MaxNumberOfResults)] = "1"
             }))
             {
-                store.Maintenance.Send(new CreateSampleDataOperation(operateOnTypes: DatabaseSmugglerOptions.DefaultOperateOnTypes));
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: DatabaseSmugglerOptions.DefaultOperateOnTypes));
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -1694,8 +1694,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -3748,7 +3748,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
 
             var lastCv = "";
-            var subscriptionName = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+            var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
             using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subscriptionName)
             {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -83,8 +83,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -152,8 +152,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -258,8 +258,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -338,8 +338,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -421,8 +421,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -534,8 +534,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -650,8 +650,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -710,8 +710,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -794,8 +794,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -907,8 +907,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -995,8 +995,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -1143,8 +1143,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {
@@ -1429,8 +1429,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-13229.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-13229.cs
@@ -88,8 +88,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }))
             {
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store2.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store2.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
                 using (var session = store2.OpenAsyncSession(new SessionOptions
                 {
                     TransactionMode = TransactionMode.ClusterWide

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-4613.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-4613.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var readBuffer = new char[buffer.Length];
 
                     long read, totalRead = 0;
-                    while ((read = reader.Read(readBuffer, 0, readBuffer.Length)) > 0)
+                    while ((read = await reader.ReadAsync(readBuffer, 0, readBuffer.Length)) > 0)
                     {
                         for (var i = 0; i < read; i++)
                             Assert.Equal(buffer[i], (byte)readBuffer[i]);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB_12012.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB_12012.cs
@@ -75,8 +75,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 RestoreBackupOperation restoreOperation = new RestoreBackupOperation(config2);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 using (var store2 = GetDocumentStore(new Options()
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -282,14 +282,14 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     command = "bash";
                     script = $"#!/bin/bash\r\necho '{localSettingsString}'";
-                    File.WriteAllText(scriptPath, script);
+                    await File.WriteAllTextAsync(scriptPath, script);
                     Process.Start("chmod", $"700 {scriptPath}");
                 }
                 else
                 {
                     command = "powershell";
                     script = $"echo '{localSettingsString}'";
-                    File.WriteAllText(scriptPath, script);
+                    await File.WriteAllTextAsync(scriptPath, script);
                 }
 
                 var putConfiguration = new ServerWideBackupConfiguration
@@ -520,8 +520,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 // new server should have only 0 backups
                 var server = GetNewServer();
@@ -535,8 +535,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Server = server
                 }))
                 {
-                    store2.Maintenance.Server.Send(restoreOperation)
-                        .WaitForCompletion(TimeSpan.FromSeconds(30));
+                    await (await store2.Maintenance.Server.SendAsync(restoreOperation))
+                        .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                     var record2 = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
                     Assert.Equal(0, record2.PeriodicBackups.Count);
@@ -686,8 +686,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 // old server should have 2: 1 server-wide and 1 regular backup
                 using (var store2 = GetDocumentStore(new Options
@@ -710,8 +710,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Server = server
                 }))
                 {
-                    store3.Maintenance.Server.Send(restoreOperation)
-                        .WaitForCompletion(TimeSpan.FromSeconds(30));
+                    await (await store3.Maintenance.Server.SendAsync(restoreOperation))
+                        .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                     var record3 = await store3.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
                     Assert.Equal(1, record3.PeriodicBackups.Count);

--- a/test/SlowTests/Server/Documents/QueueSink/KafkaQueueSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/KafkaQueueSinkTests.cs
@@ -192,7 +192,7 @@ namespace SlowTests.Server.Documents.QueueSink
         }
         
         [RequiresKafkaRetryFact]
-        public void SimpleScriptMultipleInsertsTwoBatches()
+        public async Task SimpleScriptMultipleInsertsTwoBatches()
         {
             var numberOfUsers = 10;
 
@@ -236,7 +236,7 @@ namespace SlowTests.Server.Documents.QueueSink
                 producer.Produce(UsersQueueName, kafkaMessage);
             }
 
-            etlDone.Wait(TimeSpan.FromSeconds(60));
+            await etlDone.WaitAsync(TimeSpan.FromSeconds(60));
             
             var users2 = session.Query<User>().ToList();
             Assert.Equal(20, users2.Count);

--- a/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
+++ b/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
@@ -391,8 +391,8 @@ namespace SlowTests.Server.Documents.Replication
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 // new server should have only 0 external replications
                 var server = GetNewServer();
@@ -405,8 +405,8 @@ namespace SlowTests.Server.Documents.Replication
                     Server = server
                 }))
                 {
-                    store2.Maintenance.Server.Send(restoreOperation)
-                        .WaitForCompletion(TimeSpan.FromSeconds(30));
+                    await (await store2.Maintenance.Server.SendAsync(restoreOperation))
+                        .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                     var record2 = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
                     Assert.Equal(0, record2.ExternalReplications.Count);
@@ -498,8 +498,8 @@ namespace SlowTests.Server.Documents.Replication
                 };
 
                 var restoreOperation = new RestoreBackupOperation(restoreConfig);
-                store.Maintenance.Server.Send(restoreOperation)
-                    .WaitForCompletion(TimeSpan.FromSeconds(30));
+                await (await store.Maintenance.Server.SendAsync(restoreOperation))
+                    .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                 // new server should have only 0 external replications
                 var server = GetNewServer();
@@ -512,8 +512,8 @@ namespace SlowTests.Server.Documents.Replication
                     Server = server
                 }))
                 {
-                    store2.Maintenance.Server.Send(restoreOperation)
-                        .WaitForCompletion(TimeSpan.FromSeconds(30));
+                    await (await store2.Maintenance.Server.SendAsync(restoreOperation))
+                        .WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
                     var record2 = await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
                     Assert.Equal(1, record2.ExternalReplications.Count);

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Server.Documents.TimeSeries
         {
             using (var store = GetDocumentStore(options))
             {
-                new MyTsIndex().Execute(store);
+                await new MyTsIndex().ExecuteAsync(store);
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User { Name = "EGR" }, "user/322");
@@ -87,7 +87,7 @@ namespace SlowTests.Server.Documents.TimeSeries
                 }
                 Assert.True(c >= 0);
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 await cleaner.ExecuteCleanup();
 
                 c = 0;

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -363,7 +363,7 @@ namespace SlowTests.Server
 
                 await store.ExecuteIndexAsync(new DailyInvoicesIndex());
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 await store.Maintenance.SendAsync(new StopTransactionsRecordingOperation());
             }

--- a/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationPreventDeletionsTests.cs
@@ -56,7 +56,7 @@ namespace SlowTests.Server.Replication
             //setup expiration
             await SetupExpiration(sinkStore);
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -194,7 +194,7 @@ namespace SlowTests.Server.Replication
                 ModifyDatabaseName = x => sinkDatabase
             });
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -332,7 +332,7 @@ namespace SlowTests.Server.Replication
             //setup expiration
             await SetupExpiration(sinkStore);
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -443,7 +443,7 @@ namespace SlowTests.Server.Replication
             //setup expiration
             await SetupExpiration(sinkStore);
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -588,7 +588,7 @@ namespace SlowTests.Server.Replication
                 await s.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(sinkStore);
+            await Indexes.WaitForIndexingAsync(sinkStore);
 
             using (var s = sinkStore.OpenAsyncSession())
             {
@@ -597,7 +597,7 @@ namespace SlowTests.Server.Replication
             }
 
             //setup pull replication
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
@@ -684,7 +684,7 @@ namespace SlowTests.Server.Replication
             //setup expiration
             await SetupExpiration(sinkStore);
 
-            var pullCert = new X509Certificate2(File.ReadAllBytes(certificates.ClientCertificate2Path), (string)null,
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(certificates.ClientCertificate2Path), (string)null,
                 X509KeyStorageFlags.Exportable);
 
             await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -441,14 +441,14 @@ namespace SlowTests.Server.Replication
                 }
 
                 var userIndex = new UserIndex();
-                store2.ExecuteIndex(userIndex);
+                await store2.ExecuteIndexAsync(userIndex);
 
                 using (var s2 = store2.OpenSession())
                 {
                     s2.Store(new User { Name = "test2" }, "foo/bar");
                     s2.SaveChanges();
                 }
-                Indexes.WaitForIndexing(store2);
+                await Indexes.WaitForIndexingAsync(store2);
                 await SetupReplicationAsync(store1, store2);
 
                 WaitUntilHasConflict(store2, "foo/bar");
@@ -501,19 +501,19 @@ namespace SlowTests.Server.Replication
                 }
 
                 var userIndex = new UserIndex();
-                store2.ExecuteIndex(userIndex);
+                await store2.ExecuteIndexAsync(userIndex);
 
                 using (var s2 = store2.OpenSession())
                 {
                     s2.Store(new User { Name = "test2" }, "foo/bar");
                     s2.SaveChanges();
                 }
-                Indexes.WaitForIndexing(store2);
+                await Indexes.WaitForIndexingAsync(store2);
                 await SetupReplicationAsync(store1, store2);
 
                 WaitUntilHasConflict(store2, "foo/bar");
 
-                var operation = store2.Operations.Send(new DeleteByQueryOperation(new IndexQuery { Query = $"FROM INDEX '{userIndex.IndexName}'" }));
+                var operation = await store2.Operations.SendAsync(new DeleteByQueryOperation(new IndexQuery { Query = $"FROM INDEX '{userIndex.IndexName}'" }));
 
                 Assert.Throws<DocumentConflictException>(() => operation.WaitForCompletion(TimeSpan.FromSeconds(15)));
             }
@@ -558,20 +558,20 @@ namespace SlowTests.Server.Replication
                 }
 
                 var userIndex = new UserIndex();
-                store2.ExecuteIndex(userIndex);
+                await store2.ExecuteIndexAsync(userIndex);
 
                 using (var s2 = store2.OpenSession())
                 {
                     s2.Store(new User { Name = "test2" }, "foo/bar");
                     s2.SaveChanges();
                 }
-                Indexes.WaitForIndexing(store2);
+                await Indexes.WaitForIndexingAsync(store2);
                 await SetupReplicationAsync(store1, store2);
 
                 WaitUntilHasConflict(store2, "foo/bar");
 
                 // /indexes/Raven/DocumentsByEntityName
-                var operation = store2.Operations.Send(new PatchByQueryOperation(new IndexQuery
+                var operation = await store2.Operations.SendAsync(new PatchByQueryOperation(new IndexQuery
                 {
                     Query = $"FROM INDEX '{userIndex.IndexName}' UPDATE {{ }}"
                 }));

--- a/test/SlowTests/Server/Replication/ReplicationDocuments.cs
+++ b/test/SlowTests/Server/Replication/ReplicationDocuments.cs
@@ -58,23 +58,23 @@ namespace SlowTests.Server.Replication
 
                 using (var sourceCommands = source.Commands())
                 {
-                    sourceCommands.Put("docs/1", null, new { Key = "Value" }, null);
+                    await sourceCommands.PutAsync("docs/1", null, new { Key = "Value" }, null);
 
                     Assert.True(WaitForDocument(destination, "docs/1"));
 
-                    sourceCommands.Delete("docs/1", null);
+                    await sourceCommands.DeleteAsync("docs/1", null);
                 }
 
                 using (var destinationCommands = destination.Commands())
                 {
                     for (int i = 0; i < 10; i++)
                     {
-                        if (destinationCommands.Get("docs/1") == null)
+                        if (await destinationCommands.GetAsync("docs/1") == null)
                             break;
                         Thread.Sleep(100);
                     }
 
-                    Assert.Null(destinationCommands.Get("docs/1"));
+                    Assert.Null(await destinationCommands.GetAsync("docs/1"));
                 }
             }
         }
@@ -90,16 +90,16 @@ namespace SlowTests.Server.Replication
                 using (var sourceCommands = source.Commands())
                 using (var destinationCommands = destination.Commands())
                 {
-                    sourceCommands.Put("docs/1", null, new { Key = "Value" }, null);
-                    destinationCommands.Put("docs/1", null, new { Key = "Value2" }, null);
+                    await sourceCommands.PutAsync("docs/1", null, new { Key = "Value" }, null);
+                    await destinationCommands.PutAsync("docs/1", null, new { Key = "Value2" }, null);
 
                     await SetupReplicationAsync(source, destination);
 
-                    sourceCommands.Put("marker$docs/1", null, new { Key = "Value" }, null);
+                    await sourceCommands.PutAsync("marker$docs/1", null, new { Key = "Value" }, null);
 
                     Assert.True(WaitForDocument(destination, "marker$docs/1"));
 
-                    var conflicts = destination.Commands().GetConflictsFor("docs/1");
+                    var conflicts = await destination.Commands().GetConflictsForAsync("docs/1");
                     Assert.Equal(2, conflicts.Length);
 
                     var cv1 = conflicts[0].ChangeVector.ToVersion().AsString().ToChangeVector();
@@ -124,16 +124,16 @@ namespace SlowTests.Server.Replication
                 using (var sourceCommands = source.Commands())
                 using (var destinationCommands = destination.Commands())
                 {
-                    sourceCommands.Put("docs/1", null, new { Key = "Value" }, null);
-                    destinationCommands.Put("docs/1", null, new { Key = "Value2" }, null);
+                    await sourceCommands.PutAsync("docs/1", null, new { Key = "Value" }, null);
+                    await destinationCommands.PutAsync("docs/1", null, new { Key = "Value2" }, null);
 
                     await SetupReplicationAsync(source, destination);
 
-                    sourceCommands.Put("marker$docs/1", null, new { Key = "Value" }, null);
+                    await sourceCommands.PutAsync("marker$docs/1", null, new { Key = "Value" }, null);
 
                     Assert.True(WaitForDocument(destination, "marker$docs/1"));
 
-                    conflicts = destination.Commands().GetConflictsFor("docs/1");
+                    conflicts = await destination.Commands().GetConflictsForAsync("docs/1");
                     Assert.Equal(2, conflicts.Length);
                     var cv1 = conflicts[0].ChangeVector.ToVersion().AsString().ToChangeVector();
                     var cv2 = conflicts[1].ChangeVector.ToVersion().AsString().ToChangeVector();
@@ -146,10 +146,10 @@ namespace SlowTests.Server.Replication
                 //now actually resolve the conflict
                 //(resolve by using first variant)
                 var resolution = conflicts[0];
-                destination.Commands().Put("docs/1", null, resolution.Doc);
+                await destination.Commands().PutAsync("docs/1", null, resolution.Doc);
 
                 ////this shouldn't throw since we have just resolved the conflict
-                var fetchedDoc = destination.Commands().Get("docs/1");
+                var fetchedDoc = await destination.Commands().GetAsync("docs/1");
                 var actualVal = resolution.Doc["Key"] as LazyStringValue;
                 var fetchedVal = fetchedDoc["Key"] as LazyStringValue;
 

--- a/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
+++ b/test/SlowTests/Server/Replication/ReplicationIndexesAndTransformers.cs
@@ -82,7 +82,7 @@ namespace SlowTests.Server.Replication
             using (destination)
             {
                 var userByAge = new UserByAgeIndex();
-                userByAge.Execute(source);
+                await userByAge.ExecuteAsync(source);
 
                 var sw = Stopwatch.StartNew();
                 var destIndexNames = new string[0];
@@ -106,10 +106,10 @@ namespace SlowTests.Server.Replication
             using (destination)
             {
                 var userByAge = new UserByAgeIndex();
-                userByAge.Execute(source);
+                await userByAge.ExecuteAsync(source);
 
                 var userByName = new UserByNameIndex();
-                userByName.Execute(source);
+                await userByName.ExecuteAsync(source);
 
                 var sw = Stopwatch.StartNew();
                 var destIndexNames = new string[0];
@@ -134,10 +134,10 @@ namespace SlowTests.Server.Replication
             using (destination)
             {
                 var userByAge = new UserByAgeIndex();
-                userByAge.Execute(source);
+                await userByAge.ExecuteAsync(source);
 
                 var userByName = new UserByNameIndex();
-                userByName.Execute(source);
+                await userByName.ExecuteAsync(source);
 
                 var sw = Stopwatch.StartNew();
                 var destIndexNames = new string[0];

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -68,8 +68,8 @@ namespace SlowTests.Server.Replication
                 var resolvedConflicts2 = (await store2.Maintenance.SendAsync(ctx, new GetResolvedRevisionsOperation())).Results.ToList();
                 Assert.Equal(1, resolvedConflicts2.Count);
 
-                Assert.Empty(store1.Commands().GetConflictsFor("foo/bar"));
-                Assert.Empty(store2.Commands().GetConflictsFor("foo/bar"));
+                Assert.Empty(await store1.Commands().GetConflictsForAsync("foo/bar"));
+                Assert.Empty(await store2.Commands().GetConflictsForAsync("foo/bar"));
             }
         }
 
@@ -140,7 +140,7 @@ namespace SlowTests.Server.Replication
                     {
                         Assert.Equal(e.DocId, "users/1");
                         Assert.NotEqual(e.LargestEtag, 0);
-                        slave.Commands().Delete("users/1", null); //resolve conflict to the one with tombstone
+                        await slave.Commands().DeleteAsync("users/1", null); //resolve conflict to the one with tombstone
                     }
                 }
 

--- a/test/SlowTests/Server/TransactionMergerTests.cs
+++ b/test/SlowTests/Server/TransactionMergerTests.cs
@@ -84,7 +84,7 @@ namespace SlowTests.Server
                 await session.SaveChangesAsync();
             }
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             
             using var tokenSource = new AutoCancellationTokenSource();
             
@@ -101,7 +101,7 @@ namespace SlowTests.Server
                 await session.StoreAsync(new TestObj { Prop = prop}, $"testObjs/1");
                 await session.SaveChangesAsync();
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             using (var session = store.OpenAsyncSession())
             {
@@ -109,7 +109,7 @@ namespace SlowTests.Server
                 Assert.NotEmpty(await session.Advanced.AsyncRawQuery<object>("from OutputReduceCollection").ToArrayAsync());
             }
             
-            tokenSource.Cancel();
+            await tokenSource.CancelAsync();
             await Task.WhenAll(failingTasks);
         }
 
@@ -136,7 +136,7 @@ namespace SlowTests.Server
             var amre = new AsyncManualResetEvent();
             var failingTasks = RunFailingTasks(store, amre, tokenSource.Token);
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
             await amre.WaitAsync();
             var operation = await store.Operations.SendAsync(new PatchByQueryOperation(@"
 from TestObjs as o where o.Prop = null update 
@@ -148,12 +148,12 @@ from TestObjs as o where o.Prop = null update
     }} 
 }}"));
             await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-            tokenSource.Cancel();
+            await tokenSource.CancelAsync();
             await Task.WhenAll(failingTasks);
 
             using (var session = store.OpenAsyncSession())
             {
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 var patchCount = await session.Query<TestObj>().Where(o => o.Prop == "Changed").CountAsync();
                 Assert.Equal(docCount, patchCount);
             }

--- a/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
@@ -400,7 +400,7 @@ namespace SlowTests.Sharding.Cluster
                         .Statistics(out var stat).ToListAsync();
                 }
                 
-                store.Maintenance.Send(new PutDatabaseSettingsOperation(store.Database, new Dictionary<string, string>
+                await store.Maintenance.SendAsync(new PutDatabaseSettingsOperation(store.Database, new Dictionary<string, string>
                 {
                     { RavenConfiguration.GetKey(x => x.Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdle), "0" },
                 }));
@@ -456,7 +456,7 @@ namespace SlowTests.Sharding.Cluster
                         .Statistics(out var stat).ToListAsync();
                 }
                 
-                store.Maintenance.Send(new PutDatabaseSettingsOperation(store.Database,
+                await store.Maintenance.SendAsync(new PutDatabaseSettingsOperation(store.Database,
                     new Dictionary<string, string> {{RavenConfiguration.GetKey(x => x.Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdle), "0"},}));
 
                 var db = await Sharding.GetAnyShardDocumentDatabaseInstanceFor(ShardHelper.ToShardName(store.Database, 0), cluster.Nodes);
@@ -486,7 +486,7 @@ namespace SlowTests.Sharding.Cluster
                 
                 Assert.True(idleInMem);
 
-                store.Maintenance.Send(new PutDatabaseSettingsOperation(store.Database,
+                await store.Maintenance.SendAsync(new PutDatabaseSettingsOperation(store.Database,
                     new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Indexing.TimeToWaitBeforeMarkingAutoIndexAsIdle), "30" }, }));
 
                 //run index query only on one shard

--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -982,7 +982,7 @@ namespace SlowTests.Sharding.Cluster
                 }
                 finally
                 {
-                    cts.Cancel();
+                    await cts.CancelAsync();
                     await fail;
                     await t;
                 }
@@ -1093,7 +1093,7 @@ namespace SlowTests.Sharding.Cluster
                 }
                 finally
                 {
-                    cts.Cancel();
+                    await cts.CancelAsync();
                     await fail;
                     await t;
                 }
@@ -1382,7 +1382,7 @@ namespace SlowTests.Sharding.Cluster
             }
 
 
-            var state = store.Subscriptions.GetSubscriptionState(id);
+            var state = await store.Subscriptions.GetSubscriptionStateAsync(id);
 
             Console.WriteLine("ChangeVectorForNextBatchStartingPointPerShard:");
             foreach (var cv in state.ShardingState.ChangeVectorForNextBatchStartingPointPerShard.OrderBy(x => x.Key))

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -85,7 +85,7 @@ loadToOrders(orderData);
 ";
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void RavenEtl_Unsharded_Destination()
+        public async Task RavenEtl_Unsharded_Destination()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -108,7 +108,7 @@ loadToOrders(orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -127,7 +127,7 @@ loadToOrders(orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -139,7 +139,7 @@ loadToOrders(orderData);
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void RavenEtl_Unsharded_Destination2()
+        public async Task RavenEtl_Unsharded_Destination2()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -201,7 +201,7 @@ loadToOrders(orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -213,7 +213,7 @@ loadToOrders(orderData);
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void RavenEtl_Sharded_Destination()
+        public async Task RavenEtl_Sharded_Destination()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = Sharding.GetDocumentStore())
@@ -275,7 +275,7 @@ loadToOrders(orderData);
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -287,7 +287,7 @@ loadToOrders(orderData);
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void RavenEtl_Loading_to_different_collections_with_load_document()
+        public async Task RavenEtl_Loading_to_different_collections_with_load_document()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -371,7 +371,7 @@ loadToAddresses(load(this.AddressId));
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -393,7 +393,7 @@ loadToAddresses(load(this.AddressId));
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void RavenEtl_Loading_to_different_collections()
+        public async Task RavenEtl_Loading_to_different_collections()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -457,7 +457,7 @@ loadToPeople({Name: this.Name + ' ' + this.LastName });
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromSeconds(30));
+                await etlDone.WaitAsync(TimeSpan.FromSeconds(30));
 
                 using (var session = dest.OpenSession())
                 {
@@ -475,7 +475,7 @@ loadToPeople({Name: this.Name + ' ' + this.LastName });
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Counters | RavenTestCategory.Sharding)]
-        public void RavenEtl_Should_handle_counters()
+        public async Task RavenEtl_Should_handle_counters()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -517,7 +517,7 @@ person.addCounter(loadCounter('down'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 RavenDB_11157_Raven.AssertCounters(dest, new[]
                 {
@@ -541,7 +541,7 @@ person.addCounter(loadCounter('down'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -571,7 +571,7 @@ person.addCounter(loadCounter('down'));
                     session.SaveChanges();
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
 
                 using (var session = dest.OpenSession())
                 {
@@ -704,7 +704,7 @@ person.addCounter(loadCounter('down'));
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void CanResetEtl()
+        public async Task CanResetEtl()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -742,16 +742,16 @@ person.addCounter(loadCounter('down'));
                     Database = dest.Database,
                 });
 
-                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
                 src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allUsers"));
 
-                Assert.True(resetDone.Wait(TimeSpan.FromMinutes(1)));
+                Assert.True(await resetDone.WaitAsync(TimeSpan.FromMinutes(1)));
             }
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void CanResetEtl2()
+        public async Task CanResetEtl2()
         {
             using (var src = Sharding.GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -802,7 +802,7 @@ person.addCounter(loadCounter('down'));
 
                 for (int i = 0; i < 10; i++)
                 {
-                    Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)), $"blah at {i}");
+                    Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)), $"blah at {i}");
 
                     mre.Set();
 
@@ -1992,7 +1992,7 @@ loadToOrders(partitionBy(['order_date', key]), orderData);
         }
 
         [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Sharding)]
-        public void RavenDB_20437()
+        public async Task RavenDB_20437()
         {
             using (var src = GetDocumentStore())
             using (var dest = Sharding.GetDocumentStore())
@@ -2018,7 +2018,7 @@ loadToAddresses(this.Address);
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {
@@ -2051,7 +2051,7 @@ loadToAddresses(this.Address);
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(30)));
 
                 using (var session = dest.OpenSession())
                 {

--- a/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlTests.cs
@@ -744,7 +744,7 @@ person.addCounter(loadCounter('down'));
 
                 Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
-                src.Maintenance.Send(new ResetEtlOperation("myConfiguration", "allUsers"));
+                await src.Maintenance.SendAsync(new ResetEtlOperation("myConfiguration", "allUsers"));
 
                 Assert.True(await resetDone.WaitAsync(TimeSpan.FromMinutes(1)));
             }

--- a/test/SlowTests/Sharding/Issues/RavenDB_18179.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18179.cs
@@ -39,9 +39,9 @@ public class RavenDB_18179 : ClusterTestBase
                 await session.SaveChangesAsync();
             }
 
-            new Users_ByName().Execute(store);
+            await new Users_ByName().ExecuteAsync(store);
 
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             var bucket = Sharding.GetBucket(record.Sharding, id);
             var shardNumber = ShardHelper.GetShardNumberFor(record.Sharding, bucket);

--- a/test/SlowTests/Sharding/Issues/RavenDB_19524.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_19524.cs
@@ -108,7 +108,7 @@ namespace SlowTests.Sharding.Issues
                     Assert.NotNull(att);
                 }
 
-                store.Operations.Send(new DeleteAttachmentOperation("users/1", attName));
+                await store.Operations.SendAsync(new DeleteAttachmentOperation("users/1", attName));
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Sharding/StudioBucketsTests.cs
+++ b/test/SlowTests/Sharding/StudioBucketsTests.cs
@@ -71,7 +71,7 @@ namespace SlowTests.Sharding
                         var id = $"user/{i}";
                         var shardNumberForDoc = await Sharding.GetShardNumberForAsync(store, id);
                         var cmd = new GetDocumentSizeCommand(id);
-                        executor.Execute(cmd, ctx);
+                        await executor.ExecuteAsync(cmd, ctx);
                         var size = cmd.Result.ActualSize;
                         dict[shardNumberForDoc].TotalSize += size;
                     }
@@ -168,7 +168,7 @@ namespace SlowTests.Sharding
                             var id = $"user/{i}";
                             var bucket = Sharding.GetBucket(sharding, id);
                             var cmd = new GetDocumentSizeCommand(id);
-                            executor.Execute(cmd, ctx);
+                            await executor.ExecuteAsync(cmd, ctx);
                             var docSize = cmd.Result.ActualSize;
 
                             bucketInfos[bucket].Size += docSize;

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
@@ -33,7 +33,7 @@ namespace SlowTests.Sharding.Subscriptions
             await ShardingCluster.CreateShardedDatabaseInCluster(db, 2, (nodes, leader));
             using (var store = new DocumentStore { Database = db, Urls = new[] { leader.WebUrl } }.Initialize())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -84,7 +84,7 @@ namespace SlowTests.Sharding.Subscriptions
 
             using (var store = Sharding.GetDocumentStore(options))
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -215,7 +215,7 @@ namespace SlowTests.Sharding.Subscriptions
 
             using (var store = new DocumentStore { Database = db, Urls = new[] { leader.WebUrl } }.Initialize())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -231,7 +231,7 @@ namespace SlowTests.Sharding.Subscriptions
                 }
 
                 // Wait for documents to replicate
-                Assert.True(ShardingCluster.WaitForShardedChangeVectorInCluster(nodes, store.Database, rf));
+                Assert.True(await ShardingCluster.WaitForShardedChangeVectorInClusterAsync(nodes, store.Database, rf));
 
                 var servers = await ShardingCluster.GetShardsDocumentDatabaseInstancesFor(store, nodes);
 

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -100,7 +100,7 @@ namespace SlowTests.Sharding.Subscriptions
             using (var store = Sharding.GetDocumentStore())
             {
                 var count = 10;
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -184,7 +184,7 @@ namespace SlowTests.Sharding.Subscriptions
                 }
 
                 var count = 10;
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
                 var db1 = await Sharding.GetShardsDocumentDatabaseInstancesFor(store).FirstOrDefaultAsync(x => x.ShardNumber == n);
@@ -418,7 +418,7 @@ namespace SlowTests.Sharding.Subscriptions
             using (var store = Sharding.GetDocumentStore(ops))
             {
                 var count = 10;
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -587,7 +587,7 @@ namespace SlowTests.Sharding.Subscriptions
             using (var store = Sharding.GetDocumentStore())
             {
                 var count = 10;
-                store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 5);
                 Assert.Equal(1, subscriptions.Count);
 
@@ -623,7 +623,7 @@ namespace SlowTests.Sharding.Subscriptions
                 Assert.Equal(count / 2, WaitForValue(() => docs.CurrentCount, count / 2));
                 const string newQuery = "from Users where Age > 18";
 
-                store.Subscriptions.Update(new SubscriptionUpdateOptions
+                await store.Subscriptions.UpdateAsync(new SubscriptionUpdateOptions
                 {
                     Name = state.SubscriptionName,
                     Query = newQuery,
@@ -687,7 +687,7 @@ namespace SlowTests.Sharding.Subscriptions
         {
             using (var store = Sharding.GetDocumentStore())
             {
-                var subscriptionId = store.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                var subscriptionId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionId)
                 {
                     MaxDocsPerBatch = 1,
@@ -852,7 +852,7 @@ namespace SlowTests.Sharding.Subscriptions
                     });
                     session.SaveChanges();
                 }
-                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
                 {
                     Query = @"from Dogs include Owner"
                 });
@@ -1215,7 +1215,7 @@ namespace SlowTests.Sharding.Subscriptions
         {
             using (var store = Sharding.GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -1270,7 +1270,7 @@ namespace SlowTests.Sharding.Subscriptions
         {
             using (var store = Sharding.GetDocumentStore())
             {
-                var id = store.Subscriptions.Create<User>();
+                var id = await store.Subscriptions.CreateAsync<User>();
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
@@ -1402,7 +1402,7 @@ namespace SlowTests.Sharding.Subscriptions
                     await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User> { Name = "sub2" });
                     await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
-                    var states = store1.Subscriptions.GetSubscriptions(0, 10);
+                    var states = await store1.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                     Assert.Equal(3, states.Count);
 
@@ -1412,7 +1412,7 @@ namespace SlowTests.Sharding.Subscriptions
                     operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
-                    states = store2.Subscriptions.GetSubscriptions(0, 10, store2.Database);
+                    states = await store2.Subscriptions.GetSubscriptionsAsync(0, 10, store2.Database);
 
                     Assert.Equal(3, states.Count);
                     Assert.True(states.Any(x => x.SubscriptionName.Equals("sub1")));
@@ -1472,11 +1472,11 @@ namespace SlowTests.Sharding.Subscriptions
                     await session.SaveChangesAsync();
                 }
 
-                store1.Subscriptions.Create(new SubscriptionCreationOptions<User>() { Name = "sub1" });
-                store1.Subscriptions.Create(new SubscriptionCreationOptions<User>() { Name = "sub2" });
-                store1.Subscriptions.Create(new SubscriptionCreationOptions<User>());
+                await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>() { Name = "sub1" });
+                await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>() { Name = "sub2" });
+                await store1.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
 
-                var states = store1.Subscriptions.GetSubscriptions(0, 10);
+                var states = await store1.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                 Assert.Equal(3, states.Count);
 

--- a/test/SlowTests/SlowTests/Bugs/AsyncSetBasedOps.cs
+++ b/test/SlowTests/SlowTests/Bugs/AsyncSetBasedOps.cs
@@ -60,7 +60,7 @@ namespace SlowTests.SlowTests.Bugs
                     }
                 }
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(5));
 
                 await (await store.Operations.SendAsync(new PatchByQueryOperation(
                     new IndexQuery { Query = $"FROM INDEX '{stats.IndexName}' UPDATE {{ this.FullName = this.FirstName + ' ' + this.LastName; }}" }

--- a/test/SlowTests/SlowTests/Bugs/TimeoutTester.cs
+++ b/test/SlowTests/SlowTests/Bugs/TimeoutTester.cs
@@ -95,13 +95,13 @@ namespace SlowTests.SlowTests.Bugs
                 ModifyDocumentStore = ModifyStore
             }))
             {
-                new Answers_ByAnswerEntity().Execute(store);
+                await new Answers_ByAnswerEntity().ExecuteAsync(store);
                 var answerId = "";
 
                 CreateEntities(store, 0);
 
                 const string content = "This is doable";
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 using (var session = store.OpenSession())
                 {
                     QueryStatistics stats;

--- a/test/SlowTests/SlowTests/Issues/RavenDB_2134.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB_2134.cs
@@ -41,16 +41,16 @@ namespace SlowTests.SlowTests.Issues
                     }
                 }
 
-                Indexes.WaitForIndexing(store,timeout: TimeSpan.FromMinutes(2));
+                await Indexes.WaitForIndexingAsync(store,timeout: TimeSpan.FromMinutes(2));
                 var queryToDelete = new IndexQuery()
                 {
                     Query = $"FROM INDEX '{stats.IndexName}'"
                 };
 
-                var operation = store.Operations.Send(new DeleteByQueryOperation(queryToDelete));
-                operation.WaitForCompletion(TimeSpan.FromMinutes(2));
+                var operation = await store.Operations.SendAsync(new DeleteByQueryOperation(queryToDelete));
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(2));
 
-                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(2));
+                await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(2));
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/SlowTests/Issues/RavenDB_2812.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB_2812.cs
@@ -46,7 +46,7 @@ namespace SlowTests.SlowTests.Issues
         {
             var store = GetDocumentStore(options);
 
-            new UsersAndFiendsIndex().Execute(store);
+            await new UsersAndFiendsIndex().ExecuteAsync(store);
 
             using (var bulk = store.BulkInsert())
             {
@@ -73,7 +73,7 @@ namespace SlowTests.SlowTests.Issues
                     await bulk.StoreAsync(user);
                 }
             }
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             long skippedResults = 0;
             var pagedResults = new List<User>();

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -1453,8 +1453,8 @@ namespace SlowTests.Smuggler
 
             using (var store = GetDocumentStore())
             {
-                store.Subscriptions.Create<User>(x => x.Name == "Marcin");
-                store.Subscriptions.Create<User>();
+                await store.Subscriptions.CreateAsync<User>(x => x.Name == "Marcin");
+                await store.Subscriptions.CreateAsync<User>();
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
                 Backup.UpdateConfigAndRunBackup(Server, config, store);
@@ -1477,7 +1477,7 @@ namespace SlowTests.Smuggler
                     })
                     {
                         restoredStore.Initialize();
-                        var subscriptions = restoredStore.Subscriptions.GetSubscriptions(0, 10);
+                        var subscriptions = await restoredStore.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                         Assert.Equal(2, subscriptions.Count);
 
@@ -1504,9 +1504,9 @@ namespace SlowTests.Smuggler
                 var file = Directory.GetFiles(dir).First();
 
                 var op = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
-                op.WaitForCompletion(TimeSpan.FromSeconds(30));
+                await op.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
-                var subscriptions = store.Subscriptions.GetSubscriptions(0, 10);
+                var subscriptions = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
 
                 Assert.Equal(2, subscriptions.Count);
 
@@ -1745,7 +1745,7 @@ namespace SlowTests.Smuggler
 
         private async Task ValidateSubscriptions(DocumentStore restoredStore)
         {
-            var subscriptions = restoredStore.Subscriptions.GetSubscriptions(0, 10);
+            var subscriptions = await restoredStore.Subscriptions.GetSubscriptionsAsync(0, 10);
 
             int count = 0;
 

--- a/test/SlowTests/Smuggler/RavenDB-17341.cs
+++ b/test/SlowTests/Smuggler/RavenDB-17341.cs
@@ -51,9 +51,9 @@ public class RavenDB_17341 : RavenTestBase
             using (var store2 = GetDocumentStore(new Options {ModifyDatabaseName = s => $"{s}_2"}))
             {
                 DeployIndex(store1);
-                Indexes.WaitForIndexing(store1);
+                await Indexes.WaitForIndexingAsync(store1);
                 DeployIndex(store1, isUpdate: true);
-                Indexes.WaitForIndexing(store1);
+                await Indexes.WaitForIndexingAsync(store1);
 
                 var recordToExport = await store1.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store1.Database));
                 Assert.Equal(1, recordToExport.IndexesHistory.Count);

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -147,7 +147,7 @@ namespace SlowTests.Smuggler
                             .ToList();
                     }
 
-                    new Users_ByName().Execute(store1);
+                    await new Users_ByName().ExecuteAsync(store1);
 
                     using (var session = store1.OpenAsyncSession())
                     {
@@ -245,7 +245,7 @@ namespace SlowTests.Smuggler
                             .ToList();
                     }
 
-                    new Users_ByName().Execute(store1);
+                    await new Users_ByName().ExecuteAsync(store1);
 
                     using (var session = store1.OpenAsyncSession())
                     {
@@ -305,7 +305,7 @@ namespace SlowTests.Smuggler
                             .ToList();
                     }
 
-                    new Users_ByName().Execute(store1);
+                    await new Users_ByName().ExecuteAsync(store1);
 
                     using (var session = store1.OpenAsyncSession())
                     {

--- a/test/SlowTests/Tests/Faceted/FacetsWithParameters.cs
+++ b/test/SlowTests/Tests/Faceted/FacetsWithParameters.cs
@@ -315,11 +315,11 @@ namespace SlowTests.Tests.Faceted
         {
             using (var store = GetDocumentStore(options))
             {
-                new FooIndex().Execute(store);
+                await new FooIndex().ExecuteAsync(store);
 
                 var now = DateTime.Now;
                 StoreSampleData(store, now);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Tests/Indexes/IndexLocking.cs
+++ b/test/SlowTests/Tests/Indexes/IndexLocking.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Tests.Indexes
                 {
                     Conventions = new DocumentConventions()
                 };
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
                 var indexDefinition = store.Maintenance.Send(new GetIndexOperation("IndexSample"));
                 Assert.Equal(indexDefinition.LockMode, IndexLockMode.Unlock);
@@ -84,7 +84,7 @@ namespace SlowTests.Tests.Indexes
                 {
                     Conventions = new DocumentConventions()
                 };
-                staticIndex.Execute(store);
+                await staticIndex.ExecuteAsync(store);
 
                 var indexes = await store.Maintenance.SendAsync(new GetIndexesOperation(0, 128));
                 Assert.Equal(1, indexes.Length);
@@ -94,11 +94,11 @@ namespace SlowTests.Tests.Indexes
                 var stats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.Name));
                 Assert.Equal(IndexLockMode.Unlock, stats.LockMode);
 
-                store.Maintenance.Send(new SetIndexesLockOperation(index.Name, IndexLockMode.LockedIgnore));
+                await store.Maintenance.SendAsync(new SetIndexesLockOperation(index.Name, IndexLockMode.LockedIgnore));
                 stats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.Name));
                 Assert.Equal(IndexLockMode.LockedIgnore, stats.LockMode);
                 
-                store.Maintenance.Send(new SetIndexesLockOperation(index.Name, IndexLockMode.LockedError));
+                await store.Maintenance.SendAsync(new SetIndexesLockOperation(index.Name, IndexLockMode.LockedError));
                 stats = await store.Maintenance.SendAsync(new GetIndexStatisticsOperation(index.Name));
                 Assert.Equal(IndexLockMode.LockedError, stats.LockMode);
             }
@@ -132,7 +132,7 @@ namespace SlowTests.Tests.Indexes
                 {
                     Conventions = new DocumentConventions()
                 };
-                index.Execute(store);
+                await index.ExecuteAsync(store);
                 
                 var indexes = await store.Maintenance.SendAsync(new GetIndexesOperation(0, 128));
                 Assert.Equal(2, indexes.Length);

--- a/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
+++ b/test/SlowTests/Tests/Linq/CanQueryAndIncludeRevisions.cs
@@ -1188,8 +1188,8 @@ namespace SlowTests.Tests.Linq
         {
             using (var store = GetDocumentStore(options))
             {
-                new NameIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new NameIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 const string id = "users/rhino";
 
@@ -1249,7 +1249,7 @@ select Foo(u)"
             using (var store = GetDocumentStore(options))
             {
                 await new NameIndex().ExecuteAsync(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 const string id = "users/rhino";
 
                 await RevisionsHelper.SetupRevisionsAsync(store);
@@ -1262,7 +1262,7 @@ select Foo(u)"
                     await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 string changeVector;
                 using (var session = store.OpenAsyncSession())
                 {
@@ -1582,8 +1582,8 @@ select Foo(u)"
         {
             using (var store = GetDocumentStore(options))
             {
-                new NameIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new NameIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 const string id = "users/Rhino";
                 var cvList = new List<string>();

--- a/test/SlowTests/Tests/NestedIndexing/CanTrackWhatCameFromWhat.cs
+++ b/test/SlowTests/Tests/NestedIndexing/CanTrackWhatCameFromWhat.cs
@@ -56,7 +56,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -88,7 +88,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -108,7 +108,7 @@ select new
                         session.SaveChanges();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var tx = context.OpenReadTransaction())
                     {
@@ -135,7 +135,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -156,7 +156,7 @@ select new
                         session.SaveChanges();
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var tx = context.OpenReadTransaction())
                     {
@@ -197,7 +197,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -225,7 +225,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -252,7 +252,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -280,7 +280,7 @@ select new
                     session.SaveChanges();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var database = await GetDatabase(store.Database);
                 var index = database.IndexStore.GetIndex("test");
@@ -295,10 +295,10 @@ select new
 
                     using (var commands = store.Commands())
                     {
-                        commands.Delete("items/1", null);
+                        await commands.DeleteAsync("items/1", null);
                     }
 
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
 
                     using (var tx = context.OpenReadTransaction())
                     {

--- a/test/SlowTests/Tests/Sorting/AlphaNumericSorting.cs
+++ b/test/SlowTests/Tests/Sorting/AlphaNumericSorting.cs
@@ -380,8 +380,8 @@ namespace SlowTests.Tests.Sorting
                     }
                 }
 
-                new TracksIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new TracksIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -435,8 +435,8 @@ namespace SlowTests.Tests.Sorting
                     }
                 }
 
-                new TracksIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new TracksIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -491,8 +491,8 @@ namespace SlowTests.Tests.Sorting
                     }
                 }
 
-                new TracksIndex().Execute(store);
-                Indexes.WaitForIndexing(store);
+                await new TracksIndex().ExecuteAsync(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Tests/Track/AsyncProjectionShouldWork.cs
+++ b/test/SlowTests/Tests/Track/AsyncProjectionShouldWork.cs
@@ -70,7 +70,7 @@ namespace SlowTests.Tests.Track
             using (var store = GetDocumentStore(options))
             {
                 Fill(store);
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
                 using (var session = store.OpenAsyncSession())
                 {
                     var q = session.Query<Summary>("TestObjs/Summary")

--- a/test/SlowTests/Voron/Issues/RavenDB_21107.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_21107.cs
@@ -38,7 +38,7 @@ public class RavenDB_21107 : RavenTestBase
                 new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration(compressRevisions: true, compressAllCollections: true)));
 
             await store.Maintenance.SendAsync(new CreateSampleDataOperation());
-            Indexes.WaitForIndexing(store);
+            await Indexes.WaitForIndexingAsync(store);
 
             await AssertCompressionRecoveryFiles(store, path, expectedNumberOfDictionaries: 2);
 

--- a/test/Tests.Infrastructure/EmbeddingsGenerationTestBase.cs
+++ b/test/Tests.Infrastructure/EmbeddingsGenerationTestBase.cs
@@ -83,12 +83,6 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         
         return (configuration, connectionString);
     }
-
-    protected (bool QueriesWorkerRegistered, bool IndexingWorkerRegistered) WaitForEmbeddingsGenerationWorkerToRegister(IDocumentStore store, EmbeddingsGenerationConfiguration embeddingsGenerationConfigurationTask,
-        string database = null)
-    {
-        return AsyncHelpers.RunSync(() => WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, embeddingsGenerationConfigurationTask, database));
-    }
     
     protected async Task<(bool QueriesWorkerRegistered, bool IndexingWorkerRegistered)> WaitForEmbeddingsGenerationWorkerToRegisterAsync(IDocumentStore store, EmbeddingsGenerationConfiguration embeddingsGenerationConfigurationTask, string databaseName = null)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23231

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
