### PR TITLE
RavenDB-25207 Allow to disable update of `LastWorkTime` in `LowLevelTransaction`.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -411,6 +411,7 @@ namespace Raven.Server.Documents.Indexes
             using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenWriteTransaction())
             {
+                tx.InnerTransaction.LowLevelTransaction.DisableLastWorkTimeUpdate();
                 var statsTree = tx.InnerTransaction.ReadTree(IndexSchema.StatsTree);
                 WriteElapsedSinceQueriedToStatsTree(context.Allocator, value, statsTree);
                 tx.Commit();

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -44,6 +44,7 @@ namespace Voron.Impl
         private readonly bool _disposeAllocator;
         internal long DecompressedBufferBytes;
         internal TestingStuff _forTestingPurposes;
+        private bool _updateLastWorkTime = true;
         
         public object ImmutableExternalState;
 
@@ -1123,7 +1124,11 @@ namespace Voron.Impl
 
             if (WriteToJournalIsRequired())
             {
-                Environment.LastWorkTime = DateTime.UtcNow;
+                if (_updateLastWorkTime)
+                {
+                    Environment.LastWorkTime = DateTime.UtcNow;
+                }
+                
                 CommitStage2_WriteToJournal();
             }
             
@@ -1244,7 +1249,10 @@ namespace Voron.Impl
             }
 
             if (AsyncCommit.Result)
-                Environment.LastWorkTime = DateTime.UtcNow;
+            {
+                if (_updateLastWorkTime)
+                    Environment.LastWorkTime = DateTime.UtcNow;
+            }
 
             BeforeCommitFinalization?.Invoke(this);
             CommitStage3_DisposeTransactionResources();
@@ -1470,6 +1478,15 @@ namespace Voron.Impl
             // the event cannot be called outside this class while we need to call it in 
             // StorageEnvironment.TransactionAfterCommit
             AfterCommitWhenNewTransactionsPrevented?.Invoke(this);
+        }
+
+        /// <summary>
+        /// This prevents updating last work time even if the transaction is committed. Useful for updating internal data which is not
+        /// part of work ordered by a user.
+        /// </summary>
+        public void DisableLastWorkTimeUpdate()
+        {
+            _updateLastWorkTime = false;
         }
 
 #if DEBUG

--- a/test/SlowTests/Issues/RavenDB-25207.cs
+++ b/test/SlowTests/Issues/RavenDB-25207.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25207 : StorageTest
+{
+    public RavenDB_25207(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CanDisableUpdatingLastWorkTimeInWriteTransaction()
+    {
+        var previousLastWorkTime = Env.LastWorkTime;
+        using (var wTx = Env.WriteTransaction())
+        {
+            var tree = wTx.CreateTree(nameof(CanDisableUpdatingLastWorkTimeInWriteTransaction));
+            tree.MultiAdd("test", "test");
+            wTx.Commit();
+        }
+        
+        Assert.NotEqual(previousLastWorkTime, Env.LastWorkTime);
+        Assert.True(previousLastWorkTime < Env.LastWorkTime);
+        previousLastWorkTime = Env.LastWorkTime;
+        using (var wTx = Env.WriteTransaction())
+        {
+            wTx.LowLevelTransaction.DisableLastWorkTimeUpdate();
+            var tree = wTx.CreateTree(nameof(CanDisableUpdatingLastWorkTimeInWriteTransaction));
+            tree.MultiAdd("test", "test2");
+            wTx.Commit();
+        }
+        
+        Assert.Equal(previousLastWorkTime, Env.LastWorkTime);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25207

### Additional description

Added a mechanism to disable the `LastWorkTime` update on Commit in a write transaction. This is useful for internal processes, such as updating the elapsed time from the last query, which runs in a loop and previously blocked the idling mechanism.


### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
