### PR TITLE
RavenDB-24972 : Expose query tools for GenAI

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ETL;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -31,6 +32,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
     public int MaxConcurrency { get; set; } = DefaultMaxConcurrency;
 
+    public List<AiAgentToolQuery> Queries { get; set; } = [];
 
     private List<Transformation> _transforms;
 
@@ -117,6 +119,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(UpdateScript)] = UpdateScript;
         json[nameof(GenAiTransformation)] = GenAiTransformation.ToJson();
         json[nameof(MaxConcurrency)] = MaxConcurrency;
+        json[nameof(MaxConcurrency)] = MaxConcurrency;
+        json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
 
         return json;
     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.AI;
@@ -28,7 +27,6 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Sparrow.Server.Json.Sync;
 using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
 
@@ -176,6 +174,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
     {
         OutputSchema = Configuration.JsonSchema,
         SampleObject = Configuration.SampleObject,
+        Queries = Configuration.Queries
     };
 
     private List<Exception> SendToModel(List<GenAiResultItem> items, DocumentsOperationContext context, GenAiStatsScope scope)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -34,7 +34,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
     public int RemainingToolIterations;
 
-    public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration)
+    public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, bool resetRemainingToolIterations = true)
     {
         if (Messages.Count > 0)
             throw new InvalidOperationException("conversation document is already initialized. Cannot re-initialize.");
@@ -65,6 +65,9 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
                 [ChatCompletionClient.Constants.RequestFields.Content] = ParametersToString(configuration)
             }, "system/msg"), usage: null);
         }
+
+        if (resetRemainingToolIterations == false)
+            return;
 
         RemainingToolIterations = configuration.MaxModelIterationsPerCall ?? ConversationHandler.DefaultMaxModelIterationsPerCall;
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -305,7 +305,8 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
         oldChat.Messages.Clear();
 
-        oldChat.Initialize(context, configuration);
+        oldChat.Initialize(context, configuration, resetRemainingToolIterations: false);
+
         oldChat.AddMessage(context,
             context.ReadObject(
                 new DynamicJsonValue

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.ts
@@ -86,6 +86,8 @@ const mapToDto = (
         GenAiTransformation: {
             Script: data.script,
         },
+        //temporary until UI supports queries
+        Queries: null,
     };
 };
 

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -350,6 +350,8 @@ export class TasksStubs {
                     Script: "for(const comment of this.Comments)\r\n{\r\n    ai.genContext({\r\n        Text: `Blog post topic: ${this.Topic}. Comment: ${comment.Text}`, \r\n        AuthorName: comment.Author,\r\n        CommentId: comment.Id\r\n    });\r\n}",
                 },
                 MaxConcurrency: 4,
+                // temporary until UI supports queries
+                Queries: null,
             },
             ChangeVector: null,
         };

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -85,6 +85,7 @@ public class RavenDB_24407 : RavenTestBase
                     ParametersSampleObject = "{}"
                 }
         ];
+        agent.MaxModelIterationsPerCall = 5;
 
         var identifier = (await store.AI.CreateAgentAsync<OutputSampleObject>(agent, OutputSampleObject.Instance)).Identifier;
         // start chat
@@ -134,8 +135,6 @@ public class RavenDB_24407 : RavenTestBase
         if (withHistory)
             agent.ChatTrimming.History = new();
         
-        agent.MaxModelIterationsPerCall = 5;
-
         await store.AI.CreateAgentAsync(agent, OutputSampleObject.Instance);
 
         chat.SetUserPrompt("can you give me a cheaper alternative?");

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -21,7 +21,6 @@ using SlowTests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
-using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24298.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24298.cs
@@ -9,7 +9,6 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Server.Documents.AI;
 using Sparrow.Json;
 using Tests.Infrastructure;
-using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24972.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24972.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDB_24972(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanUseQueryToolsInGenAiTask(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore();
+
+            await new ProductsByCategory().ExecuteAsync(store);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Name = "GenAi-With-QueryTool";
+            config.Identifier = "products-category-counter";
+            config.Collection = "Products";
+            config.Prompt = "Figure out if the provided products' category is popular or not. " +
+                            "'Popular' is if there are at least 3 Product records of this Category in the dataset. " +
+                            "If less than 3, then it isn't considered a popular category." +
+                            "Use provided tools.";
+
+            var sampleObject = JsonConvert.SerializeObject(new { IsPopular = true });
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(sampleObject);
+
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = "ai.genContext({ Category: this.Category });"
+            };
+
+            config.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "products-by-category",
+                    Description = "Return count of products filtered by category",
+                    Query = "from index 'ProductsByCategory' where Category = $category select Count",
+                    ParametersSampleObject = "{\"category\":\"Vegetables\"}",
+                }
+            ];
+
+            config.UpdateScript = "this.Popular = $output.IsPopular;";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            var etlDone = Etl.WaitForEtlToComplete(store);
+
+            using (var session = store.OpenSession())
+            {
+                // fruit 
+                session.Store(new Product
+                {
+                    Name = "apple",
+                    Category = "fruit"
+                });
+
+                // grains
+                session.Store(new Product
+                {
+                    Name = "rice",
+                    Category = "grains"
+                });
+                session.Store(new Product
+                {
+                    Name = "rye",
+                    Category = "grains"
+                });
+
+                // alcohol
+                session.Store(new Product
+                {
+                    Name = "beer",
+                    Category = "alcohol"
+                });
+                session.Store(new Product
+                {
+                    Name = "wine",
+                    Category = "alcohol"
+                });
+                session.Store(new Product
+                {
+                    Name = "gin",
+                    Category = "alcohol"
+                });
+                session.Store(new Product
+                {
+                    Name = "vodka",
+                    Category = "alcohol"
+                });
+
+
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+            using (var session = store.OpenSession())
+            {
+                var allProducts = session.Query<Product>().ToList();
+                Assert.Equal(7, allProducts.Count);
+
+                foreach (var p in allProducts)
+                {
+                    // only "alcohol" category is popular (4 products)
+                    Assert.Equal(p.Category == "alcohol", p.Popular);
+                }
+            }
+        }
+
+        private class Product
+        {
+            public string Name { get; set; }
+            public string Category { get; set; }
+            public bool Popular { get; set; }
+        }
+
+        private class ProductsByCategory : AbstractIndexCreationTask<Product, ProductsByCategory.Result>
+        {
+            public class Result
+            {
+                public string Category { get; set; }
+                public int Count { get; set; }
+            }
+
+            public ProductsByCategory()
+            {
+                Map = products => from p in products
+                    select new { p.Category, Count = 1 };
+
+                Reduce = results => from r in results
+                    group r by r.Category
+                    into g
+                    select new
+                    {
+                        Category = g.Key,
+                        Count = g.Sum(x => x.Count)
+                    };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24972/Define-query-tool-for-the-gen-ai

### Additional description

- Add `Queries` property to `GenAiConfiguration`
- Pass it over to the underlying `Agent` of the `GenAiTask`
- Add test case 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
