### PR TITLE
RavenDB-25170 Add data-theme on DOMContentLoaded

### DIFF
--- a/src/Raven.Studio/wwwroot/index.html
+++ b/src/Raven.Studio/wwwroot/index.html
@@ -138,37 +138,6 @@
                 }
             }
         </style>
-        <script type="text/javascript">
-            if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
-                var msViewportStyle = document.createElement("style");
-                var mq = "@@-ms-viewport{width:auto!important}";
-                msViewportStyle.appendChild(document.createTextNode(mq));
-                document.getElementsByTagName("head")[0].appendChild(msViewportStyle);
-            }
-        </script>
-    </head>
-    <body class="loading-active">
-    
-        <div class="splash-screen">
-            <div class="spinner-box">
-                <div class="orbit orbit-1">
-                    <i class="splash-screen-icon-raven"></i>
-                </div>
-                <div class="orbit orbit-2">
-                    <i class="orbit-icon"></i>
-                    <i class="orbit-icon orbit-icon-2-2"></i>
-                </div>
-                <div class="orbit orbit-3">
-                    <i class="orbit-icon"></i>
-                    <i class="orbit-icon orbit-icon-3-2"></i>
-                </div>
-            </div>
-        </div>
-        
-        <div id="applicationHost"></div>
-        <div id="bs5-modal" class="bs5"></div>
-
-        <iframe id="downloadFrame" style="display: none" name="hidden-form"></iframe>
 
         <script type="text/javascript">
             var themeToCss = {
@@ -226,8 +195,42 @@
             head.appendChild(bs5link);
             head.appendChild(link);
 
-            document.body.setAttribute("data-theme", themeToUse);
+            document.addEventListener("DOMContentLoaded", function() {
+                document.body.setAttribute("data-theme", themeToUse);
+            });
         </script>
+
+        <script type="text/javascript">
+            if (navigator.userAgent.match(/IEMobile\/10\.0/)) {
+                var msViewportStyle = document.createElement("style");
+                var mq = "@@-ms-viewport{width:auto!important}";
+                msViewportStyle.appendChild(document.createTextNode(mq));
+                document.getElementsByTagName("head")[0].appendChild(msViewportStyle);
+            }
+        </script>
+    </head>
+    <body class="loading-active">
+    
+        <div class="splash-screen">
+            <div class="spinner-box">
+                <div class="orbit orbit-1">
+                    <i class="splash-screen-icon-raven"></i>
+                </div>
+                <div class="orbit orbit-2">
+                    <i class="orbit-icon"></i>
+                    <i class="orbit-icon orbit-icon-2-2"></i>
+                </div>
+                <div class="orbit orbit-3">
+                    <i class="orbit-icon"></i>
+                    <i class="orbit-icon orbit-icon-3-2"></i>
+                </div>
+            </div>
+        </div>
+        
+        <div id="applicationHost"></div>
+        <div id="bs5-modal" class="bs5"></div>
+
+        <iframe id="downloadFrame" style="display: none" name="hidden-form"></iframe>
 
         <!-- splash screen -->
         <script type="text/javascript">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25170/Studio-does-not-overwrite-bs5-in-some-places

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
