### PR TITLE
RavenDB-25114 Check the license limit for server-wide client configur…

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -165,6 +165,10 @@ public sealed partial class ClusterStateMachine
             case nameof(EditDocumentsCompressionCommand):
                 AssertDocumentsCompressionLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
+            case nameof(PutClientConfigurationCommand):
+                if (AssertClientConfiguration(serverStore.LicenseManager.LicenseStatus, context) == false)
+                    throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding the client configuration.");
+                break;
         }
     }
 
@@ -772,6 +776,12 @@ public sealed partial class ClusterStateMachine
             case LicenseAttribute.ServerWideAnalyzers:
                 if (serverStore.LicenseManager.LicenseStatus.HasServerWideAnalyzers == false)
                     throw new LicenseLimitException(LimitType.ServerWideAnalyzers, "Your license doesn't support adding server wide analyzers.");
+
+                break;
+
+            case LicenseAttribute.ClientConfiguration:
+                if (serverStore.LicenseManager.LicenseStatus.HasClientConfiguration == false)
+                    throw new LicenseLimitException(LimitType.ServerWideBackups, "Your license doesn't support adding server wide Client Configuration .");
 
                 break;
         }

--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -961,6 +961,29 @@ public class MyAnalyzer2 : Analyzer
             }
         }
 
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing)]
+        public async Task Prevent_Put_ServerWideClientConfiguration()
+        {
+            DoNotReuseServer();
+            var server = GetNewServer();
+            var options = new Options() { Server = server };
+            using (var store = GetDocumentStore(options))
+            {
+                await DisableRevisionCompression(server, store);
+                await PutLicense(server, RL_COMM);
+
+                var config = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50 };
+
+                var command = new PutClientConfigurationCommand(config, RaftIdGenerator.NewId());
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await server.ServerStore.SendToLeaderAsync(command));
+                Assert.Equal(LimitType.ClientConfiguration, exception.LimitType);
+
+                command = new PutClientConfigurationCommand(config, RaftIdGenerator.NewId());
+                await PutLicense(server, RL_PRO);
+                await server.ServerStore.SendToLeaderAsync(command);
+            }
+        }
+
         // ----------------------------------------
         // Tests for Studio Configuration License Limits
         //  ----------------------------------------


### PR DESCRIPTION
…ation

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25114

### Additional description

Check the license limit for server-wide client configuration

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
