### PR TITLE
RavenDB-24984 : repeated tool usage should be limited to MaxModelIteationsPerCall

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -32,11 +32,11 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         AiAgentHelpers.AddDefaultValues(body.Configuration, RequestHandler.Configuration.Ai);
         AddOrUpdateAiAgentCommand.ValidateConfiguration(context, body.Configuration);
 
-        var handler = new TestConversationHandler(ServerStore, RequestHandler.Database, body.Document);
+        var handler = new TestConversationHandler(ServerStore, RequestHandler.Database, body);
         await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, token: token);
     }
 
-    public class TestConversationHandler(ServerStore server, DocumentDatabase database, BlittableJsonReaderObject document) : ConversationHandler(server, database)
+    public class TestConversationHandler(ServerStore server, DocumentDatabase database, AiAgentTestRequest request) : ConversationHandler(server, database)
     {
         protected override Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
         {
@@ -53,13 +53,13 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
 
         protected override async Task InitializeDocument(DocumentsOperationContext context)
         {
-            if (document == null)
+            if (request.Document == null)
             {
                 await base.InitializeDocument(context);
                 return;
             }
 
-            _document = ConversationDocument.ToDocument("TestConversation", document);
+            _document = ConversationDocument.ToDocument("TestConversation", request.Document, request.Configuration);
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -32,7 +32,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public DateTime CreatedAt = DateTime.UtcNow;
     public TimeSpan? Expires;
 
-    internal int NumberOfRepeatedToolCalls;
+    public int RemainingToolIterations;
 
     public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration)
     {
@@ -65,6 +65,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
                 [ChatCompletionClient.Constants.RequestFields.Content] = ParametersToString(configuration)
             }, "system/msg"), usage: null);
         }
+
+        RemainingToolIterations = configuration.MaxModelIterationsPerCall ?? ConversationHandler.DefaultMaxModelIterationsPerCall;
     }
 
     public List<AiToolCall> InitialQueries(JsonOperationContext context, AiAgentConfiguration configuration)
@@ -189,7 +191,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [nameof(CreatedAt)] = CreatedAt,
             [nameof(Expires)] = Expires,
             [nameof(CurrentUsage)] = CurrentUsage,
-            [nameof(NumberOfRepeatedToolCalls)] = NumberOfRepeatedToolCalls
+            [nameof(RemainingToolIterations)] = RemainingToolIterations
         };
     }
 
@@ -207,7 +209,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         LastMessageAt = currentDate;
     }
 
-    public static ConversationDocument ToDocument(string id, BlittableJsonReaderObject document)
+    public static ConversationDocument ToDocument(string id, BlittableJsonReaderObject document, AiAgentConfiguration config)
     {
         if (document.TryGet(nameof(Agent), out string agent) == false)
             throw new ArgumentException($"Missing Agent in '{id}' conversation document");
@@ -227,8 +229,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             throw new ArgumentException($"Missing CreatedAt in '{id}' conversation document");
         if (document.TryGet(nameof(Expires), out TimeSpan? expires) == false)
             throw new ArgumentException($"Missing Expires in '{id}' conversation document");
-        if (document.TryGet(nameof(NumberOfRepeatedToolCalls), out int numOfRepeatedToolCalls) == false)
-            throw new ArgumentException($"Missing NumberOfRepeatedToolCalls in '{id}' conversation document");
+        if (document.TryGet(nameof(RemainingToolIterations), out int remainingToolIterations) == false)
+            remainingToolIterations = config.MaxModelIterationsPerCall ?? ConversationHandler.DefaultMaxModelIterationsPerCall;
 
         var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
@@ -247,7 +249,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             LastMessageAt = lastMessageAt,
             CreatedAt = createAt,
             Expires = expires,
-            NumberOfRepeatedToolCalls = numOfRepeatedToolCalls
+            RemainingToolIterations = remainingToolIterations
         };
 
         if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsageBlittable))

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client;
 using Raven.Client.Documents.Operations.AI;
@@ -10,7 +9,6 @@ using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.NotificationCenter.Notifications.Details;
-using Raven.Server.Web.Studio;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
@@ -33,6 +31,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public DateTime LastMessageAt;
     public DateTime CreatedAt = DateTime.UtcNow;
     public TimeSpan? Expires;
+
+    internal int NumberOfRepeatedToolCalls;
 
     public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration)
     {
@@ -188,7 +188,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [nameof(LastMessageAt)] = LastMessageAt,
             [nameof(CreatedAt)] = CreatedAt,
             [nameof(Expires)] = Expires,
-            [nameof(CurrentUsage)] = CurrentUsage
+            [nameof(CurrentUsage)] = CurrentUsage,
+            [nameof(NumberOfRepeatedToolCalls)] = NumberOfRepeatedToolCalls
         };
     }
 
@@ -226,6 +227,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             throw new ArgumentException($"Missing CreatedAt in '{id}' conversation document");
         if (document.TryGet(nameof(Expires), out TimeSpan? expires) == false)
             throw new ArgumentException($"Missing Expires in '{id}' conversation document");
+        if (document.TryGet(nameof(NumberOfRepeatedToolCalls), out int numOfRepeatedToolCalls) == false)
+            throw new ArgumentException($"Missing NumberOfRepeatedToolCalls in '{id}' conversation document");
 
         var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
@@ -244,12 +247,13 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             LastMessageAt = lastMessageAt,
             CreatedAt = createAt,
             Expires = expires,
+            NumberOfRepeatedToolCalls = numOfRepeatedToolCalls
         };
 
         if (document.TryGet(nameof(CurrentUsage), out BlittableJsonReaderObject currentUsageBlittable))
         {
             conversation.CurrentUsage = JsonDeserializationClient.AiUsage(currentUsageBlittable);
-    }
+        }
         return conversation;
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -181,12 +181,17 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
             if (r.Type is AiResponseType.Result)
             {
+                _document.NumberOfRepeatedToolCalls = 0;
                 shouldContinueConversation = false;
             }
             else
             {
                 await HandleQueryToolCallsAsync(context, r.ToolCalls);
-                shouldContinueConversation = TryGetUserTools(context, r.ToolCalls) == false;
+                if (TryGetUserTools(context, r.ToolCalls))
+                {
+                    _document.NumberOfRepeatedToolCalls++;
+                    shouldContinueConversation = false;
+                }
             }
 
             _document.CurrentUsage = talker.AiUsage;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -29,14 +29,17 @@ namespace Raven.Server.Documents.Handlers.AI.Agents;
 
 internal class ConversationHandler(ServerStore server, DocumentDatabase database)
 {
+    public const int DefaultMaxModelIterationsPerCall = 16;
     private const int DefaultMaxTokensBeforeSummarization = 32 * 1024;
     private const int DefaultMaxTokensAfterSummarization = 1024;
+
     protected ConversationDocument _document;
     private string _conversationId;
     private RequestBody _request;
     private AiAgentConfiguration _configuration;
     private string _changeVector;
     private string _raftId;
+    private int _maxModelIterationsPerCall;
 
     public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null)
     {
@@ -45,6 +48,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         _configuration = configuration;
         _changeVector = changeVector;
         _raftId = raftId;
+        _maxModelIterationsPerCall = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
     }
 
     protected virtual async Task InitializeDocument(DocumentsOperationContext context)
@@ -88,7 +92,8 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         }
         else
         {
-            _document = ConversationDocument.ToDocument(_conversationId, conversation.Data);
+            _document = ConversationDocument.ToDocument(_conversationId, conversation.Data, _configuration);
+
             if (_document.Agent != agentId)
             {
                 throw new InvalidOperationException(
@@ -181,7 +186,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
             if (r.Type is AiResponseType.Result)
             {
-                _document.NumberOfRepeatedToolCalls = 0;
+                _document.RemainingToolIterations = _maxModelIterationsPerCall;
                 shouldContinueConversation = false;
             }
             else
@@ -189,7 +194,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 await HandleQueryToolCallsAsync(context, r.ToolCalls);
                 if (TryGetUserTools(context, r.ToolCalls))
                 {
-                    _document.NumberOfRepeatedToolCalls++;
                     shouldContinueConversation = false;
                 }
             }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
@@ -15,9 +15,10 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
 {
     private const int DefaultMaxModelIterationsPerCall = 16;
 
+    private int _maxModelIterationsPerCall;
     private string _schema;
     private List<BlittableJsonReaderObject> _tools;
-    private int _count;
+    private int _remainingToolIterations;
 
     public AiUsage AiUsage;
     public ChatCompletionClient Client;
@@ -28,7 +29,9 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
 
         _schema = ChatCompletionClient.GetSchemaForRequest(configuration.OutputSchema, configuration.SampleObject);
         _tools = ConversationDocument.GenerateTools(context, configuration);
-        _count = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+        
+        _maxModelIterationsPerCall = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+        _remainingToolIterations = _maxModelIterationsPerCall - document.NumberOfRepeatedToolCalls;
 
         Client = handler.CreateClient();
     }
@@ -36,7 +39,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
     public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments)
     {
         AiUsage = new();
-        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: _count-- > 0, streaming != null, _schema);
+        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: _remainingToolIterations-- > 0, streaming != null, _schema);
     }
 
     public async Task<AiResponse> RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, CancellationToken token)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
@@ -13,12 +13,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents;
 
 internal class Talker(ConversationHandler handler, JsonOperationContext context, AiAgentConfiguration configuration, ConversationDocument document, string firstStreamPropertyPath, Func<Memory<byte>, Task> streaming) : IDisposable
 {
-    private const int DefaultMaxModelIterationsPerCall = 16;
-
-    private int _maxModelIterationsPerCall;
     private string _schema;
     private List<BlittableJsonReaderObject> _tools;
-    private int _remainingToolIterations;
 
     public AiUsage AiUsage;
     public ChatCompletionClient Client;
@@ -29,9 +25,6 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
 
         _schema = ChatCompletionClient.GetSchemaForRequest(configuration.OutputSchema, configuration.SampleObject);
         _tools = ConversationDocument.GenerateTools(context, configuration);
-        
-        _maxModelIterationsPerCall = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
-        _remainingToolIterations = _maxModelIterationsPerCall - document.NumberOfRepeatedToolCalls;
 
         Client = handler.CreateClient();
     }
@@ -39,7 +32,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
     public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments)
     {
         AiUsage = new();
-        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: _remainingToolIterations-- > 0, streaming != null, _schema);
+        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: document.RemainingToolIterations-- > 0, streaming != null, _schema);
     }
 
     public async Task<AiResponse> RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, CancellationToken token)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.AI;
@@ -31,21 +32,20 @@ public class RavenDB_24984 : RavenTestBase
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-        const string systemPrompt = "your whole purpose is to run the tool called 'MyTool'";
-        var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, systemPrompt);
-        agent.Identifier = "shopping-assistant";
-
-        agent.Actions =
-        [
-            new AiAgentToolAction
+        var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, "your whole purpose is to run the tool called 'MyTool'")
+        {
+            Identifier = "shopping-assistant",
+            Actions =
+            [
+                new AiAgentToolAction
                 {
                     Name = "MyTool",
                     Description =  "returns an integer",
                     ParametersSampleObject = "{}"
                 }
-        ];
-
-        agent.MaxModelIterationsPerCall = maxModelIterationsPerCall;
+            ],
+            MaxModelIterationsPerCall = maxModelIterationsPerCall
+        };
 
         await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance);
         var chat = store.AI.Conversation(
@@ -58,7 +58,8 @@ public class RavenDB_24984 : RavenTestBase
 
         chat.SetUserPrompt("call the 'MyTool' tool until it returns the string '10' (or greater)");
 
-        var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(cts.Token);
 
         Assert.Equal(AiConversationResult.Done, result.Status);
 
@@ -69,8 +70,8 @@ public class RavenDB_24984 : RavenTestBase
         using (var session = store.OpenSession())
         {
             var conversationDoc = session.Load<BlittableJsonReaderObject>(chat.Id);
-            Assert.True(conversationDoc.TryGet(nameof(ConversationDocument.NumberOfRepeatedToolCalls), out int numOfRepeatedToolCalls));
-            Assert.Equal(0, numOfRepeatedToolCalls); // should be reset after successful completion
+            Assert.True(conversationDoc.TryGet(nameof(ConversationDocument.RemainingToolIterations), out int remainingToolIterations));
+            Assert.Equal(maxModelIterationsPerCall, remainingToolIterations); // should be reset after successful completion
         }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
@@ -1,0 +1,76 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class RavenDB_24984 : RavenTestBase
+{
+    public RavenDB_24984(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task ShouldStopUsingToolsWhenMaxModelIterationsPerCallIsReached(Options options, GenAiConfiguration config)
+    {
+        const int maxModelIterationsPerCall = 5;
+
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        const string systemPrompt = "your whole purpose is to run the tool called 'MyTool'";
+        var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, systemPrompt);
+        agent.Identifier = "shopping-assistant";
+
+        agent.Actions =
+        [
+            new AiAgentToolAction
+                {
+                    Name = "MyTool",
+                    Description =  "returns an integer",
+                    ParametersSampleObject = "{}"
+                }
+        ];
+
+        agent.MaxModelIterationsPerCall = maxModelIterationsPerCall;
+
+        await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance);
+        var chat = store.AI.Conversation(
+            agent.Identifier,
+            "chats/",
+            creationOptions: null);
+
+        int lastNumber = 1;
+        chat.Handle<object>("MyTool", _ => lastNumber++.ToString());
+
+        chat.SetUserPrompt("call the 'MyTool' tool until it returns the string '10' (or greater)");
+
+        var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+
+        Assert.Equal(AiConversationResult.Done, result.Status);
+
+        var lastToolResult = lastNumber - 1;
+        Assert.Equal(lastToolResult.ToString(), result.Answer.Answer);
+        Assert.Equal(maxModelIterationsPerCall, lastToolResult);
+
+        using (var session = store.OpenSession())
+        {
+            var conversationDoc = session.Load<BlittableJsonReaderObject>(chat.Id);
+            Assert.True(conversationDoc.TryGet(nameof(ConversationDocument.NumberOfRepeatedToolCalls), out int numOfRepeatedToolCalls));
+            Assert.Equal(0, numOfRepeatedToolCalls); // should be reset after successful completion
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24984/Uncontrolled-Tool-Call-Iterations-and-the-Need-for-a-Limit

### Additional description

- Introduce `NumberOfRepeatedToolCalls` field to `ConversationDocument` to track the number of repeated action tool calls (repeated query tool calls were already handled by a separate counter)
- Use this filed in `Talker.cs` to decide if we can use tools when creating the completion request (should stop using tools when we reach the `MaxModelIteationsPerCall`)
- Reset this field back to 0 when we get a final answer from the LLM

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
