### PR TITLE
RavenDB-25066 [6.2] Adjust menu for smaller resolutions

### DIFF
--- a/src/Raven.Studio/wwwroot/Content/css/basic-layout.less
+++ b/src/Raven.Studio/wwwroot/Content/css/basic-layout.less
@@ -88,7 +88,6 @@
     display: block;
     width: 100%;
     font-size: 16px;
-    height: @top-alert-height;
     text-align: center;
     line-height: 19px;
     color: @gray-dark;

--- a/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
+++ b/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
@@ -807,7 +807,6 @@
 @menu-width-collapsed: 120px;
 @navbar-height: 70px;
 @navbar-height-xs: 51px;
-@top-alert-height: 23px;
 
 @menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
 @layout-border: var(--border-color-light);

--- a/src/Raven.Studio/wwwroot/Content/css/root.less
+++ b/src/Raven.Studio/wwwroot/Content/css/root.less
@@ -44,7 +44,6 @@ body {
         width: 100%;
         font-size: 14px;
         letter-spacing: .15em;
-        min-height: @top-alert-height;
         text-align: center;
         color: @gray-dark;
         font-weight: bold;

--- a/src/Raven.Studio/wwwroot/Content/scss/_main-menu.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_main-menu.scss
@@ -195,8 +195,9 @@ $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
                 }
                 & > a {
                     padding: $gutter-sm calc($gutter-xs - 1px);
-                    @media (min-height: 750px) {
-                        height: 60px;
+
+                    @media (max-height: 800px) {
+                        padding: $gutter-xs calc($gutter-xs - 1px);
                     }
                     span {
                         transition: opacity 0.1s linear;
@@ -210,6 +211,11 @@ $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
                         i {
                             -webkit-transform: scale(1.4);
                             transform: scale(1.4);
+
+                            @media (max-height: 800px) {
+                                -webkit-transform: scale(1.15);
+                                transform: scale(1.15);
+                            }
                         }
                     }
                 }

--- a/src/Raven.Studio/wwwroot/Content/scss/_variables.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_variables.scss
@@ -20,7 +20,6 @@ $right-panel-width: 440px;
 $menu-width-collapsed: 120px;
 $navbar-height: 70px;
 $navbar-height-xs: $navbar-height;
-$top-alert-height: 23px;
 
 $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
 $layout-border: $hr-border;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25066/Footer-is-cut-off-on-smaller-resolution

### Additional description

- fix license header height
- use smaller menu items paddings for height <800px

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
