### PR TITLE
RavenDB-25151 Add GA events for theme

### DIFF
--- a/src/Raven.Studio/.storybook/storeDecorator.tsx
+++ b/src/Raven.Studio/.storybook/storeDecorator.tsx
@@ -56,4 +56,6 @@ function useTheme(theme: Theme) {
     themeLink.rel = "stylesheet";
     themeLink.href = stylesheetPrefix + fileName;
     document.head.insertBefore(themeLink, document.head.firstChild);
+
+    document.body.setAttribute("data-theme", theme);
 }

--- a/src/Raven.Studio/typescript/common/eventsCollector.ts
+++ b/src/Raven.Studio/typescript/common/eventsCollector.ts
@@ -130,6 +130,12 @@ class eventsCollector {
         });
     }
 
+    reportCustomEvent(eventName: string, parametersObject: Record<string, string | number | boolean>) {
+        this.report((gtagProxy: gtagFn) => {
+            gtagProxy('event', eventName, parametersObject);
+        });
+    }
+
     private report(action: (gtagProxy: gtagFn) => void) {
         if (!this.initialized) {
             this.preInitializationQueue.push(action);

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -675,6 +675,9 @@ class shell extends viewModelBase {
         studioSettings.default.registerOnSettingChangedHandler(
             name => name === "sendUsageStats",
             (name, track: simpleStudioSetting<boolean>) => eventsCollector.default.setEnabled(track.getValue()));
+        
+        const theme = document.body.getAttribute("data-theme");
+        eventsCollector.default.reportCustomEvent("theme_load", { theme });
     }
 
     static openFeedbackForm() {

--- a/src/Raven.Studio/typescript/viewmodels/shell/chooseTheme.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell/chooseTheme.ts
@@ -1,4 +1,5 @@
 import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import eventsCollector = require("common/eventsCollector");
 
 class chooseTheme extends dialogViewModelBase {
 
@@ -30,8 +31,14 @@ class chooseTheme extends dialogViewModelBase {
     }
     
     useTheme(theme: string) {
+        eventsCollector.default.reportCustomEvent("theme_change", {
+            previous_theme: this.currentTheme(),
+            new_theme: theme
+        });
+
         localStorage.setItem(chooseTheme.themeLocalStorageKey, theme);
         this.updateStylesheet(chooseTheme.themeToStylesheet[theme]);
+        document.body.setAttribute("data-theme", theme);
         this.close();
     }
     

--- a/src/Raven.Studio/wwwroot/index.html
+++ b/src/Raven.Studio/wwwroot/index.html
@@ -194,6 +194,10 @@
             
             head.appendChild(bs5link);
             head.appendChild(link);
+
+            document.addEventListener("DOMContentLoaded", function() {
+                document.body.setAttribute("data-theme", themeToUse);
+            });
         </script>
 
         <script type="text/javascript">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25151/Add-GA-event-for-theme

### Additional description

Add 2 GA events:
- "theme_change": { previous_theme: string; new_theme: string }
- "theme_load": { theme: string }

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
