### PR TITLE
RavenDB-24806 : AI Agent Truncation should be based on tokens count

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentChatTrimmingConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentChatTrimmingConfiguration.cs
@@ -168,32 +168,32 @@ namespace Raven.Client.Documents.Operations.AI.Agents
     }
 
     /// <summary>
-    /// Configuration for truncating the AI chat history based on message count.
+    /// Configuration for truncating the AI chat history based on tokens count.
     /// </summary>
     /// <remarks>
-    /// When the number of chat messages exceeds the specified maximum, the oldest messages are removed
+    /// When the number of chat tokens exceeds the specified maximum, the oldest tokens are removed
     /// and optionally archived into a separate history section.
     /// </remarks>
     public class AiAgentTruncateChat
     {
-        private const int DefaultMessagesLengthBeforeTruncate = 500;
+        private const int DefaultMessagesTokensBeforeTruncate = 500;
 
         /// <summary>
-        /// Maximum number of messages allowed before delete the old messages
+        /// Maximum number of tokens allowed before delete the old messages
         /// </summary>
-        public int MessagesLengthBeforeTruncate { get; set; } = DefaultMessagesLengthBeforeTruncate;
+        public int MessagesTokensBeforeTruncate { get; set; } = DefaultMessagesTokensBeforeTruncate;
 
         /// <summary>
-        /// Number of messages after delete the old messages
+        /// Number of tokens after delete the old messages
         /// </summary>
-        public int MessagesLengthAfterTruncate { get; set; } = DefaultMessagesLengthBeforeTruncate / 2;
+        public int MessagesTokensAfterTruncate { get; set; } = DefaultMessagesTokensBeforeTruncate / 2;
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
-                [nameof(MessagesLengthBeforeTruncate)] = MessagesLengthBeforeTruncate,
-                [nameof(MessagesLengthAfterTruncate)] = MessagesLengthAfterTruncate
+                [nameof(MessagesTokensBeforeTruncate)] = MessagesTokensBeforeTruncate,
+                [nameof(MessagesTokensAfterTruncate)] = MessagesTokensAfterTruncate
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
@@ -42,7 +42,7 @@ public class AiUsage : IDynamicJsonValueConvertible
     {
         return new AiUsage
         {
-            PromptTokens = usage2.PromptTokens - usage1.PromptTokens,
+            PromptTokens = usage2.PromptTokens - usage1.TotalTokens,
             TotalTokens = usage2.TotalTokens - usage1.TotalTokens,
             CachedTokens = usage2.CachedTokens, // we don't want to subtract cached tokens, as they are only for the last response
             CompletionTokens = usage2.CompletionTokens, // we don't want to subtract completion tokens, as they are only for the last response

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -217,16 +217,59 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
         if (reduction.Truncate != null)
         {
-            if (_document.Messages.Count > reduction.Truncate.MessagesLengthBeforeTruncate)
+            if (aiUsage.TotalTokens > reduction.Truncate.MessagesTokensBeforeTruncate)
             {
-                var truncateCount = _document.Messages.Count - reduction.Truncate.MessagesLengthAfterTruncate;
-                truncateCount = int.Min(truncateCount, _document.Messages.Count - 1); // prevent System.ArgumentException (out of bounds)
-                if (truncateCount > 0)
+                int truncateCount = 0;
+                int newTotalTokensCount = aiUsage.TotalTokens;
+                int newPromptTokensCount = aiUsage.PromptTokens;
+
+                int lastRemovableIndex = 0;
+                int messagesSinceLastUsage = 0;
+
+                var messages = _document.Messages;
+                int lastIndex = messages.Count - 1;
+                for (int i = 1; i < messages.Count; i++)
                 {
-                    var chatBefore = reduction.History == null ? null : _document.ToHistoryBlittable(context, _configuration, historyExpiration);
-                    _document.Messages.RemoveRange(1, truncateCount);
-                    return chatBefore;
+                    bool nextMessageIsUser = i < lastIndex && messages[i + 1].TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string role) && role == "user";
+
+                    if (newTotalTokensCount <= reduction.Truncate.MessagesTokensAfterTruncate && nextMessageIsUser)
+                        break;
+
+                    truncateCount++;
+
+                    var msg = messages[i];
+                    if (msg.TryGet("usage", out BlittableJsonReaderObject usageJson) == false)
+                    {
+                        continue;
+                    }
+
+
+
+                    if (i < lastIndex && nextMessageIsUser)
+                        lastRemovableIndex = i;
+
+                    if (usageJson.TryGet(nameof(aiUsage.TotalTokens), out int removedMessageTotalTokens))
+                    {
+                        newTotalTokensCount -= removedMessageTotalTokens;
+                        newPromptTokensCount -= removedMessageTotalTokens;
+                    }
                 }
+
+                int maxRemovable = lastRemovableIndex;
+
+                truncateCount = Math.Min(truncateCount, maxRemovable); // prevent out-of-bounds
+
+                if (truncateCount <= 0) 
+                    return null;
+                var chatBefore = reduction.History == null
+                    ? null
+                    : _document.ToHistoryBlittable(context, _configuration, historyExpiration);
+
+                _document.Messages.RemoveRange(1, truncateCount);
+                aiUsage.TotalTokens = newTotalTokensCount;
+                aiUsage.PromptTokens = newPromptTokensCount;
+
+                return chatBefore;
             }
         }
         else if (reduction.Tokens != null)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -224,7 +224,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 int newPromptTokensCount = aiUsage.PromptTokens;
 
                 int lastRemovableIndex = 0;
-                int messagesSinceLastUsage = 0;
 
                 var messages = _document.Messages;
                 int lastIndex = messages.Count - 1;
@@ -243,16 +242,14 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                         continue;
                     }
 
-
-
                     if (i < lastIndex && nextMessageIsUser)
                         lastRemovableIndex = i;
 
-                    if (usageJson.TryGet(nameof(aiUsage.TotalTokens), out int removedMessageTotalTokens))
-                    {
-                        newTotalTokensCount -= removedMessageTotalTokens;
-                        newPromptTokensCount -= removedMessageTotalTokens;
-                    }
+                    if (!usageJson.TryGet(nameof(aiUsage.TotalTokens), out int removedMessageTotalTokens)) 
+                        continue;
+
+                    newTotalTokensCount -= removedMessageTotalTokens;
+                    newPromptTokensCount -= removedMessageTotalTokens;
                 }
 
                 int maxRemovable = lastRemovableIndex;

--- a/src/Raven.Server/ServerWide/Commands/AI/AddOrUpdateAiAgentCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/AI/AddOrUpdateAiAgentCommand.cs
@@ -111,19 +111,19 @@ namespace Raven.Server.ServerWide.Commands.AI
 
                 if (reduction.Truncate != null)
                 {
-                    var after = reduction.Truncate.MessagesLengthAfterTruncate;
-                    var before = reduction.Truncate.MessagesLengthBeforeTruncate;
+                    var after = reduction.Truncate.MessagesTokensAfterTruncate;
+                    var before = reduction.Truncate.MessagesTokensBeforeTruncate;
                     if (after > before)
                         throw new InvalidOperationException(
-                            $"{nameof(reduction.Truncate.MessagesLengthAfterTruncate)} ({after}) must be less of equal then {nameof(reduction.Truncate.MessagesLengthBeforeTruncate)} ({before})");
+                            $"{nameof(reduction.Truncate.MessagesTokensAfterTruncate)} ({after}) must be less of equal then {nameof(reduction.Truncate.MessagesTokensBeforeTruncate)} ({before})");
 
                     if (after <= 0)
                         throw new InvalidOperationException(
-                            $"{nameof(reduction.Truncate.MessagesLengthAfterTruncate)} ({after}) must be greater then 0");
+                            $"{nameof(reduction.Truncate.MessagesTokensAfterTruncate)} ({after}) must be greater then 0");
 
                     if (before <= 0)
                         throw new InvalidOperationException(
-                            $"{nameof(reduction.Truncate.MessagesLengthBeforeTruncate)} ({before}) must be greater then 0");
+                            $"{nameof(reduction.Truncate.MessagesTokensBeforeTruncate)} ({before}) must be greater then 0");
                 }
 
                 if (reduction.Tokens != null)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -53,8 +53,8 @@ public class RavenDB_24407 : RavenTestBase
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true], Skip = "RavenDB-24806")]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false], Skip = "RavenDB-24806")]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false])]
     public async Task CanResumeConversationWithSummarization(Options options, GenAiConfiguration config, bool summarization, bool withHistory)
     {
         using var store = GetDocumentStore(options);
@@ -126,8 +126,8 @@ public class RavenDB_24407 : RavenTestBase
             {
                 Truncate = new AiAgentTruncateChat()
                 {
-                    MessagesLengthBeforeTruncate = 2,
-                    MessagesLengthAfterTruncate = 2
+                    MessagesTokensBeforeTruncate = 1,
+                    MessagesTokensAfterTruncate = 1
                 }
             };
         }
@@ -144,7 +144,7 @@ public class RavenDB_24407 : RavenTestBase
         Assert.NotNull(r.Answer);
 
         chatDoc = await GetChat(store, chat.Id);
-        Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
+        Assert.Equal(summarization ? 3 : 5, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
 
         if (withHistory)
@@ -169,7 +169,7 @@ public class RavenDB_24407 : RavenTestBase
         Assert.NotNull(r.Answer);
 
         chatDoc = await GetChat(store, chat.Id);
-        Assert.Equal(summarization ? 3 : 2, chatDoc.Messages.Count);
+        Assert.Equal(summarization ? 3 : 5, chatDoc.Messages.Count);
         Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
 
         // resume
@@ -218,8 +218,8 @@ public class RavenDB_24407 : RavenTestBase
             {
                 Truncate = new AiAgentTruncateChat()
                 {
-                    MessagesLengthBeforeTruncate = 2,
-                    MessagesLengthAfterTruncate = 2
+                    MessagesTokensBeforeTruncate = 1,
+                    MessagesTokensAfterTruncate = 1
                 }
             };
         }
@@ -268,21 +268,24 @@ public class RavenDB_24407 : RavenTestBase
 
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
+
         // can be answer *OR* another tool call
         chatDoc = await GetChat(store, chat.Id);
+
         if (r.Status == AiConversationResult.ActionRequired)
         {
             // if it is 'Tool Requests' is shouldn't be summarized
-            Assert.True(2 < chatDoc.Messages.Count);
+            Assert.True((summarization? 2 : 5) < chatDoc.Messages.Count);
             Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
             Assert.Equal(0, chatDoc.LinkedConversations.Count);
         }
         else
         {
             // if it is 'Answer' is should be summarized
-            Assert.Equal(2, chatDoc.Messages.Count);
+            Assert.Equal((summarization ? 2 : 5), chatDoc.Messages.Count);
             Assert.Equal(systemPrompt, chatDoc.Messages[0].Content);
-            Assert.Equal(withHistory ? 1 : 0, chatDoc.LinkedConversations.Count);
+
+            Assert.Equal(withHistory ? (summarization ? 1 : 0) : 0, chatDoc.LinkedConversations.Count);
         }
     }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24806.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24806.cs
@@ -1,0 +1,73 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_24806 : RavenTestBase
+    {
+        public RavenDB_24806(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task Test(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var trimmingConfig = new AiAgentChatTrimmingConfiguration
+            {
+                Truncate = new AiAgentTruncateChat()
+                {
+                    MessagesTokensBeforeTruncate = 500,
+                    MessagesTokensAfterTruncate = 300
+                }
+            };
+
+            var agentConfig = new AiAgentConfiguration("truncation-tester", config.ConnectionStringName, "You are a simple echo bot. Repeat the user's message exactly as it was given to you.")
+            {
+                ChatTrimming = trimmingConfig,
+                SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+            };
+            var agent = await store.AI.CreateAgentAsync(agentConfig);
+
+            var conversation = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions());
+
+            var longPrompt = "This is a reasonably long user prompt designed to generate a response that consumes a good number of tokens to properly test the truncation feature.";
+
+            for (int i = 0; i < 10; i++)
+            {
+                conversation.SetUserPrompt($"{longPrompt} - Message number {i + 1}");
+                await conversation.RunAsync<object>();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var convoDoc = await session.LoadAsync<BlittableJsonReaderObject>(conversation.Id);
+
+                convoDoc.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages);
+                Assert.NotNull(messages);
+
+                Assert.True(messages.Length < 21, $"Expected fewer than 21 messages after truncation, but found {messages.Length}. This indicates truncation did not occur.");
+
+                convoDoc.TryGet(nameof(ConversationDocument.CurrentUsage), out BlittableJsonReaderObject usageJson);
+                Assert.NotNull(usageJson);
+
+                usageJson.TryGet(nameof(AiUsage.TotalTokens), out long finalTokenCount);
+
+                Assert.True(finalTokenCount < 500, $"Final token count ({finalTokenCount}) should be less than the trigger limit (500).");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24806/AI-Agent-Truncation-should-be-based-on-tokens-count

### Additional description

Updated the truncation logic to be based on token count instead of message count.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
