### PR TITLE
RavenDB-25204 Save RSA key in PKCS#1 format

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -57,7 +57,7 @@ public sealed class LetsEncryptCertificateUtil
         string keyPem;
         var privateKey = cert.GetExportableRsaPrivateKey();
         if (privateKey != null)
-            keyPem = privateKey.ExportPkcs8PrivateKeyPem();
+            keyPem = privateKey.ExportRSAPrivateKeyPem();
         else
             throw new CryptographicException("No RSA private key found");
         

--- a/test/SlowTests/Issues/RavenDB-24495.cs
+++ b/test/SlowTests/Issues/RavenDB-24495.cs
@@ -74,10 +74,13 @@ public class RavenDB_24495 : ClusterTestBase
         var bcResult = ms2.ToArray();
 
         string dnExtractedCert = PemUtils.NormalizePemContent(await ExtractFileFromZipAsync(dnResult, $"{certName}.crt"));
-        string bcextractedCert = PemUtils.NormalizePemContent(await ExtractFileFromZipAsync(bcResult, $"{certName}.crt"));
+        string bcExtractedCert = PemUtils.NormalizePemContent(await ExtractFileFromZipAsync(bcResult, $"{certName}.crt"));
+        
+        string dnExtractedKey = PemUtils.NormalizePemContent(await ExtractFileFromZipAsync(dnResult, $"{certName}.key"));
+        string bcExtractedKey = PemUtils.NormalizePemContent(await ExtractFileFromZipAsync(bcResult, $"{certName}.key"));
 
-        // Checking only cert here because the private key is saved in PKCS8 now while in BouncyCastle it is saved in PKCS1
-        Assert.Equal(bcextractedCert, dnExtractedCert);
+        Assert.Equal(bcExtractedCert, dnExtractedCert);
+        Assert.Equal(bcExtractedKey, dnExtractedKey);
     }
 
     [RavenFact(RavenTestCategory.Certificates)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25204 

### Additional description

Saving RSA key in PKCS#8 was a breaking change, we should stick to PKCS#1.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
