### PR TITLE
RavenDB-25169 Fix Cluster Debug for Blue theme

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/ClusterDebug.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/ClusterDebug.tsx
@@ -45,7 +45,7 @@ export default function ClusterDebug() {
 
     return (
         <div className="flex-window padding-xs">
-            <div id="cluster-debug" className="bs5">
+            <div id="cluster-debug" className="bs5 cluster-debug">
                 <div className="flex-shrink-0 hstack gap-2 align-items-start">
                     <AboutViewHeading title="Cluster Debug" icon="cluster-debug" />
                     <FlexGrow />

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugEntries.scss
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugEntries.scss
@@ -9,12 +9,12 @@
         .nav-link {
             border: 0;
             cursor: pointer;
-            color: colors.$base-text-muted-color;
+            color: colors.$text-muted-var;
 
             &.active {
                 background: transparent;
                 border-bottom: 2px solid colors.$node-var;
-                color: colors.$base-text-emphasis-color;
+                color: colors.$text-emphasis-var;
             }
 
             &:hover {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.scss
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.scss
@@ -2,11 +2,14 @@
 @use "Content/scss/colors";
 
 table.cluster-debug-summary {
+    --bs-table-bg: var(--panel-bg-1) !important;
+
     thead {
         th {
             background-color: colors.$panel-header-bg-var !important;
         }
     }
+
     td,
     th {
         min-width: 250px;

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.tsx
@@ -91,7 +91,7 @@ export default function ClusterDebugSummary(props: ClusterDebugSummaryProps) {
 
     return (
         <React.Fragment key="summary">
-            <Table variant="dark" bordered responsive className="mb-1 rounded-1 overflow-hidden cluster-debug-summary">
+            <Table bordered responsive className="mb-1 rounded-1 overflow-hidden cluster-debug-summary">
                 <thead>
                     <tr>
                         <th></th>

--- a/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedParent.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedParent.html
@@ -7,7 +7,7 @@
         </ul>
     </div>
 
-    <div class="panel" data-bind="css: { 'flex-grow': growContainer }">
+    <div data-bind="css: { 'flex-grow': growContainer }">
         <div data-bind="router: { cacheViews: false }">
         </div>
     </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25169

### Additional description

Fixed styles for Cluster Debug on Blue theme

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
