### PR TITLE
RavenDB-25180 : flaky tests adjustments 

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -20,7 +20,6 @@ using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Platform;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
-using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,7 +29,7 @@ namespace SlowTests.Server.Documents.ETL.Olap
     {
         internal const string DefaultFrequency = "* * * * *"; // every minute
         internal const string AllFilesPattern = "*.*";
-        private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(65);
+        private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(70);
 
         public LocalTests(ITestOutputHelper output) : base(output)
         {
@@ -1905,22 +1904,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 Assert.Contains("year=2023", files[3]);
                 Assert.Contains("year=2024", files[4]);
 
-                // update 
-
-                const string documentIdColumn = "order_id";
-
-                configuration.OlapTables = new List<OlapEtlTable>
-                {
-                    new OlapEtlTable
-                    {
-                        TableName = "Orders",
-                        DocumentIdColumn = documentIdColumn
-                    }
-                };
-
-                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
-
                 // add more data
+                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -1942,8 +1927,20 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     await session.SaveChangesAsync();
                 }
 
-                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
+                // update
+                const string documentIdColumn = "order_id";
+                configuration.OlapTables = new List<OlapEtlTable>
+                {
+                    new OlapEtlTable
+                    {
+                        TableName = "Orders",
+                        DocumentIdColumn = documentIdColumn
+                    }
+                };
 
+                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+
+                // assert that batch completed successfully and that we got new files with new name of the document id column
                 r = await etlDone.WaitAsync(_defaultTimeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
@@ -2062,12 +2059,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 Assert.Contains("year=2023", files[3]);
                 Assert.Contains("year=2024", files[4]);
 
-                // update 
-
-                configuration.RunFrequency = DefaultFrequency; // every minute
-                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
-
                 // add more data
+                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -2089,8 +2082,10 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     await session.SaveChangesAsync();
                 }
 
-                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
-                
+                // update 
+                configuration.RunFrequency = DefaultFrequency; // every minute
+                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+
                 r = await etlDone.WaitAsync(timeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
 
@@ -2192,12 +2187,8 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                     Assert.Contains(customPartition, file);
                 }
 
-                // update 
-                const string newCustomPartition = "shop35";
-                configuration.CustomPartitionValue = newCustomPartition;
-                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
-
                 // add more data
+                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -2219,6 +2210,13 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                     await session.SaveChangesAsync();
                 }
 
+                // update
+                const string newCustomPartition = "shop35";
+                configuration.CustomPartitionValue = newCustomPartition;
+
+                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+
+                // assert that batch completed successfully with the new partition value
                 r = await etlDone.WaitAsync(_defaultTimeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-25178/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateCustomPartitionValuedatabaseMode-Sharded

- https://issues.hibernatingrhinos.com/issue/RavenDB-25180/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateRunFrequencydatabaseMode-Sharded

- https://issues.hibernatingrhinos.com/issue/RavenDB-25181/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateDocIdColumnNamedatabaseMode-Sharded

### Additional description

Minor adjustments to flaky OLAP tests: 
 - Set up the MRE _before_ adding more data (to avoid waiting for ETL when it's between cycles)
 - Add a missing MRE reset in between batches (`CanUpdateCustomPartitionValue`)
 - Slightly increase `WaitForEtl` timeout to provide a larger margin between the `RunFrequency` interval and the ETL timeout.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
