### PR TITLE
RavenDB-25111 Read result struct 8.0

### DIFF
--- a/bench/Voron.Benchmark/BTree/BTreeFillRandom.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeFillRandom.cs
@@ -27,10 +27,9 @@ namespace Voron.Benchmark.BTree
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static BTreeFillRandom()
         {
@@ -51,7 +50,7 @@ namespace Voron.Benchmark.BTree
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _pairs = new List<Tuple<Slice, Slice>>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/BTree/BTreeFillSequential.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeFillSequential.cs
@@ -27,10 +27,9 @@ namespace Voron.Benchmark.BTree
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static BTreeFillSequential()
         {
@@ -51,7 +50,7 @@ namespace Voron.Benchmark.BTree
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions*NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             // This will sort just the KEYS
             totalPairs.Sort((x, y) => SliceComparer.Compare(x.Item1, y.Item1));

--- a/bench/Voron.Benchmark/BTree/BTreeInsertRandom.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeInsertRandom.cs
@@ -45,10 +45,9 @@ namespace Voron.Benchmark.BTree
         public double GenerationDeletionProbability { get; set; } = 0.1;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static BTreeInsertRandom()
         {
@@ -60,8 +59,6 @@ namespace Voron.Benchmark.BTree
         {
             base.Setup();
 
-            var randomSeed = RandomSeed == -1 ? null : RandomSeed as int?;
-
             Utils.GenerateWornoutTree(
                 Env,
                 TreeNameSlice,
@@ -69,12 +66,12 @@ namespace Voron.Benchmark.BTree
                 GenerationBatchSize,
                 KeyLength,
                 GenerationDeletionProbability,
-                randomSeed);
+                RandomSeed);
 
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                randomSeed);
+                RandomSeed * 13);
 
             _pairs = new List<Tuple<Slice, Slice>>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/BTree/BTreeReadAndIterate.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeReadAndIterate.cs
@@ -48,10 +48,9 @@ namespace Voron.Benchmark.BTree
         public double GenerationDeletionProbability { get; set; } = 0.1;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 13;
 
         [Params(1, 2)]
         public int ReadParallelism { get; set; } = 1;
@@ -68,7 +67,6 @@ namespace Voron.Benchmark.BTree
         public override void Setup()
         {
             base.Setup();
-            var randomSeed = RandomSeed == -1 ? null : RandomSeed as int?;
 
             var treeKeys = Utils.GenerateWornoutTree(
                 Env,
@@ -77,7 +75,7 @@ namespace Voron.Benchmark.BTree
                 GenerationBatchSize,
                 KeyLength,
                 GenerationDeletionProbability,
-                randomSeed);
+                RandomSeed);
 
             // Distribute work amount, each one of the buckets is sorted
             for (var i = 0; i < ReadParallelism; i++)

--- a/bench/Voron.Benchmark/BTree/BTreeSimple.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeSimple.cs
@@ -1,0 +1,66 @@
+﻿using BenchmarkDotNet.Attributes;
+using Sparrow.Server;
+using Voron.Data.BTrees;
+
+namespace Voron.Benchmark.BTree
+{
+    public class BTreeSimple : StorageBenchmark
+    {
+        /// <summary>
+        /// Ensure we don't have to re-create the BTree between benchmarks
+        /// </summary>
+        public override bool DeleteBeforeEachBenchmark { get; protected set; } = false;
+
+        private static readonly Slice TreeNameSlice;
+        private static readonly Slice KeyValueSlice;
+
+        static BTreeSimple()
+        {
+            Slice.From(Configuration.Allocator, nameof(BTreeSimple), ByteStringType.Immutable, out TreeNameSlice);
+            Slice.From(Configuration.Allocator, nameof(KeyValueSlice), ByteStringType.Immutable, out KeyValueSlice);
+        }
+
+        [GlobalSetup]
+        public override void Setup()
+        {
+            base.Setup();
+
+            bool hasTree;
+            using (var tx = Env.ReadTransaction())
+            {
+                Tree tree = tx.ReadTree(TreeNameSlice);
+                hasTree = tree != null;
+            }
+
+            if (hasTree != false)
+                return;
+
+            // Create the tree as is does not exist
+            using (var tx = Env.WriteTransaction())
+            {
+                Tree tree = tx.CreateTree(TreeNameSlice);
+                tree.Add(KeyValueSlice, KeyValueSlice);
+                tx.Commit();
+            }
+        }
+
+        private const int OpsCount = 64;
+
+        [Benchmark(OperationsPerInvoke = OpsCount)]
+        public int ReadTree()
+        {
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree(TreeNameSlice);
+
+                var count = 0;
+                for (int i = 0; i < OpsCount; i++)
+                {
+                    if (tree.Read(KeyValueSlice).HasValue)
+                        count++;
+                }
+                return count;
+            }
+        }
+    }
+}

--- a/bench/Voron.Benchmark/Configuration.cs
+++ b/bench/Voron.Benchmark/Configuration.cs
@@ -7,7 +7,7 @@ namespace Voron.Benchmark
     {
         public const int RecordsPerTransaction = 1000;
         public const int Transactions = 1000;
-        public const string Path = @"Z:\Bench";
+        public const string Path = @"C:\Bench";
 
         /// <summary>
         /// This is the global allocator for test strings

--- a/bench/Voron.Benchmark/Table/SecondaryIndexFillRandom.cs
+++ b/bench/Voron.Benchmark/Table/SecondaryIndexFillRandom.cs
@@ -32,10 +32,9 @@ namespace Voron.Benchmark.Table
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(12345)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static SecondaryIndexFillRandom()
         {
@@ -74,7 +73,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _valueBuilders = new List<TableValueBuilder>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/Table/TableFillRandom.cs
+++ b/bench/Voron.Benchmark/Table/TableFillRandom.cs
@@ -64,7 +64,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _valueBuilders = new List<TableValueBuilder>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/Table/TableFillSequential.cs
+++ b/bench/Voron.Benchmark/Table/TableFillSequential.cs
@@ -29,10 +29,9 @@ namespace Voron.Benchmark.Table
         public int KeyLength { get; set; } = 100;
 
         /// <summary>
-        /// Random seed. If -1, uses time for seeding.
+        /// Random seed.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         static TableFillSequential()
         {
@@ -63,7 +62,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             // This will sort just the KEYS
             totalPairs.Sort((x, y) => SliceComparer.Compare(x.Item1, y.Item1));

--- a/bench/Voron.Benchmark/Table/TableInsertRandom.cs
+++ b/bench/Voron.Benchmark/Table/TableInsertRandom.cs
@@ -47,10 +47,9 @@ namespace Voron.Benchmark.Table
         public double GenerationDeletionProbability { get; set; } = 0.1;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         private const string TableName = "TestTable2";
 
@@ -83,7 +82,7 @@ namespace Voron.Benchmark.Table
             var totalPairs = Utils.GenerateUniqueRandomSlicePairs(
                 NumberOfTransactions * NumberOfRecordsPerTransaction,
                 KeyLength,
-                RandomSeed == -1 ? null as int? : RandomSeed);
+                RandomSeed);
 
             _valueBuilders = new List<TableValueBuilder>[NumberOfTransactions];
 

--- a/bench/Voron.Benchmark/Table/TableReadAndIterate.cs
+++ b/bench/Voron.Benchmark/Table/TableReadAndIterate.cs
@@ -52,10 +52,9 @@ namespace Voron.Benchmark.Table
         public double GenerationDeletionProbability { get; set; } = 0.5;
 
         /// <summary>
-        /// Random seed used to generate values. If -1, uses time for seeding.
+        /// Random seed used to generate values.
         /// </summary>
-        [Params(-1)]
-        public int RandomSeed { get; set; } = -1;
+        public const int RandomSeed = 42;
 
         [Params(1, 2)]
         public int ReadParallelism { get; set; } = 1;
@@ -88,7 +87,7 @@ namespace Voron.Benchmark.Table
                 GenerationBatchSize,
                 KeyLength,
                 GenerationDeletionProbability,
-                RandomSeed == -1 ? null : RandomSeed as int?
+                RandomSeed
             );
 
             // Distribute work amount, each one of the buckets is sorted

--- a/bench/Voron.Benchmark/Utils.cs
+++ b/bench/Voron.Benchmark/Utils.cs
@@ -8,13 +8,13 @@ namespace Voron.Benchmark
 {
     public class Utils
     {
-        public static List<Tuple<Slice, Slice>> GenerateUniqueRandomSlicePairs(int amount, int keyLength, int? randomSeed = null)
+        public static List<Tuple<Slice, Slice>> GenerateUniqueRandomSlicePairs(int amount, int keyLength, int randomSeed)
         {
             Debug.Assert(amount > 0);
             Debug.Assert(keyLength > 0);
 
             // Generate random key value pairs
-            var generator = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
+            var generator = new Random(randomSeed);
             var keyBuffer = new byte[keyLength];
 
             // This serves to ensure the uniqueness of keys globally (that way
@@ -68,12 +68,12 @@ namespace Voron.Benchmark
             int generationBatchSize,
             int keyLength,
             double generationDeletionProbability,
-            int? randomSeed
+            int randomSeed
             )
         {
-            List<Slice> treeKeys = new List<Slice>();
-            var generator = randomSeed.HasValue ? new Random(randomSeed.Value): new Random();
-            bool hasTree = false;
+            List<Slice> treeKeys = new();
+            var generator = new Random(randomSeed);
+            bool hasTree;
 
             using (var tx = env.ReadTransaction())
             {
@@ -122,7 +122,7 @@ namespace Voron.Benchmark
                                 values = GenerateUniqueRandomSlicePairs(
                                     generationTreeSize,
                                     keyLength,
-                                    randomSeed);
+                                    generator.Next());
                             }
 
                             var pair = values[0];
@@ -181,11 +181,11 @@ namespace Voron.Benchmark
             int generationBatchSize,
             int keyLength,
             double generationDeletionProbability,
-            int? randomSeed
+            int randomSeed
             )
         {
             var tableKeys = new List<Slice>();
-            var generator = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
+            var generator = new Random(randomSeed);
             bool hasTable;
 
             using (var tx = env.ReadTransaction())

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -496,7 +496,7 @@ public unsafe partial class IndexWriter
             // then we'll insert data to it as if it was any other term
             var entry = tree.Read(_indexedField.Name);
 
-            if (entry != null)
+            if (entry.HasValue)
             {
                 Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
                 Debug.Assert(entry.Reader.Length == sizeof((long, long)));

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -673,7 +673,16 @@ namespace Corax.Indexing
 
         private void ReadPersistedVectorRootPages(out long[] persistedVectorRootPages)
         {
-            persistedVectorRootPages = _indexMetadata?.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice)?.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray() ?? [];
+            persistedVectorRootPages = [];
+
+            if (_indexMetadata != null)
+            {
+                ReadResult entry = _indexMetadata.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice);
+                if (entry.HasValue)
+                {
+                    persistedVectorRootPages = entry.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray();
+                }
+            }
         }
 
         private void PersistVectorRootPages()

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -157,7 +157,9 @@ public partial class IndexSearcher
     {
         double termRatioToWholeCollection;
         var totalTerms = tree.NumberOfEntries;
-        var totalSum = _metadataTree.Read(field.TermLengthSumName)?.Reader.Read<long>() ?? totalTerms;
+
+        var entry = _metadataTree.Read(field.TermLengthSumName);
+        var totalSum = entry.ReadLittleEndianInt64OrDefault(totalTerms);
 
         if (totalTerms == 0 || totalSum == 0)
             termRatioToWholeCollection = 1;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -628,7 +628,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             LoadSpecialTermMarkers(_nonExistingPostingListsTree, out _nonExistingTermsMarkers);
         }
 
-        _vectorFieldsMarkers ??= _metadataTree?.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice)?.Reader.ToUnmanagedSpan<long>().ToSpan().ToArray() ?? [];
+        _vectorFieldsMarkers = _metadataTree == null ? [] : _metadataTree.Read(Constants.IndexWriter.VectorFieldsRootPagesSlice).ToArrayEmptyOnNull<long>();
     }
 
     public bool IsVectorField(string fieldName)
@@ -682,10 +682,18 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     private bool TryGetRootPageByFieldName(Slice fieldName, out long rootPage)
     {
-        var result = _fieldsTree?.Read(fieldName);
-        if (result is null)
+        const long notFound = -1;
+
+        if (_fieldsTree == null)
         {
-            rootPage = -1;
+            rootPage = notFound;
+            return false;
+        }
+        
+        var result = _fieldsTree.Read(fieldName);
+        if (result.HasValue == false)
+        {
+            rootPage = notFound;
             return false;
         }
         

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -381,12 +381,7 @@ namespace Raven.Server.Documents
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalChangeVectorSlice);
-            if (val == null)
-            {
-                return string.Empty;
-            }
-
-            return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
+            return val.ToStringValueOrDefault(string.Empty);
         }
 
         internal HashSet<string> UnusedDatabaseIds;
@@ -447,12 +442,7 @@ namespace Raven.Server.Documents
             var tx = context.Transaction.InnerTransaction;
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(GlobalFullChangeVectorSlice);
-            if (val == null)
-            {
-                return GetDatabaseChangeVector(context);
-            }
-            return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
-
+            return val.HasValue ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : GetDatabaseChangeVector(context);
         }
 
         public void SetFullDatabaseChangeVector(DocumentsOperationContext context, string changeVector)
@@ -636,13 +626,8 @@ namespace Raven.Server.Documents
             {
                 return 0;
             }
-            var readResult = tree.Read(LastCompletedClusterTransactionIndexSlice);
-            if (readResult == null)
-            {
-                return 0;
-            }
-
-            return readResult.Reader.Read<long>();
+            
+            return tree.Read(LastCompletedClusterTransactionIndexSlice).ReadLittleEndianInt64OrDefault(0);
         }
 
         public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
@@ -658,9 +643,8 @@ namespace Raven.Server.Documents
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(FixCountersLastKeySlice);
-            if (val == null)
-                return null;
-            return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
+
+            return val.HasValue ? Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length) : null;
         }
 
         public void SetLastFixedCounterKey(DocumentsOperationContext context, string lastKey)
@@ -2601,10 +2585,7 @@ namespace Raven.Server.Documents
         {
             var readTree = context.Transaction.InnerTransaction.ReadTree(LastReplicatedEtagsSlice);
             var readResult = readTree.Read(dbId);
-            if (readResult == null)
-                return 0;
-
-            return readResult.Reader.Read<long>();
+            return readResult.ReadLittleEndianInt64OrDefault(0);
         }
 
         public static void SetLastReplicatedEtagFrom(DocumentsOperationContext context, string dbId, long etag)

--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -120,7 +120,8 @@ namespace Raven.Server.Documents.Indexes
         internal static long GetVersion(Tree tree, bool isNew)
         {
             var read = tree.Read(VersionSlice);
-            if (read != null)
+
+            if (read.HasValue)
                 return read.Reader.Read<long>();
 
             return isNew
@@ -131,11 +132,12 @@ namespace Raven.Server.Documents.Indexes
         private static long GetCount(Tree tree, ref Mode mode)
         {
             var read = tree.Read(mode == Mode.X64 ? Count64Slice : Count32Slice);
-            if (read != null)
+
+            if (read.HasValue)
                 return read.Reader.Read<long>();
 
             read = tree.Read(mode == Mode.X64 ? Count32Slice : Count64Slice);
-            if (read != null)
+            if (read.HasValue)
             {
                 mode = mode == Mode.X64 ? Mode.X86 : Mode.X64;
                 return read.Reader.Read<long>();
@@ -380,10 +382,7 @@ namespace Raven.Server.Documents.Indexes
             private long ReadCount()
             {
                 var read = _tree.Read(_keySlice);
-                if (read == null)
-                    return 0;
-
-                return read.Reader.Read<long>();
+                return read.ReadLittleEndianInt64OrDefault(0);
             }
 
             internal bool Add(LazyStringValue key)
@@ -488,7 +487,7 @@ namespace Raven.Server.Documents.Indexes
                 Slice.From(_allocator, $"{_key:D5}/{number:D4}", out Slice partitionKey);
 
                 var read = _tree.Read(partitionKey);
-                if (read != null)
+                if (read.HasValue)
                 {
                     return _partitions[number] = new Partition
                     {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -797,7 +797,7 @@ namespace Raven.Server.Documents.Indexes
                     if (configurationTree != null)
                     {
                         var result = configurationTree.Read(IndexStorage.IndexSchema.SearchEngineType);
-                        if (result != null)
+                        if (result.HasValue)
                             if (Enum.TryParse(result.Reader.ToStringValue(), out searchEngineTypeFromSchema) == false)
                                 searchEngineTypeFromSchema = SearchEngineType.None;
                     }
@@ -1004,11 +1004,11 @@ namespace Raven.Server.Documents.Indexes
             using (var tx = context.OpenReadTransaction())
             {
                 var now = DocumentDatabase.Time.GetUtcNow();
-                State = _indexStorage.ReadState(tx);
-                var persistedElapsedTimeFromLastQuery = _indexStorage.ReadElapsedTimeFromLastQuery(tx) ?? TimeSpan.Zero;
+                State = IndexStorage.ReadState(tx);
+                var persistedElapsedTimeFromLastQuery = IndexStorage.ReadElapsedTimeFromLastQuery(tx) ?? TimeSpan.Zero;
                 _lastQueriedTimeTracker = new LastQueriedTimeTracker(now, persistedElapsedTimeFromLastQuery.Ticks);
                 
-                LastIndexingTime = _indexStorage.ReadLastIndexingTime(tx);
+                LastIndexingTime = IndexStorage.ReadLastIndexingTime(tx);
                 MaxNumberOfOutputsPerDocument = _indexStorage.ReadMaxNumberOfOutputsPerDocument(tx);
                 ArchivedDataProcessingBehavior = _indexStorage.ReadArchivedDataProcessingBehavior(tx);
                 CoraxComplexFieldIndexingBehavior = _indexStorage.ReadCoraxComplexFieldIndexingBehavior(tx);

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -396,7 +396,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var tree = tx.CreateTree("Definition");
             var result = tree.Read(DefinitionSlice);
-            if (result == null)
+            if (result.HasValue == false)
                 return null;
 
             var stream = result.Reader.AsStream();

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -133,7 +133,7 @@ namespace Raven.Server.Documents.Indexes
                     statsTree.Add(IndexSchema.SourceTypeSlice, tmpSlice);
 
                 var createdTimestampResult = statsTree.Read(IndexSchema.CreatedTimestampSlice);
-                if (createdTimestampResult == null)
+                if (createdTimestampResult.HasValue == false)
                 {
                     var binaryDate = CreatedTimestampAsBinary = SystemTime.UtcNow.ToBinary();
                     using (Slice.External(context.Allocator, (byte*)&binaryDate, sizeof(long), out Slice tmpSlice))
@@ -176,7 +176,7 @@ namespace Raven.Server.Documents.Indexes
                 {
                     var result = configurationTree.Read(configurationKey);
                     string persistedConfigurationValue = null;
-                    if (result != null)
+                    if (result.HasValue)
                         persistedConfigurationValue = result.Reader.ToStringValue();
                     else if (_index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.Analyzers)
                         persistedConfigurationValue = defaultAnalyzer;
@@ -202,7 +202,7 @@ namespace Raven.Server.Documents.Indexes
                     if (defaultEngineType == SearchEngineType.None)
                         throw new InvalidDataException($"Default search engine is {SearchEngineType.None}. Please set {configurationName}.");
                     var result = configurationTree.Read(configurationKey);
-                    if (result != null)
+                    if (result.HasValue)
                     {
                         if (Enum.TryParse(result.Reader.ToStringValue(), out SearchEngineType persistedSearchEngineType) == false)
                         {
@@ -230,7 +230,7 @@ namespace Raven.Server.Documents.Indexes
                         configurationTree.Add(configurationKey, _index.Definition.ArchivedDataProcessingBehavior.ToString());
                     else
                     {
-                        if (configurationTree.Read(configurationKey) != null)
+                        if (configurationTree.Read(configurationKey).HasValue)
                             return; // do not overwrite default value if it exists already
 
                         configurationTree.Add(configurationKey, defaultBehavior.ToString());
@@ -247,7 +247,7 @@ namespace Raven.Server.Documents.Indexes
                         configuredBehavior = _index.Configuration.CoraxStaticIndexComplexFieldIndexingBehavior;
 
                     var result = configurationTree.Read(configurationKey);
-                    if (result != null)
+                    if (result.HasValue)
                     {
                         var behaviorStringValue = result.Reader.ToStringValue();
 
@@ -271,8 +271,8 @@ namespace Raven.Server.Documents.Indexes
             if (_environment.IsNew == false)
             {
                 var tree = indexContext.Transaction.InnerTransaction.ReadTree(IndexSchema.LastDocumentEtagOnIndexCreationTree);
-                var result = tree?.Read(key);
-                return result?.Reader.Read<long>() ?? 0;
+                var result = tree?.Read(key) ?? ReadResult.Null;
+                return result.ReadLittleEndianInt64OrDefault(0);
             }
 
             using (var queryContext = QueryOperationContext.Allocate(DocumentDatabase, _index))
@@ -317,14 +317,11 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public IndexState ReadState(RavenTransaction tx)
+        public static IndexState ReadState(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
             var state = statsTree.Read(IndexSchema.StateSlice);
-            if (state == null)
-                return IndexState.Normal;
-
-            return (IndexState)state.Reader.Read<int>();
+            return state.HasValue ? (IndexState)state.Reader.Read<int>() : IndexState.Normal;
         }
 
         public void DeleteErrors()
@@ -402,15 +399,12 @@ namespace Raven.Server.Documents.Indexes
             }
         }
         
-        public TimeSpan? ReadElapsedTimeFromLastQuery(RavenTransaction tx)
+        public static TimeSpan? ReadElapsedTimeFromLastQuery(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastQueryTimeSlice = statsTree.Read(IndexSchema.ElapsedSinceQueriedSlice);
-            if (lastQueryTimeSlice == null)
-                return null;
-
-            return new TimeSpan(ticks: lastQueryTimeSlice.Reader.Read<long>());
+            return lastQueryTimeSlice.HasValue ? new TimeSpan(ticks: lastQueryTimeSlice.Reader.Read<long>()) : null;
         }
 
         public void WriteElapsedSinceQueried(TimeSpan value)
@@ -431,37 +425,34 @@ namespace Raven.Server.Documents.Indexes
                 statsTree.Add(IndexSchema.ElapsedSinceQueriedSlice, timeElapsedFromLastQuerySlice);
         }
         
-        public DateTime? ReadLastIndexingTime(RavenTransaction tx)
+        public static DateTime? ReadLastIndexingTime(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
-            if (lastIndexingTime == null)
-                return null;
-
-            return DateTime.FromBinary(lastIndexingTime.Reader.Read<long>());
+            return lastIndexingTime.HasValue ? DateTime.FromBinary(lastIndexingTime.Reader.Read<long>()) : null;
         }
 
         public bool IsIndexInvalid(RavenTransaction tx)
         {
             var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
-
-            var mapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice)?.Reader.Read<long>() ?? 0;
-            var mapErrors = statsTree.Read(IndexSchema.MapErrorsSlice)?.Reader.Read<long>() ?? 0;
+            
+            var mapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+            var mapErrors = statsTree.Read(IndexSchema.MapErrorsSlice).ReadLittleEndianInt64OrDefault(0);
 
             long? reduceAttempts = null, reduceErrors = null;
 
             if (_index.Type.IsMapReduce())
             {
-                reduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.Read<long>() ?? 0;
-                reduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.Read<long>() ?? 0;
+                reduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+                reduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice).ReadLittleEndianInt64OrDefault(0);
             }
 
             long mapReferenceAttempts = 0, mapReferenceErrors = 0;
             if (_index.GetReferencedCollections()?.Count > 0)
             {
-                mapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice)?.Reader.Read<long>() ?? 0;
-                mapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice)?.Reader.Read<long>() ?? 0;
+                mapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+                mapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice).ReadLittleEndianInt64OrDefault(0);
             }
 
             return IndexFailureInformation.CheckIndexInvalid(mapAttempts, mapErrors,
@@ -491,15 +482,18 @@ namespace Raven.Server.Documents.Indexes
                 };
             }
 
-            var entriesCountReader = statsTree.Read(IndexSchema.EntriesCount)?.Reader;
+            ReadResult entriesResult = statsTree.Read(IndexSchema.EntriesCount);
+            
             long? entriesCount = null;
-            if (entriesCountReader.HasValue)
+            if (entriesResult.HasValue)
             {
-                var entriesCountSize = entriesCountReader.Value.Length;
+                var entriesCountReader = entriesResult.Reader;
+                var entriesCountSize = entriesCountReader.Length;
                 //backward compatibility https://github.com/ravendb/ravendb/commit/5c53b01ee2b4fad8f3ef410f3e4976144d72c023
-                entriesCount = entriesCountSize == sizeof(long) 
-                    ? entriesCountReader.Value.Read<long>() 
-                    : entriesCountReader.Value.Read<int>();
+
+                entriesCount = entriesCountSize == sizeof(long)
+                    ? entriesCountReader.Read<long>()
+                    : entriesCountReader.Read<int>();
             }
 
             if (entriesCount != null)
@@ -512,7 +506,7 @@ namespace Raven.Server.Documents.Indexes
                 }
             }
 
-            if (lastIndexingTime != null)
+            if (lastIndexingTime.HasValue)
             {
                 stats.LastIndexingTime = DateTime.FromBinary(lastIndexingTime.Reader.Read<long>());
                 stats.MapAttempts = statsTree.Read(IndexSchema.MapAttemptsSlice).Reader.Read<int>();
@@ -523,16 +517,16 @@ namespace Raven.Server.Documents.Indexes
 
                 if (_index.Type.IsMapReduce())
                 {
-                    stats.ReduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice)?.Reader.Read<long>() ?? 0;
-                    stats.ReduceSuccesses = statsTree.Read(IndexSchema.ReduceSuccessesSlice)?.Reader.Read<long>() ?? 0;
-                    stats.ReduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice)?.Reader.Read<long>() ?? 0;
+                    stats.ReduceAttempts = statsTree.Read(IndexSchema.ReduceAttemptsSlice).ReadLittleEndianInt64OrDefault(0);
+                    stats.ReduceSuccesses = statsTree.Read(IndexSchema.ReduceSuccessesSlice).ReadLittleEndianInt64OrDefault(0);
+                    stats.ReduceErrors = statsTree.Read(IndexSchema.ReduceErrorsSlice).ReadLittleEndianInt64OrDefault(0);
                 }
 
                 if (_index.GetReferencedCollections()?.Count > 0)
                 {
-                    stats.MapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice)?.Reader.Read<int>() ?? 0;
-                    stats.MapReferenceSuccesses = statsTree.Read(IndexSchema.MapReferenceSuccessesSlice)?.Reader.Read<int>() ?? 0;
-                    stats.MapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice)?.Reader.Read<int>() ?? 0;
+                    stats.MapReferenceAttempts = statsTree.Read(IndexSchema.MapReferencedAttemptsSlice).ReadLittleEndianInt32OrDefault(0);
+                    stats.MapReferenceSuccesses = statsTree.Read(IndexSchema.MapReferenceSuccessesSlice).ReadLittleEndianInt32OrDefault(0);
+                    stats.MapReferenceErrors = statsTree.Read(IndexSchema.MapReferenceErrorsSlice).ReadLittleEndianInt32OrDefault(0);
                 }
             }
 
@@ -545,7 +539,7 @@ namespace Raven.Server.Documents.Indexes
 
             var lastIndexingTime = statsTree.Read(IndexSchema.LastIndexingTimeSlice);
 
-            if (lastIndexingTime != null)
+            if (lastIndexingTime.HasValue)
             {
                 return statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument).Reader.Read<int>();
             }
@@ -562,7 +556,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.ArchivedDataProcessingBehaviorSlice);
-            if (result == null)
+            if (result.HasValue == false)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.ArchivedDataProcessingBehaviorSlice)}' tree.");
             }
@@ -584,7 +578,7 @@ namespace Raven.Server.Documents.Indexes
             }
 
             var result = configurationTree.Read(IndexSchema.CoraxComplexFieldIndexingBehavior);
-            if (result == null)
+            if (result.HasValue == false)
             {
                 throw new InvalidOperationException($"Index does not contain {nameof(IndexSchema.CoraxComplexFieldIndexingBehavior)}' key.");
             }
@@ -663,12 +657,14 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 var tree = tx.ReadTree(_referencePrefix + collection);
-
-                var result = tree?.Read(referencedCollection.Name);
-                if (result == null)
-                    return 0;
-
-                return result.Reader.Read<long>();
+                
+                const long nonExistent = 0;
+                
+                if (tree == null)
+                    return nonExistent;
+                
+                var result = tree.Read(referencedCollection.Name);
+                return result.ReadLittleEndianInt64OrDefault(nonExistent);
             }
 
             public unsafe void WriteLastReferenceEtag(RavenTransaction tx, string collection, CollectionName referencedCollection, long etag)
@@ -705,13 +701,15 @@ namespace Raven.Server.Documents.Indexes
                     }
                 }
 
+                const long nonExistent = 0;
+                
                 var tree = tx.ReadTree(_referenceTombstonePrefix + collection);
 
-                var result = tree?.Read(referencedCollection.Name);
-                if (result == null)
-                    return 0;
-
-                return result.Reader.Read<long>();
+                if (tree == null)
+                    return nonExistent;
+                
+                var result = tree.Read(referencedCollection.Name);
+                return result.ReadLittleEndianInt64OrDefault(nonExistent);
             }
 
             public unsafe void WriteLastReferenceTombstoneEtag(RavenTransaction tx, string collection, CollectionName referencedCollection, long etag)
@@ -975,13 +973,7 @@ namespace Raven.Server.Documents.Indexes
 
         internal static long ReadLastEtag(Transaction tx, string tree, Slice collection)
         {
-            var statsTree = tx.CreateTree(tree);
-            
-            long lastEtag = 0;
-            if (statsTree.TryRead(collection, out var reader))
-                lastEtag = reader.Read<long>();
-
-            return lastEtag;
+            return tx.CreateTree(tree).Read(collection).ReadLittleEndianInt64OrDefault(0);
         }
 
         public unsafe IndexFailureInformation UpdateStats(DateTime indexingTime, TimeSpan lastQueryElapsed, IndexingRunStats stats)
@@ -1004,13 +996,13 @@ namespace Raven.Server.Documents.Indexes
                 result.MapAttempts = statsTree.Increment(IndexSchema.MapAttemptsSlice, stats.MapAttempts);
                 result.MapSuccesses = statsTree.Increment(IndexSchema.MapSuccessesSlice, stats.MapSuccesses);
                 result.MapErrors = statsTree.Increment(IndexSchema.MapErrorsSlice, stats.MapErrors);
-
-                var currentMaxNumberOfOutputs = statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument)?.Reader.Read<int>();
+                
+                var currentMaxNumberOfOutputs = statsTree.Read(IndexSchema.MaxNumberOfOutputsPerDocument).ReadLittleEndianInt32OrDefault(0);
 
                 using (statsTree.DirectAdd(IndexSchema.MaxNumberOfOutputsPerDocument, sizeof(int), out byte* ptr))
                 {
                     *(int*)ptr = currentMaxNumberOfOutputs > stats.MaxNumberOfOutputsPerDocument
-                        ? currentMaxNumberOfOutputs.Value
+                        ? currentMaxNumberOfOutputs
                         : stats.MaxNumberOfOutputsPerDocument;
                 }
 
@@ -1083,7 +1075,7 @@ namespace Raven.Server.Documents.Indexes
                 var statsTree = tx.ReadTree(IndexSchema.StatsTree);
                 if (statsTree == null)
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
-
+                
                 if (statsTree.TryRead(IndexSchema.TypeSlice, out var reader) == false)
                     throw new InvalidOperationException($"Stats tree does not contain 'Type' entry in index '{name}'.");
 
@@ -1098,7 +1090,7 @@ namespace Raven.Server.Documents.Indexes
                 var statsTree = tx.ReadTree(IndexSchema.StatsTree);
                 if (statsTree == null)
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
-
+                
                 if (statsTree.TryRead(IndexSchema.DatabaseIdSlice, out var reader) == false)
                     return null; // backward compatibility
 
@@ -1117,14 +1109,15 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 var result = configurationTree.Read(IndexSchema.SearchEngineType);
-                if (result == null)
+                if (result.HasValue == false)
                 {
                     return SearchEngineType.None;
                 }
 
-                if (Enum.TryParse(result.Reader.ToStringValue(), out SearchEngineType persistedSearchEngineType) == false)
+                string searchEngineType = result.Reader.ToStringValue();
+                if (Enum.TryParse(searchEngineType, out SearchEngineType persistedSearchEngineType) == false)
                 {
-                    throw new InvalidOperationException($"Index '{name}' does not contain valid {nameof(SearchEngineType)} property. It contains: {result.Reader.ToStringValue()}.");
+                    throw new InvalidOperationException($"Index '{name}' does not contain valid {nameof(SearchEngineType)} property. It contains: {searchEngineType}.");
                 }
 
                 return persistedSearchEngineType;
@@ -1138,7 +1131,7 @@ namespace Raven.Server.Documents.Indexes
                 var statsTree = tx.ReadTree(IndexSchema.StatsTree);
                 if (statsTree == null)
                     throw new InvalidOperationException($"Index '{name}' does not contain 'Stats' tree.");
-
+                
                 if (statsTree.TryRead(IndexSchema.SourceTypeSlice, out var reader) == false)
                     return IndexSourceType.Documents; // backward compatibility
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         {
             var read = mapEntriesTree.Read(LastMapResultIdKey);
 
-            if (read == null)
+            if (read.HasValue == false)
                 return;
 
             NextMapResultId = *(long*)read.Reader.Base;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         else
                         {
                             var read = Tree.Read(entrySlice);
-                            if (read == null)
+                            if (read.HasValue == false)
                                 throw new InvalidOperationException($"Could not find a map result with id '{id}' in '{Tree.Name}' tree");
                             return new ReadMapEntryScope(PtrSize.Create(read.Reader.Base, read.Reader.Length));
                         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/NestedMapResultsSection.cs
@@ -33,7 +33,8 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             }
             else
             {
-                IsNew = true;
+                _dataSize = reader.Length;
+                IsNew = false;
             }
         }
 
@@ -82,7 +83,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                         }
                         entry = (ResultHeader*)((byte*)entry + sizeof(ResultHeader) + entry->Size);
                     }
-
+                    
                     if (isValidReader)
                     {
                         Memory.Copy(tmpPtr, reader.Base, reader.Length);

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionActions.cs
@@ -106,13 +106,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
             var result = tree.Read(reduceResultId);
 
             // ReSharper disable once UseNullPropagation
-            if (result == null)
-            {
-                // pattern id can be null here if it was invalid for a given reduce result
-                return null;
-            }
-
-            return result.Reader.ReadString(result.Reader.Length);
+            if (result.HasValue) 
+                return result.Reader.ReadString(result.Reader.Length);
+            
+            // pattern id can be null here if it was invalid for a given reduce result
+            return null;
         }
 
         public void DeletePatternGeneratedIdForReduceOutput(Transaction tx, string reduceResultId)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1751,7 +1751,7 @@ namespace Raven.Server.Documents.Revisions
         private static long CountOfRevisions(DocumentsOperationContext context, Slice prefix)
         {
             var numbers = context.Transaction.InnerTransaction.ReadTree(RevisionsCountSlice);
-            return numbers.Read(prefix)?.Reader.Read<long>() ?? 0;
+            return numbers.Read(prefix).ReadLittleEndianInt64OrDefault(0);
         }
 
         public Document GetRevisionBefore(DocumentsOperationContext context, string id, DateTime max)
@@ -1762,7 +1762,7 @@ namespace Raven.Server.Documents.Revisions
             {
                 // Here we assume a reasonable number of revisions and scan the entire history
                 // This is because we want to handle out of order revisions from multiple nodes so the local etag
-                // order is different than the last modified order
+                // order is different from the last modified order
                 Document result = null;
                 var table = context.RevisionsTable(this);
                 foreach (var tvr in table.SeekBackwardFrom(RevisionsSchema.Indexes[IdAndEtagSlice], prefixSlice, lastKey, 0))
@@ -2788,15 +2788,11 @@ namespace Raven.Server.Documents.Revisions
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
             var tree = tx.ReadTree(DocumentsStorage.GlobalTreeSlice);
             var readResult = tree.Read(DocumentsStorage.RevisionsBinCleanerLastEtag);
-            if (readResult == null)
-            {
-                // When we start passing the revisions (forward - from the oldest) on DeleteRevisionEtagSlice index,
-                // we want to skip the revisions with key 0, because they are not relevant (not 'Delete Revisions').
-                // so we start from etag (key) 1.
-                return 1;
-            }
 
-            return readResult.Reader.Read<long>();
+            // When we start passing the revisions (forward - from the oldest) on DeleteRevisionEtagSlice index,
+            // we want to skip the revisions with key 0, because they are not relevant (not 'Delete Revisions').
+            // so we start from etag (key) 1.
+            return readResult.ReadLittleEndianInt64OrDefault(1);
         }
 
         public static unsafe void SetLastRevisionsBinCleanerLastEtag(DocumentsOperationContext context, long etag)

--- a/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
+++ b/src/Raven.Server/Documents/Sharding/BucketStatsHolder.cs
@@ -89,11 +89,7 @@ namespace Raven.Server.Documents.Sharding
             mergedCvSlice = Slices.Empty;
 
             var readResult = tree.Read(keySlice);
-            if (readResult == null)
-            {
-                stats = inMemoryStats;
-            }
-            else
+            if (readResult.HasValue)
             {
                 stats = *(Documents.BucketStats*)readResult.Reader.Base;
                 stats.Size += inMemoryStats.Size;
@@ -101,6 +97,10 @@ namespace Raven.Server.Documents.Sharding
                 stats.LastModifiedTicks = inMemoryStats.LastModifiedTicks;
 
                 mergedCv = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);
+            }
+            else
+            {
+                stats = inMemoryStats;
             }
 
             if (_mergedChangeVectors.TryGetValue(bucket, out var changeVector))

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -122,7 +122,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult == null)
+            if (readResult.HasValue == false)
                 return null;
 
             var reader = readResult.Reader;
@@ -275,7 +275,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         {
             *(int*)keyBuffer.Ptr = Bits.SwapBytes(bucket);
             var readResult = tree.Read(new Slice(keyBuffer));
-            if (readResult == null)
+            if (readResult.HasValue == false)
                 return null;
 
             var cvStr = Documents.BucketStats.GetMergedChangeVector(readResult.Reader);

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -415,7 +415,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
 
             var read = state.Read(CurrentTermSlice);
-            if (read == null || read.Reader.Length != sizeof(long))
+            if (read.HasValue == false || read.Reader.Length != sizeof(long))
             {
                 using (state.DirectAdd(CurrentTermSlice, sizeof(long), out byte* ptr))
                     *(long*)ptr = 0;
@@ -432,24 +432,25 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
 
-            var readResult = state?.Read(TagSlice);
-            return readResult == null ? InitialTag : readResult.Reader.ToStringValue();
+            if (state == null)
+                return InitialTag;
+            
+            return state.Read(TagSlice).ToStringValueOrDefault(InitialTag);
         }
 
         public static string ReadNodeTag<T>(TransactionOperationContext<T> context) where T : RavenTransaction
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
+            if (state == null)
+                return InitialTag;
 
-            var readResult = state?.Read(TagSlice);
-            return readResult == null ? InitialTag : readResult.Reader.ToStringValue();
+            return state.Read(TagSlice).ToStringValueOrDefault(InitialTag);
         }
 
         public string ReadPreviousNodeTag(ClusterOperationContext context)
         {
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
-
-            var readResult = state.Read(PreviousTagSlice);
-            return readResult?.Reader.ToStringValue();
+            return state.Read(PreviousTagSlice).ToStringValueOrDefault(null);
         }
 
         internal void SwitchToSingleLeader(ClusterOperationContext context)
@@ -1225,20 +1226,21 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (read == null)
+            
+            if (read.HasValue)
             {
-                return new ClusterTopology(
-                    null,
-                    new Dictionary<string, string>(),
-                    new Dictionary<string, string>(),
-                    new Dictionary<string, string>(),
-                    "",
-                    -1
-                );
+                var json = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+                return JsonDeserializationRachis<ClusterTopology>.Deserialize(json);
             }
 
-            var json = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
-            return JsonDeserializationRachis<ClusterTopology>.Deserialize(json);
+            return new ClusterTopology(
+                null,
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                new Dictionary<string, string>(),
+                "",
+                -1
+            );
         }
 
         public unsafe BlittableJsonReaderObject GetTopologyRaw(ClusterOperationContext context)
@@ -1246,10 +1248,10 @@ namespace Raven.Server.Rachis
             Debug.Assert(context.Transaction != null);
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(TopologySlice);
-            if (read == null)
+            if (read.HasValue == false)
                 return null;
 
-            BlittableJsonReaderObject topologyBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+            BlittableJsonReaderObject topologyBlittable = new(read.Reader.Base, read.Reader.Length, context);
 
             Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, topologyBlittable);
 
@@ -1763,12 +1765,13 @@ namespace Raven.Server.Rachis
         {
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastTruncatedSlice);
-            if (read == null)
+            if (read.HasValue == false)
             {
                 lastTruncatedIndex = 0;
                 lastTruncatedTerm = 0;
                 return;
             }
+            
             var reader = read.Reader;
             lastTruncatedIndex = reader.Read<long>();
             lastTruncatedTerm = reader.Read<long>();
@@ -1803,9 +1806,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read == null)
-                return 0;
-            return read.Reader.Read<long>();
+            return read.ReadLittleEndianInt64OrDefault(0);
         }
 
         public void GetLastCommitIndex(ClusterOperationContext context, out long index, out long term)
@@ -1814,7 +1815,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read == null)
+            if (read.HasValue == false)
             {
                 index = 0;
                 term = 0;
@@ -1842,7 +1843,7 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.ReadTree(GlobalStateSlice);
             var read = state.Read(LastCommitSlice);
-            if (read != null)
+            if (read.HasValue)
             {
                 var reader = read.Reader;
                 var oldIndex = reader.Read<long>();
@@ -2058,7 +2059,7 @@ namespace Raven.Server.Rachis
 
             // give the other side enough time to become the leader before challenging them
             Timeout.Defer(votedFor);
-                    }
+        }
 
         public (string VotedFor, long LastVotedTerm) GetWhoGotMyVoteIn(ClusterOperationContext context, long term)
         {
@@ -2066,15 +2067,15 @@ namespace Raven.Server.Rachis
 
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
             var read = state.Read(CurrentTermSlice);
-
-            var votedTerm = read?.Reader.Read<long>();
+           
+            long? votedTerm = read.HasValue ? read.Reader.Read<long>() : null;
 
             if (votedTerm != term && votedTerm.HasValue)
                 return (null, votedTerm.Value);
 
             read = state.Read(VotedForSlice);
 
-            return (read?.Reader.ReadString(read.Reader.Length), votedTerm ?? 0);
+            return (read.Reader.ReadString(read.Reader.Length), votedTerm ?? 0);
         }
 
         public event EventHandler OnDispose;
@@ -2390,12 +2391,8 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
             var reader = state.Read(SnapshotRequestSlice);
 
-            if (reader == null)
-                return false;
-
-            return Convert.ToBoolean(reader.Reader.Read<byte>());
+            return Convert.ToBoolean(reader.ReadByteOrDefault(0));
         }
-
 
         public unsafe void ClearAppendedEntriesAfter(ClusterOperationContext context, long index)
         {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3106,9 +3106,10 @@ namespace Raven.Server.ServerWide
         {
             var localState = context.Transaction.InnerTransaction.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(thumbprint);
-            if (read == null)
+            if (read.HasValue == false)
                 return null;
-            BlittableJsonReaderObject localStateBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+            
+            BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);
 
             Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, localStateBlittable);
             return localStateBlittable;

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -130,7 +130,7 @@ namespace Raven.Server.ServerWide
                         return;
 
                     var result = tree.Read(nameof(ServerStatistics));
-                    if (result == null)
+                    if (result.HasValue == false)
                         return;
 
                     using (var json = context.Sync.ReadForMemory(result.Reader.AsStream(), nameof(ServerStatistics)))

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1833,7 +1833,7 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.CreateTree("SecretKeys");
 
-            if (overwrite == false && tree.Read(name) != null)
+            if (overwrite == false && tree.Read(name).HasValue)
                 throw new InvalidOperationException($"Attempt to overwrite secret key {name}, which isn\'t permitted (you\'ll lose access to the encrypted db).");
 
             using (var rawRecord = Cluster.ReadRawDatabaseRecord(context, name))
@@ -1863,8 +1863,11 @@ namespace Raven.Server.ServerWide
 
             var tree = context.Transaction.InnerTransaction.ReadTree("SecretKeys");
 
-            var readResult = tree?.Read(name);
-            if (readResult == null)
+            if (tree == null)
+                return null;
+            
+            var readResult = tree.Read(name);
+            if (readResult.HasValue == false)
                 return null;
 
             var protectedData = new byte[readResult.Reader.Length];

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -266,10 +266,10 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                 // let's remove remaining counter trees from the root
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice) != null)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(CounterKeysSlice).HasValue)
                     step.WriteTx.DeleteTree(CounterKeysSlice);
 
-                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice) != null)
+                if (step.WriteTx.LowLevelTransaction.RootObjects.Read(AllCountersEtagSlice).HasValue)
                     step.WriteTx.DeleteFixedTree(AllCountersEtagSlice.ToString());
             }
 
@@ -496,12 +496,12 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
             var dbId = metadataTree.Read("db-id");
-            if (dbId == null)
+            if (dbId.HasValue == false)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");
 
             var buffer = new byte[16];
-            Debug.Assert(dbId != null);
+            Debug.Assert(dbId.HasValue);
             // ReSharper disable once PossibleNullReferenceException
             var dbIdBytes = dbId.Reader.Read(buffer, 16);
             if (dbIdBytes != 16)

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42012/From40011.cs
@@ -155,9 +155,10 @@ namespace Raven.Server.Storage.Schema.Updates.Server
         {
             var localState = tx.ReadTree(LocalNodeStateTreeName);
             var read = localState.Read(key);
-            if (read == null)
+            if (read.HasValue == false)
                 return null;
-            BlittableJsonReaderObject localStateBlittable = new BlittableJsonReaderObject(read.Reader.Base, read.Reader.Length, context);
+            
+            BlittableJsonReaderObject localStateBlittable = new(read.Reader.Base, read.Reader.Length, context);
 
             Transaction.DebugDisposeReaderAfterTransaction(tx, localStateBlittable);
             return localStateBlittable;

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42018/From42017.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
             step.WriteTx.DeleteTable(oldTableName);
 
             // remove the remaining CompareExchange global index
-            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex) != null)
+            if (step.WriteTx.LowLevelTransaction.RootObjects.Read(ClusterStateMachine.CompareExchangeIndex).HasValue)
                 step.WriteTx.DeleteTree(ClusterStateMachine.CompareExchangeIndex);
 
             return true;

--- a/src/Voron/Data/BTrees/Tree.Compressed.cs
+++ b/src/Voron/Data/BTrees/Tree.Compressed.cs
@@ -350,7 +350,7 @@ namespace Voron.Data.BTrees
                     return null;
             }
 
-            return new DecompressedReadResult(GetValueReaderFromHeader(node), decompressed);
+            return new DecompressedReadResult(new ReadResult(GetValueReaderFromHeader(node)), decompressed);
         }
 
         public struct DecompressionInput

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -224,7 +224,7 @@ namespace Voron.Data.BTrees
             Debug.Assert((_header.Flags & TreeFlags.MultiValue) == TreeFlags.None, "(State.Flags & TreeFlags.MultiValue) == TreeFlags.None");
 
             long currentValue = 0;
-
+            
             if (TryRead(key, out var reader))
                 currentValue = reader.Read<long>();
 
@@ -257,7 +257,6 @@ namespace Voron.Data.BTrees
 
             Debug.Assert(reader.Length == sizeof(int));
             return *(int*)reader.Base;
-
         }
 
         /// <summary>
@@ -271,7 +270,6 @@ namespace Voron.Data.BTrees
 
             Debug.Assert(reader.Length == sizeof(T));
             return *(T*)reader.Base;
-
         }
 
         public void Add(Slice key, byte value)
@@ -1108,10 +1106,7 @@ namespace Voron.Data.BTrees
 
             var p = FindPageFor(key, out TreeNodeHeader* node);
 
-            if (p.LastMatch != 0)
-                return null;
-
-            return new ReadResult(GetValueReaderFromHeader(node));
+            return p.LastMatch != 0 ? ReadResult.Null : new ReadResult(GetValueReaderFromHeader(node));
         }
 
         public bool TryRead(Slice key, out ValueReader reader)

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -390,7 +390,6 @@ public sealed partial class CompactTree : IPrepareForCommit
     public static bool HasDictionary(LowLevelTransaction llt)
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
-
         return llt.RootObjects.TryRead(dictionarySlice, out _);
     }
     

--- a/src/Voron/Data/Compression/DecompressedReadResult.cs
+++ b/src/Voron/Data/Compression/DecompressedReadResult.cs
@@ -2,11 +2,13 @@
 
 namespace Voron.Data.Compression
 {
-    public sealed class DecompressedReadResult(ValueReader reader, DecompressedLeafPage page) : ReadResult(reader), IDisposable
+    /// <summary>
+    /// A wrapper around <see cref="ReadResult"/> allowing scoping it with <see cref="IDisposable"/>.
+    /// </summary>
+    public sealed class DecompressedReadResult(ReadResult result, DecompressedLeafPage page) : IDisposable
     {
-        public void Dispose()
-        {
-            page?.Dispose();
-        }
+        public ValueReader Reader => result.Reader; 
+        
+        public void Dispose() => page?.Dispose();
     }
 }

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -326,7 +326,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         var llt = parent.Llt;
 
         LookupState header;
-
+        
         if (parent.TryRead(name, out var reader) == false)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -878,8 +878,8 @@ namespace Voron.Data.Tables
                 var dictionariesTree = tx.ReadTree(TableSchema.CompressionDictionariesSlice);
                 var rev = Bits.SwapBytes(id);
                 using var _ = Slice.From(tx.Allocator, (byte*)&rev, sizeof(int), out var slice);
-                var readResult = dictionariesTree?.Read(slice);
-                if (readResult == null)
+                ReadResult readResult;
+                if (dictionariesTree == null || (readResult = dictionariesTree.Read(slice)).HasValue == false)
                 {
                     // we may be checking an empty section, so let's return an empty
                     // dictionary there

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -653,7 +653,7 @@ namespace Voron.Impl
             {
                 if (indexDef.IsGlobal) // must not delete global indexes
                     continue;
-
+                
                 if (tableTree.TryRead(indexDef.Name, out _) == false)
                     continue;
 
@@ -668,7 +668,7 @@ namespace Voron.Impl
             {
                 if (indexDef.IsGlobal)  // must not delete global indexes
                     continue;
-
+                
                 if (tableTree.TryRead(indexDef.Name, out _) == false)
                     continue;
 
@@ -682,7 +682,7 @@ namespace Voron.Impl
             // raw data sections
 
             table.ActiveDataSmallSection.FreeRawDataSectionPages();
-
+            
             if (tableTree.TryRead(TableSchema.ActiveCandidateSectionSlice, out _))
             {
                 using (var it = table.ActiveCandidateSection.Iterate())
@@ -698,7 +698,7 @@ namespace Voron.Impl
 
                 DeleteFixedTree(table.ActiveCandidateSection, isInRoot: false);
             }
-
+            
             if (tableTree.TryRead(TableSchema.InactiveSectionSlice, out _))
                 DeleteFixedTree(table.InactiveSections, isInRoot: false);
 

--- a/src/Voron/ReadResult.cs
+++ b/src/Voron/ReadResult.cs
@@ -1,7 +1,29 @@
 namespace Voron
 {
-    public class ReadResult(ValueReader reader)
+    /// <summary>
+    /// A struct representing a read result.
+    /// If the read returns a null, <see cref="HasValue"/> is false. Otherwise, the <see cref="ValueReader"/> can be accessed via <see cref="Reader"/>.
+    /// </summary>
+    public readonly unsafe struct ReadResult(byte* val, int len)
     {
-        public ValueReader Reader { get; private set; } = reader;
+        public ReadResult(in ValueReader reader) : this(reader.Base, reader.Length) { }
+
+        public ValueReader Reader => new(val, len);
+
+        public bool HasValue => val != null;
+
+        public static readonly ReadResult Null = default;
+
+        // The null handling helper methods.
+        
+        public T[] ToArrayEmptyOnNull<T>() where T : unmanaged => HasValue ? Reader.ToUnmanagedSpan<T>().ToSpan().ToArray() : [];
+
+        public long ReadLittleEndianInt64OrDefault(long defaultValue = 0) => HasValue ? Reader.Read<long>() : defaultValue;
+        
+        public int ReadLittleEndianInt32OrDefault(int defaultValue = 0) => HasValue ? Reader.Read<int>() : defaultValue;
+        
+        public byte ReadByteOrDefault(byte defaultValue = 0) => HasValue ? Reader.Read<byte>() : defaultValue;
+
+        public string ToStringValueOrDefault(string defaultValue = null) => HasValue ? Reader.ToStringValue() : defaultValue;
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -342,12 +342,12 @@ namespace Voron
                 Debug.Assert(metadataTree != null);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbId = metadataTree.Read("db-id");
-                if (dbId == null)
+                if (dbId.HasValue == false)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "Could not find db id in metadata tree, possible mismatch / corruption?");
 
                 var buffer = new byte[16];
-                Debug.Assert(dbId != null);
+                Debug.Assert(dbId.HasValue);
                 // ReSharper disable once PossibleNullReferenceException
                 var dbIdBytes = dbId.Reader.Read(buffer, 16);
                 if (dbIdBytes != 16)
@@ -396,7 +396,7 @@ namespace Voron
                     var metadataTree = readTx.ReadTree(Constants.MetadataTreeNameSlice);
 
                     var schemaVersion = metadataTree.Read("schema-version");
-                    if (schemaVersion == null)
+                    if (schemaVersion.HasValue == false)
                         SchemaErrorException.Raise(this, "Could not find schema version in metadata tree, possible mismatch / corruption?");
 
                     schemaVersionVal = schemaVersion.Reader.Read<int>();

--- a/src/Voron/ValueReader.cs
+++ b/src/Voron/ValueReader.cs
@@ -117,16 +117,19 @@ namespace Voron
 
         public string ReadString(int length)
         {
-            var arraySegment = ReadBytes(length);
-            return Encodings.Utf8.GetString(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+            var count = Math.Min(length, _len - _pos);
+            if (count <= 0)
+                return "";
+
+            string result = Encodings.Utf8.GetString(Base + _pos, count);
+            
+            // Move forward
+            _pos += count;
+            
+            return result;
         }
 
-        public string ToStringValue()
-        {
-            int length = _len - _pos;
-            var arraySegment = ReadBytes(length);
-            return Encodings.Utf8.GetString(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
-        }
+        public string ToStringValue() => ReadString(_len - _pos);
 
         public override string ToString()
         {

--- a/test/FastTests/Voron/Journal/BasicActions.cs
+++ b/test/FastTests/Voron/Journal/BasicActions.cs
@@ -41,7 +41,7 @@ namespace FastTests.Voron.Journal
                 using (var tx = Env.ReadTransaction())
                 {
                     var tree = tx.CreateTree("foo");
-                    Assert.NotNull(tree.Read("item/" + i));
+                    Assert.True(tree.Read("item/" + i).HasValue);
                 }
             }
         }
@@ -64,7 +64,7 @@ namespace FastTests.Voron.Journal
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Assert.Null(tree.Read("items/1"));
+                Assert.False(tree.Read("items/1").HasValue);
             }
         }
 

--- a/test/FastTests/Voron/Optimizations/Writes.cs
+++ b/test/FastTests/Voron/Optimizations/Writes.cs
@@ -60,7 +60,7 @@ namespace FastTests.Voron.Optimizations
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Assert.Null(tree.Read(new string('0', keySize)));
+                Assert.False(tree.Read(new string('0', keySize)).HasValue);
 
                 var readResult = tree.Read(new string('4', 1000));
 

--- a/test/FastTests/Voron/Tables/RavenDB_17760.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_17760.cs
@@ -331,7 +331,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = GetStatsFor(tx, bucket);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var size = *(int*)readResult.Reader.Base;
                 Assert.Equal(41, size);
@@ -349,7 +349,7 @@ namespace FastTests.Voron.Tables
             using (var tx = Env.ReadTransaction())
             {
                 var readResult = GetStatsFor(tx, bucket);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var size = *(int*)readResult.Reader.Base;
                 Assert.Equal(43, size);
@@ -435,7 +435,7 @@ namespace FastTests.Voron.Tables
                 var keySlice = new Slice(keyBuffer);
                 var readResult = tree.Read(keySlice);
                 long size = 0;
-                if (readResult != null)
+                if (readResult.HasValue)
                 {
                     var reader = readResult.Reader;
                     size = *(long*)reader.Base;

--- a/test/FastTests/Voron/Trees/Basic.cs
+++ b/test/FastTests/Voron/Trees/Basic.cs
@@ -178,7 +178,7 @@ namespace FastTests.Voron.Trees
                     {
                         var key = "test-" + j.ToString("000") + "-" + i.ToString("000");
 
-                        Assert.True(tree.Read(key) != null);
+                        Assert.True(tree.Read(key).HasValue);
                     }
                 }
             }

--- a/test/FastTests/Voron/Trees/Deletes.cs
+++ b/test/FastTests/Voron/Trees/Deletes.cs
@@ -59,12 +59,9 @@ namespace FastTests.Voron.Trees
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("foo");
-                Assert.Null(tree.Read("a"));
-
+                Assert.False(tree.Read("a").HasValue);
                 tx.Commit();
             }
-
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]
@@ -75,7 +72,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.CreateTree("foo");
                 for (int i = 0; i < 1000; i++)
                 {
-                    tree.Add(string.Format("{0,5}", i), StreamFor("abcdefg"));
+                    tree.Add($"{i,5}", StreamFor("abcdefg"));
                 }
                 tx.Commit();
             }
@@ -83,7 +80,7 @@ namespace FastTests.Voron.Trees
             var expected = new List<string>();
             for (int i = 15; i < 1000; i++)
             {
-                expected.Add(string.Format("{0,5}", i));
+                expected.Add($"{i,5}");
             }
 
             using (var tx = Env.WriteTransaction())
@@ -91,7 +88,7 @@ namespace FastTests.Voron.Trees
                 var tree = tx.ReadTree("foo");
                 for (int i = 0; i < 15; i++)
                 {
-                    tree.Delete(string.Format("{0,5}", i));
+                    tree.Delete($"{i,5}");
                 }
                 tx.Commit();
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_12931.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12931.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                Assert.Null(tx.LowLevelTransaction.RootObjects.Read("docs"));
+                Assert.False(tx.LowLevelTransaction.RootObjects.Read("docs").HasValue);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_13195.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13195.cs
@@ -92,8 +92,8 @@ namespace SlowTests.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                Assert.Null(tx.LowLevelTransaction.RootObjects.Read("first"));
-                Assert.Null(tx.LowLevelTransaction.RootObjects.Read("second"));
+                Assert.False(tx.LowLevelTransaction.RootObjects.Read("first").HasValue);
+                Assert.False(tx.LowLevelTransaction.RootObjects.Read("second").HasValue);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_16193.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_16193.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Indexes;
@@ -64,7 +65,8 @@ namespace SlowTests.Issues
                     using (var tx = indexStorage.Environment().ReadTransaction())
                     {
                         var statsTree = tx.ReadTree(IndexSchema.StatsTree);
-                        return Task.FromResult(statsTree.Read(IndexSchema.EntriesCount));
+                        const string nonNull = IndexSchema.StatsTree;
+                        return Task.FromResult(statsTree.Read(IndexSchema.EntriesCount).HasValue ? nonNull : null);
                     }
                 });
 

--- a/test/SlowTests/Voron/Backups/Incremental.cs
+++ b/test/SlowTests/Voron/Backups/Incremental.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 500; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -143,7 +143,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 1000; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -213,7 +213,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 10; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -277,7 +277,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 5; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);
@@ -525,7 +525,7 @@ namespace SlowTests.Voron.Backups
                     for (int i = 0; i < 500; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/BigValue.cs
+++ b/test/SlowTests/Voron/BigValue.cs
@@ -41,7 +41,7 @@ namespace SlowTests.Voron
                 Slice key;
                 Slice.From(tx.Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);

--- a/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
+++ b/test/SlowTests/Voron/Bugs/ChecksumMismatchAfterRecovery.cs
@@ -62,7 +62,7 @@ namespace SlowTests.Voron.Bugs
                     for (int i = 0; i < 100; i++)
                     {
                         var readResult = tree.Read("items/" + i);
-                        Assert.NotNull(readResult);
+                        Assert.True(readResult.HasValue);
                         var memoryStream = new MemoryStream();
                         readResult.Reader.CopyTo(memoryStream);
                         Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
+++ b/test/SlowTests/Voron/Bugs/DataInconsistencyRepro.cs
@@ -105,18 +105,16 @@ namespace SlowTests.Voron.Bugs
                         Assert.Equal(inMemoryKey, key);
 
                         var docReadResult = docsTree.Read(key);
+                        Assert.True(docReadResult.HasValue);
 
-                        Assert.NotNull(docReadResult);
-
-                        var metadataReader = metadataTree.Read(key).Reader;
-
-                        Assert.NotNull(metadataReader);
+                        ReadResult metaResult = metadataTree.Read(key);
+                        Assert.True(metaResult.HasValue);
+                        var metadataReader = metaResult.Reader;
 
                         var etagFromMetadata = new byte[16];
                         metadataReader.Read(etagFromMetadata, 0, 16);
 
                         var readEtag = new Guid(etagFromMetadata);
-
 
                         Assert.Equal(etag, readEtag);
 

--- a/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
+++ b/test/SlowTests/Voron/Bugs/FlushingToDataFile.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Voron.Bugs
                 {
                     var readResult = tree.Read("foo/" + i);
 
-                    Assert.NotNull(readResult);
+                    Assert.True(readResult.HasValue);
                     Assert.Equal(value1.Length, readResult.Reader.Length);
 
                     var memoryStream = new MemoryStream(readResult.Reader.Length);
@@ -118,7 +118,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("foo/0");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
 
                 var memoryStream = new MemoryStream();
@@ -135,7 +135,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("foo/0");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(value1.Length, readResult.Reader.Length);
 
                 var memoryStream = new MemoryStream();

--- a/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
+++ b/test/SlowTests/Voron/Bugs/IndexPointToNonLeafPageTests.cs
@@ -50,7 +50,7 @@ namespace SlowTests.Voron.Bugs
                 {
                     var readResult = tree.Read(item.Key.ToString("0000000000000000"));
 
-                    Assert.NotNull(readResult);
+                    Assert.True(readResult.HasValue);
 
                     Assert.Equal(item.Value.Length, readResult.Reader.Length);
                 }

--- a/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
+++ b/test/SlowTests/Voron/Bugs/InvalidReleasesOfScratchPages.cs
@@ -28,7 +28,7 @@ namespace SlowTests.Voron.Bugs
 
                     using (var txr = env.ReadTransaction())
                     {
-                        Assert.NotNull(txr.CreateTree("tree0").Read("key/1"));
+                        Assert.True(txr.CreateTree("tree0").Read("key/1").HasValue);
                     }
                 }
             }

--- a/test/SlowTests/Voron/Bugs/PageTableIssue.cs
+++ b/test/SlowTests/Voron/Bugs/PageTableIssue.cs
@@ -76,7 +76,7 @@ namespace SlowTests.Voron.Bugs
 
                 Env.FlushLogToDataFile();
 
-                Assert.NotNull(txr.CreateTree("foo").Read("foos/1"));
+                Assert.True(txr.CreateTree("foo").Read("foos/1").HasValue);
             }
         }
     }

--- a/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
+++ b/test/SlowTests/Voron/Bugs/PagesFilteredOutByJournalApplicator.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Voron.Bugs
 
                 Env.FlushLogToDataFile();
 
-                Assert.NotNull(txr.CreateTree( "foo").Read("bars/1"));
+                Assert.True(txr.CreateTree( "foo").Read("bars/1").HasValue);
             }
         } 
 

--- a/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
+++ b/test/SlowTests/Voron/Bugs/RecoveryWithManualFlush.cs
@@ -63,12 +63,12 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("item/1");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(4000, readResult.Reader.Length);
 
                 readResult = tree.Read("item/2");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(3999, readResult.Reader.Length);
             }
         }
@@ -109,12 +109,12 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("item/1");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(4000, readResult.Reader.Length);
 
                 readResult = tree.Read("item/2");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(3999, readResult.Reader.Length);
             }
         }
@@ -138,7 +138,7 @@ namespace SlowTests.Voron.Bugs
                 var tree = tx.CreateTree("foo");
                 var readResult = tree.Read("items/1");
 
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
                 Assert.Equal(3, readResult.Reader.Length);
             }
         }

--- a/test/SlowTests/Voron/Checksum.cs
+++ b/test/SlowTests/Voron/Checksum.cs
@@ -82,9 +82,9 @@ namespace SlowTests.Voron
 
                             for (int i = 0; i < recordCount; i++)
                             {
-                                var readResult = tree.Read(string.Format("{0}/items/{1}", treeName, i));
+                                var readResult = tree.Read($"{treeName}/items/{i}");
 
-                                Assert.NotNull(readResult);
+                                Assert.True(readResult.HasValue);
 
                                 if (i % 2 == 0)
                                 {

--- a/test/SlowTests/Voron/Full.cs
+++ b/test/SlowTests/Voron/Full.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Voron
                         for (int i = 0; i < 1000; i++)
                         {
                             var readResult = tree.Read("items/" + i);
-                            Assert.NotNull(readResult);
+                            Assert.True(readResult.HasValue);
                             var memoryStream = new MemoryStream();
                             readResult.Reader.CopyTo(memoryStream);
                             Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/Issues/RavenDB_13384.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_13384.cs
@@ -61,10 +61,10 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.ReadTransaction())
             {
-                var result = tx.ReadTree("tree").Read("item");
-                Assert.NotNull(result);
+                var readResult = tx.ReadTree("tree").Read("item");
+                Assert.True(readResult.HasValue);
                 var buf = new byte[3];
-                var read = result.Reader.Read(buf, 0, 3);
+                var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
                 Assert.True(buf.SequenceEqual(new byte[] { 1, 2, 3 }), "buf.SequenceEqual(new byte[] { 1, 2, 3 })");
             }
@@ -105,10 +105,10 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.ReadTransaction())
             {
-                var result = tx.ReadTree("tree").Read("item");
-                Assert.NotNull(result);
+                var readResult = tx.ReadTree("tree").Read("item");
+                Assert.True(readResult.HasValue);
                 var buf = new byte[3];
-                var read = result.Reader.Read(buf, 0, 3);
+                var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
                 Assert.True(buf.SequenceEqual(new byte[] { 4, 5, 6 }), "buf.SequenceEqual(new byte[] { 4, 5, 6 })");
             }
@@ -136,10 +136,10 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.ReadTransaction())
             {
-                var result = tx.ReadTree("tree").Read("item");
-                Assert.NotNull(result);
+                var readResult = tx.ReadTree("tree").Read("item");
+                Assert.True(readResult.HasValue);
                 var buf = new byte[3];
-                var read = result.Reader.Read(buf, 0, 3);
+                var read = readResult.Reader.Read(buf, 0, 3);
                 Assert.Equal(3, read);
                 Assert.True(buf.SequenceEqual(new byte[] { 7, 8, 9 }), "buf.SequenceEqual(new byte[] { 7, 8, 9 })");
             }

--- a/test/SlowTests/Voron/Issues/RavenDB_18059.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_18059.cs
@@ -96,7 +96,7 @@ public class RavenDB_18059 : StorageTest
                 for (int i = 0; i < 5000; i++)
                 {
                     var readResult = tree.Read("items/" + i);
-                    Assert.NotNull(readResult);
+                    Assert.True(readResult.HasValue);
                     var memoryStream = new MemoryStream();
                     readResult.Reader.CopyTo(memoryStream);
                     Assert.Equal(memoryStream.ToArray(), buffer);

--- a/test/SlowTests/Voron/LongKeys.cs
+++ b/test/SlowTests/Voron/LongKeys.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Voron
                 {
                     var key = keys[i];
 
-                    Assert.NotNull(tree.Read(key));
+                    Assert.True(tree.Read(key).HasValue);
                 }
             }
 
@@ -124,7 +124,7 @@ namespace SlowTests.Voron
                 {
                     var key = keys[i];
 
-                    Assert.NotNull(tree.Read(key));
+                    Assert.True(tree.Read(key).HasValue);
                 }
             }
 
@@ -189,7 +189,7 @@ namespace SlowTests.Voron
                 {
                     var key = addedKeys[i];
 
-                    Assert.NotNull(tree.Read(key));
+                    Assert.True(tree.Read(key).HasValue);
                 }
             }
 

--- a/test/SlowTests/Voron/Recovery.cs
+++ b/test/SlowTests/Voron/Recovery.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 100; i++)
                     {
-                        Assert.NotNull(tree.Read("key" + i));
+                        Assert.True(tree.Read("key" + i).HasValue);
                     }
                 }
             }
@@ -174,22 +174,20 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 1000; i++)
                     {
-                        Assert.NotNull(aTree.Read("key" + i));
+                        Assert.True(aTree.Read("key" + i).HasValue);
                     }
 
                     for (var i = 0; i < 1; i++)
                     {
-                        Assert.NotNull(bTree.Read("key" + i));
+                        Assert.True(bTree.Read("key" + i).HasValue);
                     }
                 }
             }
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]
         public void StorageRecoveryShouldWorkWhenThereAreMultipleCommitedTransactions2()
         {
-
             using (var env = new StorageEnvironment(StorageEnvironmentOptions.ForPathForTests(DataDir)))
             {
                 using (var tx = env.WriteTransaction())
@@ -234,16 +232,15 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < 1000; i++)
                     {
-                        Assert.NotNull(aTree.Read("key" + i));
+                        Assert.True(aTree.Read("key" + i).HasValue);
                     }
 
                     for (var i = 0; i < 5; i++)
                     {
-                        Assert.NotNull(bTree.Read("key" + i));
+                        Assert.True(bTree.Read("key" + i).HasValue);
                     }
                 }
             }
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]
@@ -304,9 +301,9 @@ namespace SlowTests.Voron
 
                     for (var i = 0; i < count; i++)
                     {
-                        var read = aTree.Read("a" + i);
-                        Assert.NotNull(read);
-                        Assert.Equal(expectedString, read.Reader.ToStringValue());
+                        var readResult = aTree.Read("a" + i);
+                        Assert.True(readResult.HasValue);
+                        Assert.Equal(expectedString, readResult.Reader.ToStringValue());
                     }
 
                     using (var iterator = bTree.MultiRead("a"))

--- a/test/SlowTests/Voron/RecoveryMultipleJournals.cs
+++ b/test/SlowTests/Voron/RecoveryMultipleJournals.cs
@@ -59,10 +59,8 @@ namespace SlowTests.Voron
                 for (var i = 0; i < 1000; i++)
                 {
                     var readResult = tx.CreateTree("tree").Read("a" + i);
-                    Assert.NotNull(readResult);
-                    {
-                        Assert.Equal(100, readResult.Reader.Length);
-                    }
+                    Assert.True(readResult.HasValue);
+                    Assert.Equal(100, readResult.Reader.Length);
                 }
                 tx.Commit();
             }
@@ -178,11 +176,11 @@ namespace SlowTests.Voron
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.CreateTree("tree");
-                Assert.NotNull(tree.Read("exists"));
-                Assert.Null(tree.Read("a1"));
-                Assert.Null(tree.Read("a100"));
-                Assert.Null(tree.Read("a500"));
-                Assert.Null(tree.Read("a1000"));
+                Assert.True(tree.Read("exists").HasValue);
+                Assert.False(tree.Read("a1").HasValue);
+                Assert.False(tree.Read("a100").HasValue);
+                Assert.False(tree.Read("a500").HasValue);
+                Assert.False(tree.Read("a1000").HasValue);
 
                 tx.Commit();
             }
@@ -270,9 +268,8 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                Assert.Null(tx.CreateTree("tree").Read("a1001"));
+                Assert.False(tx.CreateTree("tree").Read("a1001").HasValue);
             }
-
         }
 
         [RavenFact(RavenTestCategory.Voron)]

--- a/test/SlowTests/Voron/Snapshots.cs
+++ b/test/SlowTests/Voron/Snapshots.cs
@@ -59,14 +59,10 @@ namespace SlowTests.Voron
 
                 for (var i = 0; i < DocumentCount; i++)
                 {
-                    var result = snapshot.CreateTree("tree1").Read("docs/" + i);
-                    Assert.NotNull(result);
-
-                    {
-                        var bytes = result.Reader.ReadBytes(result.Reader.Length);
-                        Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
-
-                    }
+                    var readResult = snapshot.CreateTree("tree1").Read("docs/" + i);
+                    Assert.True(readResult.HasValue);
+                    var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
+                    Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
             }
         }
@@ -118,13 +114,11 @@ namespace SlowTests.Voron
 
                 for (var i = 0; i < DocumentCount; i++)
                 {
-                    var result = snapshot.ReadTree("tree1").Read("docs/" + i);
-                    Assert.NotNull(result);
+                    var readResult = snapshot.ReadTree("tree1").Read("docs/" + i);
+                    Assert.True(readResult.HasValue);
 
-                    {
-                        var bytes = result.Reader.ReadBytes(result.Reader.Length);
-                        Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
-                    }
+                    var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
+                    Assert.Equal(testBuffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
             }
         }

--- a/test/SlowTests/Voron/SplittingVeryBig.cs
+++ b/test/SlowTests/Voron/SplittingVeryBig.cs
@@ -42,12 +42,12 @@ namespace SlowTests.Voron
 
             using (var tx = Env.ReadTransaction())
             {
-                var read = tx.CreateTree("tree").Read("key1");
-                Assert.NotNull(read);
+                var readResult = tx.CreateTree("tree").Read("key1");
+                Assert.True(readResult.HasValue);
 
-                var reader = read.Reader;
-                Assert.Equal(buffer.Length, read.Reader.Length);
-                var bytes = reader.ReadBytes(read.Reader.Length);
+                var reader = readResult.Reader;
+                Assert.Equal(buffer.Length, readResult.Reader.Length);
+                var bytes = reader.ReadBytes(readResult.Reader.Length);
                 Assert.Equal(buffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
             }
         }
@@ -90,15 +90,12 @@ namespace SlowTests.Voron
 
                 using (var tx = env.ReadTransaction())
                 {
-                    var read = tx.CreateTree("tree").Read("key1");
-                    Assert.NotNull(read);
+                    var readResult = tx.CreateTree("tree").Read("key1");
+                    Assert.True(readResult.HasValue);
 
-                    {
-                        Assert.Equal(buffer.Length, read.Reader.Length);
-                        var bytes = read.Reader.ReadBytes(read.Reader.Length);
-                        Assert.Equal(buffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
-
-                    }
+                    Assert.Equal(buffer.Length, readResult.Reader.Length);
+                    var bytes = readResult.Reader.ReadBytes(readResult.Reader.Length);
+                    Assert.Equal(buffer, bytes.Array.Skip(bytes.Offset).Take(bytes.Count).ToArray());
                 }
             }
         }

--- a/test/SlowTests/Voron/Storage/BigValue.cs
+++ b/test/SlowTests/Voron/Storage/BigValue.cs
@@ -59,10 +59,8 @@ namespace SlowTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Slice key;
-                Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
-                var readResult = tree.Read(key);
-                Assert.Null(readResult);
+                Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
+                Assert.False(tree.Read(key).HasValue);
             }
 
             if (restartCount >= 2)
@@ -71,10 +69,8 @@ namespace SlowTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.CreateTree("foo");
-                Slice key;
-                Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
-                var readResult = tree.Read(key);
-                Assert.Null(readResult);
+                Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
+                Assert.False(tree.Read(key).HasValue);
             }
 
             using (var tx = Env.WriteTransaction())
@@ -82,8 +78,7 @@ namespace SlowTests.Voron.Storage
                 buffer = new byte[1024 * 1024 * 3 + 1238];
                 random.NextBytes(buffer);
                 var tree = tx.CreateTree("foo");
-                Slice key;
-                Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
+                Slice.From(Allocator, BitConverter.GetBytes(1203), out Slice key);
                 tree.Add(key, new MemoryStream(buffer));
                 tx.Commit();
             }
@@ -94,7 +89,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -111,7 +106,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -127,7 +122,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -146,7 +141,7 @@ namespace SlowTests.Voron.Storage
                 Slice key;
                 Slice.From(Allocator, BitConverter.GetBytes(1203), out key);
                 var readResult = tree.Read(key);
-                Assert.NotNull(readResult);
+                Assert.True(readResult.HasValue);
 
                 var memoryStream = new MemoryStream();
                 readResult.Reader.CopyTo(memoryStream);
@@ -190,7 +185,7 @@ namespace SlowTests.Voron.Storage
                     Slice key;
                     Slice.From(Allocator, BitConverter.GetBytes(i), out key);
                     var readResult = tree.Read(key);
-                    Assert.NotNull(readResult);
+                    Assert.True(readResult.HasValue);
 
                     var memoryStream = new MemoryStream();
                     readResult.Reader.CopyTo(memoryStream);

--- a/test/SlowTests/Voron/Storage/Increments.cs
+++ b/test/SlowTests/Voron/Storage/Increments.cs
@@ -39,12 +39,11 @@ namespace SlowTests.Voron.Storage
             using (var tx = Env.ReadTransaction())
             {
                 var read = tx.ReadTree("tree0").Read("key/1");
-
-                Assert.NotNull(read);
+                
+                Assert.True(read.HasValue);
                 Assert.Equal(12, read.Reader.Read<long>());
             }
         }
-
 
         [RavenFact(RavenTestCategory.Voron)]
         public void SimpleIncrementEntriesCountShouldStayCorrectAfterCommit()

--- a/test/StressTests/Voron/PageSplitterStressTests.cs
+++ b/test/StressTests/Voron/PageSplitterStressTests.cs
@@ -102,11 +102,7 @@ namespace StressTests.Voron
                             keys.Add(iterator.CurrentKey.ToString());
                             Assert.True(ids.Contains(iterator.CurrentKey.ToString()));
                             var readResult = readTree.Read( iterator.CurrentKey);
-                            if (readResult == null)
-                            {
-
-                            }
-                            Assert.NotNull(readResult);
+                            Assert.True(readResult.HasValue);
 
                             count++;
                         }

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -516,7 +516,7 @@ namespace Tests.Infrastructure
             {
                 var tree = context.Transaction.InnerTransaction.ReadTree("values");
                 var read = tree.Read(name);
-                return read?.Reader.ToStringValue();
+                return read.HasValue ? read.Reader.ToStringValue() : null;
             }
 
             protected override void Apply(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index, Leader leader, ServerStore serverStore)
@@ -534,7 +534,7 @@ namespace Tests.Infrastructure
                         Assert.True(cmd.TryGet(nameof(TestCommand.Name), out string name0));
                         Assert.True(cmd.TryGet(nameof(TestCommand.Value), out int val0));
                         var tree0 = context.Transaction.InnerTransaction.CreateTree("values");
-                        var current0 = tree0.Read(name0)?.Reader.ToStringValue();
+                        var current0 = tree0.Read(name0).ToStringValueOrDefault(null);
                         tree0.Add(name0, current0 + val0);
                         break;
 
@@ -549,7 +549,7 @@ namespace Tests.Infrastructure
                         Assert.True(cmd.TryGet(nameof(TestCommandWithRaftId.Name), out string name2));
                         Assert.True(cmd.TryGet(nameof(TestCommandWithRaftId.Value), out int val2));
                         var tree2 = context.Transaction.InnerTransaction.CreateTree("values");
-                        var current2 = tree2.Read(name2)?.Reader.ToStringValue();
+                        var current2 = tree2.Read(name2).ToStringValueOrDefault(null);
                         tree2.Add(name2, current2 + val2);
                         break;
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25111/ReadResult-should-be-a-struct

### Additional description

#21474 migration forward

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
