### PR TITLE
RavenDB-25172 Use dotnet snmp providers

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetAESPrivacyProvider.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetAESPrivacyProvider.cs
@@ -1,0 +1,28 @@
+// Native .NET AES-128 privacy provider
+// Inherits from the native .NET base provider.
+
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Security;
+
+namespace Raven.Server.Monitoring.Snmp.Providers;
+
+/// <summary>
+/// Privacy provider for AES 128 using native .NET cryptography.
+/// </summary>
+public sealed class DotnetAESPrivacyProvider : DotnetAESPrivacyProviderBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DotnetAESPrivacyProvider"/> class.
+    /// </summary>
+    /// <param name="phrase">The phrase.</param>
+    /// <param name="auth">The authentication provider.</param>
+    public DotnetAESPrivacyProvider(OctetString phrase, IAuthenticationProvider auth)
+        : base(16, phrase, auth) // AES-128 uses a 16-byte (128-bit) key.
+    {
+    }
+
+    /// <summary>
+    /// Returns a string that represents this object.
+    /// </summary>
+    public override string ToString() => "AES 128 (native) privacy provider";
+}

--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetAESPrivacyProviderBase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetAESPrivacyProviderBase.cs
@@ -105,7 +105,7 @@ public abstract class DotnetAESPrivacyProviderBase : IPrivacyProvider
     /// Engine IDs.
     /// </summary>
     /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
-    public ICollection<OctetString>? EngineIds { get; set; }
+    public ICollection<OctetString> EngineIds { get; set; }
 
     /// <summary>
     /// Encrypt scoped PDU using AES encryption protocol

--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetAESPrivacyProviderBase.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetAESPrivacyProviderBase.cs
@@ -1,0 +1,471 @@
+// AES privacy provider
+// Copyright (C) 2009-2010 Lex Li, Milan Sinadinovic
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+/*
+ * Created by SharpDevelop.
+ * User: lextm
+ * Date: 5/30/2009
+ * Time: 8:06 PM
+ *
+ * To change this template use Tools | Options | Coding | Edit Standard Headers.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Security;
+
+namespace Raven.Server.Monitoring.Snmp.Providers;
+
+/// <summary>
+/// Privacy provider base for AES.
+/// </summary>
+/// <remarks>
+/// This is an experimental port from SNMP#NET project. As AES is not part of SNMP RFC, this class is provided as it is.
+/// If you want other AES providers, you can port them from SNMP#NET in a similar manner.
+/// </remarks>
+public abstract class DotnetAESPrivacyProviderBase : IPrivacyProvider
+{
+    private readonly SaltGenerator _salt = new();
+    private readonly OctetString _phrase;
+
+    /// <summary>
+    /// Verifies if the provider is supported.
+    /// </summary>
+    public static bool IsSupported
+    {
+        get
+        {
+            return true;
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Flag to force using legacy encryption/decryption code on .NET 6.
+    /// </summary>
+    public static bool UseLegacy { get; set; }
+#endif
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DotnetAESPrivacyProviderBase"/> class.
+    /// </summary>
+    /// <param name="keyBytes">Key bytes.</param>
+    /// <param name="phrase">The phrase.</param>
+    /// <param name="auth">The authentication provider.</param>
+    protected DotnetAESPrivacyProviderBase(int keyBytes, OctetString phrase, IAuthenticationProvider auth)
+    {
+        if (keyBytes != 16 && keyBytes != 24 && keyBytes != 32)
+        {
+            throw new ArgumentOutOfRangeException(nameof(keyBytes), "Valid key sizes are 16, 24 and 32 bytes.");
+        }
+
+        if (auth == null)
+        {
+            throw new ArgumentNullException(nameof(auth));
+        }
+
+        KeyBytes = keyBytes;
+
+        // IMPORTANT: in this way privacy cannot be non-default.
+        if (auth == DefaultAuthenticationProvider.Instance)
+        {
+            throw new ArgumentException("If authentication is off, then privacy cannot be used.", nameof(auth));
+        }
+
+        _phrase = phrase ?? throw new ArgumentNullException(nameof(phrase));
+        AuthenticationProvider = auth;
+    }
+
+    /// <summary>
+    /// Corresponding <see cref="IAuthenticationProvider"/>.
+    /// </summary>
+    public IAuthenticationProvider AuthenticationProvider { get; }
+
+    public OctetString EngineId { get; }
+
+    /// <summary>
+    /// Engine IDs.
+    /// </summary>
+    /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
+    public ICollection<OctetString>? EngineIds { get; set; }
+
+    /// <summary>
+    /// Encrypt scoped PDU using AES encryption protocol
+    /// </summary>
+    /// <param name="unencryptedData">Unencrypted scoped PDU byte array</param>
+    /// <param name="key">Encryption key. Key has to be at least 32 bytes is length</param>
+    /// <param name="engineBoots">Engine boots.</param>
+    /// <param name="engineTime">Engine time.</param>
+    /// <param name="privacyParameters">Privacy parameters out buffer. This field will be filled in with information
+    /// required to decrypt the information. Output length of this field is 8 bytes and space has to be reserved
+    /// in the USM header to store this information</param>
+    /// <returns>Encrypted byte array</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key is null or length of the encryption key is too short.</exception>
+    internal byte[] Encrypt(byte[] unencryptedData, byte[] key, int engineBoots, int engineTime, byte[] privacyParameters)
+    {
+        if (!IsSupported)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        // check the key before doing anything else
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (key.Length < KeyBytes)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), "Invalid key length.");
+        }
+
+        if (unencryptedData == null)
+        {
+            throw new ArgumentNullException(nameof(unencryptedData));
+        }
+
+        var iv = GetIV(engineBoots, engineTime, privacyParameters);
+        var pkey = GetKey(key);
+#if NET6_0_OR_GREATER
+        return UseLegacy ? LegacyEncrypt(pkey, iv, unencryptedData) : Net6Encrypt(pkey, iv, unencryptedData);
+#else
+            return LegacyEncrypt(pkey, iv, unencryptedData);
+#endif
+    }
+
+#if NET6_0_OR_GREATER
+    internal static byte[] Net6Encrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+
+        var length = (unencryptedData.Length % MinimalBlockSize == 0)
+            ? unencryptedData.Length
+            : ((unencryptedData.Length / MinimalBlockSize) + 1) * MinimalBlockSize;
+        var result = new byte[length];
+        var buffer = result.AsSpan();
+        var encryptedData = aes.EncryptCfb(unencryptedData.AsSpan(), iv.AsSpan(), buffer, PaddingMode.Zeros, 128);
+
+        // check if encrypted data is the same length as source data
+        if (encryptedData != unencryptedData.Length)
+        {
+            // cut out the padding
+            return buffer.Slice(0, unencryptedData.Length).ToArray();
+        }
+
+        return result;
+    }
+#endif
+
+    internal byte[] LegacyEncrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+#if NET471
+            using var rm = Rijndael.Create();
+#else
+        using var rm = Aes.Create();
+#endif
+        rm.KeySize = KeyBytes * 8;
+        rm.FeedbackSize = 128;
+        rm.BlockSize = 128;
+
+        // we have to use Zeros padding otherwise we get encrypt buffer size exception
+        rm.Padding = PaddingMode.Zeros;
+        rm.Mode = CipherMode.CFB;
+
+        rm.Key = key;
+        rm.IV = iv;
+        using var encryptor = rm.CreateEncryptor();
+        var encryptedData = encryptor.TransformFinalBlock(unencryptedData, 0, unencryptedData.Length);
+
+        // check if encrypted data is the same length as source data
+        if (encryptedData.Length != unencryptedData.Length)
+        {
+            // cut out the padding
+            var tmp = new byte[unencryptedData.Length];
+            Buffer.BlockCopy(encryptedData, 0, tmp, 0, unencryptedData.Length);
+            return tmp;
+        }
+
+        return encryptedData;
+    }
+
+    /// <summary>
+    /// Decrypt AES encrypted scoped PDU.
+    /// </summary>
+    /// <param name="encryptedData">Source data buffer</param>
+    /// <param name="engineBoots">Engine boots.</param>
+    /// <param name="engineTime">Engine time.</param>
+    /// <param name="key">Decryption key. Key length has to be 32 bytes in length or longer (bytes beyond 32 bytes are ignored).</param>
+    /// <param name="privacyParameters">Privacy parameters extracted from USM header</param>
+    /// <returns>Decrypted byte array</returns>
+    /// <exception cref="ArgumentNullException">Thrown when encrypted data is null or length == 0</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key length is less then 32 byte or if privacy parameters
+    /// argument is null or length other then 8 bytes</exception>
+    internal byte[] Decrypt(byte[] encryptedData, byte[] key, int engineBoots, int engineTime, byte[] privacyParameters)
+    {
+        if (!IsSupported)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (encryptedData == null)
+        {
+            throw new ArgumentNullException(nameof(encryptedData));
+        }
+
+        if (key.Length < KeyBytes)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), "Invalid key length.");
+        }
+
+        var iv = GetIV(engineBoots, engineTime, privacyParameters);
+
+        var finalKey = GetKey(key);
+#if NET6_0_OR_GREATER
+        return UseLegacy ? LegacyDecrypt(finalKey, iv, encryptedData) : Net6Decrypt(finalKey, iv, encryptedData);
+#else
+            return LegacyDecrypt(finalKey, iv, encryptedData);
+#endif
+    }
+
+#if NET6_0_OR_GREATER
+    internal static byte[] Net6Decrypt(byte[] key, byte[] iv, byte[] encryptedData)
+    {
+        using Aes aes = Aes.Create();
+        aes.Key = key;
+        if ((encryptedData.Length % MinimalBlockSize) != 0)
+        {
+            var div = encryptedData.Length / MinimalBlockSize;
+            var newLength = (div + 1) * MinimalBlockSize;
+            var decryptBuffer = new byte[newLength];
+            Buffer.BlockCopy(encryptedData, 0, decryptBuffer, 0, encryptedData.Length);
+            var buffer = new byte[newLength].AsSpan();
+            aes.DecryptCfb(decryptBuffer.AsSpan(), iv.AsSpan(), buffer, PaddingMode.Zeros, 128);
+
+            // now remove padding
+            return buffer.Slice(0, encryptedData.Length).ToArray();
+        }
+
+        return aes.DecryptCfb(encryptedData, iv, PaddingMode.Zeros, 128);
+    }
+#endif
+
+    internal byte[] LegacyDecrypt(byte[] key, byte[] iv, byte[] encryptedData)
+    {
+        // now do CFB decryption of the encrypted data
+#if NET471
+            using var rm = Rijndael.Create();
+#else
+        using var rm = Aes.Create();
+#endif
+        rm.KeySize = KeyBytes * 8;
+        rm.FeedbackSize = 128;
+        rm.BlockSize = 128;
+        rm.Padding = PaddingMode.Zeros;
+        rm.Mode = CipherMode.CFB;
+
+        rm.Key = key;
+        rm.IV = iv;
+        using var decrytor = rm.CreateDecryptor();
+        // We need to make sure that encryptedData is a collection of 128 byte blocks
+        byte[] decryptedData;
+        if ((encryptedData.Length % MinimalBlockSize) != 0)
+        {
+            var div = encryptedData.Length / MinimalBlockSize;
+            var newLength = (div + 1) * MinimalBlockSize;
+            var decryptBuffer = new byte[newLength];
+            Buffer.BlockCopy(encryptedData, 0, decryptBuffer, 0, encryptedData.Length);
+            decryptedData = decrytor.TransformFinalBlock(decryptBuffer, 0, decryptBuffer.Length);
+
+            // now remove padding
+            var buffer = new byte[encryptedData.Length];
+            Buffer.BlockCopy(decryptedData, 0, buffer, 0, encryptedData.Length);
+            return buffer;
+        }
+
+        decryptedData = decrytor.TransformFinalBlock(encryptedData, 0, encryptedData.Length);
+        return decryptedData;
+    }
+
+    /// <summary>
+    /// Returns the length of privacyParameters USM header field. For AES, field length is 8.
+    /// </summary>
+    private static int PrivacyParametersLength => 8;
+
+    /// <summary>
+    /// Returns minimum encryption/decryption key length. For DES, returned value is 16.
+    /// 
+    /// DES protocol itself requires an 8 byte key. Additional 8 bytes are used for generating the
+    /// encryption IV. For encryption itself, first 8 bytes of the key are used.
+    /// </summary>
+    private int MinimumKeyLength => KeyBytes;
+
+    /// <summary>
+    /// Return maximum encryption/decryption key length. For DES, returned value is 16
+    /// 
+    /// DES protocol itself requires an 8 byte key. Additional 8 bytes are used for generating the
+    /// encryption IV. For encryption itself, first 8 bytes of the key are used.
+    /// </summary>
+    public int MaximumKeyLength => KeyBytes;
+
+    #region IPrivacyProvider Members
+
+    /// <summary>
+    /// Decrypts the specified data.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns></returns>
+    public ISnmpData Decrypt(ISnmpData data, SecurityParameters parameters)
+    {
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        var code = data.TypeCode;
+        if (code != SnmpType.OctetString)
+        {
+            throw new ArgumentException($"Cannot decrypt the scope data: {code}.", nameof(data));
+        }
+
+        if (parameters.EngineId == null)
+        {
+            throw new ArgumentException("Invalid security parameters", nameof(parameters));
+        }
+
+        var octets = (OctetString)data;
+        var bytes = octets.GetRaw();
+        var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+
+        // decode encrypted packet
+        var decrypted = Decrypt(bytes, pkey, parameters.EngineBoots!.ToInt32(), parameters.EngineTime!.ToInt32(), parameters.PrivacyParameters!.GetRaw());
+        return DataFactory.CreateSnmpData(decrypted);
+    }
+
+    /// <summary>
+    /// Encrypts the specified scope.
+    /// </summary>
+    /// <param name="data">The scope data.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns></returns>
+    public ISnmpData Encrypt(ISnmpData data, SecurityParameters parameters)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        if (data.TypeCode != SnmpType.Sequence && !(data is ISnmpPdu))
+        {
+            throw new ArgumentException("Invalid data type.", nameof(data));
+        }
+
+        if (parameters.EngineId == null)
+        {
+            throw new ArgumentException("Invalid security parameters", nameof(parameters));
+        }
+
+        var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+        var bytes = data.ToBytes();
+        var encrypted = Encrypt(bytes, pkey, parameters.EngineBoots!.ToInt32(), parameters.EngineTime!.ToInt32(), parameters.PrivacyParameters!.GetRaw());
+        return new OctetString(encrypted);
+    }
+
+    /// <summary>
+    /// Gets the salt.
+    /// </summary>
+    /// <value>The salt.</value>
+    public OctetString Salt => new(_salt.GetSaltBytes());
+
+    /// <summary>
+    /// Gets the key bytes.
+    /// </summary>
+    /// <value>The key bytes.</value>
+    public int KeyBytes { get; } = 16;
+
+    private const int MinimalBlockSize = 16;
+
+    /// <summary>
+    /// Passwords to key.
+    /// </summary>
+    /// <param name="secret">The secret.</param>
+    /// <param name="engineId">The engine identifier.</param>
+    /// <returns></returns>
+    public byte[] PasswordToKey(byte[] secret, byte[] engineId)
+    {
+        var pkey = AuthenticationProvider.PasswordToKey(secret, engineId);
+        if (pkey.Length < MinimumKeyLength)
+        {
+            pkey = DotnetTripleDESPrivacyProvider.ExtendShortKey(pkey, engineId, AuthenticationProvider);
+        }
+
+        return pkey;
+    }
+
+    #endregion
+
+    private byte[] GetKey(byte[] key)
+    {
+        if (key.Length > KeyBytes)
+        {
+            var normKey = new byte[KeyBytes];
+            Buffer.BlockCopy(key, 0, normKey, 0, KeyBytes);
+            return normKey;
+        }
+
+        return key;
+    }
+
+    private byte[] GetIV(int engineBoots, int engineTime, byte[] privacyParameters)
+    {
+        var iv = new byte[16];
+        var bootsBytes = BitConverter.GetBytes(engineBoots);
+        iv[0] = bootsBytes[3];
+        iv[1] = bootsBytes[2];
+        iv[2] = bootsBytes[1];
+        iv[3] = bootsBytes[0];
+        var timeBytes = BitConverter.GetBytes(engineTime);
+        iv[4] = timeBytes[3];
+        iv[5] = timeBytes[2];
+        iv[6] = timeBytes[1];
+        iv[7] = timeBytes[0];
+
+        // Copy salt value to the iv array
+        Buffer.BlockCopy(privacyParameters, 0, iv, 8, PrivacyParametersLength);
+        return iv;
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetDESPrivacyProvider.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetDESPrivacyProvider.cs
@@ -30,7 +30,6 @@ namespace Raven.Server.Monitoring.Snmp.Providers;
 /// Privacy provider for DES.
 /// </summary>
 /// <remarks>Ported from SNMP#NET PrivacyDES class.</remarks>
-[Obsolete("DES is no longer secure. Please use a more secure provider.")]
 public sealed class DotnetDESPrivacyProvider : IPrivacyProvider
 {
     private readonly SaltGenerator _salt = new();
@@ -91,7 +90,7 @@ public sealed class DotnetDESPrivacyProvider : IPrivacyProvider
     /// Engine IDs.
     /// </summary>
     /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
-    public ICollection<OctetString>? EngineIds { get; set; }
+    public ICollection<OctetString> EngineIds { get; set; }
 
     /// <summary>
     /// Encrypt scoped PDU using DES encryption protocol

--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetDESPrivacyProvider.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetDESPrivacyProvider.cs
@@ -1,0 +1,502 @@
+// DES privacy provider.
+// Copyright (C) 2008-2010 Malcolm Crowe, Lex Li, and other contributors.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Security;
+
+namespace Raven.Server.Monitoring.Snmp.Providers;
+
+/// <summary>
+/// Privacy provider for DES.
+/// </summary>
+/// <remarks>Ported from SNMP#NET PrivacyDES class.</remarks>
+[Obsolete("DES is no longer secure. Please use a more secure provider.")]
+public sealed class DotnetDESPrivacyProvider : IPrivacyProvider
+{
+    private readonly SaltGenerator _salt = new();
+    private readonly OctetString _phrase;
+
+    /// <summary>
+    /// Verifies if the provider is supported.
+    /// </summary>
+    public static bool IsSupported
+    {
+        get
+        {
+            return true;
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Flag to force using legacy encryption/decryption code on .NET 6.
+    /// </summary>
+    public static bool UseLegacy { get; set; }
+#endif
+    /// <summary>
+    /// Flag to force using old ECB cipher mode encryption.
+    /// </summary>
+    public static bool UseEcbEncryption { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="phrase"/> class.
+    /// </summary>
+    /// <param name="auth">The phrase.</param>
+    /// <param name="auth">The authentication provider.</param>
+    public DotnetDESPrivacyProvider(OctetString phrase, IAuthenticationProvider auth)
+    {
+        if (auth == null)
+        {
+            throw new ArgumentNullException(nameof(auth));
+        }
+
+        // IMPORTANT: in this way privacy cannot be non-default.
+        if (auth == DefaultAuthenticationProvider.Instance)
+        {
+            throw new ArgumentException("If authentication is off, then privacy cannot be used.", nameof(auth));
+        }
+
+        _phrase = phrase ?? throw new ArgumentNullException(nameof(phrase));
+        AuthenticationProvider = auth;
+    }
+
+    /// <summary>
+    /// Corresponding <see cref="IAuthenticationProvider"/>.
+    /// </summary>
+    public IAuthenticationProvider AuthenticationProvider { get; }
+
+    public OctetString EngineId { get; }
+
+    /// <summary>
+    /// Engine IDs.
+    /// </summary>
+    /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
+    public ICollection<OctetString>? EngineIds { get; set; }
+
+    /// <summary>
+    /// Encrypt scoped PDU using DES encryption protocol
+    /// </summary>
+    /// <param name="unencryptedData">Unencrypted scoped PDU byte array</param>
+    /// <param name="key">Encryption key. Key has to be at least 32 bytes is length</param>
+    /// <param name="privacyParameters">Privacy parameters out buffer. This field will be filled in with information
+    /// required to decrypt the information. Output length of this field is 8 bytes and space has to be reserved
+    /// in the USM header to store this information</param>
+    /// <returns>Encrypted byte array</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key is null or length of the encryption key is too short.</exception>
+    public static byte[] Encrypt(byte[] unencryptedData, byte[] key, byte[] privacyParameters)
+    {
+        if (!IsSupported)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        if (unencryptedData == null)
+        {
+            throw new ArgumentNullException(nameof(unencryptedData));
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (privacyParameters == null)
+        {
+            throw new ArgumentNullException(nameof(privacyParameters));
+        }
+
+        if (key.Length < MinimumKeyLength)
+        {
+            throw new ArgumentException($"Encryption key length has to 32 bytes or more. Current: {key.Length}.", nameof(key));
+        }
+
+        var iv = GetIV(key, privacyParameters);
+
+        // DES uses 8 byte keys but we need 16 to encrypt ScopedPdu. Get first 8 bytes and use them as encryption key
+        var outKey = GetKey(key);
+
+        if (UseEcbEncryption)
+        {
+            return EcbEncrypt(outKey, iv, unencryptedData);
+        }
+
+        if ((unencryptedData.Length % 8) != 0)
+        {
+            byte[] tmpBuffer = new byte[8 * ((unencryptedData.Length / 8) + 1)];
+            Buffer.BlockCopy(unencryptedData, 0, tmpBuffer, 0, unencryptedData.Length);
+            unencryptedData = tmpBuffer;
+        }
+#if NET6_0_OR_GREATER
+        return UseLegacy ? LegacyEncrypt(outKey, iv, unencryptedData) : Net6Encrypt(outKey, iv, unencryptedData);
+#else
+            return LegacyEncrypt(outKey, iv, unencryptedData);
+#endif
+    }
+
+#if NET6_0_OR_GREATER
+    internal static byte[] Net6Encrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+        using DES des = DES.Create();
+        des.Key = key;
+        return des.EncryptCbc(unencryptedData, iv, PaddingMode.None);
+    }
+#endif
+
+    internal static byte[] LegacyEncrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+        using DES des = DES.Create();
+        des.Mode = CipherMode.CBC;
+        des.Padding = PaddingMode.None;
+
+        using var transform = des.CreateEncryptor(key, iv);
+        return transform.TransformFinalBlock(unencryptedData, 0, unencryptedData.Length);
+    }
+
+    internal static byte[] EcbEncrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+        var div = (int)Math.Floor(unencryptedData.Length / 8.0);
+        if ((unencryptedData.Length % 8) != 0)
+        {
+            div += 1;
+        }
+
+        var newLength = div * 8;
+        var result = new byte[newLength];
+        var buffer = new byte[newLength];
+
+        var inBuffer = new byte[8];
+        var cipherText = iv;
+        var posIn = 0;
+        var posResult = 0;
+        Buffer.BlockCopy(unencryptedData, 0, buffer, 0, unencryptedData.Length);
+
+        using DES des = DES.Create();
+        des.Mode = CipherMode.ECB;
+        des.Padding = PaddingMode.None;
+
+        using (var transform = des.CreateEncryptor(key, null))
+        {
+            for (var b = 0; b < div; b++)
+            {
+                for (var i = 0; i < 8; i++)
+                {
+                    inBuffer[i] = (byte)(buffer[posIn] ^ cipherText[i]);
+                    posIn++;
+                }
+
+                transform.TransformBlock(inBuffer, 0, inBuffer.Length, cipherText, 0);
+                Buffer.BlockCopy(cipherText, 0, result, posResult, cipherText.Length);
+                posResult += cipherText.Length;
+            }
+        }
+
+        des.Clear();
+
+        return result;
+    }
+
+    /// <summary>
+    /// Decrypt DES encrypted scoped PDU.
+    /// </summary>
+    /// <param name="encryptedData">Source data buffer</param>
+    /// <param name="key">Decryption key. Key length has to be 32 bytes in length or longer (bytes beyond 32 bytes are ignored).</param>
+    /// <param name="privacyParameters">Privacy parameters extracted from USM header</param>
+    /// <returns>Decrypted byte array</returns>
+    /// <exception cref="ArgumentNullException">Thrown when encrypted data is null or length == 0</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key length is less then 32 byte or if privacy parameters
+    /// argument is null or length other then 8 bytes</exception>
+    public static byte[] Decrypt(byte[] encryptedData, byte[] key, byte[] privacyParameters)
+    {
+        if (!IsSupported)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        if (encryptedData == null)
+        {
+            throw new ArgumentNullException(nameof(encryptedData));
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (privacyParameters == null)
+        {
+            throw new ArgumentNullException(nameof(privacyParameters));
+        }
+
+        if (encryptedData.Length == 0)
+        {
+            throw new ArgumentException("Empty encrypted data.", nameof(encryptedData));
+        }
+
+        if ((encryptedData.Length % 8) != 0)
+        {
+            throw new ArgumentException("Encrypted data buffer has to be divisible by 8.", nameof(encryptedData));
+        }
+
+        if (privacyParameters.Length != PrivacyParametersLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(privacyParameters), "Privacy parameters argument has to be 8 bytes long.");
+        }
+
+        if (key.Length < MinimumKeyLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), "Decryption key has to be at least 16 bytes long.");
+        }
+
+        var iv = new byte[8];
+        for (var i = 0; i < 8; ++i)
+        {
+            iv[i] = (byte)(key[8 + i] ^ privacyParameters[i]);
+        }
+
+        // .NET implementation only takes an 8 byte key
+        var outKey = new byte[8];
+        Buffer.BlockCopy(key, 0, outKey, 0, 8);
+#if NET6_0_OR_GREATER
+        return Net6Decrypt(outKey, iv, encryptedData);
+#else
+            return LegacyDecrypt(outKey, iv, encryptedData);
+#endif
+    }
+
+#if NET6_0_OR_GREATER
+    internal static byte[] Net6Decrypt(byte[] key, byte[] iv, byte[] encryptedData)
+    {
+        using DES des = DES.Create();
+        des.Key = key;
+        return des.DecryptCbc(encryptedData, iv, PaddingMode.Zeros);
+    }
+#endif
+
+    internal static byte[] LegacyDecrypt(byte[] key, byte[] iv, byte[] encryptedData)
+    {
+        using DES des = DES.Create();
+        des.Mode = CipherMode.CBC;
+        des.Padding = PaddingMode.Zeros;
+
+        des.Key = key;
+        des.IV = iv;
+        using var transform = des.CreateDecryptor();
+        var decryptedData = transform.TransformFinalBlock(encryptedData, 0, encryptedData.Length);
+        des.Clear();
+        return decryptedData;
+    }
+
+    /// <summary>
+    /// Generate IV from the privacy key and salt value returned by GetSalt method.
+    /// </summary>
+    /// <param name="privacyKey">16 byte privacy key</param>
+    /// <param name="salt">Salt value returned by GetSalt method</param>
+    /// <returns>IV value used in the encryption process</returns>
+    private static byte[] GetIV(IList<byte> privacyKey, IList<byte> salt)
+    {
+        if (privacyKey.Count < MinimumKeyLength)
+        {
+            throw new ArgumentException("Invalid privacy key length", nameof(privacyKey));
+        }
+
+        var iv = new byte[8];
+        for (var i = 0; i < iv.Length; i++)
+        {
+            iv[i] = (byte)(salt[i] ^ privacyKey[8 + i]);
+        }
+
+        return iv;
+    }
+
+    /// <summary>
+    /// Extract and return DES encryption key.
+    /// Privacy password is 16 bytes in length. Only the first 8 bytes are used as DES password. Remaining
+    /// 8 bytes are used as pre-IV value.
+    /// </summary>
+    /// <param name="privacyPassword">16 byte privacy password</param>
+    /// <returns>8 byte DES encryption password</returns>
+    private static byte[] GetKey(byte[] privacyPassword)
+    {
+        if (privacyPassword.Length < 16)
+        {
+            throw new ArgumentException("Invalid privacy key length.", nameof(privacyPassword));
+        }
+
+        var key = new byte[8];
+        Buffer.BlockCopy(privacyPassword, 0, key, 0, 8);
+        return key;
+    }
+
+    /// <summary>
+    /// Returns the length of privacyParameters USM header field. For DES, field length is 8.
+    /// </summary>
+    public static int PrivacyParametersLength => 8;
+
+    /// <summary>
+    /// Returns minimum encryption/decryption key length. For DES, returned value is 16.
+    /// 
+    /// DES protocol itself requires an 8 byte key. Additional 8 bytes are used for generating the
+    /// encryption IV. For encryption itself, first 8 bytes of the key are used.
+    /// </summary>
+    public static int MinimumKeyLength => MaximumKeyLength;
+
+    /// <summary>
+    /// Return maximum encryption/decryption key length. For DES, returned value is 16.
+    /// 
+    /// DES protocol itself requires an 8 byte key. Additional 8 bytes are used for generating the
+    /// encryption IV. For encryption itself, first 8 bytes of the key are used.
+    /// </summary>
+    public static int MaximumKeyLength => 16;
+
+    #region IPrivacyProvider Members
+
+    /// <summary>
+    /// Decrypts the specified data.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns></returns>
+    public ISnmpData Decrypt(ISnmpData data, SecurityParameters parameters)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        var code = data.TypeCode;
+        if (code != SnmpType.OctetString)
+        {
+            throw new ArgumentException($"Cannot decrypt the scope data: {code}.", nameof(data));
+        }
+
+        if (parameters.EngineId == null)
+        {
+            throw new ArgumentException("Invalid security parameters", nameof(parameters));
+        }
+
+        var octets = (OctetString)data;
+        var bytes = octets.GetRaw();
+        var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+
+        try
+        {
+            // decode encrypted packet
+            var decrypted = Decrypt(bytes, pkey, parameters.PrivacyParameters!.GetRaw());
+            var result = DataFactory.CreateSnmpData(decrypted);
+            if (result.TypeCode != SnmpType.Sequence)
+            {
+                var newException = new DecryptionException("DES decryption failed");
+                newException.SetBytes(bytes);
+                throw newException;
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            var newException = new DecryptionException("DES decryption failed", ex);
+            newException.SetBytes(bytes);
+            throw newException;
+        }
+    }
+
+    /// <summary>
+    /// Encrypts the specified scope.
+    /// </summary>
+    /// <param name="data">The scope data.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns></returns>
+    public ISnmpData Encrypt(ISnmpData data, SecurityParameters parameters)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        if (data.TypeCode != SnmpType.Sequence && !(data is ISnmpPdu))
+        {
+            throw new ArgumentException("Invalid data type.", nameof(data));
+        }
+
+        if (parameters.EngineId == null)
+        {
+            throw new ArgumentException("Invalid security parameters", nameof(parameters));
+        }
+
+        var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+        var bytes = data.ToBytes();
+        var reminder = bytes.Length % 8;
+        var count = reminder == 0 ? 0 : 8 - reminder;
+        using (var stream = new MemoryStream())
+        {
+            stream.Write(bytes, 0, bytes.Length);
+            for (var i = 0; i < count; i++)
+            {
+                stream.WriteByte(1);
+            }
+
+            bytes = stream.ToArray();
+        }
+
+        var encrypted = Encrypt(bytes, pkey, parameters.PrivacyParameters!.GetRaw());
+        return new OctetString(encrypted);
+    }
+
+    /// <summary>
+    /// Gets the salt.
+    /// </summary>
+    /// <value>The salt.</value>
+    public OctetString Salt => new(_salt.GetSaltBytes());
+
+    /// <summary>
+    /// Passwords to key.
+    /// </summary>
+    /// <param name="secret">The secret.</param>
+    /// <param name="engineId">The engine identifier.</param>
+    /// <returns></returns>
+    public byte[] PasswordToKey(byte[] secret, byte[] engineId)
+    {
+        return AuthenticationProvider.PasswordToKey(secret, engineId);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Returns a string that represents this object.
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
+    {
+        return "DES privacy provider";
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetTripleDESPrivacyProvider.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetTripleDESPrivacyProvider.cs
@@ -1,0 +1,453 @@
+// DES privacy provider.
+// Copyright (C) 2008-2010 Malcolm Crowe, Lex Li, and other contributors.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Security;
+
+namespace Raven.Server.Monitoring.Snmp.Providers;
+
+/// <summary>
+/// Privacy provider for 3DES.
+/// </summary>
+/// <remarks>
+/// <p>Ported from SNMP#NET Privacy3DES class.</p>
+/// <p>Originally defined in a draft https://datatracker.ietf.org/doc/html/draft-reeder-snmpv3-usm-3desede-00</p>
+/// </remarks>
+[Obsolete("3DES is no longer secure. Please use a more secure provider.")]
+public sealed class DotnetTripleDESPrivacyProvider : IPrivacyProvider
+{
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Flag to force using legacy encryption/decryption code on .NET 6.
+    /// </summary>
+    public static bool UseLegacy { get; set; }
+#endif
+    private readonly SaltGenerator _salt = new();
+    private readonly OctetString _phrase;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="phrase"/> class.
+    /// </summary>
+    /// <param name="auth">The phrase.</param>
+    /// <param name="auth">The authentication provider.</param>
+    public DotnetTripleDESPrivacyProvider(OctetString phrase, IAuthenticationProvider auth)
+    {
+        if (auth == null)
+        {
+            throw new ArgumentNullException(nameof(auth));
+        }
+
+        // IMPORTANT: in this way privacy cannot be non-default.
+        if (auth == DefaultAuthenticationProvider.Instance)
+        {
+            throw new ArgumentException("If authentication is off, then privacy cannot be used.", nameof(auth));
+        }
+
+        _phrase = phrase ?? throw new ArgumentNullException(nameof(phrase));
+        AuthenticationProvider = auth;
+    }
+
+    /// <summary>
+    /// Corresponding <see cref="IAuthenticationProvider"/>.
+    /// </summary>
+    public IAuthenticationProvider AuthenticationProvider { get; }
+
+    public OctetString EngineId { get; }
+
+    /// <summary>
+    /// Engine IDs.
+    /// </summary>
+    /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
+    public ICollection<OctetString>? EngineIds { get; set; }
+
+    /// <summary>
+    /// Encrypt scoped PDU using DES encryption protocol
+    /// </summary>
+    /// <param name="unencryptedData">Unencrypted scoped PDU byte array</param>
+    /// <param name="key">Encryption key. Key has to be at least 32 bytes is length</param>
+    /// <param name="privacyParameters">Privacy parameters out buffer. This field will be filled in with information
+    /// required to decrypt the information. Output length of this field is 8 bytes and space has to be reserved
+    /// in the USM header to store this information</param>
+    /// <returns>Encrypted byte array</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key is null or length of the encryption key is too short.</exception>
+    public static byte[] Encrypt(byte[] unencryptedData, byte[] key, byte[] privacyParameters)
+    {
+        if (unencryptedData == null)
+        {
+            throw new ArgumentNullException(nameof(unencryptedData));
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (privacyParameters == null)
+        {
+            throw new ArgumentNullException(nameof(privacyParameters));
+        }
+
+        if (key.Length < MinimumKeyLength)
+        {
+            throw new ArgumentException($"Encryption key length has to 32 bytes or more. Current: {key.Length}.", nameof(key));
+        }
+
+        var iv = GetIV(key, privacyParameters);
+        var outKey = GetKey(key);
+
+        // IMPORTANT: "The data to be encrypted is treated as sequence of octets. Its
+        // length should be an integral multiple of 8 - and if it is not, the
+        // data is padded at the end as necessary. The actual pad value is
+        // irrelevant."
+        if ((unencryptedData.Length % 8) != 0)
+        {
+            byte[] tmpBuffer = new byte[8 * ((unencryptedData.Length / 8) + 1)];
+            Buffer.BlockCopy(unencryptedData, 0, tmpBuffer, 0, unencryptedData.Length);
+            unencryptedData = tmpBuffer;
+        }
+#if NET6_0_OR_GREATER
+        return UseLegacy ? LegacyEncrypt(outKey, iv, unencryptedData) : Net6Encrypt(outKey, iv, unencryptedData);
+#else
+            return LegacyEncrypt(outKey, iv, unencryptedData);
+#endif
+    }
+
+#if NET6_0_OR_GREATER
+    internal static byte[] Net6Encrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+        using TripleDES des = TripleDES.Create();
+        des.Key = key;
+        return des.EncryptCbc(unencryptedData, iv, PaddingMode.None);
+    }
+#endif
+
+    internal static byte[] LegacyEncrypt(byte[] key, byte[] iv, byte[] unencryptedData)
+    {
+        using TripleDES des = TripleDES.Create();
+        des.Mode = CipherMode.CBC;
+        des.Padding = PaddingMode.None;
+
+        using var transform = des.CreateEncryptor(key, iv);
+        return transform.TransformFinalBlock(unencryptedData, 0, unencryptedData.Length);
+    }
+
+    /// <summary>
+    /// Decrypt DES encrypted scoped PDU.
+    /// </summary>
+    /// <param name="encryptedData">Source data buffer</param>
+    /// <param name="key">Decryption key. Key length has to be 32 bytes in length or longer (bytes beyond 32 bytes are ignored).</param>
+    /// <param name="privacyParameters">Privacy parameters extracted from USM header</param>
+    /// <returns>Decrypted byte array</returns>
+    /// <exception cref="ArgumentNullException">Thrown when encrypted data is null or length == 0</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when encryption key length is less then 32 byte or if privacy parameters
+    /// argument is null or length other then 8 bytes</exception>
+    public static byte[] Decrypt(byte[] encryptedData, byte[] key, byte[] privacyParameters)
+    {
+        if (encryptedData == null)
+        {
+            throw new ArgumentNullException(nameof(encryptedData));
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (privacyParameters == null)
+        {
+            throw new ArgumentNullException(nameof(privacyParameters));
+        }
+
+        if (encryptedData.Length == 0)
+        {
+            throw new ArgumentException("Empty encrypted data.", nameof(encryptedData));
+        }
+
+        if ((encryptedData.Length % 8) != 0)
+        {
+            throw new ArgumentException("Encrypted data buffer has to be divisible by 8.", nameof(encryptedData));
+        }
+
+        if (privacyParameters.Length != PrivacyParametersLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(privacyParameters), "Privacy parameters argument has to be 8 bytes long.");
+        }
+
+        if (key.Length < MinimumKeyLength)
+        {
+            throw new ArgumentOutOfRangeException(nameof(key), "Decryption key has to be at least 16 bytes long.");
+        }
+
+        var iv = GetIV(key, privacyParameters);
+        var outKey = GetKey(key);
+
+#if NET6_0_OR_GREATER
+        return UseLegacy ? LegacyDecrypt(outKey, iv, encryptedData) : Net6Decrypt(outKey, iv, encryptedData);
+#else
+            return LegacyDecrypt(outKey, iv, encryptedData);
+#endif
+    }
+
+#if NET6_0_OR_GREATER
+    internal static byte[] Net6Decrypt(byte[] key, byte[] iv, byte[] encryptedData)
+    {
+        using TripleDES des = TripleDES.Create();
+        des.Key = key;
+        return des.DecryptCbc(encryptedData, iv, PaddingMode.Zeros);
+    }
+#endif
+
+    internal static byte[] LegacyDecrypt(byte[] key, byte[] iv, byte[] encryptedData)
+    {
+        using TripleDES des = TripleDES.Create();
+        des.Mode = CipherMode.CBC;
+        des.Padding = PaddingMode.Zeros;
+
+        using var transform = des.CreateDecryptor(key, iv);
+        var decryptedData = transform.TransformFinalBlock(encryptedData, 0, encryptedData.Length);
+        return decryptedData;
+    }
+
+    /// <summary>
+    /// Generate IV from the privacy key and salt value returned by GetSalt method.
+    /// </summary>
+    /// <param name="privacyKey">32 byte privacy key</param>
+    /// <param name="salt">Salt value returned by GetSalt method</param>
+    /// <returns>IV value used in the encryption process</returns>
+    private static byte[] GetIV(IList<byte> privacyKey, IList<byte> salt)
+    {
+        if (privacyKey.Count < MinimumKeyLength)
+        {
+            throw new ArgumentException("Invalid privacy key length", nameof(privacyKey));
+        }
+
+        var iv = new byte[8];
+        for (var i = 0; i < iv.Length; i++)
+        {
+            iv[i] = (byte)(salt[i] ^ privacyKey[24 + i]);
+        }
+
+        return iv;
+    }
+
+    /// <summary>
+    /// Extract and return DES encryption key.
+    /// Privacy password is 16 bytes in length. Only the first 8 bytes are used as DES password. Remaining
+    /// 8 bytes are used as pre-IV value.
+    /// </summary>
+    /// <param name="privacyPassword">16 byte privacy password</param>
+    /// <returns>8 byte DES encryption password</returns>
+    private static byte[] GetKey(byte[] privacyPassword)
+    {
+        if (privacyPassword.Length < 32)
+        {
+            throw new ArgumentException("Invalid privacy key length.", nameof(privacyPassword));
+        }
+
+        // Important: "The first 24 octets of the 32-octet secret (private privacy key) are used as a 3DES-EDE key."
+        var key = new byte[24];
+        Buffer.BlockCopy(privacyPassword, 0, key, 0, key.Length);
+
+        // TODO: verify that K1, K2, K3 are unique.
+        return key;
+    }
+
+    /// <summary>
+    /// Returns the length of privacyParameters USM header field. For 3DES, field length is 8.
+    /// </summary>
+    public static int PrivacyParametersLength => 8;
+
+    /// <summary>
+    /// Returns minimum encryption/decryption key length. For 3DES, returned value is 32.
+    /// 
+    /// 3DES protocol itself requires an 24 byte key. Additional 8 bytes are used for generating the
+    /// encryption IV. For encryption itself, first 24 bytes of the key are used.
+    /// </summary>
+    public static int MinimumKeyLength => MaximumKeyLength;
+
+    /// <summary>
+    /// Return maximum encryption/decryption key length. For 3DES, returned value is 32.
+    /// 
+    /// 3DES protocol itself requires an 24 byte key. Additional 8 bytes are used for generating the
+    /// encryption IV. For encryption itself, first 24 bytes of the key are used.
+    /// </summary>
+    public static int MaximumKeyLength => 32;
+
+    #region IPrivacyProvider Members
+
+    /// <summary>
+    /// Decrypts the specified data.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns></returns>
+    public ISnmpData Decrypt(ISnmpData data, SecurityParameters parameters)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        var code = data.TypeCode;
+        if (code != SnmpType.OctetString)
+        {
+            throw new ArgumentException($"Cannot decrypt the scope data: {code}.", nameof(data));
+        }
+
+        if (parameters.EngineId == null)
+        {
+            throw new ArgumentException("Invalid security parameters", nameof(parameters));
+        }
+
+        var octets = (OctetString)data;
+        var bytes = octets.GetRaw();
+        var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+
+        try
+        {
+            // decode encrypted packet
+            var decrypted = Decrypt(bytes, pkey, parameters.PrivacyParameters!.GetRaw());
+            var result = DataFactory.CreateSnmpData(decrypted);
+            if (result.TypeCode != SnmpType.Sequence)
+            {
+                var newException = new DecryptionException("DES decryption failed");
+                newException.SetBytes(bytes);
+                throw newException;
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            var newException = new DecryptionException("DES decryption failed", ex);
+            newException.SetBytes(bytes);
+            throw newException;
+        }
+    }
+
+    /// <summary>
+    /// Encrypts the specified scope.
+    /// </summary>
+    /// <param name="data">The scope data.</param>
+    /// <param name="parameters">The parameters.</param>
+    /// <returns></returns>
+    public ISnmpData Encrypt(ISnmpData data, SecurityParameters parameters)
+    {
+        if (data == null)
+        {
+            throw new ArgumentNullException(nameof(data));
+        }
+
+        if (parameters == null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        if (data.TypeCode != SnmpType.Sequence && data is not ISnmpPdu)
+        {
+            throw new ArgumentException("Invalid data type.", nameof(data));
+        }
+
+        if (parameters.EngineId == null)
+        {
+            throw new ArgumentException("Invalid security parameters", nameof(parameters));
+        }
+
+        var pkey = PasswordToKey(_phrase.GetRaw(), parameters.EngineId.GetRaw());
+        var bytes = data.ToBytes();
+        var reminder = bytes.Length % 8;
+        var count = reminder == 0 ? 0 : 8 - reminder;
+        using (var stream = new MemoryStream())
+        {
+            stream.Write(bytes, 0, bytes.Length);
+            for (var i = 0; i < count; i++)
+            {
+                stream.WriteByte(1);
+            }
+
+            bytes = stream.ToArray();
+        }
+
+        var encrypted = Encrypt(bytes, pkey, parameters.PrivacyParameters!.GetRaw());
+        return new OctetString(encrypted);
+    }
+
+    /// <summary>
+    /// Gets the salt.
+    /// </summary>
+    /// <value>The salt.</value>
+    public OctetString Salt => new(_salt.GetSaltBytes());
+
+    /// <summary>
+    /// Passwords to key.
+    /// </summary>
+    /// <param name="secret">The secret.</param>
+    /// <param name="engineId">The engine identifier.</param>
+    /// <returns></returns>
+    public byte[] PasswordToKey(byte[] secret, byte[] engineId)
+    {
+        byte[] encryptionKey = AuthenticationProvider.PasswordToKey(secret, engineId);
+        if (encryptionKey.Length < MinimumKeyLength)
+        {
+            encryptionKey = ExtendShortKey(encryptionKey, engineId, AuthenticationProvider);
+        }
+
+        return encryptionKey;
+    }
+
+    internal static byte[] ExtendShortKey(byte[] shortKey, byte[] engineID, IAuthenticationProvider authProtocol)
+    {
+        int length = shortKey.Length;
+        byte[] extendedKey = new byte[MinimumKeyLength];
+        Buffer.BlockCopy(shortKey, 0, extendedKey, 0, shortKey.Length);
+
+        while (length < MinimumKeyLength)
+        {
+            byte[] key =
+                authProtocol.PasswordToKey(shortKey,
+                    engineID);
+            int copyBytes = Math.Min(MaximumKeyLength - length,
+                authProtocol.DigestLength);
+            Buffer.BlockCopy(key, 0, extendedKey, length, copyBytes);
+            length += copyBytes;
+        }
+
+        return extendedKey;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Returns a string that represents this object.
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString()
+    {
+        return "3DES privacy provider";
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetTripleDESPrivacyProvider.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetTripleDESPrivacyProvider.cs
@@ -33,7 +33,6 @@ namespace Raven.Server.Monitoring.Snmp.Providers;
 /// <p>Ported from SNMP#NET Privacy3DES class.</p>
 /// <p>Originally defined in a draft https://datatracker.ietf.org/doc/html/draft-reeder-snmpv3-usm-3desede-00</p>
 /// </remarks>
-[Obsolete("3DES is no longer secure. Please use a more secure provider.")]
 public sealed class DotnetTripleDESPrivacyProvider : IPrivacyProvider
 {
 #if NET6_0_OR_GREATER
@@ -78,7 +77,7 @@ public sealed class DotnetTripleDESPrivacyProvider : IPrivacyProvider
     /// Engine IDs.
     /// </summary>
     /// <remarks>This is an optional field, and only used by TRAP v2 authentication.</remarks>
-    public ICollection<OctetString>? EngineIds { get; set; }
+    public ICollection<OctetString> EngineIds { get; set; }
 
     /// <summary>
     /// Encrypt scoped PDU using DES encryption protocol

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -23,6 +23,7 @@ using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Monitoring.Snmp.Objects.Cluster;
 using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.Monitoring.Snmp.Objects.Server;
+using Raven.Server.Monitoring.Snmp.Providers;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands.Monitoring.Snmp;
 using Raven.Server.ServerWide.Context;
@@ -279,12 +280,12 @@ namespace Raven.Server.Monitoring.Snmp
                             if (privacyPassword == null)
                                 throw new ArgumentNullException(nameof(privacyPassword));
 
-                            return new DESPrivacyProvider(new OctetString(privacyPassword), authenticationProvider);
+                            return new DotnetDESPrivacyProvider(new OctetString(privacyPassword), authenticationProvider);
                         case SnmpPrivacyProtocol.AES:
                             if (privacyPassword == null)
                                 throw new ArgumentNullException(nameof(privacyPassword));
 
-                            return new AESPrivacyProvider(new OctetString(privacyPassword), authenticationProvider);
+                            return new DotnetAESPrivacyProvider(new OctetString(privacyPassword), authenticationProvider);
                         default:
                             throw new InvalidOperationException($"Unknown privacy protocol '{privacyProtocol}'.");
                     }

--- a/test/SlowTests/Issues/RavenDB-25172.cs
+++ b/test/SlowTests/Issues/RavenDB-25172.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using FastTests;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Messaging;
+using Lextm.SharpSnmpLib.Security;
+using Raven.Server.Config;
+using Raven.Server.Monitoring.Snmp;
+using Raven.Server.Monitoring.Snmp.Providers;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25172 : RavenTestBase
+{
+    public RavenDB_25172(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public static IEnumerable<object[]> V3SecurityCombinations()
+    {
+        foreach (var authProtocol in (SnmpAuthenticationProtocol[])Enum.GetValues(typeof(SnmpAuthenticationProtocol)))
+        {
+            foreach (var privProtocol in (SnmpPrivacyProtocol[])Enum.GetValues(typeof(SnmpPrivacyProtocol)))
+            {
+                yield return new object[] { authProtocol, privProtocol };
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Monitoring)]
+    [MemberData(nameof(V3SecurityCombinations))]
+    public void CanGetSnmp_V3_WithAuthentication(SnmpAuthenticationProtocol authProtocol, SnmpPrivacyProtocol privProtocol)
+    {
+        var port = ReservePort().Port;
+        const string testAuthPass = "test-auth-pass";
+        const string testPrivPass = "test-priv-pass";
+        const string userName = "ravendb";
+
+        var customSettings = new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Enabled)] = "true",
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.SupportedVersions)] = "V3",
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Port)] = port.ToString(),
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.AuthenticationProtocol)] = authProtocol.ToString(),
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.AuthenticationPassword)] = testAuthPass,
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.PrivacyProtocol)] = privProtocol.ToString(),
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.PrivacyPassword)] = testPrivPass,
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.AuthenticationUser)] = userName,
+        };
+
+        UseNewLocalServer(customSettings);
+
+        // Bootstrap the cluster - needed for the snmp to be available.
+        using (GetDocumentStore(new Options { CreateDatabase = true }))
+        {
+        }
+
+        var ip = new Uri(Server.WebUrl).Host;
+        var endpoint = new IPEndPoint(IPAddress.Parse(ip), port);
+
+        ReportMessage report = null;
+        // Might take a while for the snmp to be available.
+        for (var i = 0; i < 15; i++)
+        {
+            try
+            {
+                var discovery = Messenger.GetNextDiscovery(SnmpType.GetRequestPdu);
+                report = discovery.GetResponse(500, endpoint);
+                if (report != null)
+                    break;
+            }
+            catch (Exception)
+            {
+                Thread.Sleep(125);
+            }
+        }
+
+        Assert.NotNull(report);
+
+        IAuthenticationProvider authProvider = authProtocol switch
+        {
+            SnmpAuthenticationProtocol.MD5 => new MD5AuthenticationProvider(new OctetString(testAuthPass)),
+            SnmpAuthenticationProtocol.SHA1 => new SHA1AuthenticationProvider(new OctetString(testAuthPass)),
+            _ => throw new ArgumentOutOfRangeException(nameof(authProtocol), authProtocol, null)
+        };
+
+        IPrivacyProvider privProvider = privProtocol switch
+        {
+            SnmpPrivacyProtocol.None => DefaultPrivacyProvider.DefaultPair,
+            SnmpPrivacyProtocol.DES => new DotnetDESPrivacyProvider(new OctetString(testPrivPass), authProvider),
+            SnmpPrivacyProtocol.AES => new DotnetAESPrivacyProvider(new OctetString(testPrivPass), authProvider),
+            _ => throw new ArgumentOutOfRangeException(nameof(privProtocol), privProtocol, null)
+        };
+
+        var request = new GetRequestMessage(VersionCode.V3, Messenger.NextMessageId, Messenger.NextRequestId,
+            new OctetString(userName),
+            [new Variable(new ObjectIdentifier("1.3.6.1.4.1.45751.1.1.1.1.5"))],
+            privProvider,
+            Messenger.MaxMessageSize,
+            report);
+
+        ISnmpMessage reply = request.GetResponse(500, endpoint);
+
+        Assert.NotNull(reply);
+        Assert.Equal(0, reply.Pdu().ErrorStatus.ToInt32());
+    }
+
+    [RavenFact(RavenTestCategory.Monitoring)]
+    public void CanGetSnmp_V2C()
+    {
+        var port = ReservePort().Port;
+        var communityString = "public-test";
+        var customSettings = new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Enabled)] = "true",
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.SupportedVersions)] = "V2C",
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Port)] = port.ToString(),
+            [RavenConfiguration.GetKey(x => x.Monitoring.Snmp.Community)] = communityString
+        };
+
+        UseNewLocalServer(customSettings);
+
+        using (GetDocumentStore(new Options { CreateDatabase = true }))
+        {
+        }
+
+        var ip = new Uri(Server.WebUrl).Host;
+        var endpoint = new IPEndPoint(IPAddress.Parse(ip), port);
+
+        // For v2c, there is no discovery. We just send the request directly.
+        for (var i = 0; i < 15; i++)
+        {
+            try
+            {
+                var result = Messenger.Get(VersionCode.V2,
+                    endpoint,
+                    new OctetString(communityString),
+                    [new Variable(new ObjectIdentifier("1.3.6.1.4.1.45751.1.1.1.1.5"))],
+                    100);
+
+                Assert.NotEmpty(result);
+            }
+            catch (Exception)
+            {
+                Thread.Sleep(500);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25172

### Additional description

We have package `Lextm.SharpSnmpLib.Engine` in version `11.3.102`. According to docs of this package for lib only:
`DES is natively supported on .NET Core 3.1 and above, but you need to upgrade to at least C# SNMP Library 12.4.0 release`
`AES is natively supported on .NET 5 and above, but you need to upgrade to at least C# SNMP Library 12.4.0 release.` 

Adding `Lextm.SharpSnmpLib` may introduce errors in the Snmp Engine so i copied the relevant PrivacyProviders classes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
