### PR TITLE
RavenDB-25152 Fixing replication of unarchived document. We must not force 'Archived' flag then.

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -181,7 +181,10 @@ namespace Raven.Server.Documents
                     newFlags = _documentsStorage.GetFlagsFromOldDocumentForPut(newFlags, oldFlags, nonPersistentFlags);
                     
                     // if doc was Archived and isn't currently unarchived, leave the Archived flag
-                    if (oldFlags.Contain(DocumentFlags.Archived) && nonPersistentFlags.Contain(NonPersistentDocumentFlags.Unarchive) == false)
+                    // unless it is a replication operation, in which case we want to replicate the drop of the Archived flag
+                    if (oldFlags.Contain(DocumentFlags.Archived) && 
+                        nonPersistentFlags.Contain(NonPersistentDocumentFlags.Unarchive) == false && 
+                        nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromReplication) == false)
                     {
                         newFlags |= DocumentFlags.Archived;
                     }

--- a/test/SlowTests/Server/Documents/DataArchival/RavenDB_25152.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/RavenDB_25152.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.DataArchival;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Util;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
+using Xunit;
+
+namespace SlowTests.Server.Documents.DataArchival;
+
+public class RavenDB_25152 : ReplicationTestBase
+{
+    public RavenDB_25152(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Replication)]
+    public async Task PropagateDocumentUnarchivalInReplication()
+    {
+        using (var src = GetDocumentStore())
+        using (var dst = GetDocumentStore())
+        {
+            var now = SystemTime.UtcNow;
+            
+            // Insert document with archive time before activating the archival
+            var company = new Company { Name = "Company Name" };
+            var archiveAt = now.AddMinutes(5);
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(company, "companies/1-A");
+                var metadata = session.Advanced.GetMetadataFor(company);
+                metadata[Constants.Documents.Metadata.ArchiveAt] = archiveAt.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                await session.SaveChangesAsync();
+            }
+            
+            var config = new DataArchivalConfiguration { Disabled = false, ArchiveFrequencyInSec = 100 };
+
+            await DataArchivalHelper.SetupDataArchival(src, Server.ServerStore, config);
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(src);
+            database.Time.UtcDateTime = () => now.AddMinutes(10);
+            var documentsArchiver = database.DataArchivist;
+            await documentsArchiver.ArchiveDocs();
+
+            await SetupReplicationAsync(src, dst);
+            
+            var archivedCompany = await WaitForDocumentToReplicateAsync<User>(dst, "companies/1-A", TimeSpan.FromSeconds(15));
+            Assert.NotNull(archivedCompany);
+            
+            using (var session = dst.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Company>("companies/1-A");
+                var metadata = session.Advanced.GetMetadataFor(doc);
+                Assert.DoesNotContain(Constants.Documents.Metadata.ArchiveAt, metadata.Keys);
+                Assert.Contains(Constants.Documents.Metadata.Collection, metadata.Keys);
+                Assert.Contains(Constants.Documents.Metadata.Archived, metadata.Keys);
+                Assert.Equal(true, metadata[Constants.Documents.Metadata.Archived]);
+            }
+            
+            // Unarchive document using patch
+            var operation = await src.Operations.SendAsync(new PatchByQueryOperation(new IndexQuery()
+            {
+                Query = "from Companies update { archived.unarchive(this) }"
+            }));
+            await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15));
+
+            using (var s1 = src.OpenSession())
+            {
+                s1.Store(new User(), "marker/doc");
+                s1.SaveChanges();
+            }
+            
+            var marker = await WaitForDocumentToReplicateAsync<User>(dst, "marker/doc", TimeSpan.FromSeconds(15));
+            Assert.NotNull(marker);
+            
+            using (var session = dst.OpenAsyncSession())
+            {
+                // Make sure that item is unarchived so markers are gone 
+                var unarchivedCompany = await session.LoadAsync<Company>("companies/1-A");
+                var metadata = session.Advanced.GetMetadataFor(unarchivedCompany);
+                Assert.DoesNotContain(Constants.Documents.Metadata.ArchiveAt, metadata.Keys);
+                Assert.DoesNotContain(Constants.Documents.Metadata.Archived, metadata.Keys);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25152

### Additional description

This relates to changes made in https://github.com/ravendb/ravendb/pull/20982

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
