### PR TITLE
RavenDB-25150 Playwright install chromium only

### DIFF
--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -51,7 +51,7 @@ jobs:
       working-directory: ./src/Raven.Studio
 
     - name: Install Playwright
-      run: npx playwright install --with-deps
+      run: npx playwright install --with-deps chromium
       working-directory: ./src/Raven.Studio
 
     - name: Build Storybook

--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -33,6 +33,7 @@ jobs:
 
     - name: Build dotnet
       run: dotnet build
+      working-directory: ./tools/TypingsGenerator
 
     - name: Install npm dependencies
       run: npm ci

--- a/.github/workflows/studioConventions.yml
+++ b/.github/workflows/studioConventions.yml
@@ -29,6 +29,7 @@ jobs:
 
     - name: Build dotnet
       run: dotnet build
+      working-directory: ./tools/TypingsGenerator
 
     - name: Install npm dependencies
       run: npm ci


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25150/Install-Playwright-Failed-to-install-browsers

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
