### PR TITLE
RavenDB-25226 Temporarily use /p:RuntimeFrameworkVersion flag

### DIFF
--- a/scripts/buildProjects.ps1
+++ b/scripts/buildProjects.ps1
@@ -40,6 +40,8 @@ function BuildServer ( $srcDir, $outDir, $target) {
         $commandArgs += '/p:ContinuousIntegrationBuild=true'
     }
 
+    $commandArgs += '/p:RuntimeFrameworkVersion=10.0.0-rtm.25513.102'
+
     write-host -ForegroundColor Cyan "Publish server: $command $commandArgs"
     Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
@@ -199,6 +201,8 @@ function BuildTool ( $toolName, $srcDir, $outDir, $target, $trim ) {
     if ($env:RAVEN_IS_RUNNING_ON_CI){
         $commandArgs += '/p:ContinuousIntegrationBuild=true'
     }
+
+    $commandArgs += '/p:RuntimeFrameworkVersion=10.0.0-rtm.25513.102'
 
     write-host -ForegroundColor Cyan "Publish ${toolName}: $command $commandArgs"
     Invoke-Expression -Command "$command $commandArgs"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25226 

### Additional description

dotnet publish fails to run on RTM version of dotnet. We need to use flag `/p:RuntimeFrameworkVersion=10.0.0-rtm.25513.102` when publishing packages.

This change should be reverted once dotnet 10.0 stable is out.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
