### PR TITLE
RavenDB-23916 Throw an exception when filter clause is used by patch/delete by query.

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractOperationQueriesHandlerProcessor.cs
@@ -23,7 +23,7 @@ internal abstract class AbstractOperationQueriesHandlerProcessor<TRequestHandler
     protected abstract IDisposable AllocateContextForAsyncOperation(out TOperationContext asyncOperationContext);
 
     protected abstract void ScheduleOperation(TOperationContext asyncOperationContext, IDisposable returnAsyncOperationContext, IndexQueryServerSide query, long operationId, QueryOperationOptions options);
-
+    
     public override async ValueTask ExecuteAsync()
     {
         using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -37,7 +37,8 @@ internal abstract class AbstractOperationQueriesHandlerProcessor<TRequestHandler
             try
             {
                 var query = await GetIndexQueryAsync(asyncOperationContext, QueryMethod, tracker, addSpatialProperties: false);
-
+                AssertQueryDoesNotUseFilterClause(query);
+                
                 query.DisableAutoIndexCreation = RequestHandler.GetBoolValueQueryString("disableAutoIndexCreation", false) ?? false;
 
                 if (TrafficWatchManager.HasRegisteredClients)

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -17,6 +18,7 @@ internal abstract class AbstractQueriesHandlerProcessor<TRequestHandler, TOperat
     where TOperationContext : JsonOperationContext
     where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
 {
+    internal const string CannotUseFilterClauseInPatchOrDeleteByQueryOperationExceptionMessage = "Filter clause is not supported for PATCH/DELETE by query operation. Please use WHERE clause instead.";
     protected readonly QueryMetadataCache QueryMetadataCache;
     private readonly int _start, _pageSize;
     private readonly HttpContext _httpContext;
@@ -69,5 +71,13 @@ internal abstract class AbstractQueriesHandlerProcessor<TRequestHandler, TOperat
     private async ValueTask<IndexQueryServerSide> ReadIndexQueryAsync(JsonOperationContext context, RequestTimeTracker tracker, bool addSpatialProperties)
     {
         return await IndexQueryServerSide.CreateAsync(_httpContext, _start, _pageSize, context, tracker, addSpatialProperties);
+    }
+    
+    protected static void AssertQueryDoesNotUseFilterClause(IndexQueryServerSide query)
+    {
+        if (query.Metadata.FilterScript != null)
+        {
+            throw new NotSupportedException(CannotUseFilterClauseInPatchOrDeleteByQueryOperationExceptionMessage);
+        }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForPatchTest.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForPatchTest.cs
@@ -26,6 +26,7 @@ internal abstract class AbstractQueriesHandlerProcessorForPatchTest<TRequestHand
             var docId = RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("id");
 
             var query = await GetIndexQueryAsync(context, QueryMethod, null);
+            AssertQueryDoesNotUseFilterClause(query);
 
             if (TrafficWatchManager.HasRegisteredClients)
                 RequestHandler.TrafficWatchQuery(query);

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -138,11 +138,11 @@ namespace Raven.Server.Documents.Queries
             return _asJson;
         }
 
-        public IndexQueryServerSide(string query, BlittableJsonReaderObject queryParameters = null)
+        public IndexQueryServerSide(string query, BlittableJsonReaderObject queryParameters = null, QueryType queryType = QueryType.Select)
         {
             Query = Uri.UnescapeDataString(query);
             QueryParameters = queryParameters;
-            Metadata = new QueryMetadata(Query, queryParameters, 0);
+            Metadata = new QueryMetadata(Query, queryParameters, 0, queryType: queryType);
         }
 
         public static IndexQueryServerSide Create(HttpContext httpContext,

--- a/test/SlowTests/Issues/RavenDB-23916.cs
+++ b/test/SlowTests/Issues/RavenDB-23916.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Commands.Queries;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.AST;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23916(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private readonly string _exceptionMessage = Raven.Server.Documents.Handlers.Processors.Queries.AbstractQueriesHandlerProcessor<AbstractDatabaseRequestHandler<JsonOperationContext>, JsonOperationContext>.CannotUseFilterClauseInPatchOrDeleteByQueryOperationExceptionMessage;
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task DeleteByCollectionQueryWithFilterClauseWillThrow(Options options)
+    {
+        using var store = GetDocumentStoreWithDocuments(options);
+        var deleteByQuery = new DeleteByQueryOperation($"from Orders filter Company = 'RandomValue'");
+        var exception = await Assert.ThrowsAsync<RavenException>(() => store.Operations.SendAsync(deleteByQuery));
+        var innerException = Assert.IsType<NotSupportedException>(exception.InnerException);
+        Assert.Contains(_exceptionMessage, innerException.Message);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var count = await session.Query<Orders.Order>().CountAsync();
+            Assert.Equal(3, count);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task PatchByCollectionQueryWithFilterClauseWillThrow(Options options)
+    {
+        using var store = GetDocumentStoreWithDocuments(options);
+        var patchByQuery = new PatchByQueryOperation($"from Orders filter Company = 'RandomValue' update {{this.Value++;}}");
+        var exception = await Assert.ThrowsAsync<RavenException>(() => store.Operations.SendAsync(patchByQuery));
+        var innerException = Assert.IsType<NotSupportedException>(exception.InnerException);
+        Assert.Contains(_exceptionMessage, innerException.Message);
+
+        await AssertNoChanges(store);
+    }
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task DeleteByIndexQueryWithFilterClauseWillThrow(Options options)
+    {
+        using var store = GetDocumentStoreWithDocuments(options, createAutoIndex: true);
+        var deleteByQuery = new DeleteByQueryOperation($"from Orders where startsWith(Company, 't') filter Company = 'RandomValue'");
+        var exception = await Assert.ThrowsAsync<RavenException>(() => store.Operations.SendAsync(deleteByQuery));
+        var innerException = Assert.IsType<NotSupportedException>(exception.InnerException);
+        Assert.Contains(_exceptionMessage, innerException.Message);
+
+        await AssertNoChanges(store);
+    }
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task PatchByIndexQueryWithFilterClauseWillThrow(Options options = null)
+    {
+        using var store = GetDocumentStoreWithDocuments(options, createAutoIndex: true);
+        var patchByQuery = new PatchByQueryOperation($"from Orders where startsWith(Company, 't') filter Company = 'RandomValue' update {{this.Value++;}}");
+        var exception = await Assert.ThrowsAsync<RavenException>(() => store.Operations.SendAsync(patchByQuery));
+        var innerException = Assert.IsType<NotSupportedException>(exception.InnerException);
+        Assert.Contains(_exceptionMessage, innerException.Message);
+
+        await AssertNoChanges(store);
+    }
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task TestPatchByIndexQueryWithFilterClauseWillThrow(Options options = null)
+    {
+        using var store = GetDocumentStoreWithDocuments(options, createAutoIndex: true);
+        using (var commands = store.Commands())
+        {
+            var patchByQueryTestCommand = new PatchByQueryTestCommand(store.Conventions, "id",
+                new IndexQueryServerSide($"from Orders where startsWith(Company, 't') filter Company = 'RandomValue' update {{this.Value++;}}"
+                    , queryType: QueryType.Update));
+            var exception = await Assert.ThrowsAsync<RavenException>(() => commands.ExecuteAsync(patchByQueryTestCommand));
+            var innerException = Assert.IsType<NotSupportedException>(exception.InnerException);
+            Assert.Contains(_exceptionMessage, innerException.Message);
+        }
+
+        await AssertNoChanges(store);
+    }
+
+    [RavenTheory(RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task TestPatchByCollectionQueryWithFilterClauseWillThrow(Options options = null)
+    {
+        using var store = GetDocumentStoreWithDocuments(options, createAutoIndex: false);
+
+        using (var commands = store.Commands())
+        {
+            var patchByQueryTestCommand = new PatchByQueryTestCommand(store.Conventions, "id",
+                new IndexQueryServerSide($"from Orders filter Company = 'RandomValue' update {{this.Value++;}}"
+                    , queryType: QueryType.Update));
+            var exception = await Assert.ThrowsAsync<RavenException>(() => commands.ExecuteAsync(patchByQueryTestCommand));
+            var innerException = Assert.IsType<NotSupportedException>(exception.InnerException);
+            Assert.Contains(_exceptionMessage, innerException.Message);
+        }
+
+        await AssertNoChanges(store);
+    }
+
+    private async ValueTask AssertNoChanges(IDocumentStore store)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var count = await session.Query<Orders.Order>()
+                .CountAsync();
+            Assert.Equal(3, count);
+
+            var notUpdated = await session.Advanced.AsyncDocumentQuery<Orders.Order>()
+                .WaitForNonStaleResults()
+                .WhereExists("Value")
+                .ToListAsync();
+
+            Assert.Empty(notUpdated);
+        }
+    }
+
+    private IDocumentStore GetDocumentStoreWithDocuments(Options options = null, bool createAutoIndex = true)
+    {
+        var store = GetDocumentStore(options: options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Orders.Order() { Company = "test0" });
+            session.Store(new Orders.Order() { Company = "test1" });
+            session.Store(new Orders.Order() { Company = "test2" });
+            session.SaveChanges();
+
+            if (createAutoIndex)
+            {
+                var _ = session.Query<Orders.Order>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(x => x.Company.StartsWith("test"))
+                    .ToList();
+            }
+        }
+
+        return store;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23916

### Additional description

Throw an exception when filter clause is used by patch/delete by query.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
