### PR TITLE
RavenDB-25179 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -2335,15 +2335,6 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 var putResult = store.Maintenance.Send(new PutConnectionStringOperation<OlapConnectionString>(connectionString));
                 Assert.NotNull(putResult.RaftCommandIndex);
 
-                // re enable task
-
-                configuration.Disabled = false;
-                update = store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
-                Assert.NotNull(update.RaftCommandIndex);
-
-                var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(update.TaskId, OngoingTaskType.OlapEtl));
-                Assert.Equal(OngoingTaskState.Enabled, ongoingTask.TaskState);
-
                 // add more data
                 using (var session = store.OpenAsyncSession())
                 {
@@ -2365,7 +2356,17 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     await session.SaveChangesAsync();
                 }
 
+                // re enable task
+
                 etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
+
+                configuration.Disabled = false;
+                update = store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+                Assert.NotNull(update.RaftCommandIndex);
+
+                var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(update.TaskId, OngoingTaskType.OlapEtl));
+                Assert.Equal(OngoingTaskState.Enabled, ongoingTask.TaskState);
+
                 r = await etlDone.WaitAsync(_defaultTimeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25179/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateLocalSettingsdatabaseMode-Single

### Additional description

Flaky OLAP test fix — set up the `WaitForEtl` MRE and add more data _before_ re-enabling the task to avoid hitting the OLAP ETL cool-down period when waiting for the batch to complete.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
